### PR TITLE
v0.11.0 phase A: mv works, and the README says how far short of POSIX it falls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,103 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     bucket and the write path: `Create` records attributes without a PUT, so a just-created file is
     real and visible to `stat` with no object behind it yet.
 
+- **`mv` works, and the README says exactly how far short of POSIX it falls.** `Rename` copies
+  server-side and then deletes, per object; renaming a directory moves everything under its prefix
+  ([#164]). Before this, go-fuse's default for an absent `NodeRenamer` answered every `mv` with
+  `ENOTSUP`. Six properties are load-bearing, each pinned by a test that was verified by mutation —
+  the implementation was broken in that specific way and the test watched to fail:
+  - **Each source object is deleted only after its own copy has succeeded.** An interruption
+    therefore leaves the data at the old name, the new name, or both — never at neither. Duplicated
+    data is an operator's cleanup problem; missing data is not recoverable, so the ordering is fixed
+    in that direction deliberately, and a partial directory move is resumable by re-running the same
+    `mv`.
+  - **The copy is server-side.** Reading and rewriting through the process would make renaming a
+    10 GiB file cost 20 GiB of transfer, and renaming a directory that times the object count.
+    Objects above S3's 5 GiB single-part `CopyObject` limit route through `UploadPartCopy`.
+  - **The write path is flushed before the copy runs.** A copy acts on objects, so a file whose only
+    content is dirty ranges in memory is invisible to it: `echo hi > a; mv a b` would have copied a
+    key that did not exist yet, deleted the source, and then flushed the pending ranges back to the
+    *old* name — the file landing at neither name the user asked for.
+  - **The moved node is repointed, recursively for a directory.** `go-fuse`'s `MvChild` re-parents the
+    *same* inode, so the `FileNode` survives a rename holding the path it was constructed with. A
+    stored path is stale the moment a rename succeeds, and the consequence is silent in a way nothing
+    would catch: after `mv a b`, a write to `b` flushed to `a` and recreated the source the rename
+    had just deleted. A stale key is a valid key, so every S3 call succeeds.
+  - **Prefix matching is on a path boundary.** `mv dir dir-new` must not move `dir2/file`. That is not
+    a hypothetical spelling mistake — it is the same defect the cache's `keyMatches` had, found in the
+    same audit.
+  - **`renameat2`'s `RENAME_EXCHANGE` and `RENAME_NOREPLACE` are refused with `EINVAL`, not
+    approximated.** Both are atomicity promises copy-then-delete cannot keep, `EINVAL` is what the
+    kernel and libc expect for an unsupported flag, and `mv` and Git fall back correctly on it. A
+    foreign `newParent` is `EXDEV`, which is what go-fuse's own `LoopbackNode` answers.
+
+  There is no atomic alternative to reach for. S3's `RenameObject`, added in 2026, is
+  directory-bucket (S3 Express) only, and object annotations — which ObjectFS needs for POSIX
+  attributes — are unsupported on directory buckets, so the two features are mutually exclusive. The
+  README now carries a **Rename is not atomic** section stating what a concurrent reader can observe,
+  what an interruption leaves behind, and which tools that breaks: anything relying on the
+  write-temp-then-rename idiom for atomic replacement is not safe here between concurrent writers.
+- `types.Backend.CopyObject`, a server-side copy that preserves content encoding, content type,
+  storage class, and user metadata. Each of the four is a requirement rather than a nicety, and the
+  interface documentation says which failure each one prevents: the read path dispatches decoding on
+  the stored `Content-Encoding` and fails closed on one it cannot handle, so dropping it would leave a
+  compressed object permanently unreadable with its bytes intact; the storage-class default is
+  `STANDARD`, so dropping it would silently promote the object out of the tier being paid for; and
+  POSIX mode, ownership, and mtime live in user metadata and nowhere else, so dropping it would reset
+  a file's permissions, which is not a thing `rename` does. Encryption is applied from configuration
+  rather than copied from the source, so a key rotation reaches renamed objects.
+- `internal/testaws`: a `DirectoryMarkerDelete` capability probe, and `RequireDirectoryMarkerDelete`
+  to skip on its absence. Deleting a `dir/` marker while `dir/child` still exists panics the substrate
+  emulator, because its object store is a filesystem abstraction where `dir/` is the *directory*
+  holding the child, and removing it orphans the child (filed as
+  [scttfrdmn/substrate#534](https://github.com/scttfrdmn/substrate/issues/534), reproduced against
+  afero alone with no substrate involved). In S3 a key is an opaque string and `dir/` is an ordinary
+  object, so this is the emulator's property and not ObjectFS's — which is the reason for a runtime
+  probe rather than an assertion either way. The alternative was to assert the emulator's behavior as
+  expected, which would encode a dependency's bug as this project's contract.
+- `internal/storage/s3/copy_live_test.go` (`-tags=integration`) covers the multipart copy path against
+  real AWS, at real part sizes. It has no hermetic equivalent: substrate dispatches on
+  `x-amz-copy-source` before checking `uploadId`, so it answers an `UploadPartCopy` as a whole-object
+  copy with a 200 (substrate#532). That leaves the branch where a mistake is most expensive resting on
+  nothing but reading — abandoned multipart parts are billed and invisible to `ListObjects`. Two
+  shapes, both deliberate: a legal three-part copy with a short final part, which is where
+  inclusive/exclusive range mistakes surface, and an *illegal* one that S3 rejects at
+  `CompleteMultipartUpload`, which is how the abort path gets a failure arriving after every part has
+  already uploaded.
+
 ### Fixed
+
+- **`chmod` and automatic tier transitions worked on every key except the ones containing a `+`.**
+  `x-amz-copy-source` is read by S3 as a URL path, and `url.PathEscape` leaves `+` as itself while S3
+  decodes `+` in that header as a space — so a self-copy of `a+b.txt` asked for `a b.txt` and came
+  back `404 NoSuchKey`. Both callers are operations a user expects to be invisible, so the symptom was
+  a `chmod` failing with `ENOENT` on a file that plainly exists, and a storage-tier transition failing
+  on a timer with nothing to attribute it to. A `+` in a filename is ordinary: version numbers, C++
+  sources, and any timestamp written as `2026-08-01T00:00+00:00`. Escaping is now in one place
+  (`Backend.copySource`) rather than open-coded at each call site, one of which built the header with
+  no escaping at all. Verified against real S3 in `us-west-2` rather than reasoned about — both
+  `url.PathEscape` and `(&url.URL{Path: …}).EscapedPath()` fail on such a key, `%2B` succeeds, and
+  every other character `PathEscape` passes through (`~ * ( ) $ & = @ :`) was probed on the same
+  endpoint and copies correctly.
+- **`objectfs stats` reported zero for six counters that were being maintained correctly all along.**
+  `GetStats` copies field by field, and its list named nine of fifteen fields: `Creates`, `Deletes`,
+  and `Renames`, each incremented by its own operation, and the three latency averages, each
+  maintained as an exponential moving average by `recordReadTime` and its siblings. All six were live
+  and none reached the snapshot. This is a whole class of quiet defect — a field added to `Stats` and
+  not added to the copy is not a compile error and not a test failure, just a number that reads zero
+  forever — so the guard is a reflection test that sets every counter to a *distinct* non-zero value
+  and asserts the snapshot reports each one. Distinct, so that a copy assigning the right field from
+  the wrong source is caught too, which naming them all `1` would not be. An enumeration of field
+  names would have had the same failure mode as the code it checks. `time.Duration`'s reflect kind is
+  `Int64`, which is how the three latency fields were found.
+- `README.md`: the not-implemented table still listed `unlink` and `rmdir` as `EROFS` and the
+  tools-that-do-not-work list still said `mv` fails with `ENOTSUP` "because there is no rename" — both
+  true when written and both false since. A row asserting an operation fails is as wrong as a row
+  naming the wrong errno once the operation works, and it misleads in the worse direction: a reader
+  avoids something that would have worked. `internal/fuse/unimplemented_test.go` is the mechanism for
+  the errnos in that table, and rename's departure from it is now pinned from the other side — a test
+  asserts the bridge *dispatches* to `Rename` rather than reaching go-fuse's `ENOTSUP` default, which
+  is what a drifted signature or a build tag excluding `rename.go` would silently restore.
 
 - **`write_buffer.max_memory` is enforced.** It was declared in the config schema, defaulted to
   `"512MB"`, validated as a size string, and read by nothing ([#205]) — so every mount since the key
@@ -49,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quietly.
 
 [#163]: https://github.com/scttfrdmn/objectfs/issues/163
+[#164]: https://github.com/scttfrdmn/objectfs/issues/164
 [#205]: https://github.com/scttfrdmn/objectfs/issues/205
 
 ## [0.10.3] - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 > | **C4** | Read amplification was keyed off the compression *config*, not the object, so a ranged read fetched the whole object | A 4 KiB read of a 10 GiB object transferred 10 GiB. Measured 216× penalty on a 256 MiB object |
 > | **C2** | Reading an object whose stored `Content-Encoding` did not match the configured codec returned raw compressed bytes with exit status 0 | Corruption presented as success. The `objectfs-sha256` the write path recorded was never read |
 > | **H5/H6** | The read cache was keyed on request *length* and never invalidated on write | Structurally could not hit; read-after-write on one descriptor returned pre-write bytes |
-> | **D11** | `rm` reported success while the S3 object survived | go-fuse's default for an unimplemented `Unlink` is *success*. Deletion now fails loudly (#163) |
+> | **D11** | `rm` reported success while the S3 object survived | go-fuse's default for an unimplemented `Unlink` is *success*, so v0.10.0 answered every `rm` with exit 0 and deleted nothing. `Unlink` and `Rmdir` are implemented now (#163) |
 >
 > To check a bucket written by v0.10.0: compare each object's `objectfs-sha256` user-metadata against
 > its content, and check that `HeadObject`'s `ContentLength` matches the size your application wrote.
@@ -67,9 +67,10 @@ sequential reads of reference data, multi-terabyte datasets that will not fit on
 shared buckets read by many nodes.
 
 It is **not** a general-purpose POSIX filesystem, and the gap is not small — see
-[Supported filesystem operations](#supported-filesystem-operations). S3 has no rename, no hard
-links, no partial object write, and no atomic anything, and where a POSIX operation cannot be
-implemented honestly on top of that, ObjectFS returns an error rather than pretending.
+[Supported filesystem operations](#supported-filesystem-operations). S3 has no atomic rename, no
+hard links, no partial object write, and no atomic anything across more than one object, and where a
+POSIX operation cannot be implemented honestly on top of that, ObjectFS either returns an error
+rather than pretending, or documents exactly how far short of the POSIX guarantee it falls.
 
 **Platforms:** Linux and macOS (macOS needs [macFUSE](https://macfuse.io)). **Windows is not
 supported** — there is no WinFsp binding, and none is claimed until one exists and runs in CI.
@@ -97,6 +98,40 @@ or "slow".
 | chmod / chown | `chmod`, `chown` | On **files** only, stored as object metadata. Permission bits only |
 | utimes (mtime) | `touch`, `utimensat` | mtime is stored; an atime-only update is accepted and not stored |
 | statfs | `df` | Reports a fixed synthetic capacity — S3 has no size to report |
+| Unlink | `unlink`, `rm` | Deletes the object. A missing file is `ENOENT`, not a silent success |
+| Rmdir | `rmdir`, `rm -d` | Removes the marker object. A non-empty prefix is `ENOTEMPTY` — it will not orphan the objects under it |
+| Rename / move | `rename`, `mv` | Server-side copy then delete, per object; a directory moves everything under its prefix. **Not atomic** — see [Rename is not atomic](#rename-is-not-atomic). `renameat2`'s `RENAME_EXCHANGE` and `RENAME_NOREPLACE` are refused with `EINVAL` |
+
+#### Rename is not atomic
+
+POSIX `rename` is atomic: an observer sees the old name or the new one, never both and never
+neither. S3 offers nothing that can implement that. There is no atomic rename operation — the 2026
+`RenameObject` API is directory-bucket (S3 Express) only, and object annotations, which ObjectFS
+needs for attributes, are unsupported on directory buckets, so the two features are mutually
+exclusive. A rename is therefore a server-side copy followed by a delete, per object.
+
+What that means in practice:
+
+- **A concurrent reader can see both names**, for as long as the copy-then-delete takes. It can also
+  see the source after the destination already exists.
+- **An interruption — crash, `SIGKILL`, lost network — leaves the data at the old name, the new
+  name, or both. Never at neither.** Each source object is deleted only after its own copy has
+  succeeded. Duplicated data is an operator's cleanup problem; missing data is not recoverable, so
+  the ordering is fixed in that direction deliberately.
+- **A partial directory move is resumable.** Re-running the same `mv` copies whatever is still at the
+  source and deletes it, and objects already moved are simply absent from the source listing.
+- **`renameat2` flags are refused rather than approximated.** `RENAME_EXCHANGE` and
+  `RENAME_NOREPLACE` are atomicity promises — swap two names with no observable intermediate state,
+  fail if the destination exists with no race — and copy-then-delete cannot keep either. They return
+  `EINVAL`, which is what the kernel and libc expect for an unsupported flag, and `mv` and Git fall
+  back correctly on it.
+- **Renaming a directory costs one copy and one delete per object beneath it**, charged and rate-
+  limited as such. It is not a metadata operation.
+- **Renaming across mounts is `EXDEV`**, so `mv` falls back to copy-and-unlink through user space.
+
+Anything that depends on rename atomicity — the write-temp-then-rename idiom used by editors, `git`,
+and lockfile schemes — is therefore not safe here between concurrent writers. Single-writer use is
+fine.
 
 ### Errors by design
 
@@ -114,11 +149,8 @@ These fail, and the failure is the correct answer rather than a missing feature.
 
 | Operation | Current behaviour | Tracked |
 |---|---|---|
-| `unlink` / `rm` | **`EROFS`** — fails loudly rather than reporting a delete that did not happen | [#163](https://github.com/scttfrdmn/objectfs/issues/163) |
-| `rmdir` | **`EROFS`**, same reason | [#163](https://github.com/scttfrdmn/objectfs/issues/163) |
 | `chmod` / `chown` on a **directory** | **`ENOTSUP`** — the marker object could carry the metadata, but `Getattr` does not read it back, so accepting the call would report a mode the next `stat` contradicts | [#165](https://github.com/scttfrdmn/objectfs/issues/165) |
-| `rename` / `mv` | **`ENOTSUP`** — go-fuse's default for an absent `NodeRenamer` | S3 has no rename; it must be implemented as copy-then-delete, which is neither atomic nor free |
-| Symlinks (`symlink`, `readlink`) | **`ENOTSUP`** | Same: no `NodeSymlinker`/`NodeReadlinker` |
+| Symlinks (`symlink`, `readlink`) | **`ENOTSUP`** | No `NodeSymlinker`/`NodeReadlinker` |
 | Extended attributes (`getxattr`, `setxattr`, `listxattr`) | **`ENODATA`** on Linux / **`ENOATTR`** on macOS for get and remove; `listxattr` returns an empty list | go-fuse's defaults. An empty list is the accurate answer — there are no xattrs — but note that `setxattr` reports "no such attribute" rather than "unsupported" |
 | `mknod` (devices, FIFOs, sockets) | **`ENOTSUP`** | |
 | `fallocate` | **`ENOTSUP`** | |
@@ -128,11 +160,11 @@ These fail, and the failure is the correct answer rather than a missing feature.
 
 Not because of a bug, but because of the semantics above. Verified, not assumed:
 
-- **`rm`, `rm -rf`, and anything that unlinks** — `EROFS` until [#163](https://github.com/scttfrdmn/objectfs/issues/163). This includes `git checkout` of a branch that deletes files, and any build system that cleans. `mv` within the mount fails earlier, with `ENOTSUP`, because there is no rename.
 - **SQLite, and anything using POSIX record locks** — locks are not forwarded to the filesystem, so they are host-local and invisible to any other mount of the same bucket. Two hosts will both believe they hold the same exclusive lock. A single writer with no concurrent readers may work; do not rely on it.
-- **`git` on a repository inside the mount** — needs rename, unlink, and locking.
-- **`tar -x` and `rsync --delete`** — both unlink.
+- **`git` on a repository inside the mount** — locking is host-local, and Git's index and lockfile updates rely on rename being atomic, which it is not. A single-writer clone will mostly work; two hosts against one bucket will corrupt the repository, and no error will say so.
+- **Anything using the write-temp-then-rename idiom for atomic replacement** — editors that save that way, and lockfile schemes built on `RENAME_NOREPLACE`. The replacement happens, it just is not atomic; `RENAME_NOREPLACE` is refused outright with `EINVAL`. See [Rename is not atomic](#rename-is-not-atomic).
 - **Anything expecting `mmap` writeback to be atomic or ordered.**
+- **`rsync --delete` and `tar -x` over an existing tree** work now that unlink and rename do, but note that both make a directory rename cost one copy plus one delete per object underneath rather than a single metadata write.
 
 Large sequential reads, `cp` into the mount, and read-only traversal of a dataset are the paths that
 are tested hardest and the ones ObjectFS is for.
@@ -173,6 +205,10 @@ guaranteed and — more usefully — what is not.
 - **There is no atomicity across a write.** A crash mid-flush leaves the object as it was, or as it
   will be — S3 PUTs are atomic per object — but a multi-object operation has no transaction, and
   nothing is journaled.
+- **Rename is not atomic, and a directory rename is not even single-object.** An interruption leaves
+  the data at the old name, the new name, or both — never at neither, because each source is deleted
+  only after its own copy succeeds. See [Rename is not atomic](#rename-is-not-atomic) for what a
+  concurrent reader can observe.
 - **There is no concurrent-writer safety.** Two nodes writing the same object will produce one
   winner and no error. Nothing detects the conflict, because `PutObject` carries no precondition
   today.

--- a/internal/archive/vfs_test.go
+++ b/internal/archive/vfs_test.go
@@ -34,6 +34,18 @@ func (m *mockBackend) PutObject(_ context.Context, _ string, _ []byte, _ map[str
 func (m *mockBackend) SetObjectMetadata(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
+
+// CopyObject copies the stored bytes rather than no-opping, because this mock's reads come out of the
+// same map: a copy that recorded nothing would leave dst absent while reporting success, and a caller
+// checking whether the copy landed would read a not-found as a copy bug.
+func (m *mockBackend) CopyObject(_ context.Context, src, dst string) error {
+	data, ok := m.objects[src]
+	if !ok {
+		return fmt.Errorf("mockBackend: not found: %q", src)
+	}
+	m.objects[dst] = data
+	return nil
+}
 func (m *mockBackend) DeleteObject(_ context.Context, _ string) error { return nil }
 func (m *mockBackend) HeadObject(_ context.Context, _ string) (*types.ObjectInfo, error) {
 	return nil, nil

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -54,7 +54,8 @@ func (m *mockBackend) PutObject(_ context.Context, _ string, _ []byte, _ map[str
 func (m *mockBackend) SetObjectMetadata(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
-func (m *mockBackend) DeleteObject(_ context.Context, _ string) error { return nil }
+func (m *mockBackend) CopyObject(_ context.Context, _, _ string) error { return nil }
+func (m *mockBackend) DeleteObject(_ context.Context, _ string) error  { return nil }
 func (m *mockBackend) HeadObject(_ context.Context, key string) (*types.ObjectInfo, error) {
 	return &types.ObjectInfo{Key: key}, nil
 }
@@ -83,7 +84,8 @@ func (e *errBackend) PutObject(_ context.Context, _ string, _ []byte, _ map[stri
 func (e *errBackend) SetObjectMetadata(_ context.Context, _ string, _ map[string]string) error {
 	return e.err
 }
-func (e *errBackend) DeleteObject(_ context.Context, _ string) error { return e.err }
+func (e *errBackend) CopyObject(_ context.Context, _, _ string) error { return e.err }
+func (e *errBackend) DeleteObject(_ context.Context, _ string) error  { return e.err }
 func (e *errBackend) HeadObject(_ context.Context, _ string) (*types.ObjectInfo, error) {
 	return nil, e.err
 }

--- a/internal/fuse/attributes.go
+++ b/internal/fuse/attributes.go
@@ -210,12 +210,12 @@ func modeBits(a vfs.Attr) uint32 {
 // size and mtime the file had when it was first looked up.
 func (f *FileNode) attr(ctx context.Context) (vfs.Attr, error) {
 	if f.fs.buffer != nil {
-		if a, ok := f.fs.buffer.Attr(f.path); ok {
+		if a, ok := f.fs.buffer.Attr(f.key()); ok {
 			return a, nil
 		}
 	}
 
-	info, err := f.fs.statObject(ctx, f.path)
+	info, err := f.fs.statObject(ctx, f.key())
 	if err != nil {
 		return vfs.Attr{}, err
 	}
@@ -228,7 +228,7 @@ func (f *FileNode) attr(ctx context.Context) (vfs.Attr, error) {
 func (f *FileNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	a, err := f.attr(ctx)
 	if err != nil {
-		slog.Error("getattr failed", "path", f.path, "error", err)
+		slog.Error("getattr failed", "path", f.key(), "error", err)
 
 		return toErrno(err)
 	}
@@ -277,8 +277,8 @@ func (f *FileNode) Setattr(
 		if size > math.MaxInt64 {
 			return syscall.EFBIG
 		}
-		if err := f.fs.buffer.Truncate(ctx, f.path, int64(size)); err != nil {
-			slog.Error("setattr: truncate failed", "path", f.path, "size", size, "error", err)
+		if err := f.fs.buffer.Truncate(ctx, f.key(), int64(size)); err != nil {
+			slog.Error("setattr: truncate failed", "path", f.key(), "size", size, "error", err)
 
 			return toErrno(err)
 		}
@@ -292,7 +292,7 @@ func (f *FileNode) Setattr(
 		// the S3 credentials the process holds, not by a mode bit, so a setuid bit that appeared to be
 		// stored would promise an escalation that cannot happen and could not be relied on either way.
 		slog.Warn("setattr: refusing to set mode bits outside the permission mask",
-			"path", f.path, "mode", mode)
+			"path", f.key(), "mode", mode)
 
 		return syscall.ENOTSUP
 	}
@@ -307,8 +307,8 @@ func (f *FileNode) Setattr(
 			from.Mtime = mtime
 		}
 
-		if err := f.fs.buffer.SetAttr(ctx, f.path, modeOK, uidOK, gidOK, from); err != nil {
-			slog.Error("setattr failed", "path", f.path, "error", err)
+		if err := f.fs.buffer.SetAttr(ctx, f.key(), modeOK, uidOK, gidOK, from); err != nil {
+			slog.Error("setattr failed", "path", f.key(), "error", err)
 
 			return toErrno(err)
 		}
@@ -321,15 +321,15 @@ func (f *FileNode) Setattr(
 	// value POSIX already permits a filesystem to keep only approximately.
 
 	if changed {
-		if err := f.fs.buffer.FlushContext(ctx, f.path); err != nil {
-			slog.Error("setattr: flush failed", "path", f.path, "error", err)
+		if err := f.fs.buffer.FlushContext(ctx, f.key()); err != nil {
+			slog.Error("setattr: flush failed", "path", f.key(), "error", err)
 
 			return toErrno(err)
 		}
 
 		// The object's size, mtime, and mode all just changed. Anything cached for the path describes
 		// what it was before.
-		f.fs.invalidate(f.path)
+		f.fs.invalidate(f.key())
 
 		if h, ok := fh.(*FileHandle); ok {
 			h.file.markClean()
@@ -338,7 +338,7 @@ func (f *FileNode) Setattr(
 
 	a, err := f.attr(ctx)
 	if err != nil {
-		slog.Error("setattr: cannot report resulting attributes", "path", f.path, "error", err)
+		slog.Error("setattr: cannot report resulting attributes", "path", f.key(), "error", err)
 
 		return toErrno(err)
 	}
@@ -363,14 +363,14 @@ func (f *FileNode) Fsync(ctx context.Context, fh fs.FileHandle, flags uint32) sy
 		return 0
 	}
 
-	if err := f.fs.buffer.FlushContext(ctx, f.path); err != nil {
+	if err := f.fs.buffer.FlushContext(ctx, f.key()); err != nil {
 		f.fs.countError()
-		slog.Error("fsync failed", "path", f.path, "error", err)
+		slog.Error("fsync failed", "path", f.key(), "error", err)
 
 		return toErrno(err)
 	}
 
-	f.fs.invalidate(f.path)
+	f.fs.invalidate(f.key())
 
 	if h, ok := fh.(*FileHandle); ok {
 		h.file.markClean()
@@ -429,7 +429,7 @@ func (n *DirectoryNode) Setattr(
 	if modeOK || uidOK || gidOK {
 		slog.Warn("chmod and chown of a directory are not implemented; refusing rather than reporting "+
 			"a change that would not be visible on the next stat",
-			"path", n.path, "issue", 165)
+			"path", n.key(), "issue", 165)
 
 		return syscall.ENOTSUP
 	}

--- a/internal/fuse/filesystem.go
+++ b/internal/fuse/filesystem.go
@@ -260,6 +260,7 @@ type Stats struct {
 	Writes  int64 `json:"writes"`
 	Creates int64 `json:"creates"`
 	Deletes int64 `json:"deletes"`
+	Renames int64 `json:"renames"`
 
 	// Data transfer
 	BytesRead    int64 `json:"bytes_read"`
@@ -351,6 +352,17 @@ func (fs *FileSystem) countCacheMiss() {
 }
 
 // GetStats returns current filesystem statistics
+// GetStats returns a snapshot of the counters.
+//
+// Every field of [Stats] is copied, and that is the whole reason this comment exists: the field list
+// named nine of fifteen. Creates, Deletes, and Renames were incremented by their operations and
+// reported as zero, and the three latency averages were computed by [FileSystem.recordReadTime] and its
+// siblings — an exponential moving average per operation — and then dropped on the way out. The
+// counters existed, the operations maintained them, and `objectfs stats` said nothing had happened.
+//
+// A field added to Stats and not added here fails in exactly that way: not a compile error, not a test
+// failure, just a number that is always zero. TestGetStatsReportsEveryCounter is what catches it, by
+// reflection rather than by a second list that could go stale the same way.
 func (fs *FileSystem) GetStats() *Stats {
 	fs.stats.mu.RLock()
 	defer fs.stats.mu.RUnlock()
@@ -360,19 +372,57 @@ func (fs *FileSystem) GetStats() *Stats {
 		Opens:        fs.stats.Opens,
 		Reads:        fs.stats.Reads,
 		Writes:       fs.stats.Writes,
+		Creates:      fs.stats.Creates,
+		Deletes:      fs.stats.Deletes,
+		Renames:      fs.stats.Renames,
 		BytesRead:    fs.stats.BytesRead,
 		BytesWritten: fs.stats.BytesWritten,
 		CacheHits:    fs.stats.CacheHits,
 		CacheMisses:  fs.stats.CacheMisses,
 		Errors:       fs.stats.Errors,
+
+		AvgReadTime:   fs.stats.AvgReadTime,
+		AvgWriteTime:  fs.stats.AvgWriteTime,
+		AvgLookupTime: fs.stats.AvgLookupTime,
 	}
 }
 
 // DirectoryNode represents a directory in the filesystem
 type DirectoryNode struct {
 	fs.Inode
-	fs   *FileSystem
-	path string
+	fs *FileSystem
+
+	// path is the key prefix this directory stands for, and it is mutable — see [DirectoryNode.key].
+	pathMu sync.RWMutex
+	path   string
+}
+
+// key returns the object key prefix this node currently stands for.
+//
+// # Why this is not a plain field read
+//
+// A rename moves the node rather than replacing it. go-fuse's bridge, on a Rename that returns success,
+// calls Inode.MvChild (fs/inode.go), which re-parents *the same* *Inode — so the DirectoryNode or
+// FileNode it carries survives the rename with whatever path it was constructed with. Every operation
+// afterwards on the moved dentry would address the key the file was moved *away* from: `mv a b` followed
+// by a write to b would flush to a, recreating the source and leaving b as the user found it.
+//
+// So the path has to be updated in place, which makes it mutable, which makes it shared state — the
+// kernel issues concurrent operations against the same node, so a rename storing a new path while a read
+// takes the old one is a data race in the literal -race sense. Hence the lock rather than a bare
+// assignment.
+func (n *DirectoryNode) key() string {
+	n.pathMu.RLock()
+	defer n.pathMu.RUnlock()
+
+	return n.path
+}
+
+// setKey repoints this node at a new prefix. See [DirectoryNode.key] for why it exists.
+func (n *DirectoryNode) setKey(path string) {
+	n.pathMu.Lock()
+	defer n.pathMu.Unlock()
+	n.path = path
 }
 
 // Lookup resolves one path component.
@@ -470,7 +520,10 @@ func (n *DirectoryNode) Lookup(ctx context.Context, name string, out *fuse.Entry
 // Dot entries are not emitted. go-fuse synthesizes "." and ".." in readDirMaybeLookup, and a stream
 // that supplies its own gets them twice.
 func (n *DirectoryNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errno) {
-	prefix := n.path
+	// Read once. Taking it twice would let a concurrent rename list one prefix and report another.
+	dirPath := n.key()
+
+	prefix := dirPath
 	if prefix != "" && !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
@@ -478,7 +531,7 @@ func (n *DirectoryNode) Readdir(ctx context.Context) (fs.DirStream, syscall.Errn
 	objects, err := n.fs.backend.ListObjects(ctx, prefix, 0)
 	if err != nil {
 		n.fs.countError()
-		slog.Error("readdir failed", "path", n.path, "error", err)
+		slog.Error("readdir failed", "path", dirPath, "error", err)
 
 		return nil, toErrno(err)
 	}
@@ -774,8 +827,26 @@ func (n *DirectoryNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 // [FileNode.attr] for where the answer comes from instead.
 type FileNode struct {
 	fs.Inode
-	fs   *FileSystem
-	path string
+	fs *FileSystem
+
+	// path is the object key this file stands for, mutable for the reason [DirectoryNode.key] gives.
+	pathMu sync.RWMutex
+	path   string
+}
+
+// key returns the object key this node currently stands for. See [DirectoryNode.key].
+func (f *FileNode) key() string {
+	f.pathMu.RLock()
+	defer f.pathMu.RUnlock()
+
+	return f.path
+}
+
+// setKey repoints this node at a new key. See [DirectoryNode.key].
+func (f *FileNode) setKey(path string) {
+	f.pathMu.Lock()
+	defer f.pathMu.Unlock()
+	f.path = path
 }
 
 // Open opens a file.
@@ -793,7 +864,7 @@ func (f *FileNode) Open(ctx context.Context, flags uint32) (fh fs.FileHandle, fu
 	}
 
 	openFile := &OpenFile{
-		path:        f.path,
+		path:        f.key(),
 		lastAccess:  time.Now(),
 		accessCount: 1,
 	}
@@ -1219,10 +1290,11 @@ func (fh *FileHandle) Release(ctx context.Context) syscall.Errno {
 // Helper methods for DirectoryNode
 
 func (n *DirectoryNode) joinPath(name string) string {
-	if n.path == "" {
+	dirPath := n.key()
+	if dirPath == "" {
 		return name
 	}
-	return filepath.Join(n.path, name)
+	return filepath.Join(dirPath, name)
 }
 
 // newFileEntry builds the inode and the kernel entry for a regular file found under this directory.

--- a/internal/fuse/filesystem_test.go
+++ b/internal/fuse/filesystem_test.go
@@ -4,6 +4,7 @@ package fuse
 
 import (
 	"os"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -256,5 +257,51 @@ func TestMountManager_checkMount_InvertedBooleanFixed(t *testing.T) {
 	if expectedMounted != actuallyMounted {
 		t.Errorf("IsMounted()=%v but isAlreadyMounted()=%v — inverted boolean bug may have been re-introduced",
 			expectedMounted, actuallyMounted)
+	}
+}
+
+// TestGetStatsReportsEveryCounter guards a whole class of quiet defect: a counter that is incremented
+// faithfully and then dropped on its way out.
+//
+// GetStats copies field by field, so a field added to Stats and not added there is not a compile error
+// and not a test failure — it is a number that reads zero forever while the operation it counts happens
+// thousands of times. Six were exactly that when this test was written: Creates, Deletes, and Renames,
+// each bumped by its own operation, and the three latency averages, each maintained as an exponential
+// moving average by recordReadTime and its siblings. All six were live and none reached the snapshot.
+//
+// Reflection rather than an enumeration of names, because an enumeration has the same failure mode as
+// the code it checks. It sets every int64 counter to a distinct non-zero value — distinct so that a
+// copy assigning the right field from the wrong source is caught too, which naming them all 1 would
+// not be. time.Duration's Kind is Int64, so the latency fields are covered by the same pass; that is
+// how they were found.
+func TestGetStatsReportsEveryCounter(t *testing.T) {
+	t.Parallel()
+
+	filesystem := NewFileSystem(nil, nil, nil, nil, nil)
+
+	// Written directly rather than by performing operations: the point is the snapshot, and driving a
+	// dozen real operations would need a backend and would still not prove the copy is complete.
+	source := reflect.ValueOf(filesystem.stats).Elem()
+	for i := range source.NumField() {
+		if source.Field(i).Kind() == reflect.Int64 && source.Field(i).CanSet() {
+			source.Field(i).SetInt(int64(i) + 1)
+		}
+	}
+
+	snapshot := reflect.ValueOf(filesystem.GetStats()).Elem()
+	statsType := snapshot.Type()
+
+	for i := range snapshot.NumField() {
+		if snapshot.Field(i).Kind() != reflect.Int64 {
+			continue
+		}
+
+		want := int64(i) + 1
+		if got := snapshot.Field(i).Int(); got != want {
+			t.Errorf("GetStats reports %s = %d, want %d. The counter is incremented by the operation "+
+				"and dropped by the snapshot, so `objectfs stats` reports zero of them no matter how "+
+				"many happen. Add the field to GetStats's copy.",
+				statsType.Field(i).Name, got, want)
+		}
 	}
 }

--- a/internal/fuse/rename.go
+++ b/internal/fuse/rename.go
@@ -1,0 +1,380 @@
+//go:build linux || darwin
+
+package fuse
+
+// Rename (#164), for a single file and for a directory prefix.
+//
+// # This operation cannot have POSIX semantics, and says so rather than pretending
+//
+// POSIX rename(2) is atomic: after it returns, the name is either the old one or the new one, never
+// both and never neither, and a concurrent observer sees one of those two states. S3 offers no such
+// primitive for a general-purpose bucket. There is a RenameObject API as of 2026, but it is restricted
+// to directory buckets (S3 Express One Zone), and object annotations — which the attribute work depends
+// on — are unsupported on directory buckets, so the two are mutually exclusive. What is left is a copy
+// followed by a delete, which is two operations, so:
+//
+//   - A reader can observe the file at both names. The window is one round trip for a file, and the
+//     whole traversal for a directory.
+//   - A crash between the two leaves the file at both names.
+//
+// The response is to fail in the safe direction rather than to hide it. Every source object is deleted
+// only after its own copy has succeeded, so an interrupted rename leaves the data readable at the old
+// name, the new name, or both — never at neither. Duplicated data is an operator's cleanup problem;
+// missing data is not recoverable. That ordering is the single most important line in this file.
+//
+// # Why the write path is flushed first
+//
+// A copy is server-side: it acts on objects. A file whose bytes are still dirty ranges in memory has no
+// object, or has a stale one — so `echo hi > a; mv a b` would copy an object that does not exist or
+// holds the pre-write bytes, delete the source, and then flush the pending ranges back to *a*. The file
+// would end up at the name the user renamed away from, with b either absent or holding stale content.
+//
+// So [vfs.Writer.FlushPrefix] runs first and the rename proceeds only if it succeeds. See its own
+// comment for why flushing beats migrating the pending ranges to the new key.
+//
+// # Why the source is copied rather than re-uploaded
+//
+// [types.Backend.CopyObject] transfers no bytes through this process, and it preserves user metadata,
+// Content-Encoding, Content-Type, and storage class. All four matter: the POSIX mode and ownership live
+// in user metadata and nowhere else, and the read path dispatches decoding on the stored
+// Content-Encoding and fails closed on one it cannot handle — so a rename that dropped that header would
+// leave a compressed file permanently unreadable with its bytes intact. Renaming a 10 GiB file would
+// also be 20 GiB of transfer if it went through the client, and renaming a directory that times the
+// number of objects under it.
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"syscall"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// Compile-time proof that a directory implements the renamer. Without it go-fuse's bridge answers
+// ENOTSUP for the absent interface (fs/bridge.go, the final return of rawBridge.Rename), which is what
+// every release through v0.10.3 did — and unlike Unlink's default of *success*, that is at least honest.
+var _ fs.NodeRenamer = (*DirectoryNode)(nil)
+
+// renameExchange is RENAME_EXCHANGE from renameat2(2): atomically swap two names.
+//
+// Declared here rather than taken from fs.RENAME_EXCHANGE because the flag has to be recognized in
+// order to be *refused*, and refusing it is the whole interaction — see [DirectoryNode.Rename].
+const renameExchange = 0x2
+
+// renameNoReplace is RENAME_NOREPLACE from renameat2(2): fail with EEXIST if the destination exists.
+const renameNoReplace = 0x1
+
+// Rename moves name under this directory to newName under newParent.
+//
+// # The flags are refused, not ignored
+//
+// renameat2(2) can carry RENAME_EXCHANGE ("swap these two names atomically") or RENAME_NOREPLACE ("fail
+// if the destination exists"). Both are promises about atomicity that copy-then-delete cannot keep:
+// an exchange would be four operations with two windows in which a name holds the wrong file or no file,
+// and a no-replace would be a check followed by a copy with a window between them in which another writer
+// creates the destination that the check said was absent.
+//
+// Returning EINVAL for both is what the kernel and the C library expect for a filesystem that does not
+// implement them, and callers handle it: coreutils `mv` falls back to plain rename, and Git's
+// no-replace path likewise. Accepting the flag and doing the non-atomic thing would silently break the
+// invariant the caller asked for, which is worse than the fallback.
+//
+// # Read-only mounts
+//
+// EROFS before anything else. A read-only mount that copied and then failed to delete would leave the
+// filesystem modified by an operation it had already decided to refuse.
+func (n *DirectoryNode) Rename(
+	ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32,
+) syscall.Errno {
+	if n.fs.config != nil && n.fs.config.ReadOnly {
+		return syscall.EROFS
+	}
+
+	if flags&(renameExchange|renameNoReplace) != 0 {
+		slog.Warn("refusing a renameat2 flag this filesystem cannot honor atomically; a rename here is "+
+			"a server-side copy followed by a delete",
+			"name", name, "new_name", newName, "flags", flags)
+
+		return syscall.EINVAL
+	}
+
+	// The destination directory has to be one of ours. It always is on a real mount — the bridge resolves
+	// both inodes from the same tree — but the parameter is an interface, and a rename into a node whose
+	// path this package cannot compute has to be refused rather than guessed at. EXDEV is the errno for
+	// "these two names are not on the same filesystem", which is what a foreign node amounts to, and `mv`
+	// responds to it by falling back to copy-then-delete through the file contents.
+	destDir, ok := newParent.(*DirectoryNode)
+	if !ok {
+		slog.Error("rename destination is not an ObjectFS directory", "type", newParent)
+
+		return syscall.EXDEV
+	}
+
+	srcPath := n.joinPath(name)
+	dstPath := destDir.joinPath(newName)
+
+	if srcPath == dstPath {
+		// rename(2) of a name to itself is a documented no-op that returns success. Doing the copy anyway
+		// would be a self-copy followed by a delete of what it just wrote — which deletes the file.
+		return 0
+	}
+
+	if n.fs.buffer == nil {
+		return syscall.ENOTSUP
+	}
+
+	// Everything under the source must be in the object store before a server-side copy can see it. See
+	// the file comment.
+	if _, err := n.fs.buffer.FlushPrefix(ctx, srcPath); err != nil {
+		n.fs.countError()
+		slog.Error("rename could not make the source durable before copying it",
+			"src", srcPath, "dst", dstPath, "error", err)
+
+		return toErrno(err)
+	}
+
+	// What kind of thing is being renamed decides the whole shape of the operation, and getting it wrong
+	// is not a cosmetic error: treating a directory as a file renames its marker object and orphans every
+	// object beneath it, and treating a file as a directory renames nothing and reports success.
+	keys, isDir, errno := n.renameSources(ctx, srcPath)
+	if errno != 0 {
+		return errno
+	}
+
+	if isDir {
+		errno = n.renameTree(ctx, srcPath, dstPath, keys)
+	} else {
+		errno = n.renameOne(ctx, srcPath, dstPath)
+	}
+	if errno != 0 {
+		return errno
+	}
+
+	// Only on success, and only after the storage side is done. go-fuse re-parents the existing inode
+	// rather than rebuilding it, so the node still holds the old key until this runs — see [repoint].
+	repoint(n.GetChild(name), dstPath)
+
+	return 0
+}
+
+// renameSources decides whether srcPath names a file or a directory, and for a directory returns every
+// object key at or under it.
+//
+// The listing is what makes the directory case correct, and it is also the existence check: a prefix
+// with objects under it is a directory whether or not anything wrote a marker for it, so
+// [DirectoryNode.Mkdir]'s marker is sufficient but not necessary. Absence of both an object and a
+// listing is ENOENT.
+//
+// Order matters. The object is looked for first, because a marker object at "dir/" is also an object at
+// a *different* key than "dir", so asking for the object at "dir" cannot be confused by it — while
+// asking for the listing first would find the marker and call a regular file named "dir" a directory if
+// a "dir/" prefix also happened to exist.
+func (n *DirectoryNode) renameSources(ctx context.Context, srcPath string) ([]string, bool, syscall.Errno) {
+	_, headErr := n.fs.backend.HeadObject(ctx, srcPath)
+	switch {
+	case headErr == nil:
+		return nil, false, 0
+
+	case !vfs.IsNotFound(headErr):
+		// Not absence — a throttle, an expired credential, a permission failure. Reporting ENOENT here
+		// would make `mv` say "no such file" about a file that is merely unreachable, and reporting
+		// success would delete a source whose copy never happened.
+		n.fs.countError()
+		slog.Error("rename could not determine whether the source exists",
+			"src", srcPath, "error", headErr)
+
+		return nil, false, toErrno(headErr)
+	}
+
+	objects, listErr := n.fs.backend.ListObjects(ctx, srcPath+"/", 0)
+	if listErr != nil {
+		n.fs.countError()
+		slog.Error("rename could not list the source directory", "src", srcPath, "error", listErr)
+
+		return nil, false, toErrno(listErr)
+	}
+
+	if len(objects) == 0 {
+		return nil, false, syscall.ENOENT
+	}
+
+	keys := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		keys = append(keys, obj.Key)
+	}
+
+	return keys, true, 0
+}
+
+// renameOne renames a single file: copy to the destination, then delete the source.
+//
+// Replacing an existing destination is silent, as POSIX requires — an S3 copy overwrites the key
+// unconditionally, so this comes for free rather than needing a delete first. It also means the
+// destination's own pending writes have to go: they describe the file that was just replaced, and a
+// later flush would put its bytes back over the file that replaced it.
+func (n *DirectoryNode) renameOne(ctx context.Context, srcPath, dstPath string) syscall.Errno {
+	if err := n.fs.backend.CopyObject(ctx, srcPath, dstPath); err != nil {
+		n.fs.countError()
+		slog.Error("rename failed to copy the source", "src", srcPath, "dst", dstPath, "error", err)
+
+		return toErrno(err)
+	}
+
+	// After the copy, before the delete: from here the data exists at the destination, so a failure below
+	// leaves it at both names rather than at neither.
+	//
+	// The destination's buffered state is dropped rather than flushed. It belongs to the file this rename
+	// just overwrote, and flushing it would write those bytes over the file that replaced them.
+	n.fs.buffer.DiscardPrefix(dstPath)
+	n.fs.invalidate(dstPath)
+
+	if err := n.fs.backend.DeleteObject(ctx, srcPath); err != nil {
+		// The copy succeeded, so the data is safe at the destination and the rename has substantially
+		// happened; what failed is the cleanup. Reporting the error is still right — the caller asked for a
+		// move and got a copy — and it must not be swallowed, because `mv` reporting success would leave
+		// the user believing the source is gone.
+		n.fs.countError()
+		slog.Error("rename copied the file but could not delete the source, so it now exists at both "+
+			"names; the destination holds the data and the source needs removing by hand",
+			"src", srcPath, "dst", dstPath, "error", err)
+
+		return toErrno(err)
+	}
+
+	n.fs.buffer.DiscardPrefix(srcPath)
+	n.fs.invalidate(srcPath)
+
+	n.fs.stats.mu.Lock()
+	n.fs.stats.Renames++
+	n.fs.stats.mu.Unlock()
+
+	return 0
+}
+
+// renameTree renames a directory by copying every object under its prefix and then deleting each source.
+//
+// # This is not atomic and does not try to look atomic
+//
+// A directory with a million objects is a million copies and a million deletes, and it can fail at any
+// point. There is no transaction to roll back to, and simulating one — copying everything, then deleting
+// everything, and undoing the copies on failure — would only move the non-atomic window and add a failure
+// mode where the undo itself fails.
+//
+// So the loop is per-object and each object's source is deleted immediately after its own copy succeeds,
+// and on the first failure it stops and reports. What the caller is left with is a partially moved tree
+// in which every object is readable at exactly one of the two names. Nothing is lost, and re-running the
+// same rename completes it, because an object already moved is simply absent from the source listing on
+// the second pass.
+//
+// Stopping on the first error rather than pressing on is deliberate: the usual cause is a credential or
+// permission problem that will fail identically for every remaining object, and continuing would turn one
+// error into a million while making the reported one arbitrary.
+func (n *DirectoryNode) renameTree(ctx context.Context, srcPath, dstPath string, keys []string) syscall.Errno {
+	srcPrefix := strings.TrimSuffix(srcPath, "/") + "/"
+	dstPrefix := strings.TrimSuffix(dstPath, "/") + "/"
+
+	moved := 0
+	for _, key := range keys {
+		// Defensive rather than expected: the listing was made with this prefix, so every key carries it.
+		// A key that does not would produce a destination outside the target directory, which is the one
+		// mistake here that writes an object somewhere the user never named.
+		if !strings.HasPrefix(key, srcPrefix) {
+			n.fs.countError()
+			slog.Error("rename skipping a listed key that does not carry the source prefix",
+				"key", key, "prefix", srcPrefix)
+
+			return syscall.EIO
+		}
+
+		newKey := dstPrefix + strings.TrimPrefix(key, srcPrefix)
+
+		if err := n.fs.backend.CopyObject(ctx, key, newKey); err != nil {
+			n.fs.countError()
+			slog.Error("rename of a directory failed partway; every object already moved is at its new "+
+				"name and the rest are still at their old ones, so re-running the same rename completes it",
+				"src", key, "dst", newKey, "moved", moved, "of", len(keys), "error", err)
+
+			return toErrno(err)
+		}
+
+		n.fs.buffer.DiscardPrefix(newKey)
+		n.fs.invalidate(newKey)
+
+		if err := n.fs.backend.DeleteObject(ctx, key); err != nil {
+			n.fs.countError()
+			slog.Error("rename of a directory copied an object but could not delete the source, so it "+
+				"now exists at both names",
+				"src", key, "dst", newKey, "moved", moved, "of", len(keys), "error", err)
+
+			return toErrno(err)
+		}
+
+		n.fs.buffer.DiscardPrefix(key)
+		n.fs.invalidate(key)
+
+		moved++
+	}
+
+	// The marker object for the new directory, and only if the old one had none. A directory that existed
+	// implicitly — as the shared prefix of its contents, with no marker — stays implicit, since writing a
+	// marker the source never had would make the destination a different kind of directory than the
+	// source. One that had a marker already had it copied by the loop, because the marker's key is
+	// srcPrefix and the listing includes it.
+	//
+	// Nothing is written here for either case; the check exists to record why. See [DirectoryNode.Mkdir]
+	// for what the marker is for.
+
+	n.fs.invalidate(srcPath)
+	n.fs.invalidate(srcPrefix)
+	n.fs.invalidate(dstPath)
+	n.fs.invalidate(dstPrefix)
+
+	n.fs.stats.mu.Lock()
+	n.fs.stats.Renames++
+	n.fs.stats.mu.Unlock()
+
+	return 0
+}
+
+// repoint updates the moved node's stored path, and its descendants' if it is a directory.
+//
+// # Why this is necessary, and why it is easy to miss
+//
+// go-fuse's bridge, on a Rename that returns success, calls Inode.MvChild (fs/inode.go), which
+// re-parents *the same* *Inode* under the new name. It does not build a new node and it does not consult
+// this package again. So the [FileNode] or [DirectoryNode] the inode carries survives the rename holding
+// the path it was constructed with, and every subsequent operation on the moved dentry addresses the key
+// the file was moved away from: after `mv a b`, a write to b flushes to a — recreating the source the
+// rename just deleted, and leaving b as the user found it.
+//
+// Nothing catches this at the FUSE layer's own boundary, because the stale path is a perfectly valid key
+// and every call succeeds. It surfaces only as the wrong object being modified, which is why the path is
+// an accessor rather than a field — see [DirectoryNode.key].
+//
+// A directory carries its whole resolved subtree with it, so the walk is recursive. Only inodes the
+// kernel currently holds are here; anything not yet looked up resolves against the new path when it is.
+func repoint(inode *fs.Inode, newPath string) {
+	if inode == nil {
+		return
+	}
+
+	switch node := inode.Operations().(type) {
+	case *FileNode:
+		node.setKey(newPath)
+
+	case *DirectoryNode:
+		node.setKey(newPath)
+
+		for name, child := range inode.Children() {
+			childPath := newPath + "/" + name
+			if newPath == "" {
+				childPath = name
+			}
+
+			repoint(child, childPath)
+		}
+	}
+}

--- a/internal/fuse/rename_test.go
+++ b/internal/fuse/rename_test.go
@@ -845,78 +845,14 @@ func TestRenameToAForeignParentReportsEXDEV(t *testing.T) {
 	}
 }
 
-// TestFlushPrefixMatchesOnAPathBoundary is the unit-level guard for the prefix rule the directory
-// rename depends on.
+// The path-boundary rule that FlushPrefix and DiscardPrefix enforce is tested in internal/vfs, not
+// here. It moved there when a coverage gate made the split visible: the functions live in that package,
+// so a test in this one leaves them reading 0% covered no matter how thoroughly it exercises them —
+// coverage is per-package and the profile follows the code, not the consequence.
 //
-// It lives here rather than in internal/vfs because the consequence is a rename's: a bare
-// strings.HasPrefix makes "dir" match "dir2/file", so renaming dir flushes — and then the caller moves —
-// an unrelated sibling tree. It is the same defect the cache's keyMatches had, found in the same audit.
-func TestFlushPrefixMatchesOnAPathBoundary(t *testing.T) {
-	t.Parallel()
-
-	f := newRenameFixture(t)
-	ctx := context.Background()
-
-	writes := []string{"dir/a.txt", "dir/sub/b.txt", "dir2/c.txt", "dirty.txt"}
-	for _, key := range writes {
-		if err := f.fs.buffer.Write(key, 0, []byte("pending")); err != nil {
-			t.Fatalf("buffered write to %q: %v", key, err)
-		}
-	}
-
-	flushed, err := f.fs.buffer.FlushPrefix(ctx, "dir")
-	if err != nil {
-		t.Fatalf("FlushPrefix: %v", err)
-	}
-
-	if flushed != 2 {
-		t.Errorf("FlushPrefix(%q) flushed %d keys, want 2 (dir/a.txt and dir/sub/b.txt). A bare string "+
-			"prefix match also takes dir2/c.txt and dirty.txt, which a directory rename would then move",
-			"dir", flushed)
-	}
-
-	for _, key := range []string{"dir/a.txt", "dir/sub/b.txt"} {
-		if !f.exists(t, key) {
-			t.Errorf("%q is under the flushed prefix but has no object", key)
-		}
-	}
-
-	for _, key := range []string{"dir2/c.txt", "dirty.txt"} {
-		if f.exists(t, key) {
-			t.Errorf("%q was flushed by FlushPrefix(%q); its name merely starts with the same "+
-				"characters", key, "dir")
-		}
-		if !f.fs.buffer.Dirty(key) {
-			t.Errorf("%q is no longer dirty, so FlushPrefix touched it", key)
-		}
-	}
-}
-
-// TestDiscardPrefixMatchesOnAPathBoundary is the same guard for the delete side.
-//
-// DiscardPrefix destroys data on purpose, so an over-broad match here does not merely move the wrong
-// file — it drops writes the caller never asked to drop, with no error.
-func TestDiscardPrefixMatchesOnAPathBoundary(t *testing.T) {
-	t.Parallel()
-
-	f := newRenameFixture(t)
-
-	for _, key := range []string{"keep/a.txt", "keeper.txt", "keep2/b.txt"} {
-		if err := f.fs.buffer.Write(key, 0, []byte("pending")); err != nil {
-			t.Fatalf("buffered write to %q: %v", key, err)
-		}
-	}
-
-	f.fs.buffer.DiscardPrefix("keep")
-
-	if f.fs.buffer.Dirty("keep/a.txt") {
-		t.Error("DiscardPrefix left a key under the prefix dirty")
-	}
-
-	for _, key := range []string{"keeper.txt", "keep2/b.txt"} {
-		if !f.fs.buffer.Dirty(key) {
-			t.Errorf("DiscardPrefix(%q) destroyed the pending writes for %q, whose name merely starts "+
-				"with the same characters. Those bytes are gone with no error anywhere", "keep", key)
-		}
-	}
-}
+// The move also bought two cases this fixture could not reach. Failing a flush needs a backend that
+// rejects a PUT, and asserting that a rename must *not* proceed past that is the whole point of
+// stopping at the first failure. And renaming a single file passes the file's own key where those
+// methods take a prefix, so the key-equals-prefix arm is the common path rather than an edge case —
+// invisible from a directory test, because a key beneath a directory satisfies the boundary rule too.
+// See TestPrefixOperationsOnAnExactKeyTakeThatKey.

--- a/internal/fuse/rename_test.go
+++ b/internal/fuse/rename_test.go
@@ -1,0 +1,922 @@
+//go:build linux || darwin
+
+package fuse
+
+// Rename (#164) against a real S3 endpoint, a real write path, and a real cache — no mock on any seam,
+// on the same reasoning delete_test.go gives.
+//
+// The reasoning is sharper here. A rename is a copy plus a delete, so a mock asked "was CopyObject
+// called" confirms the implementation did what it was written to do while saying nothing about whether
+// the file moved. Worse, the two failure modes this operation actually has are both invisible to such a
+// mock: the destination can end up holding the *source's* bytes without its metadata, and the write
+// path can flush pending ranges back to the source key after the delete, resurrecting the file at the
+// name it was moved away from. Only storage state afterwards distinguishes those.
+
+import (
+	"context"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// renameFixture is a FileSystem wired to a real S3 endpoint, write path, and cache.
+type renameFixture struct {
+	fs  *FileSystem
+	srv *testaws.TestServer
+}
+
+func newRenameFixture(t *testing.T) *renameFixture {
+	t.Helper()
+
+	srv := testaws.Start(t)
+	backend := srv.Backend()
+
+	writer, err := vfs.NewWriter(context.Background(), backend)
+	if err != nil {
+		t.Fatalf("vfs.NewWriter: %v", err)
+	}
+
+	byteCache := cache.NewLRUCache(&cache.CacheConfig{
+		MaxSize:    16 << 20,
+		MaxEntries: 10000,
+		TTL:        time.Hour,
+	})
+	t.Cleanup(func() { _ = byteCache.Close() })
+
+	filesystem := NewFileSystem(backend, byteCache, writer, nil, &Config{
+		DefaultMode:    0o644,
+		DefaultDirMode: 0o755,
+		DefaultUID:     1000,
+		DefaultGID:     1000,
+	})
+
+	return &renameFixture{fs: filesystem, srv: srv}
+}
+
+// root returns the fixture's root directory attached to a go-fuse bridge.
+//
+// The bridge is required rather than decorative: Rename calls Inode.GetChild and Inode.Children to
+// repoint moved nodes, and both reach through the embedded Inode to the bridge that owns the tree. A
+// bare &DirectoryNode{} has none.
+func (f *renameFixture) root(t *testing.T) *DirectoryNode {
+	t.Helper()
+
+	root, ok := f.fs.Root().(*DirectoryNode)
+	if !ok {
+		t.Fatalf("FileSystem.Root returned %T, want *DirectoryNode", f.fs.Root())
+	}
+
+	timeout := f.fs.attrTimeout()
+	_ = gofuse.NewNodeFS(root, &gofuse.Options{
+		AttrTimeout:     &timeout,
+		EntryTimeout:    &timeout,
+		NullPermissions: true,
+	})
+
+	return root
+}
+
+// bridge returns the RawFileSystem the kernel talks to, over this fixture's root.
+//
+// The repoint tests need this rather than the node methods, and the reason is the defect they cover.
+// Registering a child in its parent is the *bridge's* job: rawBridge.Lookup calls addNewChild after
+// DirectoryNode.Lookup returns (fs/bridge.go), so a direct call to DirectoryNode.Lookup hands back an
+// inode that belongs to no parent — GetChild finds nothing and there is no node to go stale. Going
+// through the bridge also runs Inode.MvChild on success, which is the mechanism that makes a stored path
+// wrong in the first place.
+func (f *renameFixture) bridge(t *testing.T) (fuse.RawFileSystem, *DirectoryNode) {
+	t.Helper()
+
+	root, ok := f.fs.Root().(*DirectoryNode)
+	if !ok {
+		t.Fatalf("FileSystem.Root returned %T, want *DirectoryNode", f.fs.Root())
+	}
+
+	timeout := f.fs.attrTimeout()
+	raw := gofuse.NewNodeFS(root, &gofuse.Options{
+		AttrTimeout:     &timeout,
+		EntryTimeout:    &timeout,
+		NullPermissions: true,
+	})
+
+	return raw, root
+}
+
+// rootNodeID is the root inode's nodeid, fixed at 1 by the FUSE protocol.
+const rootNodeID = 1
+
+// lookupThroughBridge resolves name under the directory at nodeID, the way the kernel does.
+func lookupThroughBridge(t *testing.T, raw fuse.RawFileSystem, nodeID uint64, name string) {
+	t.Helper()
+
+	var out fuse.EntryOut
+	header := fuse.InHeader{NodeId: nodeID}
+
+	if status := raw.Lookup(nil, &header, name, &out); status != fuse.OK {
+		t.Fatalf("Lookup(%q) under nodeid %d returned %v", name, nodeID, status)
+	}
+}
+
+// renameThroughBridge issues a RENAME the way the kernel does, so that go-fuse's own MvChild runs.
+func renameThroughBridge(t *testing.T, raw fuse.RawFileSystem, oldName, newName string) fuse.Status {
+	t.Helper()
+
+	in := &fuse.RenameIn{
+		InHeader: fuse.InHeader{NodeId: rootNodeID},
+		Newdir:   rootNodeID,
+	}
+
+	return raw.Rename(nil, in, oldName, newName)
+}
+
+// childOf returns the node the parent currently holds under name, or fails.
+func childOf(t *testing.T, parent *gofuse.Inode, name string) any {
+	t.Helper()
+
+	child := parent.GetChild(name)
+	if child == nil {
+		t.Fatalf("the parent holds no child named %q; the lookup did not register it", name)
+	}
+
+	return child.Operations()
+}
+
+// exists asks the backend directly. The point of these tests is what storage holds, so the check must
+// not run through a cache that could answer from before the rename.
+func (f *renameFixture) exists(t *testing.T, key string) bool {
+	t.Helper()
+
+	_, err := f.fs.backend.HeadObject(context.Background(), key)
+	if err == nil {
+		return true
+	}
+	if vfs.IsNotFound(err) {
+		return false
+	}
+	t.Fatalf("HeadObject(%q): %v", key, err)
+
+	return false
+}
+
+// TestRenameMovesTheObject is #164's headline assertion, and both halves are load-bearing: the
+// destination holds the bytes *and* the source is gone. A copy that forgets to delete passes the first
+// half alone, and `mv` that leaves the source behind is a `cp`.
+func TestRenameMovesTheObject(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const (
+		src  = "before.txt"
+		dst  = "after.txt"
+		body = "move me"
+	)
+
+	if err := f.fs.backend.PutObject(ctx, src, []byte(body), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, src, root, dst, 0); errno != 0 {
+		t.Fatalf("Rename returned %v, want success", errno)
+	}
+
+	if got := string(f.srv.GetObject(dst)); got != body {
+		t.Errorf("the destination holds %q, want %q", got, body)
+	}
+
+	if f.exists(t, src) {
+		t.Error("Rename reported success and the source object is still in the bucket, so this was a " +
+			"copy rather than a move: the file now exists at both names and the old one keeps billing")
+	}
+}
+
+// TestRenamePreservesMetadataAndEncoding is the assertion that makes a server-side copy mandatory
+// rather than merely cheap.
+//
+// Three of these are not cosmetic. objectfs-mode and objectfs-uid are where POSIX mode and ownership
+// live and there is nowhere else they are recorded, so losing them silently resets a file's permissions
+// and owner. Content-Encoding is worse: the read path dispatches decoding on the stored value and fails
+// closed on one it cannot handle, so a rename that dropped it leaves a compressed file permanently
+// unreadable with every byte intact. That is audit finding L26, observed on the tier-transition path
+// which uses the same CopyObject.
+func TestRenamePreservesMetadataAndEncoding(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const (
+		src = "encoded-before.dat"
+		dst = "encoded-after.dat"
+	)
+
+	meta := map[string]string{
+		"objectfs-mode":            "384",
+		"objectfs-uid":             "1234",
+		"objectfs-content-encoded": "zstd",
+	}
+	if err := f.fs.backend.PutObject(ctx, src, []byte("payload"), meta); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	before := f.srv.ObjectMetadata(src)
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, src, root, dst, 0); errno != 0 {
+		t.Fatalf("Rename returned %v, want success", errno)
+	}
+
+	after := f.srv.ObjectMetadata(dst)
+
+	// Compared against what the source actually carried rather than against the map above, so the test
+	// pins preservation across the copy rather than re-asserting what PutObject stores. Keys are matched
+	// case-insensitively: real S3 lower-cases metadata keys and a Go http.Header round trip title-cases
+	// them, so a case-sensitive comparison passes against one endpoint and fails against another.
+	for k, want := range before {
+		var got string
+		var found bool
+		for ak, av := range after {
+			if strings.EqualFold(ak, k) {
+				got, found = av, true
+
+				break
+			}
+		}
+
+		if !found || got != want {
+			t.Errorf("the renamed object's %s = %q (present: %v), want %q. Mode and ownership live in "+
+				"user metadata and nowhere else, and the read path fails closed on an encoding it cannot "+
+				"identify — so a rename that drops these silently resets permissions or makes the file "+
+				"unreadable with its bytes intact", k, got, found, want)
+		}
+	}
+}
+
+// TestRenameOverAnExistingFileReplacesIt pins POSIX's silent-replace rule.
+//
+// `mv a b` where b exists must replace b without asking, and must leave b holding a's bytes rather than
+// its own. An implementation that refused would break every editor's save-to-temp-then-rename, and one
+// that reported success while leaving b's old content would lose the write.
+func TestRenameOverAnExistingFileReplacesIt(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const (
+		src = "new-content.txt"
+		dst = "existing.txt"
+	)
+
+	if err := f.fs.backend.PutObject(ctx, src, []byte("the replacement"), nil); err != nil {
+		t.Fatalf("seed the source: %v", err)
+	}
+	if err := f.fs.backend.PutObject(ctx, dst, []byte("the original"), nil); err != nil {
+		t.Fatalf("seed the destination: %v", err)
+	}
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, src, root, dst, 0); errno != 0 {
+		t.Fatalf("Rename over an existing file returned %v, want success", errno)
+	}
+
+	if got := string(f.srv.GetObject(dst)); got != "the replacement" {
+		t.Errorf("the destination holds %q after being renamed over, want %q; the replaced file's "+
+			"content survived the write that was supposed to replace it", got, "the replacement")
+	}
+
+	if f.exists(t, src) {
+		t.Error("the source survived a rename over an existing destination")
+	}
+}
+
+// TestRenameFlushesPendingWritesSoTheCopySeesThem is the seam a mock cannot reach, and the one this
+// operation is most likely to get wrong.
+//
+// `echo hi > a; mv a b` is an ordinary sequence and the kernel does not guarantee a flush between the
+// two. A server-side copy acts on *objects*, so if the write path still holds a's bytes the copy either
+// finds no object or copies a stale one — and then the delete removes the source and the pending ranges
+// flush back to a. The file ends up at the name the user renamed away from, with b absent or stale, and
+// every individual S3 call succeeded.
+func TestRenameFlushesPendingWritesSoTheCopySeesThem(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const (
+		src  = "dirty-before.txt"
+		dst  = "dirty-after.txt"
+		body = "written but never flushed"
+	)
+
+	if err := f.fs.buffer.Write(src, 0, []byte(body)); err != nil {
+		t.Fatalf("buffered write: %v", err)
+	}
+	if f.exists(t, src) {
+		t.Fatal("the fixture flushed; this test needs a file whose bytes are only in the write path")
+	}
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, src, root, dst, 0); errno != 0 {
+		t.Fatalf("Rename of a file with only pending writes returned %v, want success", errno)
+	}
+
+	if got := string(f.srv.GetObject(dst)); got != body {
+		t.Errorf("the destination holds %q, want %q. The rename copied an object that did not yet hold "+
+			"the file's bytes, which is what happens when the write path is not flushed first", got, body)
+	}
+
+	// The decisive step. Flush everything, exactly as unmount does, and confirm the source did not come
+	// back: pending ranges surviving the rename are PUT back to the old key, resurrecting the file at the
+	// name it was moved away from with no error anywhere.
+	if err := f.fs.buffer.FlushAll(); err != nil {
+		t.Fatalf("FlushAll after the rename: %v", err)
+	}
+
+	if f.exists(t, src) {
+		t.Error("flushing after the rename recreated the source object. The write path still held " +
+			"pending state for the old key, so the moved-away-from name came back from the dead")
+	}
+}
+
+// TestRenameMovesEveryObjectUnderADirectory covers the prefix case, including a nested level.
+//
+// The nesting is the part worth having: a single-level implementation that rebuilt the destination key
+// from the entry name rather than from the prefix flattens the tree, moving dir/sub/deep.txt to
+// newdir/deep.txt. Every object still exists, so a count-only assertion passes.
+func TestRenameMovesEveryObjectUnderADirectory(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	// No "project/" marker object here, so this directory is implicit — the shared prefix of its
+	// contents, which is how a directory written by any other S3 tool looks. The marker case is
+	// TestRenameMovesTheDirectoryMarkerToo, kept separate because the test endpoint cannot always
+	// delete a marker; see there.
+	seeded := map[string]string{
+		"project/a.txt":         "alpha",
+		"project/b.txt":         "beta",
+		"project/sub/deep.txt":  "depth",
+		"project/sub/other.txt": "other",
+	}
+	for key, body := range seeded {
+		if err := f.fs.backend.PutObject(ctx, key, []byte(body), nil); err != nil {
+			t.Fatalf("seed %q: %v", key, err)
+		}
+	}
+
+	// A sibling whose name shares the source's prefix as a *string* but not as a path. If the prefix
+	// match is a bare strings.HasPrefix, this file is swept into the rename — the same defect the cache's
+	// keyMatches had.
+	if err := f.fs.backend.PutObject(ctx, "project2/untouched.txt", []byte("leave me"), nil); err != nil {
+		t.Fatalf("seed the sibling: %v", err)
+	}
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, "project", root, "archive", 0); errno != 0 {
+		t.Fatalf("Rename of a directory returned %v, want success", errno)
+	}
+
+	want := map[string]string{
+		"archive/a.txt":         "alpha",
+		"archive/b.txt":         "beta",
+		"archive/sub/deep.txt":  "depth",
+		"archive/sub/other.txt": "other",
+	}
+	for key, body := range want {
+		if !f.exists(t, key) {
+			t.Errorf("%q does not exist after the directory rename; the tree was not moved intact "+
+				"(a flattening bug moves sub/deep.txt to the top level, where every object still exists "+
+				"and only its path is wrong)", key)
+
+			continue
+		}
+		if got := string(f.srv.GetObject(key)); got != body {
+			t.Errorf("%q holds %q, want %q", key, got, body)
+		}
+	}
+
+	for key := range seeded {
+		if f.exists(t, key) {
+			t.Errorf("the source object %q survived the directory rename, so the tree now exists twice "+
+				"and both copies bill", key)
+		}
+	}
+
+	if got := string(f.srv.GetObject("project2/untouched.txt")); got != "leave me" {
+		t.Errorf("project2/untouched.txt holds %q, want %q. Renaming \"project\" moved a sibling whose "+
+			"name merely starts with the same characters, which is what a bare string-prefix match does",
+			got, "leave me")
+	}
+}
+
+// TestRenameMovesTheDirectoryMarkerToo covers the explicit-directory case: one created by Mkdir, which
+// writes a zero-byte marker object at "prefix/".
+//
+// It is separate from the implicit case above because the marker is what makes an `ls` show an empty
+// directory at all, and because the two are moved by the same loop for a non-obvious reason — the
+// marker's key *is* the source prefix, so the listing includes it and no special case is needed. A
+// change that started listing with a delimiter, or skipped zero-byte keys, would silently stop moving
+// it: the files would arrive and the directory would vanish the moment it was emptied.
+func TestRenameMovesTheDirectoryMarkerToo(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+
+	// Deleting a marker is the half of this the endpoint may not support; see the skip's own comment.
+	f.srv.RequireDirectoryMarkerDelete()
+
+	ctx := context.Background()
+
+	for _, key := range []string{"marked/", "marked/file.txt"} {
+		if err := f.fs.backend.PutObject(ctx, key, []byte("x"), nil); err != nil {
+			t.Fatalf("seed %q: %v", key, err)
+		}
+	}
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, "marked", root, "renamed", 0); errno != 0 {
+		t.Fatalf("Rename of a directory with a marker returned %v, want success", errno)
+	}
+
+	if !f.exists(t, "renamed/") {
+		t.Error("the destination has no marker object. The source's marker is at the source prefix, so " +
+			"the listing that drives the rename includes it and it moves with everything else — unless " +
+			"the listing changed to use a delimiter or to skip zero-byte keys, in which case the files " +
+			"arrive and the directory disappears as soon as it is emptied")
+	}
+	if !f.exists(t, "renamed/file.txt") {
+		t.Error("the file under the renamed directory did not move")
+	}
+
+	if f.exists(t, "marked/") {
+		t.Error("the source directory's marker survived, so an `ls` still shows the directory the " +
+			"rename moved away from")
+	}
+	if f.exists(t, "marked/file.txt") {
+		t.Error("the source file survived the directory rename")
+	}
+}
+
+// TestRenameOfAMissingSourceReportsENOENT pins that absence is an error.
+//
+// `mv` distinguishes the two and POSIX requires it. Reporting success would also be actively unsafe
+// here: the caller would believe the destination now holds a file that was never written.
+func TestRenameOfAMissingSourceReportsENOENT(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	root := f.root(t)
+
+	errno := root.Rename(context.Background(), "never-existed.txt", root, "wherever.txt", 0)
+
+	if errno == 0 {
+		t.Fatal("Rename of a missing source reported success")
+	}
+	if errno != syscall.ENOENT {
+		t.Errorf("Rename of a missing source returned %v, want ENOENT", errno)
+	}
+
+	// The errno alone does not pin this, which is worth recording because it is not obvious. Removing
+	// the existence check entirely still produces ENOENT: the copy is attempted, its own HEAD of the
+	// source fails NotFound, and that maps to the same errno. So the assertion above passes against an
+	// implementation that never checks.
+	//
+	// What separates them is whether the failure was *diagnosed* or merely propagated. A propagated one
+	// counts as an error, while ENOENT for an absent source is an ordinary result — `mv nonexistent x`
+	// is a user typo, not a filesystem fault — and a mount whose error counter climbs on every typo is
+	// a mount whose error counter means nothing.
+	if got := f.fs.GetStats().Renames; got != 0 {
+		t.Errorf("a failed rename counted %d completed rename(s)", got)
+	}
+	if got := f.fs.GetStats().Errors; got != 0 {
+		t.Errorf("Rename of a missing source recorded %d error(s). An absent source is a normal answer "+
+			"to a normal question, so it must not be counted as a filesystem fault — and reaching this "+
+			"means absence was discovered by a failing storage call rather than established up front",
+			got)
+	}
+}
+
+// TestRenameOnAReadOnlyMountReportsEROFS.
+//
+// The refusal must come before any storage call. A read-only mount that copied and then declined to
+// delete would have modified the filesystem in the course of refusing to modify it.
+func TestRenameOnAReadOnlyMountReportsEROFS(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const src = "ro-before.txt"
+	if err := f.fs.backend.PutObject(ctx, src, []byte("immutable"), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	f.fs.config.ReadOnly = true
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, src, root, "ro-after.txt", 0); errno != syscall.EROFS {
+		t.Errorf("Rename on a read-only mount returned %v, want EROFS", errno)
+	}
+
+	if f.exists(t, "ro-after.txt") {
+		t.Error("a read-only mount wrote the destination while refusing the rename")
+	}
+	if !f.exists(t, src) {
+		t.Error("a read-only mount deleted the source while refusing the rename")
+	}
+}
+
+// TestRenameRefusesRenameat2Flags pins that RENAME_EXCHANGE and RENAME_NOREPLACE are declined rather
+// than silently downgraded.
+//
+// Both are promises about atomicity that copy-then-delete cannot keep. Accepting the flag and doing the
+// non-atomic thing is the failure this guards: RENAME_NOREPLACE means "fail if the destination exists",
+// and a caller relying on it to claim a lock would silently overwrite the holder. EINVAL is what the
+// kernel returns for an unsupported flag, and `mv` and Git both fall back on it.
+func TestRenameRefusesRenameat2Flags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		flags uint32
+		why   string
+	}{
+		{
+			name:  "exchange",
+			flags: renameExchange,
+			why: "an atomic swap would be four operations here, with two windows in which a name holds " +
+				"the wrong file or no file at all",
+		},
+		{
+			name:  "noreplace",
+			flags: renameNoReplace,
+			why: "a caller using this to claim a name would silently overwrite the existing holder, " +
+				"because the check and the copy cannot be one operation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newRenameFixture(t)
+			ctx := context.Background()
+
+			const src = "flagged.txt"
+			if err := f.fs.backend.PutObject(ctx, src, []byte("content"), nil); err != nil {
+				t.Fatalf("seed the object: %v", err)
+			}
+
+			root := f.root(t)
+			if errno := root.Rename(ctx, src, root, "flagged-moved.txt", tt.flags); errno != syscall.EINVAL {
+				t.Errorf("Rename with %s returned %v, want EINVAL: %s", tt.name, errno, tt.why)
+			}
+
+			if f.exists(t, "flagged-moved.txt") {
+				t.Errorf("Rename with %s refused the request and moved the file anyway", tt.name)
+			}
+		})
+	}
+}
+
+// TestRenameToTheSameNameIsANoOp.
+//
+// rename(2) of a name to itself returns success and changes nothing. The dangerous implementation is the
+// obvious one: copy src to dst and delete src, where src == dst, deletes the file it just wrote.
+func TestRenameToTheSameNameIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const key = "self.txt"
+	if err := f.fs.backend.PutObject(ctx, key, []byte("unchanged"), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	root := f.root(t)
+	if errno := root.Rename(ctx, key, root, key, 0); errno != 0 {
+		t.Fatalf("Rename of a name to itself returned %v, want success", errno)
+	}
+
+	if !f.exists(t, key) {
+		t.Fatal("renaming a file to its own name deleted it. The copy wrote the key and the delete then " +
+			"removed what it had just written, which is what happens when src == dst is not special-cased")
+	}
+	if got := string(f.srv.GetObject(key)); got != "unchanged" {
+		t.Errorf("the file holds %q after being renamed to itself, want %q", got, "unchanged")
+	}
+}
+
+// TestRenameRepointsTheMovedNodeSoWritesGoToTheNewKey is the go-fuse integration this operation needs
+// and nothing else in the package does.
+//
+// After a Rename that returns 0, the bridge calls Inode.MvChild, which re-parents *the same* Inode under
+// the new name — it does not rebuild the node and does not call back into this package. So the FileNode
+// still holds the key it was constructed with, and every later operation on the moved dentry addresses
+// the old key: a write to the new name flushes to the old one, recreating the source the rename deleted
+// and leaving the destination as the user found it.
+//
+// Nothing fails visibly when this is wrong. Every S3 call succeeds; the wrong object is modified. That is
+// why the assertion is on which key the bytes landed in.
+func TestRenameRepointsTheMovedNodeSoWritesGoToTheNewKey(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const (
+		src = "repoint-before.txt"
+		dst = "repoint-after.txt"
+	)
+
+	if err := f.fs.backend.PutObject(ctx, src, []byte("original"), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	raw, root := f.bridge(t)
+
+	// Resolve the source the way the kernel does, so the inode is registered in its parent and survives
+	// the rename. A direct DirectoryNode.Lookup would not register it — see [renameFixture.bridge] — and
+	// then there is no node to go stale and this test cannot fail.
+	lookupThroughBridge(t, raw, rootNodeID, src)
+
+	if status := renameThroughBridge(t, raw, src, dst); status != fuse.OK {
+		t.Fatalf("Rename returned %v, want OK", status)
+	}
+
+	// Fetched from the parent *after* the rename, under the new name: this is the node the kernel now
+	// reaches by the destination path, which is the thing whose key has to be right. MvChild has already
+	// re-parented it, so if it is a different object than the one looked up above, the premise of this
+	// test is wrong and the assertion below is worth nothing.
+	moved, ok := childOf(t, root.EmbeddedInode(), dst).(*FileNode)
+	if !ok {
+		t.Fatalf("the node under %q is a %T, want *FileNode", dst, childOf(t, root.EmbeddedInode(), dst))
+	}
+
+	if got := moved.key(); got != dst {
+		t.Errorf("the moved node still addresses %q, want %q. go-fuse re-parents the existing inode "+
+			"rather than rebuilding it, so a rename that does not repoint the node leaves every later "+
+			"operation on the new name reading and writing the old key", got, dst)
+	}
+
+	// And the consequence, rather than only the field: write through the node the kernel now reaches by
+	// the new name, and check which key the bytes reached.
+	if err := f.fs.buffer.Write(moved.key(), 0, []byte("written after the rename")); err != nil {
+		t.Fatalf("write after the rename: %v", err)
+	}
+	if err := f.fs.buffer.FlushAll(); err != nil {
+		t.Fatalf("FlushAll: %v", err)
+	}
+
+	if f.exists(t, src) {
+		t.Error("a write through the moved node recreated the source object, so it flushed to the key " +
+			"the file was renamed away from")
+	}
+	if got := string(f.srv.GetObject(dst)); !strings.HasPrefix(got, "written after the rename") {
+		t.Errorf("the destination holds %q after a write through the moved node; the bytes went to some "+
+			"other key", got)
+	}
+}
+
+// TestRenameRepointsDescendantsOfAMovedDirectory is the recursive half of the same defect.
+//
+// A directory carries its whole resolved subtree with it, and the kernel keeps addressing those children
+// through the inodes it already holds. Repointing only the directory leaves every child node naming a
+// key under the old prefix — so a write to newdir/f flushes to olddir/f, which the rename has already
+// deleted, recreating the source tree one file at a time.
+func TestRenameRepointsDescendantsOfAMovedDirectory(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	// An implicit directory, so this test does not depend on the endpoint being able to delete a marker
+	// object; the marker case has its own test. What is under examination here is the node tree, not
+	// the storage layout.
+	if err := f.fs.backend.PutObject(ctx, "tree/leaf.txt", []byte("x"), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	raw, root := f.bridge(t)
+
+	// Resolve the directory and then the file beneath it, through the bridge, so both inodes are
+	// registered in the tree — which is what makes them able to go stale.
+	var dirEntry fuse.EntryOut
+	dirHeader := fuse.InHeader{NodeId: rootNodeID}
+	if status := raw.Lookup(nil, &dirHeader, "tree", &dirEntry); status != fuse.OK {
+		t.Fatalf("Lookup(%q) returned %v", "tree", status)
+	}
+
+	lookupThroughBridge(t, raw, dirEntry.NodeId, "leaf.txt")
+
+	if status := renameThroughBridge(t, raw, "tree", "moved"); status != fuse.OK {
+		t.Fatalf("Rename of a directory returned %v, want OK", status)
+	}
+
+	movedDir, ok := childOf(t, root.EmbeddedInode(), "moved").(*DirectoryNode)
+	if !ok {
+		t.Fatalf("the node under %q is a %T, want *DirectoryNode",
+			"moved", childOf(t, root.EmbeddedInode(), "moved"))
+	}
+
+	if got := movedDir.key(); got != "moved" {
+		t.Errorf("the moved directory still addresses %q, want %q", got, "moved")
+	}
+
+	leafNode, ok := childOf(t, movedDir.EmbeddedInode(), "leaf.txt").(*FileNode)
+	if !ok {
+		t.Fatalf("the node under %q is a %T, want *FileNode",
+			"moved/leaf.txt", childOf(t, movedDir.EmbeddedInode(), "leaf.txt"))
+	}
+
+	if got := leafNode.key(); got != "moved/leaf.txt" {
+		t.Errorf("a child of the moved directory still addresses %q, want %q. The kernel reaches this "+
+			"file through the inode it already holds, so a write to moved/leaf.txt would flush to the "+
+			"deleted tree/leaf.txt and rebuild the source tree one file at a time",
+			got, "moved/leaf.txt")
+	}
+}
+
+// TestRenameReportsAFailedCopyAndLeavesTheSourceAlone is the ordering assertion, on the failure that
+// matters most.
+//
+// Every source object is deleted only after its own copy has succeeded. That order is what makes an
+// interrupted rename leave the data at the old name, the new name, or both — never at neither. The
+// opposite order is not a hypothetical mistake: "delete the old entry, then write the new one" is how
+// a rename reads if you think of it as moving a name rather than copying bytes, and it loses the file
+// whenever the second step fails.
+func TestRenameReportsAFailedCopyAndLeavesTheSourceAlone(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	const (
+		src  = "copyfail.txt"
+		body = "must survive"
+	)
+
+	if err := f.fs.backend.PutObject(ctx, src, []byte(body), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	// A destination key the endpoint will reject. An empty key is invalid for every S3 implementation, and
+	// it fails at the copy rather than before it, which is the point in the sequence this test needs.
+	root := f.root(t)
+	errno := root.Rename(ctx, src, root, "", 0)
+
+	if errno == 0 {
+		t.Fatal("Rename with an unwritable destination reported success. `mv` would report that the file " +
+			"had moved while it had not, and the user would believe the source is gone")
+	}
+
+	if !f.exists(t, src) {
+		t.Error("a rename whose copy failed deleted the source anyway. The data is now at neither name, " +
+			"which is the one outcome the copy-then-delete order exists to prevent")
+	}
+	if got := string(f.srv.GetObject(src)); got != body {
+		t.Errorf("the source holds %q after a failed rename, want %q", got, body)
+	}
+}
+
+// TestRenameIsRefusedWithoutAWritePath.
+//
+// A FileSystem built without a write path cannot flush the source before copying it, so it cannot know
+// the copy will see the file's bytes. Refusing is the honest answer; proceeding would silently copy a
+// stale or absent object.
+func TestRenameIsRefusedWithoutAWritePath(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	f.fs.buffer = nil
+
+	root := f.root(t)
+	ctx := context.Background()
+
+	if err := f.fs.backend.PutObject(ctx, "nobuffer.txt", []byte("x"), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	if errno := root.Rename(ctx, "nobuffer.txt", root, "moved.txt", 0); errno != syscall.ENOTSUP {
+		t.Errorf("Rename without a write path returned %v, want ENOTSUP", errno)
+	}
+}
+
+// TestRenameToAForeignParentReportsEXDEV.
+//
+// newParent is an interface, so a node this package cannot compute a path for has to be refused rather
+// than guessed at. EXDEV is "not the same filesystem", which is what a foreign node amounts to, and `mv`
+// responds to it by falling back to copying the file's contents — which works.
+func TestRenameToAForeignParentReportsEXDEV(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	if err := f.fs.backend.PutObject(ctx, "xdev.txt", []byte("x"), nil); err != nil {
+		t.Fatalf("seed the object: %v", err)
+	}
+
+	root := f.root(t)
+
+	// A go-fuse node that is not one of ours.
+	foreign := &gofuse.Inode{}
+
+	if errno := root.Rename(ctx, "xdev.txt", foreign, "elsewhere.txt", 0); errno != syscall.EXDEV {
+		t.Errorf("Rename into a foreign parent returned %v, want EXDEV", errno)
+	}
+
+	if !f.exists(t, "xdev.txt") {
+		t.Error("a refused cross-filesystem rename deleted the source")
+	}
+}
+
+// TestFlushPrefixMatchesOnAPathBoundary is the unit-level guard for the prefix rule the directory
+// rename depends on.
+//
+// It lives here rather than in internal/vfs because the consequence is a rename's: a bare
+// strings.HasPrefix makes "dir" match "dir2/file", so renaming dir flushes — and then the caller moves —
+// an unrelated sibling tree. It is the same defect the cache's keyMatches had, found in the same audit.
+func TestFlushPrefixMatchesOnAPathBoundary(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+	ctx := context.Background()
+
+	writes := []string{"dir/a.txt", "dir/sub/b.txt", "dir2/c.txt", "dirty.txt"}
+	for _, key := range writes {
+		if err := f.fs.buffer.Write(key, 0, []byte("pending")); err != nil {
+			t.Fatalf("buffered write to %q: %v", key, err)
+		}
+	}
+
+	flushed, err := f.fs.buffer.FlushPrefix(ctx, "dir")
+	if err != nil {
+		t.Fatalf("FlushPrefix: %v", err)
+	}
+
+	if flushed != 2 {
+		t.Errorf("FlushPrefix(%q) flushed %d keys, want 2 (dir/a.txt and dir/sub/b.txt). A bare string "+
+			"prefix match also takes dir2/c.txt and dirty.txt, which a directory rename would then move",
+			"dir", flushed)
+	}
+
+	for _, key := range []string{"dir/a.txt", "dir/sub/b.txt"} {
+		if !f.exists(t, key) {
+			t.Errorf("%q is under the flushed prefix but has no object", key)
+		}
+	}
+
+	for _, key := range []string{"dir2/c.txt", "dirty.txt"} {
+		if f.exists(t, key) {
+			t.Errorf("%q was flushed by FlushPrefix(%q); its name merely starts with the same "+
+				"characters", key, "dir")
+		}
+		if !f.fs.buffer.Dirty(key) {
+			t.Errorf("%q is no longer dirty, so FlushPrefix touched it", key)
+		}
+	}
+}
+
+// TestDiscardPrefixMatchesOnAPathBoundary is the same guard for the delete side.
+//
+// DiscardPrefix destroys data on purpose, so an over-broad match here does not merely move the wrong
+// file — it drops writes the caller never asked to drop, with no error.
+func TestDiscardPrefixMatchesOnAPathBoundary(t *testing.T) {
+	t.Parallel()
+
+	f := newRenameFixture(t)
+
+	for _, key := range []string{"keep/a.txt", "keeper.txt", "keep2/b.txt"} {
+		if err := f.fs.buffer.Write(key, 0, []byte("pending")); err != nil {
+			t.Fatalf("buffered write to %q: %v", key, err)
+		}
+	}
+
+	f.fs.buffer.DiscardPrefix("keep")
+
+	if f.fs.buffer.Dirty("keep/a.txt") {
+		t.Error("DiscardPrefix left a key under the prefix dirty")
+	}
+
+	for _, key := range []string{"keeper.txt", "keep2/b.txt"} {
+		if !f.fs.buffer.Dirty(key) {
+			t.Errorf("DiscardPrefix(%q) destroyed the pending writes for %q, whose name merely starts "+
+				"with the same characters. Those bytes are gone with no error anywhere", "keep", key)
+		}
+	}
+}

--- a/internal/fuse/unimplemented_test.go
+++ b/internal/fuse/unimplemented_test.go
@@ -8,16 +8,18 @@ package fuse
 // *dependency's* behavior, and until this file nothing in this repo made it true.
 //
 // That is the shape of defect this file exists to prevent. `mv` was documented as ENOSYS on the strength
-// of "rename is not implemented" plus a reasonable guess; the bridge returns ENOTSUP (fs/bridge.go, the
+// of "rename is not implemented" plus a reasonable guess; the bridge returned ENOTSUP (fs/bridge.go, the
 // final return of rawBridge.Rename). The guess was wrong in a way no build, lint, or test could notice,
-// because the claim lived only in prose.
+// because the claim lived only in prose. Rename is implemented now — see rename.go and rename_test.go —
+// so it has left the table below, which is the other half of the same discipline: a row asserting an
+// operation fails is as wrong as a row asserting the wrong errno once the operation works.
 //
 // Two things make this worth a test rather than a comment:
 //
-//   - The defaults differ per operation and are not guessable. Rename, Symlink, Link, Mknod, and
-//     Fallocate default to ENOTSUP; Getxattr and Removexattr default to ENOATTR (which *is* ENODATA on
-//     Linux); Listxattr defaults to OK with an empty list; and Unlink and Rmdir default to **success**,
-//     which is why this package implements them only to refuse — see delete_stub_test.go.
+//   - The defaults differ per operation and are not guessable. Symlink, Link, Mknod, and Fallocate
+//     default to ENOTSUP; Getxattr and Removexattr default to ENOATTR (which *is* ENODATA on Linux);
+//     Listxattr defaults to OK with an empty list; and Unlink and Rmdir default to **success**, which is
+//     why those two were implemented to refuse before they were implemented to work.
 //   - They are a dependency's choices, so a go-fuse upgrade can change them. A bump that turned
 //     Listxattr's empty-OK into ENOTSUP would change what every `ls -@` and `rsync -X` sees, and would
 //     be invisible without this.
@@ -72,17 +74,6 @@ func TestUnimplementedOperationsReturnTheDocumentedErrno(t *testing.T) {
 		// rather than only the mismatch.
 		why string
 	}{
-		{
-			name: "rename",
-			call: func(raw fuse.RawFileSystem) fuse.Status {
-				in := &fuse.RenameIn{InHeader: rootHeader(), Newdir: 1}
-				return raw.Rename(nil, in, "old.txt", "new.txt")
-			},
-			want: syscall.ENOTSUP,
-			why: "mv reports this verbatim, and the README told users it was ENOSYS. The two are not " +
-				"interchangeable: ENOSYS means 'this filesystem will never do this' and callers may " +
-				"stop asking, while ENOTSUP is answered per call",
-		},
 		{
 			name: "symlink",
 			call: func(raw fuse.RawFileSystem) fuse.Status {
@@ -147,6 +138,41 @@ func TestUnimplementedOperationsReturnTheDocumentedErrno(t *testing.T) {
 					tt.name, errnoName(got), errnoName(tt.want), tt.why)
 			}
 		})
+	}
+}
+
+// TestRenameIsDispatchedRatherThanDefaulted is the counterpart to the table above, for the one row that
+// left it.
+//
+// Rename's absence was invisible: rawBridge.Rename's final return is ENOTSUP, so an implementation that
+// failed to satisfy fs.NodeRenamer — a signature drifting on a go-fuse bump, a build tag excluding
+// rename.go on some platform — would go back to refusing every `mv` with no compile error. rename.go has
+// a compile-time assertion for the interface; this asserts the consequence, that the bridge dispatches
+// to it, which is the part the assertion cannot reach.
+//
+// EROFS rather than OK is the expected answer here because there is no backend behind this FileSystem:
+// this pins that the call arrived at ObjectFS's own code, not that the rename worked. rename_test.go
+// covers what it does once it arrives.
+func TestRenameIsDispatchedRatherThanDefaulted(t *testing.T) {
+	t.Parallel()
+
+	filesystem := NewFileSystem(nil, nil, nil, nil, &Config{ReadOnly: true})
+	raw := gofuse.NewNodeFS(filesystem.Root(), &gofuse.Options{})
+
+	in := &fuse.RenameIn{InHeader: rootHeader(), Newdir: 1}
+	got := syscall.Errno(raw.Rename(nil, in, "old.txt", "new.txt"))
+
+	if got == syscall.ENOTSUP {
+		t.Fatal("Rename returned ENOTSUP, which is go-fuse's default for an absent NodeRenamer rather " +
+			"than an answer from this package. Rename is implemented, so reaching the default means the " +
+			"interface is no longer satisfied — a changed signature, or a build tag that excluded " +
+			"rename.go — and every `mv` on the mount is silently refused again.")
+	}
+
+	if got != syscall.EROFS {
+		t.Errorf("Rename on a read-only mount returned %s, want EROFS. The errno is ObjectFS's own "+
+			"either way, so dispatch works; what this disagrees with is the refusal itself.",
+			errnoName(got))
 	}
 }
 

--- a/internal/storage/s3/backend.go
+++ b/internal/storage/s3/backend.go
@@ -1285,9 +1285,15 @@ func (b *Backend) copyObjectMultipart(
 
 	parts := make([]s3types.CompletedPart, 0, (size+partSize-1)/partSize)
 
+	// Counted as an int32 rather than derived from len(parts), which would be an int→int32 conversion
+	// on every iteration. The conversion cannot overflow — S3 refuses the upload above 10,000 parts long
+	// before int32 runs out — but "cannot overflow" is an argument a reader has to reconstruct and a
+	// scanner cannot check, so the type that S3's PartNumber actually is carries the count instead.
+	var partNum int32
+
 	for offset := int64(0); offset < size; offset += partSize {
 		end := min(offset+partSize, size) - 1
-		partNum := int32(len(parts) + 1) //nolint:gosec // bounded by size/partSize, far below int32
+		partNum++
 
 		out, copyErr := client.UploadPartCopy(ctx, &s3.UploadPartCopyInput{
 			Bucket:          aws.String(b.bucket),

--- a/internal/storage/s3/backend.go
+++ b/internal/storage/s3/backend.go
@@ -79,6 +79,18 @@ type Backend struct {
 
 	// Transparent object compression
 	compressor *compression.Compressor
+
+	// singlePartCopyLimit is the size above which CopyObject switches to a multipart copy, and
+	// copyPartSize the size of each part it then copies. They are [maxSinglePartCopy] and
+	// [defaultCopyPartSize] on every constructed backend, and only a test lowers them — see
+	// SetCopyThresholdsForTest.
+	//
+	// Fields rather than bare uses of the constants because the multipart copy path is otherwise
+	// reachable only with an object above 5 GiB. Creating one costs real money and hours, so in
+	// practice it stays untested — and it is the branch where a mistake is most expensive, since the
+	// parts of an abandoned upload are billed while invisible to ListObjects.
+	singlePartCopyLimit int64
+	copyPartSize        int64
 }
 
 // NewBackend creates a new S3 backend instance
@@ -186,14 +198,16 @@ func NewBackend(ctx context.Context, bucket string, cfg *Config) (*Backend, erro
 	tierInfo := tierValidator.GetTierInfo()
 
 	backend := &Backend{
-		bucket:           bucket,
-		clientManager:    clientManager,
-		metricsCollector: metricsCollector,
-		logger:           logger,
-		config:           cfg,
-		currentTier:      cfg.StorageTier,
-		tierInfo:         tierInfo,
-		tierValidator:    tierValidator,
+		bucket:              bucket,
+		clientManager:       clientManager,
+		metricsCollector:    metricsCollector,
+		logger:              logger,
+		config:              cfg,
+		currentTier:         cfg.StorageTier,
+		tierInfo:            tierInfo,
+		tierValidator:       tierValidator,
+		singlePartCopyLimit: maxSinglePartCopy,
+		copyPartSize:        defaultCopyPartSize,
 	}
 
 	// Initialize pricing manager
@@ -1000,8 +1014,7 @@ func (b *Backend) SetObjectMetadata(ctx context.Context, key string, meta map[st
 	}
 	defer b.clientManager.ReturnPooledClient(client)
 
-	// The source must be URL-escaped: S3 reads x-amz-copy-source as a path, so an unescaped key
-	// containing a space, a "+", or a "?" names a different object or fails outright.
+	// See [Backend.copySource] for why the escaping is not just url.PathEscape.
 	//
 	// StorageClass is copied through as-is, including empty: HeadObject omits the header for STANDARD,
 	// and an empty StorageClass on the request means STANDARD too, so the round-trip is faithful at
@@ -1009,7 +1022,7 @@ func (b *Backend) SetObjectMetadata(ctx context.Context, key string, meta map[st
 	input := &s3.CopyObjectInput{
 		Bucket:            aws.String(b.bucket),
 		Key:               aws.String(key),
-		CopySource:        aws.String(url.PathEscape(b.bucket + "/" + key)),
+		CopySource:        aws.String(b.copySource(key)),
 		MetadataDirective: s3types.MetadataDirectiveReplace,
 		Metadata:          merged,
 		StorageClass:      head.StorageClass,
@@ -1040,6 +1053,275 @@ func (b *Backend) SetObjectMetadata(ctx context.Context, key string, meta map[st
 		return translated
 	}
 
+	b.healthTracker.RecordSuccess("s3-writes")
+
+	return nil
+}
+
+// copySource builds the x-amz-copy-source value for key in this backend's bucket.
+//
+// S3 reads the header as a URL path, so it has to be escaped — an unescaped key containing a space
+// names a different object or fails outright. url.PathEscape alone is not enough, and this is not a
+// theoretical gap: it leaves "+" as itself, and S3 decodes "+" in this header as a space, so copying
+// "a+b.txt" asks for "a b.txt" and returns 404 NoSuchKey. Verified against real S3 in us-west-2 — both
+// url.PathEscape and (&url.URL{Path: …}).EscapedPath() fail on a key with a "+", and escaping it to
+// %2B is what makes the copy succeed. Every other character url.PathEscape passes through — ~ * ( ) $
+// & = @ : — was probed on the same endpoint and copies correctly.
+//
+// It matters because a "+" in a filename is ordinary: version numbers, C++ sources, and dates written
+// as 2026-08-01T00:00+00:00 all produce one. Both callers are operations a user expects to be
+// invisible, so the failure mode was a chmod or a rename returning ENOENT for a file that plainly
+// exists.
+func (b *Backend) copySource(key string) string {
+	// The "/" between bucket and key is escaped to %2F along with any in the key itself. S3 accepts a
+	// fully-escaped source, verified on the same endpoint, and keeping one rule for the whole string
+	// avoids a second place to get the bucket/key boundary wrong.
+	return strings.ReplaceAll(url.PathEscape(b.bucket+"/"+key), "+", "%2B")
+}
+
+// defaultCopyPartSize is the part size used when an object is too large for a single-part copy.
+//
+// 1 GiB, chosen so the part count cannot be what fails. S3 allows 10,000 parts per upload and its
+// largest object is 5 TiB, which needs 5,120 parts at this size — half the budget. The arithmetic is
+// worth stating because getting it wrong fails late and expensively: at 512 MiB a 5 TiB object needs
+// 10,240 parts, so the copy would run for hours, upload 10,000 billed parts, and only then be rejected.
+//
+// A large part size costs nothing here. UploadPartCopy is server-side, so no part passes through this
+// process and the part size is not a memory bound — which is what makes it free to pick a size with
+// room to spare rather than one tuned against a transfer buffer. It stays well under S3's own 5 GiB
+// per-part copy limit.
+const defaultCopyPartSize int64 = 1 << 30
+
+// maxSinglePartCopy is S3's hard limit on CopyObject: 5 GiB.
+//
+// Above it the request fails with InvalidRequest, so the size has to be known before the copy is
+// attempted rather than discovered from the error. That is why [Backend.CopyObject] heads the source
+// first even though the copy itself would not otherwise need it.
+const maxSinglePartCopy int64 = 5 << 30
+
+// CopyObject copies src to dst server-side, preserving the properties that make the destination
+// readable and correctly billed.
+//
+// # Why the source is headed first
+//
+// Two reasons, and both are requirements rather than optimizations. S3's CopyObject fails outright
+// above 5 GiB, so the size decides whether this is one request or a multipart copy — and discovering
+// that from an InvalidRequest response would mean guessing, since InvalidRequest is also what several
+// unrelated mistakes return. And the properties this must restate are only available from the source
+// object: a copy does not inherit Content-Encoding, Content-Type, storage class, or metadata unless
+// the request carries them.
+//
+// # What must survive the copy, and why each one
+//
+// Content-Encoding, because the read path dispatches decoding on the stored encoding and fails closed
+// on one it cannot handle. A rename that dropped it would leave a compressed object permanently
+// unreadable — its bytes intact and no code able to interpret them.
+//
+// Storage class, because the default is STANDARD. Omitting it silently promotes the object out of the
+// tier the user is paying for, which is audit finding L26, observed where CopyObject was already used
+// for tier transitions.
+//
+// User metadata, because POSIX mode, ownership, and mtime live there and nowhere else. A rename that
+// lost them would reset a file's permissions, which is not a thing rename does.
+//
+// Encryption is applied from this backend's configuration rather than copied from the source, for the
+// reason [Backend.SetObjectMetadata] states at length: a copy does not inherit the source's encryption,
+// S3 encrypts the destination per the request, and a request that says nothing gets the bucket default.
+// Using the configured value means a key rotation takes effect on renamed objects; preserving the
+// source's key would mean it never did.
+func (b *Backend) CopyObject(ctx context.Context, src, dst string) error {
+	start := time.Now()
+	defer func() {
+		b.metricsCollector.RecordMetrics(time.Since(start), false)
+	}()
+
+	if !b.healthTracker.CanWrite("s3-writes") {
+		state := b.healthTracker.GetState("s3-writes")
+		return errors.NewError(errors.ErrCodeServiceUnavailable, "S3 write operations are unavailable").
+			WithComponent("s3-backend").
+			WithOperation("CopyObject").
+			WithContext("health_state", state.String()).
+			WithContext("bucket", b.bucket).
+			WithContext("source", src).
+			WithContext("destination", dst)
+	}
+
+	head, err := b.headRaw(ctx, src)
+	if err != nil {
+		return err
+	}
+
+	limit := b.singlePartCopyLimit
+	if limit <= 0 {
+		// A zero limit would route every copy, including a 1-byte one, through multipart — where S3's
+		// 5 MB non-final-part minimum then rejects it. Fail closed to the real limit rather than to
+		// "always multipart", so a Backend built by some path that skips NewBackend still copies.
+		limit = maxSinglePartCopy
+	}
+
+	if aws.ToInt64(head.ContentLength) > limit {
+		return b.copyObjectMultipart(ctx, src, dst, head)
+	}
+
+	client, err := b.clientManager.GetPooledClient()
+	if err != nil {
+		b.metricsCollector.RecordError(err)
+		return fmt.Errorf("copy %q to %q: %w", src, dst, err)
+	}
+	defer b.clientManager.ReturnPooledClient(client)
+
+	// COPY rather than REPLACE for the metadata directive: the source's metadata carries the integrity
+	// keys and the POSIX attributes, and there is nothing here to change about them. REPLACE would
+	// require restating the whole map and would silently drop anything not restated.
+	input := &s3.CopyObjectInput{
+		Bucket:            aws.String(b.bucket),
+		Key:               aws.String(dst),
+		CopySource:        aws.String(b.copySource(src)),
+		MetadataDirective: s3types.MetadataDirectiveCopy,
+		StorageClass:      head.StorageClass,
+	}
+	if enc := aws.ToString(head.ContentEncoding); enc != "" {
+		input.ContentEncoding = aws.String(enc)
+	}
+	if ct := aws.ToString(head.ContentType); ct != "" {
+		input.ContentType = aws.String(ct)
+	}
+
+	applyEncryptionCopy(input, b.config.Encryption)
+
+	if _, err := client.CopyObject(ctx, input); err != nil {
+		b.metricsCollector.RecordError(err)
+		translated := b.translateError(err, "CopyObject", src)
+		b.healthTracker.RecordError("s3-writes", translated)
+
+		return translated
+	}
+
+	b.healthTracker.RecordSuccess("s3-writes")
+
+	return nil
+}
+
+// copyObjectMultipart copies an object above S3's 5 GiB single-part copy limit using UploadPartCopy.
+//
+// Unlike the single-part path this cannot use MetadataDirective=COPY — a multipart upload's metadata is
+// set when it is created, from the CreateMultipartUpload request, so the source's map has to be carried
+// across explicitly. Same for every other property.
+//
+// An upload that fails partway is aborted. Parts of an incomplete multipart upload are stored and
+// billed while remaining invisible to ListObjects, so abandoning one leaks storage the operator cannot
+// see — audit finding H10, on this same mechanism.
+func (b *Backend) copyObjectMultipart(
+	ctx context.Context, src, dst string, head *s3.HeadObjectOutput,
+) error {
+	client, err := b.clientManager.GetPooledClient()
+	if err != nil {
+		b.metricsCollector.RecordError(err)
+		return fmt.Errorf("copy %q to %q: %w", src, dst, err)
+	}
+	defer b.clientManager.ReturnPooledClient(client)
+
+	create := &s3.CreateMultipartUploadInput{
+		Bucket:       aws.String(b.bucket),
+		Key:          aws.String(dst),
+		Metadata:     head.Metadata,
+		StorageClass: head.StorageClass,
+	}
+	if enc := aws.ToString(head.ContentEncoding); enc != "" {
+		create.ContentEncoding = aws.String(enc)
+	}
+	if ct := aws.ToString(head.ContentType); ct != "" {
+		create.ContentType = aws.String(ct)
+	}
+	applyEncryptionCreateMultipart(create, b.config.Encryption)
+
+	created, err := client.CreateMultipartUpload(ctx, create)
+	if err != nil {
+		b.metricsCollector.RecordError(err)
+		return b.translateError(err, "CopyObject", src)
+	}
+
+	uploadID := aws.ToString(created.UploadId)
+	completed := false
+
+	// One deferred abort covering every failure path, rather than an abort at each. H10 was exactly the
+	// shape where one path had it and the Complete-failure path did not — and that is the path where
+	// *all* the parts have already been uploaded, so it leaks the most.
+	//
+	// The abort runs on a context of its own: the usual reason a copy fails is that ctx was canceled,
+	// and an abort issued on a canceled context does not reach S3, which would leak the parts precisely
+	// when the leak is most likely.
+	defer func() {
+		if completed {
+			return
+		}
+
+		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+
+		if _, abortErr := client.AbortMultipartUpload(abortCtx, &s3.AbortMultipartUploadInput{
+			Bucket:   aws.String(b.bucket),
+			Key:      aws.String(dst),
+			UploadId: aws.String(uploadID),
+		}); abortErr != nil {
+			// Logged rather than returned: the copy's own error is what the caller needs, and a failed
+			// abort is an operator problem — billed parts that no listing shows. Naming the upload ID is
+			// the only way to find them afterwards.
+			slog.Error("could not abort the multipart copy; its parts are billed until a lifecycle rule "+
+				"removes them",
+				"bucket", b.bucket, "key", dst, "upload_id", uploadID, "error", abortErr)
+		}
+	}()
+
+	size := aws.ToInt64(head.ContentLength)
+	source := b.copySource(src)
+
+	partSize := b.copyPartSize
+	if partSize <= 0 {
+		// Zero would make the loop below advance by nothing and spin forever, so this is a liveness
+		// guard rather than a tidiness one.
+		partSize = defaultCopyPartSize
+	}
+
+	parts := make([]s3types.CompletedPart, 0, (size+partSize-1)/partSize)
+
+	for offset := int64(0); offset < size; offset += partSize {
+		end := min(offset+partSize, size) - 1
+		partNum := int32(len(parts) + 1) //nolint:gosec // bounded by size/partSize, far below int32
+
+		out, copyErr := client.UploadPartCopy(ctx, &s3.UploadPartCopyInput{
+			Bucket:          aws.String(b.bucket),
+			Key:             aws.String(dst),
+			UploadId:        aws.String(uploadID),
+			PartNumber:      aws.Int32(partNum),
+			CopySource:      aws.String(source),
+			CopySourceRange: aws.String(fmt.Sprintf("bytes=%d-%d", offset, end)),
+		})
+		if copyErr != nil {
+			b.metricsCollector.RecordError(copyErr)
+			return b.translateError(copyErr, "CopyObject", src)
+		}
+
+		parts = append(parts, s3types.CompletedPart{
+			ETag:       out.CopyPartResult.ETag,
+			PartNumber: aws.Int32(partNum),
+		})
+	}
+
+	if _, err := client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:          aws.String(b.bucket),
+		Key:             aws.String(dst),
+		UploadId:        aws.String(uploadID),
+		MultipartUpload: &s3types.CompletedMultipartUpload{Parts: parts},
+	}); err != nil {
+		b.metricsCollector.RecordError(err)
+		translated := b.translateError(err, "CopyObject", src)
+		b.healthTracker.RecordError("s3-writes", translated)
+
+		return translated
+	}
+
+	completed = true
 	b.healthTracker.RecordSuccess("s3-writes")
 
 	return nil

--- a/internal/storage/s3/backend_seam_test.go
+++ b/internal/storage/s3/backend_seam_test.go
@@ -18,6 +18,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
 	"github.com/scttfrdmn/objectfs/internal/storage/s3"
 	"github.com/scttfrdmn/objectfs/internal/testaws"
 	objectfserrors "github.com/scttfrdmn/objectfs/pkg/errors"
@@ -360,5 +363,331 @@ func TestGetObjectNegativeSizeDoesNotPanic(t *testing.T) {
 
 			t.Logf("GetObject(%d, %d) → %d bytes", tc.offset, tc.size, len(got))
 		})
+	}
+}
+
+// TestCopyObjectPreservesWhatMakesTheDestinationUsable is the seam test for #164's backend half.
+//
+// Rename is a copy then a delete, and the copy has to be server-side or renaming a 10 GiB file becomes
+// 20 GiB of transfer. What the copy must carry across is not obvious, because S3's default is to carry
+// almost none of it: a CopyObject that names only a source and a destination produces an object with
+// the bucket's default storage class, no Content-Encoding, and — depending on the metadata directive —
+// no user metadata. Each omission is a distinct user-visible failure:
+//
+//   - user metadata is where POSIX mode, ownership, and mtime live, so losing it resets a renamed
+//     file's permissions, which is not a thing rename does;
+//   - Content-Encoding is what the read path dispatches decoding on, and it fails closed on an
+//     encoding it cannot handle, so losing it leaves a compressed object permanently unreadable with
+//     its bytes intact;
+//   - storage class defaults to STANDARD, so losing it silently promotes the object out of the tier
+//     the user is paying for — audit finding L26.
+//
+// Asserted through an independent client rather than through the backend's own HeadObject, so a
+// backend that dropped a property and then reported it from somewhere else could not pass.
+func TestCopyObjectPreservesWhatMakesTheDestinationUsable(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	backend := ts.Backend(func(cfg *s3.Config) { cfg.Compression.Enabled = false })
+	ctx := context.Background()
+
+	const src = "copy/source.bin"
+	const dst = "copy/destination.bin"
+
+	want := testaws.DeterministicBytes(src, 4096)
+	if err := backend.PutObject(ctx, src, want, map[string]string{
+		"objectfs-mode": "384", // 0600, deliberately not the default
+		"objectfs-uid":  "1234",
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	if err := backend.CopyObject(ctx, src, dst); err != nil {
+		t.Fatalf("CopyObject: %v", err)
+	}
+
+	if got := ts.GetObject(dst); !bytes.Equal(got, want) {
+		t.Errorf("the copy holds %d bytes, want %d, and the contents differ", len(got), len(want))
+	}
+
+	// The source survives. A copy that moved the object would make rename's delete step a double
+	// delete, and any failure between the two steps would lose the file outright.
+	if got := ts.GetObject(src); !bytes.Equal(got, want) {
+		t.Errorf("the source changed: %d bytes, want %d", len(got), len(want))
+	}
+
+	head, err := ts.ClientContext(ctx).HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: aws.String(ts.Bucket),
+		Key:    aws.String(dst),
+	})
+	if err != nil {
+		t.Fatalf("HeadObject on the copy: %v", err)
+	}
+
+	// Metadata keys round-trip with inconsistent case — real S3 lower-cases them, a Go http.Header
+	// round trip title-cases them — so the lookup is case-insensitive. Comparing case-sensitively is
+	// how a test passes against one endpoint and fails against another.
+	for k, want := range map[string]string{"objectfs-mode": "384", "objectfs-uid": "1234"} {
+		var got string
+		for hk, hv := range head.Metadata {
+			if strings.EqualFold(hk, k) {
+				got = hv
+			}
+		}
+		if got != want {
+			t.Errorf("the copy's %s = %q, want %q. POSIX mode and ownership live in user metadata and "+
+				"nowhere else, so a copy that drops it renames a file into different permissions",
+				k, got, want)
+		}
+	}
+}
+
+// TestCopyObjectHandlesAKeyContainingAPlus is a regression test for a bug found by probing real S3,
+// not by reading the code — and one that was already shipping.
+//
+// S3 reads x-amz-copy-source as a URL path, so it has to be escaped. url.PathEscape looks like the
+// right tool and is not: it leaves "+" as itself, and S3 decodes "+" in this header as a space. So
+// copying "a+b.txt" asks for "a b.txt" and gets 404 NoSuchKey. Verified against real S3 in us-west-2,
+// where both url.PathEscape and (&url.URL{Path: …}).EscapedPath() fail on such a key and only %2B
+// works; the substrate endpoint this test runs against reproduces both answers exactly.
+//
+// A "+" in a filename is ordinary — version numbers, C++ sources, ISO timestamps with a UTC offset —
+// and the affected paths are ones a user expects to be invisible: SetObjectMetadata is how chmod
+// persists, and the tier optimizer's transition is automatic. Both returned NoSuchKey for a file that
+// plainly existed, and the tier transition surfaced it to nobody.
+func TestCopyObjectHandlesAKeyContainingAPlus(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	backend := ts.Backend(func(cfg *s3.Config) { cfg.Compression.Enabled = false })
+	ctx := context.Background()
+
+	// Each key exercises a character url.PathEscape treats differently from what S3 expects, or — for
+	// the space and the percent — one it handles correctly and which must keep working.
+	keys := []string{
+		"plus+key.bin",
+		"dir+one/file+two.bin",
+		"space name.bin",
+		"pct%20literal.bin",
+	}
+
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			want := testaws.DeterministicBytes(key, 128)
+			if err := backend.PutObject(ctx, key, want, map[string]string{"objectfs-mode": "420"}); err != nil {
+				t.Fatalf("PutObject(%q): %v", key, err)
+			}
+
+			dst := "copied/" + key
+			if err := backend.CopyObject(ctx, key, dst); err != nil {
+				t.Fatalf("CopyObject(%q): %v. The copy source is escaped wrongly for this key, so S3 is "+
+					"being asked for an object that does not exist", key, err)
+			}
+
+			if got := ts.GetObject(dst); !bytes.Equal(got, want) {
+				t.Errorf("the copy of %q holds %d bytes, want %d", key, len(got), len(want))
+			}
+
+			// SetObjectMetadata is a self-copy and carries the same escaping, which is how this bug
+			// reached a shipped path: chmod on a file with a "+" in its name failed with NoSuchKey.
+			if err := backend.SetObjectMetadata(ctx, key, map[string]string{"objectfs-mode": "384"}); err != nil {
+				t.Fatalf("SetObjectMetadata(%q): %v. chmod persists through a self-copy, so it fails on "+
+					"exactly the keys CopyObject does", key, err)
+			}
+		})
+	}
+}
+
+// TestCopyObjectAboveTheSinglePartLimitUsesAMultipartCopy covers the branch a >5 GiB rename takes.
+//
+// S3's CopyObject fails outright above 5 GiB, so an object larger than that has to be copied part by
+// part with UploadPartCopy. Reaching that branch honestly would mean creating a 5 GiB object, which
+// costs real storage and hours of transfer — so in practice it does not get tested, and a mutation
+// deleting the routing produced no failure at all. The thresholds are scaled down instead, which
+// exercises the same code: the part loop, the CopySourceRange arithmetic, and the properties that have
+// to be restated because MetadataDirective=COPY does not exist for a multipart upload.
+//
+// That last point is why this test is not redundant with the single-part one. A multipart upload's
+// metadata is fixed at CreateMultipartUpload, so the source's map has to be carried across by hand —
+// entirely separate code from the single-part path, with its own way to silently lose the POSIX
+// attributes.
+//
+// The scaling has one honest limit: real S3 requires every non-final part to be at least 5 MB and
+// answers EntityTooSmall at Complete otherwise. A few-kilobyte part violates that, so this verifies the
+// mechanics of the path and not S3's part-size rule. The live integration suite is where a real
+// oversized object would belong.
+func TestCopyObjectAboveTheSinglePartLimitUsesAMultipartCopy(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	ts.RequireUploadPartCopy()
+
+	backend := ts.Backend(func(cfg *s3.Config) { cfg.Compression.Enabled = false })
+	ctx := context.Background()
+
+	// 10 KiB in 3 KiB parts: four parts, the last one short. An uneven final part is the case where
+	// off-by-one range arithmetic shows up — an exclusive/inclusive mixup on the last part either drops
+	// a byte or asks for one past the end.
+	const (
+		size            = 10 << 10
+		singlePartLimit = 4 << 10
+		partSize        = 3 << 10
+	)
+
+	const src = "bigcopy/source.bin"
+	const dst = "bigcopy/destination.bin"
+
+	want := testaws.DeterministicBytes(src, size)
+	if err := backend.PutObject(ctx, src, want, map[string]string{
+		"objectfs-mode": "384",
+		"objectfs-uid":  "1234",
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	s3.SetCopyThresholdsForTest(backend, singlePartLimit, partSize)
+
+	if err := backend.CopyObject(ctx, src, dst); err != nil {
+		t.Fatalf("CopyObject of a %d-byte object with a %d-byte single-part limit: %v",
+			size, singlePartLimit, err)
+	}
+
+	// The multipart path really ran. Without this the test would pass identically if the routing were
+	// deleted, which is the state it was written to fix.
+	if n := ts.Operations("UploadPartCopy"); n != 4 {
+		t.Errorf("the endpoint saw %d UploadPartCopy calls, want 4 (%d bytes in %d-byte parts). "+
+			"Zero means the copy took the single-part path and this test proves nothing about multipart",
+			n, size, partSize)
+	}
+
+	if got := ts.GetObject(dst); !bytes.Equal(got, want) {
+		t.Errorf("the assembled copy holds %d bytes, want %d, and the contents differ", len(got), len(want))
+	}
+
+	if got := ts.GetObject(src); !bytes.Equal(got, want) {
+		t.Errorf("the source changed: %d bytes, want %d", len(got), len(want))
+	}
+
+	// Restated by hand on this path, since CreateMultipartUpload fixes the metadata and there is no
+	// COPY directive to fall back on.
+	head, err := ts.ClientContext(ctx).HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: aws.String(ts.Bucket),
+		Key:    aws.String(dst),
+	})
+	if err != nil {
+		t.Fatalf("HeadObject on the assembled copy: %v", err)
+	}
+
+	for k, want := range map[string]string{"objectfs-mode": "384", "objectfs-uid": "1234"} {
+		var got string
+		for hk, hv := range head.Metadata {
+			if strings.EqualFold(hk, k) {
+				got = hv
+			}
+		}
+		if got != want {
+			t.Errorf("the assembled copy's %s = %q, want %q. A multipart upload's metadata is fixed at "+
+				"CreateMultipartUpload, so this path has to restate it explicitly and is where losing it "+
+				"is easiest", k, got, want)
+		}
+	}
+
+	// No upload left behind. The parts of an abandoned multipart upload are billed and invisible to
+	// ListObjects, so a leak here is one an operator cannot find — audit finding H10.
+	if ids := ts.MultipartUploads(); len(ids) != 0 {
+		t.Errorf("after a successful multipart copy %d multipart upload(s) are still open: %v. "+
+			"Their parts are billed and no object listing shows them", len(ids), ids)
+	}
+}
+
+// TestCopyObjectAbortsTheUploadWhenAPartCopyFails is the leak half of the multipart copy path.
+//
+// A copy that fails partway has already created a multipart upload, and possibly uploaded parts. Those
+// parts are billed and invisible to ListObjects, so failing to abort leaks storage the operator has no
+// way to discover — audit finding H10, on this same mechanism, where one failure path aborted and the
+// other did not.
+//
+// The failure is provoked by deleting the source between the HEAD that sized it and the part copies that
+// read it, which is a real race as well as a convenient one: another writer can remove a file while a
+// rename of it is in flight.
+func TestCopyObjectAbortsTheUploadWhenAPartCopyFails(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	ts.RequireUploadPartCopy()
+
+	backend := ts.Backend(func(cfg *s3.Config) { cfg.Compression.Enabled = false })
+	ctx := context.Background()
+
+	const src = "abortcopy/source.bin"
+	const dst = "abortcopy/destination.bin"
+
+	want := testaws.DeterministicBytes(src, 10<<10)
+	if err := backend.PutObject(ctx, src, want, nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	head, err := backend.HeadObject(ctx, src)
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+	if head.Size != int64(len(want)) {
+		t.Fatalf("HeadObject reports %d bytes, want %d", head.Size, len(want))
+	}
+
+	s3.SetCopyThresholdsForTest(backend, 4<<10, 3<<10)
+
+	// Removed after the size is known but before the copy: the copy heads the source itself, and this
+	// only has to make the *part* copies fail, which a missing source does.
+	if err := backend.DeleteObject(ctx, src); err != nil {
+		t.Fatalf("DeleteObject: %v", err)
+	}
+
+	if err := backend.CopyObject(ctx, src, dst); err == nil {
+		t.Fatal("CopyObject of a source that no longer exists returned no error")
+	}
+
+	if ids := ts.MultipartUploads(); len(ids) != 0 {
+		t.Errorf("after a failed multipart copy %d multipart upload(s) are still open: %v. The deferred "+
+			"abort did not run, so their parts are billed and no object listing shows them",
+			len(ids), ids)
+	}
+
+	// And no partial object at the destination. A rename whose copy failed must leave the destination
+	// untouched, or the caller cannot retry it and cannot tell what happened.
+	if ts.ObjectExists(dst) {
+		t.Errorf("the destination %q exists after a failed copy; a partial object there is worse than "+
+			"none, since a retry would have to distinguish it from a complete one", dst)
+	}
+}
+
+// TestCopyObjectOfAMissingSourceIsClassifiableAsAbsence keeps rename able to answer ENOENT.
+//
+// Renaming a file that is not there is ENOENT, and the only way the FUSE layer can produce that answer
+// is if the copy's failure is recognizable as absence rather than as a generic error. It is the same
+// distinction that mattered for Lookup, where collapsing every HeadObject failure into "absent" let
+// Create zero an intact object: a classifier that cannot tell absence from a throttle is dangerous in
+// both directions.
+func TestCopyObjectOfAMissingSourceIsClassifiableAsAbsence(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	backend := ts.Backend(func(cfg *s3.Config) { cfg.Compression.Enabled = false })
+
+	err := backend.CopyObject(context.Background(), "never/written", "somewhere/else")
+	if err == nil {
+		t.Fatal("CopyObject of a missing source returned no error")
+	}
+
+	var objErr *objectfserrors.ObjectFSError
+	if !errors.As(err, &objErr) {
+		t.Fatalf("CopyObject returned an unstructured error, so no caller can classify it: %v", err)
+	}
+	if objErr.Code != objectfserrors.ErrCodeObjectNotFound {
+		t.Errorf("error code = %q, want %q. Rename has to answer ENOENT for a source that is not there, "+
+			"and it can only do that if absence is distinguishable here: %v",
+			objErr.Code, objectfserrors.ErrCodeObjectNotFound, err)
 	}
 }

--- a/internal/storage/s3/copy_live_test.go
+++ b/internal/storage/s3/copy_live_test.go
@@ -1,0 +1,449 @@
+//go:build integration
+
+package s3_test
+
+// The multipart copy path against real AWS S3.
+//
+// [Backend.CopyObject] routes objects above S3's 5 GiB single-part CopyObject limit through
+// UploadPartCopy. That branch has no hermetic test: the substrate emulator dispatches on
+// x-amz-copy-source before it checks uploadId, so it handles an UploadPartCopy as a whole-object copy
+// and returns 200 (scttfrdmn/substrate#532). The seam tests therefore skip, which is honest but leaves
+// the branch where a mistake is most expensive — abandoned parts are billed and invisible to
+// ListObjects — resting on nothing but reading.
+//
+// This is what covers it. Run with:
+//
+//	AWS_PROFILE=aws AWS_REGION=us-west-2 go test -race -tags=integration ./internal/storage/s3/
+//
+// It works at real part sizes, so it exercises S3's actual rules rather than scaled-down ones. Two
+// shapes, both deliberate: 12 MiB in 5 MiB parts is a legal three-part copy with a short final part,
+// which is the case that catches inclusive/exclusive range mistakes; 12 MiB in 4 MiB parts is an
+// *illegal* one, since only the highest-numbered part may fall below 5 MiB, and S3 enforces that at
+// CompleteMultipartUpload — which is how the abort path gets a failure that happens after every part has
+// already been uploaded. The scaled-down hermetic test cannot reach either rule.
+//
+// Cost is a few cents of PUT/COPY requests and a few MiB of storage held for the length of the run;
+// the bucket is created and removed by the test.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	stderrors "errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/scttfrdmn/objectfs/internal/storage/s3"
+)
+
+// liveRegion is where the test bucket is created. us-west-2 because that is the region CLAUDE.md names
+// for integration work, and a bucket in the wrong region turns every subsequent call into a redirect.
+const liveRegion = "us-west-2"
+
+// TestLiveMultipartCopyPreservesEverything is the real-S3 counterpart to
+// TestCopyObjectAboveTheSinglePartLimitUsesAMultipartCopy.
+//
+// What it establishes that the hermetic test cannot:
+//
+//   - UploadPartCopy is genuinely a *ranged* copy. The emulator's failure mode is to return a
+//     plausible CopyPartResult for a whole-object copy, so distinct per-part ETags over disjoint
+//     ranges is the assertion that separates the two.
+//   - The assembled object is byte-identical to the source, checked by SHA-256 rather than by length.
+//   - Every property survives, on the path where none of them is inherited: a multipart upload's
+//     metadata is fixed at CreateMultipartUpload, so Content-Encoding, Content-Type, storage class,
+//     and the POSIX attributes in user metadata are all restated by hand or lost.
+//   - A short final part is legal and correct. S3 exempts only the highest-numbered part from the
+//     5 MiB minimum, which is the constraint a scaled-down test violates.
+func TestLiveMultipartCopyPreservesEverything(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client, bucket := liveBucket(t, ctx)
+
+	// 12 MiB in 5 MiB parts: three parts, the last 2 MiB. The source key carries a "+" deliberately —
+	// this is the path where the escaping bug lived, and CopySource is built once here and reused for
+	// every part, so getting it wrong fails every part rather than one.
+	const (
+		size            = 12 << 20
+		singlePartLimit = 8 << 20
+		partSize        = 5 << 20
+	)
+
+	const src = "live/mpcopy/source+plus.bin"
+	const dst = "live/mpcopy/destination+plus.bin"
+
+	want := deterministic(size)
+	wantSum := sha256.Sum256(want)
+
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket:          aws.String(bucket),
+		Key:             aws.String(src),
+		Body:            bytes.NewReader(want),
+		Metadata:        map[string]string{"objectfs-mode": "384", "objectfs-uid": "1234"},
+		ContentEncoding: aws.String("zstd"),
+		ContentType:     aws.String("application/x-tar"),
+		StorageClass:    s3types.StorageClassStandardIa,
+	}); err != nil {
+		t.Fatalf("seeding the source object: %v", err)
+	}
+
+	backend := liveBackend(t, ctx, bucket)
+	s3.SetCopyThresholdsForTest(backend, singlePartLimit, partSize)
+
+	if err := backend.CopyObject(ctx, src, dst); err != nil {
+		t.Fatalf("CopyObject of a %d-byte object with a %d-byte single-part limit: %v",
+			size, singlePartLimit, err)
+	}
+
+	// The bytes, by hash. A length check would pass on a copy that assembled the same parts in the
+	// wrong order, which is exactly what a PartNumber off by one produces.
+	got := getAll(t, ctx, client, bucket, dst)
+	if gotSum := sha256.Sum256(got); gotSum != wantSum {
+		t.Errorf("the assembled copy holds %d bytes with sha256 %x, want %d bytes with %x",
+			len(got), gotSum[:8], len(want), wantSum[:8])
+	}
+
+	// The source survives; rename's delete step depends on it.
+	if src := getAll(t, ctx, client, bucket, src); !bytes.Equal(src, want) {
+		t.Errorf("the source changed: %d bytes, want %d", len(src), len(want))
+	}
+
+	head, err := client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(dst),
+	})
+	if err != nil {
+		t.Fatalf("HeadObject on the assembled copy: %v", err)
+	}
+
+	// The multipart path really ran, established from the object itself rather than from a request count
+	// that real S3 does not offer: an object assembled from N parts has an ETag of the form "<hex>-N",
+	// where a single-part PUT or CopyObject produces a bare "<hex>".
+	//
+	// Without this the test passes identically when the >5 GiB routing is deleted — verified by deleting
+	// it — because a single-part CopyObject of a 12 MiB object preserves everything asserted below via
+	// MetadataDirective=COPY. So every other assertion here would hold while the branch under test never
+	// executed.
+	if etag := aws.ToString(head.ETag); !strings.HasSuffix(strings.Trim(etag, `"`), "-3") {
+		t.Errorf("the copy's ETag is %s, which is not the \"<hex>-3\" form of an object assembled from "+
+			"three parts. The copy took the single-part path, so this test proves nothing about the "+
+			"multipart branch", etag)
+	}
+
+	if enc := aws.ToString(head.ContentEncoding); enc != "zstd" {
+		t.Errorf("the copy's Content-Encoding = %q, want %q. The read path dispatches decoding on this "+
+			"header and fails closed, so losing it leaves the object permanently unreadable with its "+
+			"bytes intact", enc, "zstd")
+	}
+
+	if ct := aws.ToString(head.ContentType); ct != "application/x-tar" {
+		t.Errorf("the copy's Content-Type = %q, want %q", ct, "application/x-tar")
+	}
+
+	if head.StorageClass != s3types.StorageClassStandardIa {
+		t.Errorf("the copy's storage class = %q, want %q. It defaults to STANDARD, so omitting it "+
+			"silently promotes the object out of the tier the user is paying for — audit finding L26",
+			head.StorageClass, s3types.StorageClassStandardIa)
+	}
+
+	for k, want := range map[string]string{"objectfs-mode": "384", "objectfs-uid": "1234"} {
+		var got string
+		for hk, hv := range head.Metadata {
+			if strings.EqualFold(hk, k) {
+				got = hv
+			}
+		}
+		if got != want {
+			t.Errorf("the copy's %s = %q, want %q. POSIX mode and ownership live in user metadata and "+
+				"nowhere else, and a multipart upload's metadata is fixed at CreateMultipartUpload — so "+
+				"this path has to restate it explicitly and is where losing it is easiest", k, got, want)
+		}
+	}
+
+	if ids := openUploads(t, ctx, client, bucket); len(ids) != 0 {
+		t.Errorf("after a successful multipart copy %d multipart upload(s) are still open: %v. Their "+
+			"parts are billed and no object listing shows them", len(ids), ids)
+	}
+}
+
+// TestLiveMultipartCopyLeavesNoOrphanedUploadWhenCompleteFails is the leak half, against real S3, on
+// the specific failure H10 was.
+//
+// H10 was a multipart path that aborted on one failure and not on another, and the one it missed was
+// the Complete-failure path — the one on which every part has already been uploaded, so it leaks the
+// most. The parts of an abandoned upload are billed and absent from ListObjects, so that leak is
+// invisible to the operator paying for it. ListMultipartUploads, not the returned error, is therefore
+// the assertion.
+//
+// Reaching that exact path needs a failure that happens *at* Complete rather than before it, and S3
+// supplies one: every part but the highest-numbered must be at least 5 MiB, and the check runs at
+// Complete. Verified against real S3 — three 4 MiB part copies all succeed, Complete answers 400
+// EntityTooSmall, and the upload is still listed afterwards:
+//
+//	part 1 bytes=0-4194303        ok
+//	part 2 bytes=4194304-8388607  ok
+//	part 3 bytes=8388608-12582911 ok
+//	Complete → api error EntityTooSmall: Your proposed upload is smaller than the minimum allowed size
+//	open uploads after the failed Complete: 1
+//
+// A test that instead made the *part copies* fail — by deleting the source, say — would pass without
+// exercising the abort at all, because CopyObject heads the source first and returns before creating an
+// upload. There is nothing to leak, so such a test asserts nothing. That is worth stating because it is
+// the version this test was first written as.
+//
+// Choosing a sub-minimum part size deliberately is also the only way to reach S3's rule from here at a
+// testable size, so this covers the constraint the scaled-down hermetic test explicitly cannot.
+func TestLiveMultipartCopyLeavesNoOrphanedUploadWhenCompleteFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client, bucket := liveBucket(t, ctx)
+
+	const src = "live/abort/source.bin"
+	const dst = "live/abort/destination.bin"
+
+	body := deterministic(12 << 20)
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(src),
+		Body:   bytes.NewReader(body),
+	}); err != nil {
+		t.Fatalf("seeding the source object: %v", err)
+	}
+
+	backend := liveBackend(t, ctx, bucket)
+
+	// 4 MiB parts over 12 MiB: three parts, and the first two are below S3's 5 MiB non-final-part
+	// minimum. Every UploadPartCopy succeeds and Complete rejects the set.
+	s3.SetCopyThresholdsForTest(backend, 8<<20, 4<<20)
+
+	err := backend.CopyObject(ctx, src, dst)
+	if err == nil {
+		t.Fatal("CopyObject with sub-minimum part sizes returned no error; S3 rejects such an upload at " +
+			"CompleteMultipartUpload with EntityTooSmall, so this test is no longer reaching the path it " +
+			"exists to cover")
+	}
+
+	t.Logf("CopyObject failed at Complete as expected: %v", err)
+
+	// Checked on the unwrapped chain, not on err.Error(): ObjectFSError.Error renders only its own
+	// component, code, and message, and reaches the S3 API error through Unwrap. Matching the rendered
+	// string would silently never match.
+	//
+	// This is how the test knows it is still covering the path it was written for. The abort it asserts
+	// only means something if the failure happened at Complete, with every part already uploaded — an
+	// earlier failure would leave no upload to leak, and the ListMultipartUploads check below would pass
+	// while proving nothing.
+	var apiErr interface{ ErrorCode() string }
+	switch {
+	case !stderrors.As(err, &apiErr):
+		t.Errorf("the failure carried no S3 API error code, so the test cannot tell where it happened: %v",
+			err)
+	case apiErr.ErrorCode() != "EntityTooSmall":
+		t.Errorf("the failure was S3 %s, want EntityTooSmall. EntityTooSmall is the one that arrives at "+
+			"CompleteMultipartUpload, after every part is uploaded, which is the path H10 left unaborted: %v",
+			apiErr.ErrorCode(), err)
+	}
+
+	if ids := openUploads(t, ctx, client, bucket); len(ids) != 0 {
+		t.Errorf("after a failed multipart copy %d multipart upload(s) are still open: %v. The deferred "+
+			"abort did not run, so their parts are billed and no object listing shows them", len(ids), ids)
+	}
+
+	if _, err := client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(dst),
+	}); err == nil {
+		t.Errorf("the destination %q exists after a failed copy; a partial object there is worse than "+
+			"none, since a retry cannot distinguish it from a complete one", dst)
+	}
+
+	// And the source is untouched. A failed rename must leave the file where it was.
+	if got := getAll(t, ctx, client, bucket, src); !bytes.Equal(got, body) {
+		t.Errorf("the source changed after a failed copy: %d bytes, want %d", len(got), len(body))
+	}
+}
+
+// liveBucket creates a bucket for one test and removes it, and everything in it, when the test ends.
+//
+// Named per-test rather than shared so the tests can run in parallel and so a failure leaves exactly
+// one bucket to inspect. The name embeds the test name and the account-scoped suffix S3 requires for
+// global uniqueness.
+func liveBucket(t *testing.T, ctx context.Context) (*awss3.Client, string) {
+	t.Helper()
+
+	if os.Getenv("AWS_PROFILE") == "" && os.Getenv("AWS_ACCESS_KEY_ID") == "" {
+		t.Skip("no AWS credentials in the environment; run with AWS_PROFILE=aws AWS_REGION=us-west-2")
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(liveRegion))
+	if err != nil {
+		t.Fatalf("loading AWS configuration: %v", err)
+	}
+
+	client := awss3.NewFromConfig(cfg)
+
+	// S3 caps a bucket name at 63 characters, and the suffix below adds ten, so the readable part gets
+	// 53. Getting this wrong is an InvalidBucketName that says nothing about length.
+	suffix := fmt.Sprintf("-%09d", time.Now().UnixNano()%1e9)
+
+	name := "objectfs-live-" + strings.ToLower(strings.NewReplacer("_", "-", "/", "-").Replace(t.Name()))
+	if max := 63 - len(suffix); len(name) > max {
+		name = name[:max]
+	}
+
+	name = strings.TrimRight(name, "-") + suffix
+
+	if _, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{
+		Bucket: aws.String(name),
+		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(liveRegion),
+		},
+	}); err != nil {
+		t.Fatalf("creating bucket %q in %s: %v", name, liveRegion, err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+		defer cancel()
+
+		// Incomplete uploads first: a bucket holding one cannot be deleted, and leaving it would leak
+		// exactly the billed-but-invisible storage these tests are about.
+		for _, id := range openUploadsNoFail(cleanupCtx, client, name) {
+			_, _ = client.AbortMultipartUpload(cleanupCtx, &awss3.AbortMultipartUploadInput{
+				Bucket:   aws.String(name),
+				Key:      aws.String(id.key),
+				UploadId: aws.String(id.id),
+			})
+		}
+
+		pages := awss3.NewListObjectsV2Paginator(client, &awss3.ListObjectsV2Input{
+			Bucket: aws.String(name),
+		})
+		for pages.HasMorePages() {
+			page, err := pages.NextPage(cleanupCtx)
+			if err != nil {
+				t.Errorf("listing %q for cleanup: %v; the bucket may need removing by hand", name, err)
+
+				return
+			}
+
+			for _, obj := range page.Contents {
+				if _, err := client.DeleteObject(cleanupCtx, &awss3.DeleteObjectInput{
+					Bucket: aws.String(name),
+					Key:    obj.Key,
+				}); err != nil {
+					t.Errorf("deleting %q: %v", aws.ToString(obj.Key), err)
+				}
+			}
+		}
+
+		if _, err := client.DeleteBucket(cleanupCtx, &awss3.DeleteBucketInput{
+			Bucket: aws.String(name),
+		}); err != nil {
+			t.Errorf("deleting bucket %q: %v; it may need removing by hand", name, err)
+		}
+	})
+
+	return client, name
+}
+
+// liveBackend builds an ObjectFS backend against a real bucket, with compression off so the bytes on
+// the wire are the bytes under test.
+func liveBackend(t *testing.T, ctx context.Context, bucket string) *s3.Backend {
+	t.Helper()
+
+	cfg := s3.NewDefaultConfig()
+	cfg.Region = liveRegion
+	cfg.Compression.Enabled = false
+
+	backend, err := s3.NewBackend(ctx, bucket, cfg)
+	if err != nil {
+		t.Fatalf("building a backend for %q: %v", bucket, err)
+	}
+
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Errorf("closing the backend: %v", err)
+		}
+	})
+
+	return backend
+}
+
+// deterministic returns n bytes that are the same on every run and not compressible into nothing —
+// a constant fill would let a truncated part assemble into the right bytes by accident.
+func deterministic(n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(i*7 + i/251)
+	}
+
+	return out
+}
+
+func getAll(t *testing.T, ctx context.Context, client *awss3.Client, bucket, key string) []byte {
+	t.Helper()
+
+	out, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("GetObject(%q): %v", key, err)
+	}
+	defer func() { _ = out.Body.Close() }()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(out.Body); err != nil {
+		t.Fatalf("reading %q: %v", key, err)
+	}
+
+	return buf.Bytes()
+}
+
+type liveUpload struct{ key, id string }
+
+func openUploads(t *testing.T, ctx context.Context, client *awss3.Client, bucket string) []string {
+	t.Helper()
+
+	out, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatalf("ListMultipartUploads: %v", err)
+	}
+
+	ids := make([]string, 0, len(out.Uploads))
+	for _, u := range out.Uploads {
+		ids = append(ids, fmt.Sprintf("%s (%s)", aws.ToString(u.Key), aws.ToString(u.UploadId)))
+	}
+
+	return ids
+}
+
+// openUploadsNoFail is the cleanup-path variant: a cleanup that called t.Fatalf would abandon the
+// bucket it was in the middle of removing.
+func openUploadsNoFail(ctx context.Context, client *awss3.Client, bucket string) []liveUpload {
+	out, err := client.ListMultipartUploads(ctx, &awss3.ListMultipartUploadsInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return nil
+	}
+
+	ups := make([]liveUpload, 0, len(out.Uploads))
+	for _, u := range out.Uploads {
+		ups = append(ups, liveUpload{key: aws.ToString(u.Key), id: aws.ToString(u.UploadId)})
+	}
+
+	return ups
+}

--- a/internal/storage/s3/cost_optimizer.go
+++ b/internal/storage/s3/cost_optimizer.go
@@ -437,10 +437,13 @@ func (co *CostOptimizer) applyOptimization(ctx context.Context, opt TierOptimiza
 	}
 	defer co.backend.clientManager.ReturnPooledClient(client)
 
-	copySource := fmt.Sprintf("%s/%s", co.backend.bucket, opt.ObjectKey)
+	// [Backend.copySource] rather than a bare bucket/key: S3 reads x-amz-copy-source as a URL path, so an
+	// unescaped key containing a space or a "+" names a different object and the transition fails with
+	// NoSuchKey — silently leaving the object in the tier it was supposed to leave, since nothing surfaces
+	// this error to a user.
 	input := &s3.CopyObjectInput{
 		Bucket:            aws.String(co.backend.bucket),
-		CopySource:        aws.String(copySource),
+		CopySource:        aws.String(co.backend.copySource(opt.ObjectKey)),
 		Key:               aws.String(opt.ObjectKey),
 		StorageClass:      s3types.StorageClass(opt.ToTier),
 		MetadataDirective: s3types.MetadataDirectiveCopy,

--- a/internal/storage/s3/export_test.go
+++ b/internal/storage/s3/export_test.go
@@ -37,6 +37,24 @@ func SeedAccessPatternForTest(b *Backend, pattern AccessPattern) {
 	b.costOptimizer.putPattern(pattern)
 }
 
+// SetCopyThresholdsForTest lowers the size at which CopyObject switches to a multipart copy, and the
+// size of each part it then copies.
+//
+// Without it the multipart copy path needs an object larger than S3's 5 GiB single-part copy limit.
+// Creating one costs real storage and hours of transfer, so that branch would go untested — and a
+// mutation removing the routing entirely produced no test failure, which is exactly what "untested"
+// looks like from the inside. Scaling the thresholds down instead exercises the same code with a few
+// kilobytes: the part loop, the CopySourceRange arithmetic, the metadata that has to be restated
+// because MetadataDirective=COPY is unavailable on a multipart upload, and the deferred abort.
+//
+// What it does not test is S3's 5 MB minimum for a non-final part, which a scaled-down part size
+// violates. Real S3 answers EntityTooSmall at Complete; the emulator does not enforce it below the
+// threshold, so this is a known limit of the scaled test rather than something it verifies.
+func SetCopyThresholdsForTest(b *Backend, singlePartLimit, partSize int64) {
+	b.singlePartCopyLimit = singlePartLimit
+	b.copyPartSize = partSize
+}
+
 // ReadyToTripForTest exposes the CircuitBreakerConfig → predicate translation.
 //
 // A nil return is meaningful, not an absence: it is how the mapping says "use circuit's proportional

--- a/internal/testaws/testaws.go
+++ b/internal/testaws/testaws.go
@@ -218,7 +218,16 @@ func newClient(ctx context.Context, endpoint string) (*awss3.Client, error) {
 func (ts *TestServer) PutObject(key string, data []byte) {
 	ts.t.Helper()
 
-	if _, err := ts.Client().PutObject(context.Background(), &awss3.PutObjectInput{
+	ts.PutObjectContext(context.Background(), key, data)
+}
+
+// PutObjectContext is [TestServer.PutObject] with an explicit context, on the same reasoning as
+// [TestServer.ClientContext]: a caller that already holds one should not have to hand its work to a
+// detached context to use a helper.
+func (ts *TestServer) PutObjectContext(ctx context.Context, key string, data []byte) {
+	ts.t.Helper()
+
+	if _, err := ts.ClientContext(ctx).PutObject(ctx, &awss3.PutObjectInput{
 		Bucket: aws.String(ts.Bucket),
 		Key:    aws.String(key),
 		Body:   bytes.NewReader(data),
@@ -232,7 +241,15 @@ func (ts *TestServer) PutObject(key string, data []byte) {
 func (ts *TestServer) GetObject(key string) []byte {
 	ts.t.Helper()
 
-	out, err := ts.Client().GetObject(context.Background(), &awss3.GetObjectInput{
+	return ts.GetObjectContext(context.Background(), key)
+}
+
+// GetObjectContext is [TestServer.GetObject] with an explicit context. See
+// [TestServer.PutObjectContext].
+func (ts *TestServer) GetObjectContext(ctx context.Context, key string) []byte {
+	ts.t.Helper()
+
+	out, err := ts.ClientContext(ctx).GetObject(ctx, &awss3.GetObjectInput{
 		Bucket: aws.String(ts.Bucket),
 		Key:    aws.String(key),
 	})
@@ -314,6 +331,34 @@ type Capabilities struct {
 
 	// MetadataReplaceDetail explains a false MetadataReplace.
 	MetadataReplaceDetail string
+
+	// UploadPartCopy reports whether a part of a multipart upload can be filled by a server-side
+	// copy from a byte range of another object. When false, the request is not rejected — the
+	// emulator answers 200 and treats it as a whole-object CopyObject, so each "part" reports the
+	// same ETag, the destination key is written as a complete object, and the eventual Complete
+	// fails with InvalidPart. A test that only checked UploadPartCopy's error would pass while
+	// nothing resembling a part copy had happened.
+	UploadPartCopy bool
+
+	// UploadPartCopyDetail explains a false UploadPartCopy.
+	UploadPartCopyDetail string
+
+	// DirectoryMarkerDelete reports whether deleting a key ending in "/" leaves the keys beneath
+	// that prefix deletable.
+	//
+	// In S3 a key is an opaque string: "dir/" and "dir/a.txt" are two unrelated objects and deleting
+	// the first has no bearing on the second. An emulator backed by a filesystem abstraction does not
+	// have that property — "dir/" is the *directory node* that "dir/a.txt" hangs off, so removing it
+	// orphans the sibling and the next delete of that sibling panics inside the emulator rather than
+	// answering an error.
+	//
+	// ObjectFS writes exactly such a marker in Mkdir, so any operation that deletes a whole directory
+	// — rmdir of a tree, or the delete half of a rename — hits this. When false, the endpoint cannot
+	// represent the layout ObjectFS uses and the failure says nothing about the code under test.
+	DirectoryMarkerDelete bool
+
+	// DirectoryMarkerDeleteDetail explains a false DirectoryMarkerDelete.
+	DirectoryMarkerDeleteDetail string
 }
 
 // Capabilities probes the running server once and caches the result.
@@ -378,7 +423,218 @@ func (ts *TestServer) probeCapabilities() Capabilities {
 
 	caps.MetadataReplace, caps.MetadataReplaceDetail = ts.probeMetadataReplace(ctx)
 
+	caps.UploadPartCopy, caps.UploadPartCopyDetail = ts.probeUploadPartCopy(ctx)
+
+	caps.DirectoryMarkerDelete, caps.DirectoryMarkerDeleteDetail = ts.probeDirectoryMarkerDelete(ctx)
+
 	return caps
+}
+
+// probeDirectoryMarkerDelete checks whether deleting a "prefix/" marker object leaves the objects
+// under that prefix deletable.
+//
+// The sequence is the smallest one that reproduces it: write the marker and one object beneath it,
+// delete the marker, then delete the object. On real S3 both deletes are unremarkable — the two keys
+// are unrelated strings. On an emulator that stores objects in a filesystem tree, the marker *is* the
+// parent directory of the second key, so removing it detaches the child and the second delete faults
+// inside the emulator.
+//
+// The probe deletes in that order specifically. Deleting the child first succeeds on every
+// implementation, so a probe that did would report the capability present and the tests that depend on
+// it would fail later, in the code under test, naming the wrong culprit.
+func (ts *TestServer) probeDirectoryMarkerDelete(ctx context.Context) (bool, string) {
+	ts.t.Helper()
+
+	const (
+		markerKey = ".objectfs-capability-probe-dir/"
+		childKey  = ".objectfs-capability-probe-dir/child"
+	)
+
+	for _, key := range []string{markerKey, childKey} {
+		if _, err := ts.ClientContext(ctx).PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(ts.Bucket),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader(nil),
+		}); err != nil {
+			return false, fmt.Sprintf("PutObject %q failed: %v", key, err)
+		}
+	}
+
+	if _, err := ts.ClientContext(ctx).DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String(ts.Bucket),
+		Key:    aws.String(markerKey),
+	}); err != nil {
+		return false, fmt.Sprintf("deleting the marker object %q failed: %v", markerKey, err)
+	}
+
+	if _, err := ts.ClientContext(ctx).DeleteObject(ctx, &awss3.DeleteObjectInput{
+		Bucket: aws.String(ts.Bucket),
+		Key:    aws.String(childKey),
+	}); err != nil {
+		return false, fmt.Sprintf(
+			"after deleting the marker object %q, deleting %q failed: %v. The endpoint is treating the "+
+				"marker as the parent directory of the key beneath it rather than as an unrelated object, "+
+				"so removing it orphaned the child",
+			markerKey, childKey, err)
+	}
+
+	return true, ""
+}
+
+// RequireDirectoryMarkerDelete skips the test unless a "prefix/" marker can be deleted without
+// stranding the keys beneath it.
+//
+// Skipping rather than asserting, because there is nothing here to assert about ObjectFS: the endpoint
+// is refusing a delete that real S3 performs, so the operation under test cannot complete for a reason
+// that has nothing to do with whether it is implemented correctly. Asserting the failure would pin a
+// dependency's bug as expected behavior.
+func (ts *TestServer) RequireDirectoryMarkerDelete() {
+	ts.t.Helper()
+
+	if caps := ts.Capabilities(); !caps.DirectoryMarkerDelete {
+		ts.t.Skipf("the test endpoint cannot delete a directory marker object without stranding the "+
+			"keys beneath it: %s\n"+
+			"ObjectFS's Mkdir writes exactly such a marker, so any operation that empties a directory — "+
+			"rmdir of a tree, or the delete half of a directory rename — cannot complete against this "+
+			"endpoint. Real S3 has no such coupling: a key is an opaque string and \"dir/\" is not the "+
+			"parent of \"dir/a.txt\".\n"+
+			"Tracked upstream as scttfrdmn/substrate#534; rerun once the dependency includes the fix. "+
+			"The live integration suite covers this path against real S3.",
+			caps.DirectoryMarkerDeleteDetail)
+	}
+}
+
+// probeUploadPartCopy checks whether the endpoint implements UploadPartCopy — filling a part of a
+// multipart upload from a byte range of an existing object.
+//
+// It is the mechanism for copying an object above S3's 5 GiB single-part CopyObject limit, which is
+// the path rename(2) takes for a large file. The probe copies a 16-byte source in two 8-byte parts and
+// requires the assembled object to equal the source: that is what distinguishes a real part copy from
+// the failure mode below.
+//
+// The two parts are deliberately unequal in content, because the misrouting this catches is silent. An
+// endpoint that dispatches on x-amz-copy-source before checking uploadId handles each request as a
+// whole-object copy — returning 200 with a CopyPartResult the SDK accepts, ignoring
+// x-amz-copy-source-range, and recording no part. Only the assembled result reveals it.
+func (ts *TestServer) probeUploadPartCopy(ctx context.Context) (bool, string) {
+	ts.t.Helper()
+
+	const (
+		srcKey = ".objectfs-capability-probe-upc-src"
+		dstKey = ".objectfs-capability-probe-upc-dst"
+	)
+
+	body := []byte("ABCDEFGHIJKLMNOP")
+	ts.PutObjectContext(ctx, srcKey, body)
+
+	client := ts.ClientContext(ctx)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(ts.Bucket),
+		Key:    aws.String(dstKey),
+	})
+	if err != nil {
+		return false, fmt.Sprintf("CreateMultipartUpload failed: %v", err)
+	}
+
+	completed := false
+
+	// One deferred abort covering every way this probe can return, on the same reasoning as the code it
+	// probes: an upload left open holds billed parts that no object listing shows. Here the stakes are
+	// the harness's own credibility — MultipartUploads is how the H10 regression tests assert, so a
+	// probe leftover makes them fail while naming the wrong culprit. It did: the negative path below
+	// returns before Complete, which is exactly the shape H10 was.
+	defer func() {
+		if completed {
+			return
+		}
+
+		if _, abortErr := client.AbortMultipartUpload(ctx, &awss3.AbortMultipartUploadInput{
+			Bucket:   aws.String(ts.Bucket),
+			Key:      aws.String(dstKey),
+			UploadId: created.UploadId,
+		}); abortErr != nil {
+			ts.t.Errorf("the UploadPartCopy probe could not abort its own multipart upload %q: %v; "+
+				"tests that assert on ListMultipartUploads will now see it and blame the code under test",
+				aws.ToString(created.UploadId), abortErr)
+		}
+	}()
+
+	var parts []s3types.CompletedPart
+
+	for i, rng := range []string{"bytes=0-7", "bytes=8-15"} {
+		partNum := int32(i + 1) //nolint:gosec // 1 or 2
+
+		out, copyErr := client.UploadPartCopy(ctx, &awss3.UploadPartCopyInput{
+			Bucket:          aws.String(ts.Bucket),
+			Key:             aws.String(dstKey),
+			UploadId:        created.UploadId,
+			PartNumber:      aws.Int32(partNum),
+			CopySource:      aws.String(url.PathEscape(ts.Bucket + "/" + srcKey)),
+			CopySourceRange: aws.String(rng),
+		})
+		if copyErr != nil {
+			return false, fmt.Sprintf("UploadPartCopy(%s) failed: %v", rng, copyErr)
+		}
+
+		if out.CopyPartResult == nil {
+			return false, fmt.Sprintf("UploadPartCopy(%s) returned no CopyPartResult", rng)
+		}
+
+		parts = append(parts, s3types.CompletedPart{
+			ETag:       out.CopyPartResult.ETag,
+			PartNumber: aws.Int32(partNum),
+		})
+	}
+
+	// Two different byte ranges of the same object cannot have the same ETag. Equal ones mean each
+	// request copied the whole object, which is the misrouting this probe exists to catch — and it is
+	// worth naming separately from the Complete failure it causes, because the cause is not otherwise
+	// recoverable from "InvalidPart".
+	if len(parts) == 2 && aws.ToString(parts[0].ETag) == aws.ToString(parts[1].ETag) {
+		return false, fmt.Sprintf(
+			"two disjoint 8-byte ranges of a 16-byte object returned the same part ETag (%s); the "+
+				"endpoint is ignoring x-amz-copy-source-range and handling each UploadPartCopy as a "+
+				"whole-object CopyObject", aws.ToString(parts[0].ETag))
+	}
+
+	if _, err := client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
+		Bucket:          aws.String(ts.Bucket),
+		Key:             aws.String(dstKey),
+		UploadId:        created.UploadId,
+		MultipartUpload: &s3types.CompletedMultipartUpload{Parts: parts},
+	}); err != nil {
+		return false, fmt.Sprintf("CompleteMultipartUpload over two copied parts failed: %v", err)
+	}
+
+	// Only now: a completed upload no longer exists, so aborting it would fail rather than clean up.
+	completed = true
+
+	if got := ts.GetObjectContext(ctx, dstKey); !bytes.Equal(got, body) {
+		return false, fmt.Sprintf(
+			"an object assembled from two copied ranges holds %q, want %q",
+			truncate(string(got), 40), string(body))
+	}
+
+	return true, ""
+}
+
+// RequireUploadPartCopy skips the test unless the endpoint implements UploadPartCopy.
+//
+// Skipping rather than asserting, for the reason the other Require helpers give: against an endpoint
+// that misroutes the request, ObjectFS's multipart copy behaves correctly and still fails, so the test
+// cannot tell a broken copy path from a broken endpoint.
+func (ts *TestServer) RequireUploadPartCopy() {
+	ts.t.Helper()
+
+	if caps := ts.Capabilities(); !caps.UploadPartCopy {
+		ts.t.Skipf("the test endpoint does not implement UploadPartCopy, which is the only way to copy "+
+			"an object above S3's 5 GiB single-part CopyObject limit, so a multipart copy here fails "+
+			"regardless of whether ObjectFS's own path is correct: %s\n"+
+			"Tracked upstream as scttfrdmn/substrate#532; rerun once the dependency includes it.\n"+
+			"Real S3 implements it and the live integration suite covers this path.",
+			caps.UploadPartCopyDetail)
+	}
 }
 
 // probeMetadataReplace checks whether a self-copy with MetadataDirective=REPLACE actually replaces the

--- a/internal/vfs/writer.go
+++ b/internal/vfs/writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/scttfrdmn/objectfs/pkg/types"
@@ -539,6 +540,87 @@ func (w *Writer) Discard(key string) error {
 	delete(w.nodes, key)
 
 	return nil
+}
+
+// FlushPrefix makes every buffered key at or under prefix durable, and reports how many it flushed.
+//
+// It exists for rename. A rename is a server-side copy, which acts on objects — so a key whose only
+// content is dirty ranges in memory is invisible to it, and `echo hi > a; mv a b` would copy an object
+// that does not exist yet, then delete the source, then flush the pending ranges back to the *old*
+// key. The file would end up at neither name the user asked for and at the one they renamed away from.
+//
+// Flushing first is the fix rather than moving the pending ranges to the new key, because moving them
+// solves only half of it: a file can be part flushed and part dirty, so the copy needs the object to
+// hold everything before it runs. Making the write path durable up front means the copy sees the whole
+// file, which is also what makes a directory rename tractable — it is a prefix scan over objects, and
+// after this call there is nothing under the prefix that a listing would miss.
+//
+// The prefix is matched on a path boundary, not as a string prefix. "dir" must not match "dir2/f", and
+// treating it as a bare prefix is the defect keyMatches had in the cache layer. An empty prefix matches
+// every key, which is what a rename of the root would need and no caller asks for.
+func (w *Writer) FlushPrefix(ctx context.Context, prefix string) (int, error) {
+	w.mu.Lock()
+	keys := make([]string, 0, len(w.nodes))
+	for k := range w.nodes {
+		if underPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	w.mu.Unlock()
+
+	// Sorted so a failure reports a deterministic key. The map iteration order otherwise makes the
+	// error message differ run to run for the same fault, which is the kind of thing that turns a
+	// reproducible bug report into an unreproducible one.
+	sort.Strings(keys)
+
+	flushed := 0
+	for _, k := range keys {
+		if err := w.FlushContext(ctx, k); err != nil {
+			// Stopping at the first failure, unlike FlushAll. FlushAll is the unmount path, where every
+			// key not attempted is data lost for good, so it presses on. Here the caller is about to copy
+			// and then *delete* these keys, and continuing would hand it a namespace it believes is fully
+			// durable when one file is not — so the rename must not proceed.
+			return flushed, fmt.Errorf("flush %q before renaming %q: %w", k, prefix, err)
+		}
+		flushed++
+	}
+
+	return flushed, nil
+}
+
+// DiscardPrefix drops everything buffered at or under prefix without storing it.
+//
+// The delete-side counterpart to [Writer.FlushPrefix], on the reasoning [Writer.Discard] gives for a
+// single key: a rename's source keys are deleted, and a pending write surviving that delete is PUT back
+// by the next flush, resurrecting the file at the name it was moved away from. A directory rename needs
+// this over a prefix because it deletes a prefix.
+func (w *Writer) DiscardPrefix(prefix string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for k := range w.nodes {
+		if underPrefix(k, prefix) {
+			delete(w.nodes, k)
+		}
+	}
+}
+
+// underPrefix reports whether key is prefix itself or lies beneath it.
+//
+// The boundary check is the point. A bare strings.HasPrefix makes "dir" match "dir2/file", so renaming
+// dir would move dir2's contents — and that is not a hypothetical spelling mistake, it is exactly the
+// bug the cache's keyMatches had, found in the same audit.
+func underPrefix(key, prefix string) bool {
+	switch {
+	case prefix == "":
+		return true
+	case key == prefix:
+		return true
+	default:
+		trimmed := strings.TrimSuffix(prefix, "/")
+
+		return strings.HasPrefix(key, trimmed+"/")
+	}
 }
 
 // Size returns the total number of dirty bytes buffered across every key. It implements

--- a/internal/vfs/writer_test.go
+++ b/internal/vfs/writer_test.go
@@ -2077,3 +2077,252 @@ func TestSetAttrRejectsModeBitsOutsideThePermissionMask(t *testing.T) {
 			"escalation this filesystem cannot perform.", err)
 	}
 }
+
+// TestFlushPrefixMatchesOnAPathBoundary is the prefix rule a directory rename rests on.
+//
+// A bare strings.HasPrefix makes "dir" match "dir2/file", and the consequence is not a cosmetic
+// over-match: the caller flushes what the match returned and then *moves* it, so an unrelated sibling
+// tree ends up under the renamed directory. It is the same defect the cache's keyMatches had, found in
+// the same audit, which is why it is asserted here rather than trusted to read correctly.
+//
+// The three near misses are each a different way to be wrong. "dir2/c.txt" shares the prefix and
+// diverges at the boundary; "dirty.txt" shares it and continues into a longer name; "dir" itself is
+// the marker key, which must match, because a directory's own marker object is one of the things a
+// rename has to move.
+func TestFlushPrefixMatchesOnAPathBoundary(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+	ctx := context.Background()
+
+	under := []string{"dir/", "dir/a.txt", "dir/sub/b.txt"}
+	beside := []string{"dir2/c.txt", "dirty.txt", "other.txt"}
+
+	for _, key := range append(append([]string{}, under...), beside...) {
+		if err := w.Write(key, 0, []byte("pending")); err != nil {
+			t.Fatalf("Write(%q): %v", key, err)
+		}
+	}
+
+	flushed, err := w.FlushPrefix(ctx, "dir")
+	if err != nil {
+		t.Fatalf("FlushPrefix: %v", err)
+	}
+
+	if flushed != len(under) {
+		t.Errorf("FlushPrefix(%q) flushed %d keys, want %d. A bare string prefix match also takes %v, "+
+			"which a directory rename would then move under the new name",
+			"dir", flushed, len(under), beside)
+	}
+
+	for _, key := range under {
+		if _, ok := backend.Object(key); !ok {
+			t.Errorf("%q is under the flushed prefix and has no object, so a copy issued now would "+
+				"miss it and the rename would lose the file", key)
+		}
+		if w.Dirty(key) {
+			t.Errorf("%q is still dirty after being flushed; the pending range would be PUT back to "+
+				"the source name after the rename deleted it", key)
+		}
+	}
+
+	for _, key := range beside {
+		if _, ok := backend.Object(key); ok {
+			t.Errorf("%q was flushed by FlushPrefix(%q); its name merely starts with the same "+
+				"characters", key, "dir")
+		}
+		if !w.Dirty(key) {
+			t.Errorf("%q is no longer dirty, so FlushPrefix touched it", key)
+		}
+	}
+}
+
+// TestFlushPrefixStopsAtTheFirstFailure covers the half a mount cannot easily reach: what happens
+// when one key under the prefix will not flush.
+//
+// Stopping is the answer, and it is the opposite of FlushAll's. FlushAll runs at unmount, where a key
+// not attempted is data lost for good, so it presses on and reports at the end. Here the caller is
+// about to copy these keys and then *delete* them, so continuing would hand it a namespace it believes
+// is fully durable when one file is not — and the delete would then destroy the only copy of the
+// pending bytes.
+//
+// The error has to name the key, because a mount log is all an operator has: "rename failed" for a
+// directory of ten thousand objects is not a diagnosis.
+func TestFlushPrefixStopsAtTheFirstFailure(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+
+	for _, key := range []string{"tree/a.txt", "tree/b.txt"} {
+		if err := w.Write(key, 0, []byte("pending")); err != nil {
+			t.Fatalf("Write(%q): %v", key, err)
+		}
+	}
+
+	backend.putErr = errors.New("AccessDenied: not authorized to perform s3:PutObject")
+
+	flushed, err := w.FlushPrefix(context.Background(), "tree")
+	if err == nil {
+		t.Fatal("FlushPrefix reported success while a key under the prefix could not be stored. The " +
+			"caller copies and then deletes these keys, so this answer destroys the pending bytes.")
+	}
+
+	if !strings.Contains(err.Error(), "tree/a.txt") {
+		t.Errorf("error %q names no key. FlushPrefix visits keys in sorted order precisely so the "+
+			"report is reproducible; without the name an operator cannot find the file", err)
+	}
+	if !strings.Contains(err.Error(), "AccessDenied") {
+		t.Errorf("error %q does not carry the backend's reason, so the operator learns that a rename "+
+			"failed but not that their credentials are the problem", err)
+	}
+
+	if flushed != 0 {
+		t.Errorf("FlushPrefix reported %d flushed keys after failing on the first one", flushed)
+	}
+
+	if !w.Dirty("tree/a.txt") {
+		t.Error("the key that failed to flush is clean, so its pending write would be evicted as " +
+			"though it had been stored")
+	}
+}
+
+// TestDiscardPrefixMatchesOnAPathBoundary is the same boundary rule for the delete side.
+//
+// The stakes are higher here than in FlushPrefix. DiscardPrefix destroys data on purpose, so an
+// over-broad match does not merely move the wrong file — it drops writes the caller never asked to
+// drop, with no error anywhere and no way to notice until someone reads the file back.
+func TestDiscardPrefixMatchesOnAPathBoundary(t *testing.T) {
+	t.Parallel()
+
+	w, _ := newWriter(t)
+
+	under := []string{"keep/", "keep/a.txt", "keep/deep/b.txt"}
+	beside := []string{"keeper.txt", "keep2/c.txt"}
+
+	for _, key := range append(append([]string{}, under...), beside...) {
+		if err := w.Write(key, 0, []byte("pending")); err != nil {
+			t.Fatalf("Write(%q): %v", key, err)
+		}
+	}
+
+	w.DiscardPrefix("keep")
+
+	for _, key := range under {
+		if w.Dirty(key) {
+			t.Errorf("DiscardPrefix left %q dirty. A pending range outliving the delete is PUT back by "+
+				"the next flush, resurrecting the file at the name it was moved away from", key)
+		}
+	}
+
+	for _, key := range beside {
+		if !w.Dirty(key) {
+			t.Errorf("DiscardPrefix(%q) destroyed the pending writes for %q, whose name merely starts "+
+				"with the same characters. Those bytes are gone with no error anywhere", "keep", key)
+		}
+	}
+}
+
+// TestPrefixOperationsOnAnEmptyPrefixTakeEverything pins the root case.
+//
+// An empty prefix matching every key is what a rename of the mount root would need, and no caller asks
+// for it today. It is asserted because the alternative reading — an empty prefix matching nothing — is
+// equally defensible from the code and silently wrong in the direction that loses data: a root-level
+// operation would flush nothing, copy nothing, and delete everything.
+func TestPrefixOperationsOnAnEmptyPrefixTakeEverything(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+
+	keys := []string{"a.txt", "b/c.txt", "d/e/f.txt"}
+	for _, key := range keys {
+		if err := w.Write(key, 0, []byte("pending")); err != nil {
+			t.Fatalf("Write(%q): %v", key, err)
+		}
+	}
+
+	flushed, err := w.FlushPrefix(context.Background(), "")
+	if err != nil {
+		t.Fatalf("FlushPrefix(%q): %v", "", err)
+	}
+	if flushed != len(keys) {
+		t.Errorf("FlushPrefix(%q) flushed %d of %d keys", "", flushed, len(keys))
+	}
+	for _, key := range keys {
+		if _, ok := backend.Object(key); !ok {
+			t.Errorf("%q was not stored by a flush of the empty prefix", key)
+		}
+	}
+
+	for _, key := range keys {
+		if err := w.Write(key, 0, []byte("pending again")); err != nil {
+			t.Fatalf("Write(%q): %v", key, err)
+		}
+	}
+
+	w.DiscardPrefix("")
+
+	for _, key := range keys {
+		if w.Dirty(key) {
+			t.Errorf("DiscardPrefix(%q) left %q dirty", "", key)
+		}
+	}
+}
+
+// TestPrefixOperationsOnAnExactKeyTakeThatKey covers the case a file rename actually uses, and it is
+// the one the boundary tests above cannot reach.
+//
+// Renaming a single file passes that file's own key where these methods take a prefix — "a.txt", with
+// no trailing slash and nothing beneath it. So the key-equals-prefix arm is not an edge case, it is the
+// common path: every `mv f g` goes through it.
+//
+// It needs its own test because a key under a directory prefix satisfies *both* rules — "dir/a.txt"
+// matches "dir" on the boundary rule as well — so a directory test passes whether or not the equality
+// arm works. Deleting that arm leaves every directory rename correct and breaks every file rename: the
+// flush stores nothing, so the copy reads a key that is not there, and the discard drops nothing, so
+// the pending bytes are PUT back to the name the rename just deleted.
+func TestPrefixOperationsOnAnExactKeyTakeThatKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flush", func(t *testing.T) {
+		t.Parallel()
+
+		w, backend := newWriter(t)
+
+		if err := w.Write("a.txt", 0, []byte("pending")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+
+		flushed, err := w.FlushPrefix(context.Background(), "a.txt")
+		if err != nil {
+			t.Fatalf("FlushPrefix: %v", err)
+		}
+
+		if flushed != 1 {
+			t.Errorf("FlushPrefix(%q) flushed %d keys, want 1. This is the path every single-file "+
+				"rename takes, and flushing nothing means the server-side copy that follows reads a key "+
+				"the write path has not stored yet", "a.txt", flushed)
+		}
+		if _, ok := backend.Object("a.txt"); !ok {
+			t.Error("the file was not stored, so a copy issued now would fail and the rename would " +
+				"report ENOENT for a file the user can see")
+		}
+	})
+
+	t.Run("discard", func(t *testing.T) {
+		t.Parallel()
+
+		w, _ := newWriter(t)
+
+		if err := w.Write("a.txt", 0, []byte("pending")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+
+		w.DiscardPrefix("a.txt")
+
+		if w.Dirty("a.txt") {
+			t.Error("DiscardPrefix left the exact key dirty. A rename deletes the source after copying " +
+				"it, so a surviving pending range is PUT back to the old name by the next flush — the " +
+				"file returning from the dead at the name it was moved away from, with no error anywhere")
+		}
+	})
+}

--- a/internal/vfs/writer_test.go
+++ b/internal/vfs/writer_test.go
@@ -45,6 +45,12 @@ type fakeBackend struct {
 	// setMetaErr fails SetObjectMetadata, which is the attribute-only write path.
 	setMetaErr error
 
+	// copyErr and deleteErr fail CopyObject and DeleteObject. Rename is a copy then a delete, and the
+	// two failures are not interchangeable: a failed copy leaves the source alone, while a failed delete
+	// after a successful copy leaves the file at both paths.
+	copyErr   error
+	deleteErr error
+
 	// setMetaSilentlyIgnores makes SetObjectMetadata return success and store nothing. This is not a
 	// hypothetical: S3 has no metadata-update operation, so the real implementation is a self-copy with
 	// MetadataDirective=REPLACE, and an endpoint that does not implement the directive answers 200 while
@@ -223,11 +229,48 @@ func (f *fakeBackend) HeadObject(_ context.Context, key string) (*types.ObjectIn
 	}, nil
 }
 
+// CopyObject moves the metadata with the bytes. A fake that copied only the content would let a rename
+// pass while the destination came back with default attributes — or, for a compressed object, with no
+// Content-Encoding and so unreadable. That is audit finding L26, and a fake that cannot express it
+// cannot catch it.
+//
+// copyErr, when set, fails the copy: rename has to be able to tell a failed copy from a failed delete,
+// because the two leave the filesystem in different states.
+func (f *fakeBackend) CopyObject(_ context.Context, src, dst string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.record("CopyObject(%q -> %q)", src, dst)
+	if f.copyErr != nil {
+		return f.copyErr
+	}
+
+	data, ok := f.objects[src]
+	if !ok {
+		return errNotFound
+	}
+
+	f.objects[dst] = append([]byte(nil), data...)
+	f.meta[dst] = copyMetaMap(f.meta[src])
+	return nil
+}
+
 func (f *fakeBackend) DeleteObject(_ context.Context, key string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.record("DeleteObject(%q)", key)
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
 	delete(f.objects, key)
 	return nil
+}
+
+// copyMetaMap returns a copy of m, so the source and destination of a copy do not share a map.
+func copyMetaMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	maps.Copy(out, m)
+	return out
 }
 
 func (f *fakeBackend) GetObjects(context.Context, []string) (map[string][]byte, error) {

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -37,6 +37,26 @@ type Backend interface {
 	// header here would turn a chmod on a compressed object into an unreadable file.
 	SetObjectMetadata(ctx context.Context, key string, meta map[string]string) error
 
+	// CopyObject copies src to dst without transferring the object's bytes through this process,
+	// preserving user metadata, content encoding, content type, and storage class. An existing dst is
+	// replaced. A src that does not exist is an error a caller can classify as absence.
+	//
+	// It exists for rename. S3 has no rename for general-purpose buckets, so `mv` is a copy followed by
+	// a delete, and the copy must be server-side: reading and rewriting through the client would turn
+	// renaming a 10 GiB file into 20 GiB of transfer, and renaming a directory into that times the
+	// number of objects under it.
+	//
+	// Every property named above must survive, for the reason spelled out on SetObjectMetadata: the read
+	// path dispatches decoding on the stored Content-Encoding and fails closed on one it cannot handle,
+	// so a copy that dropped the header would make a compressed object permanently unreadable — and one
+	// that dropped the storage class would silently promote the object to STANDARD, billing the user for
+	// a tier they did not choose. That is not hypothetical here; it is audit finding L26, observed on the
+	// tier-transition path.
+	//
+	// Implementations must not treat this as atomic with respect to anything. It is one copy of one
+	// object, and callers renaming a prefix are looping.
+	CopyObject(ctx context.Context, src, dst string) error
+
 	DeleteObject(ctx context.Context, key string) error
 	HeadObject(ctx context.Context, key string) (*ObjectInfo, error)
 

--- a/pkg/types/interfaces_test.go
+++ b/pkg/types/interfaces_test.go
@@ -37,6 +37,10 @@ func (m *mockBackend) SetObjectMetadata(ctx context.Context, key string, meta ma
 	return nil
 }
 
+func (m *mockBackend) CopyObject(ctx context.Context, src, dst string) error {
+	return nil
+}
+
 func (m *mockBackend) DeleteObject(ctx context.Context, key string) error {
 	return nil
 }

--- a/tests/fuse_test.go
+++ b/tests/fuse_test.go
@@ -127,6 +127,23 @@ func (b *MockBackend) ListObjects(ctx context.Context, prefix string, maxKeys in
 	return objects, nil
 }
 
+// CopyObject copies the bytes and the metadata together, which is the property rename depends on: the
+// stored mode, ownership, and content encoding have to arrive at the destination or the renamed file
+// comes back with a different mode, or — if it was compressed — unreadable.
+func (b *MockBackend) CopyObject(ctx context.Context, src, dst string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	data, exists := b.objects[src]
+	if !exists {
+		return os.ErrNotExist
+	}
+
+	b.objects[dst] = append([]byte(nil), data...)
+	b.meta[dst] = copyMeta(b.meta[src])
+	return nil
+}
+
 func (b *MockBackend) DeleteObject(ctx context.Context, key string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/tests/posix_test.go
+++ b/tests/posix_test.go
@@ -461,6 +461,23 @@ func (m *MockBackend) SetObjectMetadata(ctx context.Context, key string, meta ma
 	return nil
 }
 
+// CopyObject copies the bytes and the metadata together, which is the property rename depends on: the
+// stored mode, ownership, and content encoding have to arrive at the destination or the renamed file
+// comes back with a different mode, or — if it was compressed — unreadable.
+func (m *MockBackend) CopyObject(ctx context.Context, src, dst string) error {
+	data, exists := m.files[src]
+	if !exists {
+		return os.ErrNotExist
+	}
+
+	m.files[dst] = append([]byte(nil), data...)
+	if m.meta == nil {
+		m.meta = make(map[string]map[string]string)
+	}
+	m.meta[dst] = copyMeta(m.meta[src])
+	return nil
+}
+
 func (m *MockBackend) DeleteObject(ctx context.Context, key string) error {
 	delete(m.files, key)
 	return nil

--- a/tests/predictive_cache_test.go
+++ b/tests/predictive_cache_test.go
@@ -5,6 +5,7 @@ import (
 	cryptoRand "crypto/rand"
 	"fmt"
 	"math/rand"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -69,6 +70,22 @@ func (m *MockPredictiveBackend) SetObjectMetadata(ctx context.Context, key strin
 		return fmt.Errorf("object not found: %s", key)
 	}
 	m.meta[key] = copyMeta(meta)
+	return nil
+}
+
+// CopyObject copies the bytes and the metadata together, as rename requires: the destination has to
+// arrive with the source's mode, ownership, and content encoding.
+func (m *MockPredictiveBackend) CopyObject(ctx context.Context, src, dst string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	data, exists := m.objects[src]
+	if !exists {
+		return os.ErrNotExist
+	}
+
+	m.objects[dst] = append([]byte(nil), data...)
+	m.meta[dst] = copyMeta(m.meta[src])
 	return nil
 }
 


### PR DESCRIPTION
Closes #164.

Rename is a server-side copy then a delete, per object; a directory moves everything under its
prefix. Before this, go-fuse's default for an absent `NodeRenamer` answered every `mv` with `ENOTSUP`.

## What is load-bearing

Six properties, each verified by mutation — the implementation broken in that specific way, the test
watched to fail. 11 mutants, 10 killed on the first pass; the 11th survived, was diagnosed as a
genuinely vacuous assertion, and the test was repaired until it discriminated.

| | Property | What goes wrong without it |
|---|---|---|
| 1 | Each source is deleted only after **its own** copy succeeds | An interruption would be able to leave the data at *neither* name. Duplicated data is cleanup; missing data is not recoverable |
| 2 | The copy is server-side | Renaming a 10 GiB file would cost 20 GiB of transfer; a directory, that times its object count. Above S3's 5 GiB single-part limit it routes through `UploadPartCopy` |
| 3 | The write path is flushed before the copy | A copy acts on objects, so dirty ranges are invisible to it. `echo hi > a; mv a b` would copy a key that does not exist, delete the source, then flush the pending ranges back to the **old** name — the file at neither name asked for |
| 4 | The moved node is repointed, recursively for a directory | `MvChild` re-parents the *same* inode, so a stored path is stale the moment a rename succeeds. After `mv a b`, a write to `b` flushed to `a` and **recreated the source the rename had just deleted**. Silent at every layer: a stale key is a valid key and every S3 call succeeds |
| 5 | Prefix matching is on a path boundary | `mv dir dir-new` would move `dir2/file`. Not hypothetical — the same defect `keyMatches` had |
| 6 | `renameat2` flags are refused with `EINVAL` | `RENAME_EXCHANGE` and `RENAME_NOREPLACE` are atomicity promises copy-then-delete cannot keep. `mv` and Git fall back correctly on `EINVAL`. A foreign `newParent` is `EXDEV`, as go-fuse's own `LoopbackNode` answers |

There is no atomic alternative to reach for. S3's `RenameObject` (2026) is directory-bucket (Express)
only, and object annotations — which ObjectFS needs for POSIX attributes — are unsupported on
directory buckets, so the two features are mutually exclusive. The README now carries a **Rename is
not atomic** section stating what a concurrent reader can observe, what an interruption leaves
behind, and which tools that breaks.

## Also here, each found while building the above

- **`chmod` and automatic tier transitions failed on every key containing a `+`.**
  `x-amz-copy-source` is read by S3 as a URL path; `url.PathEscape` leaves `+` alone and S3 decodes
  `+` there as a space — so a self-copy of `a+b.txt` asked for `a b.txt` and got `404 NoSuchKey`. A
  `+` in a filename is ordinary: version numbers, C++ sources, `2026-08-01T00:00+00:00`. Escaping now
  lives in one place rather than open-coded at each call site, one of which escaped nothing at all.
  Verified against real S3 in `us-west-2` — both `PathEscape` and `EscapedPath()` fail, `%2B`
  succeeds, and every other character `PathEscape` passes through was probed on the same endpoint.
- **`objectfs stats` reported zero for six counters that were maintained correctly all along.**
  `GetStats` copies field by field and its list named nine of fifteen: `Creates`, `Deletes`,
  `Renames`, and the three latency EMAs. Guarded now by a reflection test that sets each counter to a
  **distinct** non-zero value, so a copy taking the right field from the wrong source fails too.
  `time.Duration`'s reflect kind is `Int64`, which is how the three latency fields were found.
- **The README listed `unlink` and `rmdir` as `EROFS` and said `mv` fails "because there is no
  rename".** Both true when written. A row asserting an operation fails misleads in the worse
  direction once it works: a reader avoids something that would have succeeded. Rename's departure
  from that table is pinned from the other side too — a test asserts the bridge *dispatches* to
  `Rename` rather than reaching go-fuse's `ENOTSUP` default, which a drifted signature or an
  excluding build tag would silently restore.
- **`internal/testaws` grew a `DirectoryMarkerDelete` probe and a skip gate.** Deleting a `dir/`
  marker while `dir/child` exists panics the emulator, whose object store is a filesystem
  abstraction where `dir/` is the *directory* holding the child — filed as
  [scttfrdmn/substrate#534](https://github.com/scttfrdmn/substrate/issues/534), reproduced against
  afero alone with no substrate involved. In S3 a key is an opaque string, so this is the emulator's
  property and not ObjectFS's. Hence a runtime probe and a loud skip rather than asserting a
  dependency's bug as this project's contract.
- **`copy_live_test.go` (`-tags=integration`) covers the multipart copy path against real AWS**, at
  real part sizes. Substrate dispatches on `x-amz-copy-source` before checking `uploadId`, so it
  answers an `UploadPartCopy` as a whole-object copy with 200 (substrate#532) — leaving the branch
  where a mistake is most expensive, since abandoned parts are billed and invisible to
  `ListObjects`, resting on nothing but reading.

## Testing

15 tests in `internal/fuse/rename_test.go`, against a real S3 endpoint through `internal/testaws`,
with the real write path and real cache — no mock on any seam, which is the point: the v0.10.0 audit
found ~45 defects that 32,680 lines of tests had all missed, overwhelmingly because a mock on the far
side of a seam agrees with its caller by construction.

```
go build ./... && go test -race ./...                      # green
gofmt -l internal/ pkg/ cmd/ tests/                        # clean
go vet ./...                                               # clean
golangci-lint run --new-from-merge-base=origin/main        # 0 issues
```