### PR TITLE
docs: restore the Go Reference badge, now that the page has something on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ObjectFS
 
-<!-- Badges: each one must report something real. Three were removed rather than fixed, because a
+<!-- Badges: each one must report something real. Two are still removed rather than fixed, because a
      badge that renders "unknown" or "retired" is worse than no badge — it reads as a broken project
      to anyone who looks, and as a passing check to anyone who does not.
 
@@ -9,18 +9,21 @@
          .coverage-floors, which is a job in ci.yml, so the CI badge already covers it. There is no
          separate percentage to display and no service to display it.
        - Go Report Card rendered "retired": the service no longer reports for this module.
-       - Go Reference (pkg.go.dev) rendered empty. go.mod used to declare
-         github.com/objectfs/objectfs, which is not this project — it is an unrelated Python
-         repository from 2017 — so the module could not be fetched under the name it gave for
-         itself and pkg.go.dev had nothing to index (#213). The path is fixed; this badge should be
-         restored once a tag has been published under the corrected path and pkg.go.dev has indexed
-         it, which is not something to assert in advance.
+
+     Go Reference is back, below. It rendered empty until v0.10.2 because go.mod declared
+     github.com/objectfs/objectfs, which is not this project — it is an unrelated Python repository
+     from 2017 — so the module could not be fetched under the name it gave for itself and pkg.go.dev
+     had nothing to index (#213). Restored only after checking what a reader actually gets: the page
+     resolves for v0.10.2 and documents the 16 packages under pkg/ and sdks/go, which is the whole
+     public surface. Most of this module is internal/ and pkg.go.dev does not document that, by
+     design — so the badge points at a real API reference rather than at an empty shell (#219).
 
      The GitHub stars badge is also gone: a star count is not a property of the software. -->
 
 [![CI](https://github.com/scttfrdmn/objectfs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/scttfrdmn/objectfs/actions/workflows/ci.yml)
 [![Security](https://github.com/scttfrdmn/objectfs/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/scttfrdmn/objectfs/actions/workflows/security.yml)
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/scttfrdmn/objectfs.svg)](https://pkg.go.dev/github.com/scttfrdmn/objectfs)
 [![Release](https://img.shields.io/github/v/release/scttfrdmn/objectfs)](https://github.com/scttfrdmn/objectfs/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/scttfrdmn/objectfs)](go.mod)


### PR DESCRIPTION
## What

Restores the `pkg.go.dev` badge to `README.md`, and rewrites the badge comment so it records what is actually true now rather than the pre-#213 state.

## Why now

The #213 sweep removed this badge because it rendered empty — `go.mod` declared `github.com/objectfs/objectfs`, an unrelated 2017 Python repository, so the module could not be fetched under the name it gave for itself. The removal note set the condition for restoring it:

> should be restored once a tag has been published under the corrected path and pkg.go.dev has indexed it, which is not something to assert in advance

#219 adds the check that matters:

> Verify by loading the badge SVG and the page, not by assuming the proxy implies the docs site. … most of this module is under `internal/`, which pkg.go.dev will not document … so confirm what a reader actually sees is useful before pointing a badge at it.

## Verified, both directions

| check | result |
|---|---|
| badge SVG colour | `#007D9C` (Go blue) — a real badge, not a grey "unknown" |
| `pkg.go.dev/github.com/scttfrdmn/objectfs@v0.10.2` | HTTP 200, real content |
| what the page documents | 16 packages: `pkg/api`, `pkg/archive`, `pkg/compression`, `pkg/errors`, `pkg/health`, `pkg/memmon`, `pkg/optimization`, `pkg/profiling`, `pkg/recovery`, `pkg/retry`, `pkg/status`, `pkg/types`, `pkg/utils`, `sdks/c`, `sdks/go/objectfs`, `cmd/objectfs` |

That last row is why the second check was worth running separately: a badge can resolve and still point at an empty shell. `pkg/` and `sdks/go` are the whole public surface of this module, so a reader following the badge gets the real API reference.

The other two badges removed in #213 stay removed, and the comment now says so explicitly — codecov (the repo has no Codecov integration; the coverage gate is `make .coverage-floors` in `ci.yml`) and Go Report Card (renders "retired" for this module).

Closes #219