### PR TITLE
v0.11.0 phase A: the docs outside the README stop describing the pre-rename filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   asserts the bridge *dispatches* to `Rename` rather than reaching go-fuse's `ENOTSUP` default, which
   is what a drifted signature or a build tag excluding `rename.go` would silently restore.
 
+- **Eight documents outside the README described the pre-rename filesystem, and four of them told
+  users an operation fails that works** ([#162]). `docs/architecture/overview.md` listed `unlink`,
+  `rmdir`, and `rename` as unimplemented and said `rm` returns `EROFS`; `docs-platform/guide/`
+  told users `mv` fails with `ENOTSUP` "because there is no rename"; the playground's benchmark
+  script worked around `rm` by shelling out to `aws s3 rm`. Every one was an accurate description of
+  v0.10.3 being read by users of a version where those operations work — understating rather than
+  overstating, which is friendlier and still wrong, because it sends people to build workarounds for
+  a problem that is fixed.
+
+  Two mechanical gates now cover the class, because it has gone stale twice in the same place
+  (`internal/config/docs_posix_test.go`):
+  - **No document may state an operation count.** Eight files said "roughly 10 of ~40 VFS operations
+    are implemented", each having copied it from the audit that measured it once; six operations
+    landed across three releases and not one sentence changed. This is the version-constant problem
+    exactly — one number, many copies, no way for a copy to learn it is wrong — so it gets the same
+    answer: say a subset is implemented and point at the table. `CHANGELOG.md` is exempt, with the
+    reason recorded in the code: a released section is an immutable record of what that release did,
+    and editing its counts to match today would falsify the record.
+  - **The README's "Not implemented" table may not name an operation whose go-fuse interface
+    `internal/fuse` asserts.** It reads the `_ fs.NodeUnlinker = (*DirectoryNode)(nil)` assertions
+    rather than the method set, because the assertion is what makes support real — go-fuse probes each
+    interface with a type assertion and substitutes a default when it is absent, and for `Unlink` and
+    `Rmdir` that default is *success*. A method with a drifted signature compiles and is silently
+    never called; the assertion is what fails.
+
+  The tempting third gate — flag any line pairing an implemented operation with a refusal errno,
+  repo-wide — was written, measured, and rejected: ten hits, of which eight are changelog entries
+  correctly describing past releases. A gate whose output is 80% false gets deleted. Both surviving
+  gates were verified by mutation, and the first one's word list is written out in full because a
+  first draft with `ten|twenty|thirty|forty` passed on "sixteen of forty VFS operations" — a narrow
+  pattern that passes is indistinguishable from a correct repository.
+
+- `internal/filesystem/interface.go` says what it is: a design sketch with **no importers anywhere in
+  the tree**, whose only implementation is its own test mock. It reads like a capability list — it
+  declares `Rename`, `Truncate`, `Chmod`, `Chown`, `Link`, `Symlink`, `Readlink`, four xattr methods,
+  and `Statfs` — and a reader taking a method there as evidence of support would be wrong about
+  several. That is not hypothetical: `internal/vfs`'s `FileType` comment already records this
+  interface advertising `Symlink` and `Link` with nothing behind them as what went wrong in v0.10.0.
+  Kept rather than deleted because the multi-protocol work it sketches is tracked ([#181]) and this is
+  the record of its original shape.
+
 - **`write_buffer.max_memory` is enforced.** It was declared in the config schema, defaulted to
   `"512MB"`, validated as a size string, and read by nothing ([#205]) — so every mount since the key
   appeared reported a write-buffer ceiling and enforced none, on the one path that holds user data in
@@ -144,8 +185,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   succeeds and that the resulting object is whole, so a lossy reclaim fails rather than passing
   quietly.
 
+[#162]: https://github.com/scttfrdmn/objectfs/issues/162
 [#163]: https://github.com/scttfrdmn/objectfs/issues/163
 [#164]: https://github.com/scttfrdmn/objectfs/issues/164
+[#181]: https://github.com/scttfrdmn/objectfs/issues/181
 [#205]: https://github.com/scttfrdmn/objectfs/issues/205
 
 ## [0.10.3] - 2026-08-02

--- a/OBJECTFS.md
+++ b/OBJECTFS.md
@@ -18,8 +18,10 @@
 >   exactly this reason.
 > - **"POSIX-compliant" was wrong** and is corrected in the body rather than only noted here — a
 >   banner a reader may skip is weaker than a sentence that no longer makes the claim. ObjectFS
->   presents a POSIX interface over object storage. There is no rename, no links, no locking. See the
->   README's supported-operations table.
+>   presents a POSIX interface over object storage. There are no hard links and no cross-host
+>   locking, and `rename` works but is not atomic. See the README's supported-operations table,
+>   which is the authority; this line named the missing operations and went stale the moment three
+>   of them landed.
 > - **The performance and coverage figures are aspirations**, including a "95%" coverage badge and a
 >   "10-100x" speedup, neither of which was measured.
 >

--- a/docs-platform/guide/getting-started.md
+++ b/docs-platform/guide/getting-started.md
@@ -138,16 +138,22 @@ cp /path/to/local/file.txt /mnt/objectfs/
 mkdir /mnt/objectfs/my-folder
 ```
 
-Two operations this section used to show do **not** work, and fail loudly rather than silently:
+`mv` and `rm` work now, and both have a caveat worth knowing before you rely on them:
 
 ```bash
-mv /mnt/objectfs/old.txt /mnt/objectfs/new.txt   # ENOTSUP — there is no rename
-rm /mnt/objectfs/unwanted-file.txt               # EROFS   — delete is not implemented
+mv /mnt/objectfs/old.txt /mnt/objectfs/new.txt   # works — but not atomically
+rm /mnt/objectfs/unwanted-file.txt               # works — deletes the object
 ```
 
-`rm` returning an error is deliberate. go-fuse defaults an unimplemented `Unlink` to *success*, so
-without the refusal `rm` would exit 0 while the object survived in S3 — the user believes the file is
-gone and it is still there and still billing. The
+A rename is a server-side copy followed by a delete, because S3 has no atomic rename to use. So a
+concurrent reader can briefly see both names, and an interruption leaves the data at the old name,
+the new one, or both — never at neither, since each source is deleted only after its own copy
+succeeds. Anything that depends on rename being atomic, such as the write-temp-then-rename idiom,
+is not safe here between concurrent writers.
+
+Earlier releases refused both operations: `mv` returned `ENOTSUP` and `rm` returned `EROFS`. The
+`rm` refusal was deliberate rather than an oversight — go-fuse defaults an unimplemented `Unlink`
+to *success*, so without it `rm` exited 0 while the object survived in S3. The
 [supported-operations table](https://github.com/scttfrdmn/objectfs#supported-operations) is the
 authority on which operations are in which state.
 

--- a/docs-platform/guide/index.md
+++ b/docs-platform/guide/index.md
@@ -1,9 +1,9 @@
 # Introduction to ObjectFS
 
 ObjectFS presents a POSIX *interface* over AWS S3 using FUSE, so ordinary tools can read and write
-objects as files. It is **not** a POSIX-compliant filesystem — roughly 10 of ~40 VFS operations are
-implemented, and the gap is structural rather than incidental: S3 has no rename, no hard links, and
-no partial write. The
+objects as files. It is **not** a POSIX-compliant filesystem — a subset of the POSIX surface is
+implemented, and the gap is structural rather than incidental: S3 has no *atomic* rename, no hard
+links, and no partial object write. The
 [supported-operations table](https://github.com/scttfrdmn/objectfs/blob/main/README.md) is the
 authority for what works, what fails by design, and which tools are known not to work. Check it
 before pointing a workload here.
@@ -13,12 +13,12 @@ before pointing a workload here.
 ObjectFS uses FUSE (Filesystem in Userspace) to mount S3 buckets as local directories. This means
 you can:
 
-- **Use standard file operations** — `ls`, `cat`, `cp`, and redirection. Not `mv`: there is no
-  `rename`, and it returns `ENOTSUP`
+- **Use standard file operations** — `ls`, `cat`, `cp`, `rm`, `mkdir`, `rmdir`, `mv`, and redirection
 - **Access datasets stored in S3** as if they were local files, without downloading them first
-- **Run applications that read and write whole files.** Applications needing rename, hard links,
-  extended attributes, or byte-range locking will not work — `git`, `sqlite3`, and `tar -x` are
-  known not to
+- **Run applications that read and write whole files.** Applications needing *atomic* rename, hard
+  links, extended attributes, or byte-range locking will not work — `git` and `sqlite3` are known
+  not to. `mv` works, but as a server-side copy followed by a delete, so it is not atomic and the
+  write-temp-then-rename idiom is not safe between concurrent writers
 
 ## Key Features
 

--- a/docs-platform/playground/index.md
+++ b/docs-platform/playground/index.md
@@ -237,9 +237,8 @@ for cache_size in "1GB" "4GB" "8GB" "16GB"; do
     sync
     time dd if=/mnt/test/testfile of=/dev/null bs=1M 2>/dev/null
 
-    # Cleanup. rm returns EROFS on a mount today, so remove the object at the
-    # source; unmount by signalling the process, which flushes on the way out.
-    aws s3 rm s3://benchmark-bucket/testfile
+    # Cleanup. Unmount by signalling the process, which flushes on the way out.
+    rm /mnt/test/testfile
     kill -TERM "$objectfs_pid"
     wait "$objectfs_pid" 2>/dev/null
 

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -13,9 +13,10 @@ These principles guide every architectural and implementation decision in Object
 ### What This Means
 
 - ✅ **A POSIX interface**: applications call `open`/`read`/`write` and get a filesystem, with no
-  ObjectFS-specific API. Not full POSIX compliance — this said "Full POSIX compliance" against ten
-  of roughly forty VFS operations, and the operations that are missing or refused are in the
-  [README's supported-operations table](../README.md#supported-operations). The principle is that
+  ObjectFS-specific API. Not full POSIX compliance — this said "Full POSIX compliance" against a
+  fraction of the VFS surface, and the operations that are missing or refused are in the
+  [README's supported-operations table](../README.md#supported-operations), which is the authority
+  on the count as well as the list. The principle is that
   ObjectFS does not ask applications to change; where S3 cannot support an operation, the aim is to
   fail loudly rather than to appear compliant
 - ✅ **No API changes required**: Existing code works unmodified

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -6,9 +6,12 @@
 
 This is a vision document: it describes what ObjectFS is *for*, not what it currently does. Where the
 two differ, the [README's supported-operations table](../README.md#supported-operations) is the
-authority. In particular, "POSIX-compliant" appeared three times below and is gone from all three:
-ObjectFS implements roughly ten of forty VFS operations, has no rename and no links, and full
-compliance is not reachable over an object store rather than merely unfinished.
+authority — and it is the authority for the count as well as the list. "POSIX-compliant" appeared
+three times below and is gone from all three, but the sentence that replaced it went on to state a
+fraction of the VFS surface as a number, which went stale the moment `unlink`, `rmdir`, and `rename`
+landed. What does not go stale is the reason: full POSIX compliance is unreachable over an object
+store, not merely unfinished, because S3 has no atomic rename, no hard links, and no partial object
+write.
 
 We exist to eliminate the friction between cloud object storage and traditional filesystem-based workflows, enabling researchers and engineers to access petabytes of data as naturally as local files.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -160,14 +160,22 @@ interface that applications interact with.
 [supported-operations table in the README](../../README.md#supported-filesystem-operations), derived
 from the methods that exist in `internal/fuse` and `internal/vfs`.
 
-Summarised: read, write at any offset, truncate, flush/fsync, stat, create, mkdir, paginated
-readdir, chmod/chown on files, and statfs are implemented. **`unlink`, `rmdir`, `rename`, symlinks,
-xattrs, `mknod`, `fallocate`, and locking are not**, and each fails rather than silently doing
-nothing — `rm` returns `EROFS` rather than reporting a delete that did not happen.
+Summarised: read, write at any offset, truncate, flush/fsync, stat, create, mkdir, paginated readdir,
+chmod/chown on files, statfs, `unlink`, `rmdir`, and `rename` are implemented. **Symlinks, xattrs,
+`mknod`, `fallocate`, hard links, and locking are not**, and each fails rather than silently doing
+nothing.
 
-This list previously named `Rename()`, `Link()`, and `Symlink()` as supported. None of the three
-exists, and `Rmdir` and `Unlink` exist only as loud refusals. That gap is what the README table now
-pins, and it is checked against the code rather than against intent.
+Two entries need their caveat stated here rather than only in the table. `rename` is a server-side
+copy followed by a delete, per object, so it is **not atomic** and `renameat2`'s `RENAME_EXCHANGE`
+and `RENAME_NOREPLACE` are refused with `EINVAL` rather than approximated. Hard links are not
+"not yet" — S3 has no concept of two names for one object, so they will never be supported.
+
+This summary has been wrong in both directions, which is why it now points at the table first. It
+once named `Rename()`, `Link()`, and `Symlink()` as supported when none of the three existed; it was
+then corrected to say `unlink`, `rmdir`, and `rename` were unimplemented and that `rm` returned
+`EROFS`, and stayed that way after all three landed. A prose summary of a table is a second copy of
+the same facts, so it can only ever be as fresh as its last edit — the table is derived from the
+methods in `internal/fuse` and `internal/vfs` and is the thing to trust.
 
 ### 2. Cache Layer
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ ObjectFS transforms S3-compatible object storage into a high-performance filesys
 ## Overview
 
 ObjectFS is a FUSE filesystem for Linux and macOS that presents a POSIX interface over S3-compatible
-object storage. It is **not** a POSIX-compliant filesystem: roughly 10 of ~40 VFS operations are
-implemented, and several others fail by design rather than silently doing the wrong thing. The
+object storage. It is **not** a POSIX-compliant filesystem — a subset of the POSIX surface is
+implemented, and several operations fail by design rather than silently doing the wrong thing. The
 [supported-operations table in the README](https://github.com/scttfrdmn/objectfs#supported-operations)
 is the authority on what works, what errors, and which tools are known not to work.
 

--- a/internal/config/docs_posix_test.go
+++ b/internal/config/docs_posix_test.go
@@ -1,0 +1,330 @@
+// The supported-operations table is a contract, and these are the two ways it has actually gone
+// stale — both mechanically checkable, so neither should get a third turn.
+//
+// This is the fifth documentation gate, alongside docs_test.go (config YAML, version claims),
+// docs_links_test.go (link targets), docs_symbols_test.go (Go symbols, CLI invocations), and
+// changelog_test.go. Same reasoning as all of them: prose has no mechanism for noticing it is stale,
+// so the only thing that can notice is a test.
+//
+// # What went wrong twice
+//
+// **A restated operation count.** Eight documents said "roughly 10 of ~40 VFS operations are
+// implemented", each having copied it from the audit that measured it once. It was true when
+// written and false the moment Setattr, Statfs, Fsync, Unlink, Rmdir, and Rename landed — six
+// operations in three releases, and not one of the eight sentences changed. This is the version
+// constant problem exactly (see version_test.go): one number, many copies, no way for a copy to
+// learn it is wrong.
+//
+// **A refusal that is no longer refused.** `docs/architecture/overview.md` said `unlink`, `rmdir`,
+// and `rename` were unimplemented and that `rm` returned `EROFS`; `docs-platform` told users `mv`
+// fails with `ENOTSUP` "because there is no rename"; the playground worked around `rm` by shelling
+// out to `aws s3 rm`. All three were accurate descriptions of v0.10.3 being read by users of a
+// version where `rm` and `mv` work. Understating is friendlier than overstating, but it is still
+// wrong, and it sends people to build workarounds for a problem that is fixed.
+//
+// # Why the second gate is scoped to the README's own table
+//
+// The tempting check is repo-wide: flag any line pairing an implemented operation with a refusal
+// errno. It was written and measured before being rejected — it produces ten hits of which eight
+// are CHANGELOG entries correctly describing what a past release did, and one is the
+// getting-started note that deliberately records the old behavior so a user on an older build is
+// not confused. A gate whose output is 80% false is a gate someone deletes.
+//
+// So the check is narrow and load-bearing instead: the README's own "Not implemented" table may not
+// name an operation whose go-fuse interface `internal/fuse` demonstrably implements. That table is
+// the authority every other document defers to, so it is the one place where being wrong propagates
+// — and it is the row that was actually stale.
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// vfsOperationCounts matches a claim about how many VFS operations exist or are implemented.
+//
+// Both spellings the repository used, because it used both: the digit form from the audit
+// ("roughly 10 of ~40 VFS operations") and the word form someone typed when rephrasing it ("ten of
+// forty VFS operations"). A pattern that caught only the first would have passed docs/VISION.md,
+// which is the point version_test.go's comment makes about a narrow regexp being indistinguishable
+// from a clean repository.
+//
+// Scoped to the phrase "VFS operations" / "POSIX operations" rather than to bare numbers. "10 of
+// 40" on its own appears in benchmark tables and issue references; it is the claim about the
+// operation *surface* that has no business being a hardcoded number.
+// The word list is written out in full rather than abbreviated to the ones the repository happened to
+// contain. A first draft had "ten|twenty|thirty|forty" and passed on "sixteen of forty VFS
+// operations", which is exactly the trap version_test.go's comment describes: a narrow pattern that
+// passes is indistinguishable from a correct repository. The mutation was run, it survived, and this
+// is the fix.
+const numberWord = `(?:one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|` +
+	`fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|` +
+	`eighty|ninety|hundred)`
+
+const countHedge = `(?:roughly|about|approximately|around|some|nearly|only)?\s*`
+
+var vfsOperationCounts = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b` + countHedge + `~?\d+\s+of\s+` + countHedge + `~?\d+\s+` +
+		`(?:VFS|POSIX|filesystem)\s+operations`),
+	regexp.MustCompile(`(?i)\b` + countHedge + numberWord + `\s+of\s+` + countHedge +
+		numberWord + `\s+(?:VFS|POSIX|filesystem)\s+operations`),
+}
+
+// countExemptDocs are files where a count is a historical record rather than a claim about now.
+//
+// One entry, and it is not a loophole. A changelog entry says what a *past release* did, and Keep a
+// Changelog's whole premise is that released sections are immutable — "ten of roughly forty VFS
+// operations" in the v0.10.1 section is the measurement that motivated the work in that release, and
+// it stays true about that release forever. Editing it to match today's surface would falsify the
+// record, which is worse than the staleness this test exists to prevent.
+//
+// The distinction is the same one version_test.go draws between a plan and a claim: a document may
+// discuss numbers freely, and what it may not do is assert one about the present. A changelog only
+// ever talks about the past.
+//
+// Do not add a file here because it currently fails. An entry has to name a file whose counts are
+// historical *by construction*; anything else belongs fixed.
+var countExemptDocs = map[string]string{
+	"CHANGELOG.md": "released sections are an immutable record of what each release changed; the " +
+		"counts in them are measurements of the moment that release was cut and stay true about it",
+}
+
+// TestNoDocumentCountsTheImplementedOperations pins the same single-source rule the version has.
+//
+// A document may say the surface is a subset, may say which operations are missing, and may point at
+// the README's table. What it may not do is assert a count, because a count is a measurement with a
+// timestamp it cannot carry.
+//
+// The README's table is exempt in the sense that it does not state a count at all — it lists rows, so
+// it is its own answer and cannot disagree with itself.
+func TestNoDocumentCountsTheImplementedOperations(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range markdownFiles(t) {
+		rel := shortName(t, path)
+
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+
+			if reason, exempt := countExemptDocs[rel]; exempt {
+				t.Skipf("exempt: %s", reason)
+			}
+
+			body, err := os.ReadFile(path) //nolint:gosec // a path from a walk of this repository
+			if err != nil {
+				t.Fatalf("reading %s: %v", rel, err)
+			}
+
+			for i, line := range strings.Split(string(body), "\n") {
+				for _, pattern := range vfsOperationCounts {
+					if match := pattern.FindString(line); match != "" {
+						t.Errorf(`%s:%d states an operation count: %q
+
+A number here is a measurement of one moment. Six operations landed between v0.10.1 and v0.11.0 —
+Setattr, Statfs, Fsync, Unlink, Rmdir, Rename — and eight documents went on reporting the count from
+before them, because a sentence cannot notice that it is stale.
+
+Say that a subset is implemented and point at the supported-operations table in README.md, which is
+derived from the methods that exist in internal/fuse and internal/vfs.`,
+							rel, i+1, match)
+					}
+				}
+			}
+		})
+	}
+}
+
+// implementedNodeInterfaces are the go-fuse node interfaces whose presence in internal/fuse means an
+// operation is supported outright, mapped to how the README's table names it.
+//
+// Only interfaces where support is *total*. Three are deliberately absent, and the reason is the
+// same in each case — the interface is implemented but some cases within it are not, so its presence
+// proves less than this gate would conclude:
+//
+//   - NodeSetattrer: chmod/chown work on files and return ENOTSUP on directories (#165), because a
+//     directory marker could carry the mode but Getattr does not read it back. The README correctly
+//     lists the directory case under "Not implemented" while listing the file case under
+//     "Implemented", and a gate keyed on the interface alone would call that a contradiction.
+//   - NodeFsyncer: fsync on a file is durable; on a directory it succeeds and does nothing, which is
+//     under "Errors by design" rather than "Not implemented".
+//   - NodeGetattrer / NodeLookuper / NodeOpener / NodeReaddirer / NodeCreater: nothing in the
+//     not-implemented table could plausibly name them, so including them buys no coverage.
+//
+// The value is the string the README row would have to contain. Matching is on the whole row, so a
+// row reading "Unlink | unlink, rm | ..." matches on "unlink" wherever in the row it appears.
+var implementedNodeInterfaces = map[string]string{
+	"NodeUnlinker": "unlink",
+	"NodeRmdirer":  "rmdir",
+	"NodeRenamer":  "rename",
+	"NodeMkdirer":  "mkdir",
+	"NodeStatfser": "statfs",
+}
+
+// nodeAssertion matches a compile-time interface assertion, `_ fs.NodeUnlinker = (*DirectoryNode)(nil)`.
+//
+// Reading the assertions rather than the method set is deliberate. The assertions are what make the
+// support real: go-fuse probes each interface with a type assertion and substitutes a default when it
+// is absent, and three of those defaults are harmful — mode 0000 for a missing Getattr under
+// NullPermissions, a zeroed statfs, and *success* for a missing Unlink or Rmdir. A method with a
+// typo'd signature compiles fine and is silently never called; the assertion is what fails. So the
+// assertion block is both the proof of support and the thing this gate should trust.
+var nodeAssertion = regexp.MustCompile(`_\s+fs\.(Node\w+)\s+=`)
+
+// TestReadmeDoesNotListAnImplementedOperationAsMissing checks the table against the code.
+//
+// The stale rows this catches were real: after Unlink and Rmdir landed, the README's not-implemented
+// table still carried `unlink` and `rmdir` as EROFS, and the tools-that-do-not-work list still said
+// `mv` fails with ENOTSUP because there is no rename. All three were caught by hand, late, while
+// writing the rename documentation — which is to say by luck.
+func TestReadmeDoesNotListAnImplementedOperationAsMissing(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	implemented := assertedNodeInterfaces(t, filepath.Join(root, "internal", "fuse"))
+
+	if len(implemented) == 0 {
+		t.Fatal("found no fs.Node* assertions in internal/fuse, and an empty set passes every " +
+			"assertion below; the assertion block in attributes.go is what this reads")
+	}
+
+	//nolint:gosec // a path built from the module root this test located itself
+	body, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatalf("reading README.md, which holds the authoritative operations table: %v", err)
+	}
+
+	rows := notImplementedRows(string(body))
+	if len(rows) == 0 {
+		t.Fatal(`found no rows under README.md's "### Not implemented" heading. Either the heading was
+renamed — in which case fix notImplementedRows, since the table is what every other document defers
+to — or the table is empty, which would be a surprising thing to have happened silently.`)
+	}
+
+	for iface, token := range implementedNodeInterfaces {
+		if !implemented[iface] {
+			continue
+		}
+
+		for _, row := range rows {
+			if !strings.Contains(strings.ToLower(row.text), token) {
+				continue
+			}
+
+			t.Errorf(`README.md:%d lists %q as not implemented, but internal/fuse asserts fs.%s:
+
+  %s
+
+The assertion is what makes the operation real — go-fuse substitutes a default for an absent
+interface, and for Unlink and Rmdir that default is *success*. So if the assertion is there, the
+operation works and the row is stale.
+
+Move it to the "Implemented" table with whatever caveat it needs. If the operation is only partly
+supported, the row belongs under "Implemented" or "Errors by design" with the unsupported case
+named — see how chmod/chown on a directory is split, and add the interface to the documented
+exclusions in implementedNodeInterfaces.`,
+				row.line, token, iface, strings.TrimSpace(row.text))
+		}
+	}
+}
+
+// tableRow is one markdown table row: its 1-based line number in the file, and its text.
+type tableRow struct {
+	line int
+	text string
+}
+
+// notImplementedRows returns the table rows under README.md's "### Not implemented" heading.
+//
+// Bounded by the next heading of any level, so it cannot bleed into "Tools known not to work" below
+// it. Header and separator rows are dropped: `|---|---|` would match any token asked about it, and a
+// gate that always fires is a gate that gets deleted.
+func notImplementedRows(markdown string) []tableRow {
+	var (
+		rows    []tableRow
+		inTable bool
+	)
+
+	for i, line := range strings.Split(markdown, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "#") {
+			// Enter on the heading itself, leave on the next one whatever its level.
+			inTable = strings.EqualFold(trimmed, "### Not implemented")
+
+			continue
+		}
+
+		if !inTable || !strings.HasPrefix(trimmed, "|") {
+			continue
+		}
+
+		// The separator, `|---|---|` in any spacing, and the header row.
+		//
+		// The header is identified by its first cell being "Operation" rather than by any later
+		// column name. The second column's heading is the British spelling of "behavior", which the
+		// misspell linter rejects in Go source while the README is entitled to keep — so matching on
+		// it would mean carrying a nolint for a string this test only needs in order to skip a row.
+		// Keying on the first cell also survives a column being renamed.
+		if strings.Trim(trimmed, "|-: ") == "" || firstCell(trimmed) == "operation" {
+			continue
+		}
+
+		rows = append(rows, tableRow{line: i + 1, text: trimmed})
+	}
+
+	return rows
+}
+
+// firstCell returns a table row's first cell, lowercased and trimmed of markdown emphasis.
+//
+// `| **Operation** |` and `| Operation |` both answer "operation", so a header row stays recognized
+// if someone bolds it.
+func firstCell(row string) string {
+	cells := strings.Split(strings.Trim(row, "|"), "|")
+	if len(cells) == 0 {
+		return ""
+	}
+
+	return strings.ToLower(strings.Trim(cells[0], " *`_"))
+}
+
+// assertedNodeInterfaces returns the set of go-fuse node interfaces asserted anywhere under dir.
+//
+// Across the whole package rather than one file, because the assertions are deliberately not
+// centralized: NodeRenamer is asserted in rename.go next to the code that implements it, with a
+// comment explaining that its absence is why every release through v0.10.3 answered ENOTSUP. That
+// placement is right, and a gate that only read attributes.go would have missed rename entirely —
+// which is the operation whose documentation was most wrong.
+func assertedNodeInterfaces(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+
+	found := make(map[string]bool)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") ||
+			strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+
+		//nolint:gosec // a path from a directory read of this repository
+		body, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", entry.Name(), err)
+		}
+
+		for _, match := range nodeAssertion.FindAllStringSubmatch(string(body), -1) {
+			found[match[1]] = true
+		}
+	}
+
+	return found
+}

--- a/internal/filesystem/interface.go
+++ b/internal/filesystem/interface.go
@@ -1,7 +1,27 @@
-// Package filesystem defines the common interface that all protocol handlers use
-// to interact with the ObjectFS backend. This abstraction allows FUSE, SMB, NFS,
-// and other protocols to share the same S3 backend, cost optimization, and
-// enterprise pricing features without code duplication.
+// Package filesystem declares a protocol-agnostic filesystem interface that nothing implements.
+//
+// # This is a design sketch, not a working contract
+//
+// The intent was for FUSE, SMB, and NFS handlers to share one backend abstraction. That has not
+// happened and this package is not on the way there: it has **no importers anywhere in the tree**,
+// and [FilesystemInterface]'s only implementation is `mockFilesystem` in this package's own test.
+// The live path is `internal/fuse` → `internal/vfs` → `pkg/types.Backend`, which owes nothing to
+// anything here.
+//
+// The distinction matters because this file reads like a capability list. It declares Rename,
+// Truncate, Chmod, Chown, Link, Symlink, Readlink, four xattr methods, and Statfs — and a reader
+// who takes a method here as evidence of support will be wrong about several of them. Symlinks,
+// hard links, and xattrs are not implemented at all, and hard links never will be: S3 has no
+// concept of two names for one object. See [internal/vfs.FileType], whose comment records that
+// this interface advertising Symlink and Link with no implementation behind them is precisely what
+// went wrong in v0.10.0.
+//
+// The supported-operations table in README.md is the authority, and it is derived from the methods
+// that exist in `internal/fuse` and `internal/vfs`. Do not infer support from this file.
+//
+// Kept rather than deleted because the multi-protocol work it sketches is tracked (#181) and this
+// records the original shape of it. If that work starts, this interface is a starting point to
+// argue with — not a contract to fill in.
 package filesystem
 
 import (
@@ -11,9 +31,10 @@ import (
 	"time"
 )
 
-// FilesystemInterface defines the common operations that all protocol handlers
-// need to perform. This interface abstracts away the specific S3 backend
-// implementation and allows multiple protocols to operate on the same data.
+// FilesystemInterface is the operation set a protocol handler would implement.
+//
+// Nothing implements it except this package's test mock, and the presence of a method here says
+// nothing about whether the operation works on a mount. See the package comment.
 type FilesystemInterface interface {
 	// File operations
 	Open(ctx context.Context, path string, flags int) (FileHandle, error)


### PR DESCRIPTION
Closes #162.

#164 landed `mv` and rewrote the README's supported-operations table around it. Eight other documents were still describing v0.10.3, and four of them told users an operation fails that works:

| file | said |
|---|---|
| `docs/architecture/overview.md` | `unlink`, `rmdir`, `rename` unimplemented; "`rm` returns `EROFS`" |
| `docs-platform/guide/index.md` | "Not `mv`: there is no `rename`, and it returns `ENOTSUP`" |
| `docs-platform/guide/getting-started.md` | a fenced block showing `mv` → `ENOTSUP` and `rm` → `EROFS` |
| `docs-platform/playground/index.md` | benchmark cleanup shelling out to `aws s3 rm` because "rm returns EROFS on a mount today" |

Understating is friendlier than overstating and still wrong: it sends people to build workarounds for a problem that is fixed. The other four restated an operation *count* — "roughly 10 of ~40 VFS operations" — which is the version-constant problem in a different costume.

## The two gates

`internal/config/docs_posix_test.go`, joining the four documentation gates already in that package.

**No document may state an operation count.** Eight files carried the number, each having copied it from the audit that measured it once. Six operations landed across three releases (`Setattr`, `Statfs`, `Fsync`, `Unlink`, `Rmdir`, `Rename`) and not one sentence changed, because a sentence has no way to learn it is stale. Same answer as the version constant: one authority, and a test that fails when a second appears.

`CHANGELOG.md` is exempt, and the reason is in the code rather than in an ignore list — a released section is an immutable record of what that release changed, so the count in the v0.10.1 section stays true about v0.10.1 forever. Editing it to match today would falsify the record, which is worse than the staleness the gate prevents.

**The README's "Not implemented" table may not name an operation whose go-fuse interface `internal/fuse` asserts.** It reads the `_ fs.NodeUnlinker = (*DirectoryNode)(nil)` block rather than the method set, because the assertion is what makes support real: go-fuse probes each interface with a type assertion and substitutes a default when it is absent, and for `Unlink` and `Rmdir` that default is *success*. A method with a drifted signature compiles fine and is silently never called; the assertion is what fails.

Three interfaces are deliberately excluded, with the reason on each: `NodeSetattrer` (chmod/chown work on files, `ENOTSUP` on directories per #165), `NodeFsyncer` (durable on a file, no-op on a directory), and the ones no not-implemented row could plausibly name.

## What was rejected

A third gate: flag any line pairing an implemented operation with a refusal errno, repo-wide. Written, measured, rejected — ten hits, of which eight are changelog entries correctly describing what a past release did and one is a deliberate note about older builds. A gate whose output is 80% false is a gate someone deletes.

## Verification

Both gates verified by mutation, and **one mutant survived the first pass**: the word list had `ten|twenty|thirty|forty` and passed on "sixteen of forty VFS operations" — exactly the trap `version_test.go`'s comment describes, where a narrow pattern that passes is indistinguishable from a correct repository. The list is written out in full now, and four phrasings were re-run against it.

Reading the whole `internal/fuse` package rather than `attributes.go` alone is also load-bearing, proven the same way: excluding `rename.go` from the scan let a `Rename / move | ENOTSUP` row through. `NodeRenamer` is asserted next to the code that implements it, which is the right place for it — and it is the operation whose documentation was most wrong.

Also: `internal/filesystem/interface.go` now says what it is (#162's last unmet acceptance criterion). It has **no importers anywhere in the tree** and its only implementation is its own test mock, while declaring `Rename`, `Truncate`, `Chmod`, `Chown`, `Link`, `Symlink`, `Readlink`, four xattr methods, and `Statfs`. That is not a hypothetical risk: `internal/vfs`'s `FileType` comment already records this interface advertising `Symlink` and `Link` with nothing behind them as what went wrong in v0.10.0.