### PR TITLE
fix: a tier's billing minimum is not a reason to refuse a write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A mount on `STANDARD_IA`, `ONEZONE_IA`, or `GLACIER_IR` could not create anything at all.**
+  `mkdir` and `touch` both failed, and so did writing any file smaller than 128 KiB ([#154]). AWS's
+  per-tier minimum object size is a *billing* floor — S3 stores a zero-byte `STANDARD_IA` object and
+  bills it as 128 KiB — but `TierValidator.ValidateWrite` enforced it as though S3 would reject the
+  write, and it is called before anything else in `PutObject`. Both of the ways this filesystem
+  brings a name into existence go under that floor: `Mkdir` writes a zero-byte marker object so an
+  empty directory is distinguishable from a prefix that never existed, and a `Create` followed by a
+  small write flushes a small object. So the three tiers most of the cost documentation recommends
+  were the three a filesystem could not be used on, and an IA-tier integration test could not get
+  past its own setup.
+
+  It is a warning now, naming the size written alongside the size that will be billed — which is the
+  actionable fact, since a tier that bills every object as 128 KiB is more expensive than `STANDARD`
+  for a workload of small files, and nothing downstream would have mentioned it. What still refuses
+  a write is `tier_constraints.min_object_size`: an operator who sets that has asked for a floor that
+  is not AWS's, and a policy someone chose is the only kind worth enforcing. Note the consequence of
+  the split, which is tested rather than left to be rediscovered — setting that key to the tier's own
+  published minimum reinstates exactly the old gate, zero-byte directory markers included.
+
+  The gate is enforced two layers below the operation that trips it, so it is pinned at both: the
+  validator's own tests assert a zero-byte write is accepted *and* that the billing warning carries
+  both numbers, and a test in `internal/fuse` drives real `Mkdir` and `Create` calls against a real
+  endpoint on every tier that has a minimum, reading the tier list from `StorageTiers` so a class
+  that gains one later is covered without editing the test. Only the second layer establishes that a
+  `mkdir` is a zero-byte PUT, which is the step that turned a billing gate into an unusable mount.
 - **`chmod` and automatic tier transitions worked on every key except the ones containing a `+`.**
   `x-amz-copy-source` is read by S3 as a URL path, and `url.PathEscape` leaves `+` as itself while S3
   decodes `+` in that header as a space — so a self-copy of `a+b.txt` asked for `a b.txt` and came
@@ -185,6 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   succeeds and that the resulting object is whole, so a lossy reclaim fails rather than passing
   quietly.
 
+[#154]: https://github.com/scttfrdmn/objectfs/issues/154
 [#162]: https://github.com/scttfrdmn/objectfs/issues/162
 [#163]: https://github.com/scttfrdmn/objectfs/issues/163
 [#164]: https://github.com/scttfrdmn/objectfs/issues/164

--- a/docs/features/compression.md
+++ b/docs/features/compression.md
@@ -155,9 +155,12 @@ minimum for `GLACIER` and `DEEP_ARCHIVE` and a 128 KB minimum for `INTELLIGENT_T
 AWS publishes. Corrected in [#229](https://github.com/scttfrdmn/objectfs/issues/229), which gave the
 40 KB and the 128 KB fields named for what they are — `PerObjectOverheadBytes` and
 `MonitoringEligibilityBytes` — and pinned all eight classes against the AWS pages linked above in
-`TestTierSizeThresholdsMatchWhatAWSPublishes`. That the table is a *write gate* rather than a billing
-hint remains its own defect ([#154](https://github.com/scttfrdmn/objectfs/issues/154)). The AWS pages
-are the authority, not this page and not that table.
+`TestTierSizeThresholdsMatchWhatAWSPublishes`. The minimum is also no longer a *write gate*: through
+v0.11.0 a write below a tier's minimum was refused, which is not what a billing floor is, and it made
+`mkdir` and `touch` fail on all three of those classes because both create a zero-byte object. It
+warns now, naming the written size and the size that will be billed
+([#154](https://github.com/scttfrdmn/objectfs/issues/154)). The AWS pages are the authority, not this
+page and not that table.
 
 ---
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -489,10 +489,13 @@ func (a *Adapter) buildS3Config() *s3.Config {
 	// TierConstraints, CostOptimization, PricingConfig and the credential fields are deliberately
 	// left at their zero values, and each for its own reason rather than by omission:
 	//
-	//   - TierConstraints overrides a tier's built-in minimum size and deletion embargo. Those come
-	//     from StorageTiers, which is derived from what AWS actually enforces; a config file that
-	//     could raise or lower them has no correct value to hold, and lowering one produces writes
-	//     S3 rejects.
+	//   - TierConstraints is a policy floor, not a description of S3. Its MinObjectSize is the one
+	//     value in the struct that still refuses a write, and it refuses writes S3 would accept —
+	//     AWS's per-tier minimum is a billing floor, so a smaller object is stored and billed as the
+	//     minimum (see TierValidator.ValidateWrite). Mapping it from a config file would mean a mount
+	//     could be given a floor above zero by default, and a floor above zero rejects the zero-byte
+	//     PUTs that create directories and empty files. If it is ever mapped, it has to stay opt-in
+	//     and unset by default, and the deletion embargo needs the same care for the same reason.
 	//
 	//   - CostOptimization is not mappable. internal/config.S3CostOptimization and
 	//     s3.CostOptimization are disjoint types — {Enabled, TieringEnabled, LifecycleEnabled,

--- a/internal/fuse/tier_min_size_test.go
+++ b/internal/fuse/tier_min_size_test.go
@@ -1,0 +1,153 @@
+//go:build linux || darwin
+
+package fuse
+
+// A mount on a tier with a minimum billable object size has to be able to create things.
+//
+// AWS publishes a 128 KiB minimum billable size for STANDARD_IA, ONEZONE_IA, and GLACIER_IR. It is a
+// pricing floor — S3 stores a zero-byte object on those classes and bills it as 128 KiB — but
+// `TierValidator.ValidateWrite` enforced it as though S3 would refuse the write. Both of the ways
+// this filesystem brings a name into existence PUT zero bytes: `Mkdir` writes an empty marker object
+// immediately, and `Create` records attributes that flush as an empty object. So on any of those
+// three tiers, `mkdir` and `touch` both failed, and nothing on the mount could be created (#154).
+//
+// This lives in internal/fuse rather than beside the validator's own tests because the validator
+// cannot see the sizes its callers pass. `internal/storage/s3` tests assert that a zero-byte write is
+// accepted; only this layer establishes that zero bytes is what a mkdir actually sends, which is the
+// step that turned a billing gate into an unusable filesystem.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	"github.com/scttfrdmn/objectfs/internal/storage/s3"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// TestMountOnATierWithABillingMinimumCanCreate runs mkdir and touch on every tier that has a
+// minimum billable size, reading the list from StorageTiers so a tier that gains one later is
+// covered without editing this test.
+func TestMountOnATierWithABillingMinimumCanCreate(t *testing.T) {
+	t.Parallel()
+
+	var tiers []string
+
+	for tier, info := range s3.StorageTiers {
+		if info.MinObjectSize > 0 {
+			tiers = append(tiers, tier)
+		}
+	}
+
+	if len(tiers) == 0 {
+		t.Fatal("no tier in s3.StorageTiers has a MinObjectSize, so this test asserts nothing")
+	}
+
+	for _, tier := range tiers {
+		t.Run(tier, func(t *testing.T) {
+			t.Parallel()
+
+			srv := testaws.Start(t)
+			backend := srv.Backend(func(cfg *s3.Config) {
+				cfg.StorageTier = tier
+				// Compression off: it changes the stored length, so leaving it on would mean a pass could
+				// come from a body that happened to land above the minimum rather than from the gate.
+				cfg.Compression.Enabled = false
+				cfg.EnableCargoShipOptimization = false
+			})
+
+			ctx := context.Background()
+
+			writer, err := vfs.NewWriter(ctx, backend)
+			if err != nil {
+				t.Fatalf("vfs.NewWriter: %v", err)
+			}
+
+			byteCache := cache.NewLRUCache(&cache.CacheConfig{
+				MaxSize:    16 << 20,
+				MaxEntries: 10000,
+				TTL:        time.Hour,
+			})
+			t.Cleanup(func() { _ = byteCache.Close() })
+
+			filesystem := NewFileSystem(backend, byteCache, writer, nil, &Config{
+				DefaultMode:    0o644,
+				DefaultDirMode: 0o755,
+				DefaultUID:     1000,
+				DefaultGID:     1000,
+			})
+
+			root, ok := filesystem.Root().(*DirectoryNode)
+			if !ok {
+				t.Fatalf("FileSystem.Root returned %T, want *DirectoryNode", filesystem.Root())
+			}
+
+			// The bridge, because Mkdir and Create both call NewInode through it and a node with no
+			// bridge panics on the first child.
+			timeout := filesystem.attrTimeout()
+			_ = gofuse.NewNodeFS(root, &gofuse.Options{
+				AttrTimeout:     &timeout,
+				EntryTimeout:    &timeout,
+				NullPermissions: true,
+			})
+
+			// mkdir: a zero-byte marker object, PUT synchronously.
+			var mkdirOut fuse.EntryOut
+			if _, errno := root.Mkdir(ctx, "data", 0o755, &mkdirOut); errno != 0 {
+				t.Fatalf("mkdir on storage_tier %q returned %v.\nThe directory marker is a zero-byte "+
+					"PUT and %q has a %d-byte minimum billable size — which AWS bills against, not "+
+					"validates against. A mount that cannot mkdir cannot be used at all",
+					tier, errno, tier, s3.StorageTiers[tier].MinObjectSize)
+			}
+
+			if !srv.ObjectExists("data/") {
+				t.Errorf("mkdir on %q reported success and wrote no marker object; an empty prefix is "+
+					"indistinguishable from one that was never created", tier)
+			}
+
+			// create: attributes recorded now, no PUT. So the tier gate is reached at flush rather than
+			// here, which means a create that reports success is not yet evidence the file can land.
+			var createOut fuse.EntryOut
+
+			_, _, _, errno := root.Create(ctx, "small.txt", 0, 0o644, &createOut)
+			if errno != 0 {
+				t.Fatalf("create on storage_tier %q returned %v", tier, errno)
+			}
+
+			// A body far below the minimum, because that is the size the gate refused and the size a
+			// research workload has thousands of.
+			//
+			// Nine bytes rather than zero, and the difference is a property of the write path rather
+			// than of this tier: a file created and never written flushes through the attribute-only
+			// path, which finds no object to carry the metadata and deliberately stores nothing
+			// (see Flusher.attemptAttrOnly). So `touch f` alone cannot exercise a write gate at all —
+			// the first flush with content is what reaches it.
+			const body = "9 bytes!!"
+
+			if err := filesystem.buffer.Write("small.txt", 0, []byte(body)); err != nil {
+				t.Fatalf("buffered write on storage_tier %q: %v", tier, err)
+			}
+
+			if err := filesystem.buffer.FlushAll(); err != nil {
+				t.Fatalf("flushing a %d-byte file on storage_tier %q: %v.\n%q has a %d-byte minimum "+
+					"billable size, which AWS bills against rather than validates against — S3 accepts "+
+					"this PUT. Refusing it here loses the write at close(2)",
+					len(body), tier, err, tier, s3.StorageTiers[tier].MinObjectSize)
+			}
+
+			if !srv.ObjectExists("small.txt") {
+				t.Fatalf("the flush on %q reported success and no object exists", tier)
+			}
+
+			if got := srv.ObjectSize("small.txt"); got != int64(len(body)) {
+				t.Errorf("the flushed file is %d bytes, want %d; the write has to actually be below the "+
+					"minimum for this test to exercise the gate", got, len(body))
+			}
+		})
+	}
+}

--- a/internal/storage/s3/metadata_listing_test.go
+++ b/internal/storage/s3/metadata_listing_test.go
@@ -195,8 +195,9 @@ func TestSetObjectMetadataPreservesStorageClass(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	// Above STANDARD_IA's 128 KiB billing minimum, which the tier's own ValidateWrite enforces on the
-	// way in — a smaller object is refused before there is any metadata to preserve.
+	// Above STANDARD_IA's 128 KiB billing minimum, so the write is not one ValidateWrite warns about.
+	// The size is not load-bearing since #154 — a smaller object is stored, not refused — but keeping
+	// it above the minimum keeps the log clean and the test about metadata.
 	const (
 		key  = "attrs/tiered"
 		size = 192 * 1024

--- a/internal/storage/s3/storage_tier_seam_test.go
+++ b/internal/storage/s3/storage_tier_seam_test.go
@@ -4,7 +4,7 @@ package s3_test
 // is the stored object.
 //
 // Every layer between the config and S3 agrees on the tier by construction: ValidateWrite enforces the
-// tier's minimum size, the logs name the tier, and ConvertTierToStorageClass has a unit test asserting
+// tier's minimum-size warning names the tier, the logs name the tier, and ConvertTierToStorageClass has a unit test asserting
 // it maps STANDARD_IA to STANDARD_IA. All of that passed while the upload path stored a different class
 // entirely, because the class the object is written with is chosen inside the CargoShip transporter
 // from a config built alongside — not from the value those layers agree about. A tier defect is silent
@@ -60,7 +60,9 @@ func TestConfiguredStorageTierReachesTheStoredObject(t *testing.T) {
 			ts := testaws.Start(t)
 			ctx := context.Background()
 
-			// 192 KiB clears the 128 KiB billing minimum the IA tiers enforce on the way in.
+			// 192 KiB clears the 128 KiB billing minimum the IA tiers warn about on the way in. Not
+			// required since #154 — a smaller object is stored and billed as the minimum rather than
+			// refused — but this test is about the storage class, not about the warning.
 			const size = 192 * 1024
 
 			for _, path := range []struct {

--- a/internal/storage/s3/tier_min_size_test.go
+++ b/internal/storage/s3/tier_min_size_test.go
@@ -1,0 +1,200 @@
+package s3
+
+// The tier minimum-size gate, which used to refuse writes AWS accepts.
+//
+// AWS publishes a 128 KiB minimum billable object size for STANDARD_IA, ONEZONE_IA, and GLACIER_IR.
+// It is a pricing floor: S3 stores a 1-byte object on those classes and bills it as 128 KiB. It has
+// never been an API restriction. `ValidateWrite` enforced it as one, and `internal/fuse` creates
+// both directory markers and empty files by PUTting zero bytes — so a mount on any of those three
+// tiers could not create anything at all, and an IA-tier integration test could not even set itself
+// up (#154).
+//
+// These tests assert the two halves of the new contract separately, because they have to be able to
+// disagree: AWS's floor warns, and an operator's explicitly configured floor still refuses.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// logRecord is one slog line, decoded far enough to read the fields the warning promises.
+type logRecord struct {
+	Level      string `json:"level"`
+	Msg        string `json:"msg"`
+	Size       *int64 `json:"size"`
+	BilledSize *int64 `json:"billed_size"`
+	Tier       string `json:"tier"`
+	Key        string `json:"key"`
+}
+
+// captureValidator returns a validator whose log output is readable, so the warning can be asserted
+// on rather than assumed. A test that only checks the error is nil cannot tell "warned about the
+// billing" from "said nothing", and saying nothing is the failure mode that matters here: the write
+// succeeds either way, and the operator finds out from an invoice.
+func captureValidator(t *testing.T, tier string, constraints TierConstraints) (*TierValidator, func() []logRecord) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	return NewTierValidator(tier, constraints, logger), func() []logRecord {
+		t.Helper()
+
+		var out []logRecord
+
+		dec := json.NewDecoder(strings.NewReader(buf.String()))
+		for {
+			var rec logRecord
+			if err := dec.Decode(&rec); err != nil {
+				if err == io.EOF {
+					break
+				}
+
+				t.Fatalf("decoding captured log output: %v\nraw:\n%s", err, buf.String())
+			}
+
+			out = append(out, rec)
+		}
+
+		return out
+	}
+}
+
+// TestBillingMinimumDoesNotRefuseTheWrite is the defect itself: the sizes a FUSE mount actually
+// PUTs, on the tiers that have a minimum.
+func TestBillingMinimumDoesNotRefuseTheWrite(t *testing.T) {
+	t.Parallel()
+
+	// Every tier with a non-zero MinObjectSize, read from StorageTiers rather than listed, so a tier
+	// that gains a minimum later is covered without editing this test.
+	var tiers []string
+
+	for tier, info := range StorageTiers {
+		if info.MinObjectSize > 0 {
+			tiers = append(tiers, tier)
+		}
+	}
+
+	if len(tiers) == 0 {
+		t.Fatal("no tier in StorageTiers has a MinObjectSize, so this test asserts nothing; if the " +
+			"field was removed, remove this test with it rather than leaving it passing vacuously")
+	}
+
+	// Zero is the size that broke the filesystem — Mkdir and Create both PUT an empty body. The
+	// others are the small-file sizes a research workload has plenty of.
+	sizes := []int64{0, 1, 4096, 40 * 1024}
+
+	for _, tier := range tiers {
+		for _, size := range sizes {
+			t.Run(tier, func(t *testing.T) {
+				t.Parallel()
+
+				validator, logs := captureValidator(t, tier, TierConstraints{})
+
+				if err := validator.ValidateWrite("dir/", size); err != nil {
+					t.Fatalf("ValidateWrite(%d bytes) on %s = %v, want nil.\nAWS's %d-byte minimum is a "+
+						"billing floor, not an API restriction — S3 accepts this write. Refusing it means "+
+						"mkdir and touch fail on this tier, since both PUT zero bytes",
+						size, tier, err, StorageTiers[tier].MinObjectSize)
+				}
+
+				// The warning has to carry both numbers, because the actionable fact is the gap between
+				// them. "object is small" is not a reason to change anything; "48 bytes will be billed as
+				// 131072" is.
+				var warned bool
+
+				for _, rec := range logs() {
+					if rec.Level != "WARN" || rec.BilledSize == nil || rec.Size == nil {
+						continue
+					}
+
+					if *rec.BilledSize != StorageTiers[tier].MinObjectSize {
+						continue
+					}
+
+					if *rec.Size != size {
+						t.Errorf("the billing warning reported size=%d for a %d-byte write", *rec.Size, size)
+					}
+
+					if rec.Tier != tier {
+						t.Errorf("the billing warning reported tier=%q, want %q", rec.Tier, tier)
+					}
+
+					if rec.Key != "dir/" {
+						t.Errorf("the billing warning reported key=%q, want %q", rec.Key, "dir/")
+					}
+
+					warned = true
+				}
+
+				if !warned {
+					t.Errorf("a %d-byte write to %s was accepted with no billing warning naming both the "+
+						"written size and the %d bytes it is billed as.\nAccepting the write silently is "+
+						"the other half of this defect: the operator pays the minimum for every small "+
+						"object and the first report of it is the bill.\nCaptured records: %+v",
+						size, tier, StorageTiers[tier].MinObjectSize, logs())
+				}
+			})
+		}
+	}
+}
+
+// TestConfiguredMinimumStillRefusesTheWrite is the half that must not have been relaxed. An operator
+// who sets tier_constraints.min_object_size has asked for a floor that is not AWS's; that is a
+// deliberate policy and the only kind worth enforcing.
+func TestConfiguredMinimumStillRefusesTheWrite(t *testing.T) {
+	t.Parallel()
+
+	const configured = 256 * 1024
+
+	// STANDARD deliberately: it has no minimum of its own, so a refusal here can only have come from
+	// the constraint. Asserting this on STANDARD_IA would pass even if the code were reading the
+	// tier's 128 KiB and ignoring the constraint entirely.
+	validator, _ := captureValidator(t, TierStandard, TierConstraints{MinObjectSize: configured})
+
+	err := validator.ValidateWrite("small.bin", 128*1024)
+	if err == nil {
+		t.Fatal("ValidateWrite accepted a 128 KiB write under a configured 256 KiB minimum on " +
+			"STANDARD, a tier with no minimum of its own; the operator's floor is not being read")
+	}
+
+	// The message has to say whose rule this is. A refusal that reads as an S3 limitation sends the
+	// operator to the AWS documentation, where they will find that S3 accepts the write.
+	for _, want := range []string{"configured minimum", "min_object_size", "ObjectFS policy"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not contain %q, so it does not distinguish itself from an S3 "+
+				"limit the operator would go looking for in the AWS docs: %v", want, err)
+		}
+	}
+
+	if err := validator.ValidateWrite("big.bin", configured); err != nil {
+		t.Errorf("ValidateWrite at exactly the configured minimum = %v, want nil; the floor is "+
+			"inclusive", err)
+	}
+}
+
+// TestConfiguringTheTierMinimumRestoresTheOldBehavior records the sharp edge the split leaves, so
+// that it is a documented consequence rather than a surprise. Setting the constraint to the tier's
+// own published number is a way to reinstate exactly the gate #154 removed, zero-byte directory
+// markers included.
+func TestConfiguringTheTierMinimumRestoresTheOldBehavior(t *testing.T) {
+	t.Parallel()
+
+	info := StorageTiers[TierStandardIA]
+	if info.MinObjectSize == 0 {
+		t.Skip("STANDARD_IA no longer has a minimum billable size")
+	}
+
+	validator, _ := captureValidator(t, TierStandardIA, TierConstraints{MinObjectSize: info.MinObjectSize})
+
+	if err := validator.ValidateWrite("dir/", 0); err == nil {
+		t.Error("setting tier_constraints.min_object_size to STANDARD_IA's own 128 KiB did not refuse " +
+			"a zero-byte write.\nIt should: that is an explicit operator policy and enforcing it is " +
+			"the point. This test exists so that the consequence — mkdir and touch fail again under " +
+			"that setting — stays a known, tested property rather than a rediscovered bug")
+	}
+}

--- a/internal/storage/s3/tier_test.go
+++ b/internal/storage/s3/tier_test.go
@@ -284,10 +284,15 @@ func TestTierValidator(t *testing.T) {
 	t.Run("Standard-IA Tier Validation", func(t *testing.T) {
 		validator := NewTierValidator(TierStandardIA, TierConstraints{}, logger)
 
-		// Should reject small objects
-		err := validator.ValidateWrite("small.txt", 1024) // 1KB < 128KB minimum
-		if err == nil {
-			t.Error("Standard-IA tier should reject objects smaller than 128KB")
+		// Allowed, and this assertion is the reverse of what it used to be. AWS's 128 KiB minimum is a
+		// billing floor, not an API restriction: S3 stores a 1 KiB STANDARD_IA object and bills it as
+		// 128 KiB. Refusing it here made every mkdir and every touch fail on this tier, because both
+		// PUT zero bytes (#154).
+		err := validator.ValidateWrite("small.txt", 1024)
+		if err != nil {
+			t.Errorf("Standard-IA rejected a 1 KiB write: %v.\nAWS accepts it and bills it as 128 KiB. "+
+				"Refusing it here means a mount on this tier cannot create a directory or an empty "+
+				"file, since both are zero-byte PUTs", err)
 		}
 
 		// Should allow objects >= 128KB

--- a/internal/storage/s3/tiers.go
+++ b/internal/storage/s3/tiers.go
@@ -291,24 +291,46 @@ func NewTierValidator(tier string, constraints TierConstraints, logger *slog.Log
 
 // ValidateWrite validates a write operation against tier constraints.
 //
-// Note what the minimum check does and does not mean. AWS accepts an object below a tier's minimum
-// billable size and bills it as though it were that size; it does not reject the write. So refusing
-// here is ObjectFS's policy, not S3's behavior, and #154 is about downgrading it to a warning. What
-// #229 fixed is the input: this gate previously refused writes under 40 KB to GLACIER and
-// DEEP_ARCHIVE and under 128 KB to INTELLIGENT_TIERING, and AWS publishes no minimum billable size
-// for any of those three — so it was rejecting writes on the strength of numbers that were not
-// minimums at all. Those three now have no minimum, and the two archive classes warn about their
-// per-object overhead instead, which is the real cost and points the other way.
+// Two different things are checked against a size here, and only one of them can refuse the write.
+//
+// AWS's per-tier minimum is a *billing* floor: S3 accepts a 1-byte STANDARD_IA object and bills it
+// as 128 KiB. It never rejects the write. Refusing it here was therefore ObjectFS policy dressed as
+// S3 behavior, and it made the filesystem unusable rather than expensive — `internal/fuse` creates
+// both directory markers and new files by PUTting zero bytes, so on any tier with a minimum every
+// `mkdir` and every `touch` failed, including the ones an IA-tier test needs to set itself up. It is
+// a warning now, reporting the size that will be billed alongside the size that was written (#154).
+//
+// `TierConstraints.MinObjectSize` is the one that still errors. An operator who sets it has asked
+// for a floor that is not AWS's, and a policy nobody configured is the only kind worth removing.
+// Note the consequence of that split, because it is easy to configure by accident: setting the
+// constraint to the tier's own published minimum restores the old behavior in full, zero-byte
+// directory markers included.
+//
+// What #229 fixed is the input to all of this: the gate previously refused writes under 40 KB to
+// GLACIER and DEEP_ARCHIVE and under 128 KB to INTELLIGENT_TIERING, and AWS publishes no minimum
+// billable size for any of those three — so it was rejecting writes on the strength of numbers that
+// were not minimums at all. Those three now have no minimum, and the two archive classes warn about
+// their per-object overhead instead, which is the real cost and points the other way.
 func (tv *TierValidator) ValidateWrite(key string, dataSize int64) error {
-	// Check minimum object size constraint
-	minSize := tv.tierInfo.MinObjectSize
-	if tv.constraints.MinObjectSize > 0 {
-		minSize = tv.constraints.MinObjectSize
+	// The operator's floor, if there is one: a deliberate policy, still enforced.
+	if minSize := tv.constraints.MinObjectSize; minSize > 0 && dataSize < minSize {
+		return fmt.Errorf("object size %d bytes is below the configured minimum of %d bytes for the "+
+			"%s tier (tier_constraints.min_object_size); AWS would accept this write and bill it as "+
+			"%d bytes, so this refusal is ObjectFS policy — unset that key to allow it",
+			dataSize, minSize, tv.tier, minSize)
 	}
 
-	if dataSize < minSize {
-		return fmt.Errorf("object size %d bytes is below minimum %d bytes for %s tier",
-			dataSize, minSize, tv.tier)
+	// AWS's billing floor: not a reason to refuse, but worth saying out loud, because the object
+	// costs a multiple of what its size suggests and nothing downstream will mention it again.
+	if minBillable := tv.tierInfo.MinObjectSize; minBillable > 0 && dataSize < minBillable {
+		tv.logger.Warn("object is smaller than this tier's minimum billable size",
+			"tier", tv.tier,
+			"key", key,
+			"size", dataSize,
+			"billed_size", minBillable,
+			"note", "AWS accepts the write and bills it as the minimum; a smaller object on this "+
+				"tier costs the same as one at the minimum, so many small objects here are more "+
+				"expensive than the same bytes on STANDARD")
 	}
 
 	// The archive classes bill 40 KB of metadata per object regardless of its size, so a small object


### PR DESCRIPTION
Closes #154.

A mount on `STANDARD_IA`, `ONEZONE_IA`, or `GLACIER_IR` could not create anything: `mkdir` failed, `touch` failed, and so did writing any file under 128 KiB.

AWS's per-tier minimum object size is a **billing** floor — S3 stores a zero-byte `STANDARD_IA` object and bills it as 128 KiB. `TierValidator.ValidateWrite` enforced it as an API restriction, and `PutObject` calls it before anything else. Both of the ways this filesystem brings a name into existence go under that floor: `Mkdir` writes a zero-byte marker object so an empty directory is distinguishable from a prefix that never existed, and a `Create` plus a small write flushes a small object. So the three tiers most of the cost documentation recommends were the three a filesystem could not be used on, and an IA-tier integration test could not get past its own setup.

## What changed

- **AWS's floor warns**, naming the size written alongside the size that will be billed. That gap is the actionable fact: a tier billing every object as 128 KiB is more expensive than `STANDARD` for a workload of small files, and nothing downstream would have mentioned it.
- **`tier_constraints.min_object_size` still refuses.** An operator who sets it has asked for a floor that is not AWS's; a policy someone chose is the only kind worth enforcing. The refusal message says whose rule it is, so it does not send the reader to the AWS docs to find that S3 accepts the write.
- The sharp edge that split leaves is tested rather than left to be rediscovered: setting the constraint to the tier's own published minimum reinstates exactly the old gate, zero-byte directory markers included.
- `adapter.go`'s note on why `TierConstraints` is deliberately unmapped now records that `MinObjectSize` is the one field in it that can refuse a write, so if it is ever mapped it has to stay unset by default.

`ValidateSize`, which the issue also names, does not exist. The other caller is `Backend.ValidateObjectForTier`, which delegates straight to `ValidateWrite` and is therefore consistent by construction.

## Tests

Pinned at **both** layers, because the gate is enforced two below the operation that trips it:

- `internal/storage/s3/tier_min_size_test.go` — a zero-byte write is accepted on every tier with a minimum, *and* the warning carries the written size, the billed size, the tier, and the key. A test that only checks `err == nil` cannot tell "warned about the billing" from "said nothing", and saying nothing is the failure mode that matters: the write succeeds either way and the operator finds out from an invoice.
- `internal/fuse/tier_min_size_test.go` — real `Mkdir` and `Create` calls through a go-fuse bridge against a real substrate endpoint, on every tier with a minimum, read from `StorageTiers` so a class that gains one later is covered without editing the test. Only this layer establishes that a `mkdir` *is* a zero-byte PUT, which is the step that turned a billing hint into an unusable mount.
- `tier_test.go`'s "Standard-IA should reject objects smaller than 128KB" assertion is reversed, with the reason in place.

Writing this surfaced a related property worth recording in the test: `touch f` alone cannot exercise a write gate at all. A file created and never written flushes through `Flusher.attemptAttrOnly`, which finds no object to carry the metadata and deliberately stores nothing — so the FUSE-level test writes 9 bytes, and says why.

## Verified by mutation

```
restore the old hard gate       → 12 assertions fail at the validator,
                                  every mkdir fails at the mount
drop the warning, keep accept   → 12 assertions fail
ignore the operator constraint  → TestConfiguredMinimumStillRefusesTheWrite fails
```

## Local checks

- `go build ./...`, `go vet ./...` clean
- `go test -race ./internal/... ./pkg/...` — all pass
- `golangci-lint run --new-from-merge-base=origin/main` — 0 issues
- coverage: `internal/storage/s3` 82.4% (floor 81), `internal/fuse` 66.2% (floor 59)