### PR TITLE
fix: a mount reads every compression algorithm it can write (#230)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -35,7 +35,9 @@
 #                       built on it, which it does, with the message it exists to print
 #   pkg/archive         no tests — metadata types; dead code pending a decision (Part 4)
 #   pkg/compression     no tests in this package; its constants and SupportedAlgorithms list are
-#                       exercised from internal/compression, which is at 87.3%
+#                       exercised from internal/compression, which is at 88.6%. SupportedAlgorithms
+#                       is load-bearing there since #230 — the decoder table is derived from it, so
+#                       adding an algorithm to that list makes it readable with no second edit
 #   sdks/c              no tests — cgo shim, not reachable from `go test`
 
 internal/analytics       96
@@ -43,7 +45,9 @@ internal/archive         90
 internal/awsname         100
 internal/cache/redis     87
 internal/circuit         96
-internal/compression     87
+# internal/compression goes from 87 to 88 with the decoder-table tests #230 added: a matrix over
+# every writable algorithm read back by every algorithm and by a disabled compressor.
+internal/compression     88
 # internal/config goes from 83 to 86 with the validation the config plumbing added. The two points
 # that raise is worth are in what the new tests assert rather than in the number: each case checks
 # that the rejection message names the YAML path, because the failure being prevented is not "a bad

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Changing `compression.algorithm` no longer orphans every object already in the bucket.** A mount
+  now decodes any algorithm ObjectFS can write, chosen from the object's stored `Content-Encoding`
+  rather than from the configuration ([#230]). Before this, `Compressor` held exactly one codec and
+  `Decompress` compared the stored encoding against that codec's token, so a mount could read back
+  only what it was currently configured to write. Switching `zstd` to `lz4` made every existing zstd
+  object unreadable — and so did setting `enabled: false`, which is how an operator turns compression
+  off after deciding the read amplification was not worth it. Turning compression off stops new
+  objects being compressed; it does not make the existing ones uncompressed, and it was the change
+  most likely to be made and least likely to be expected to break anything.
+
+  Nobody got wrong bytes: the read failed closed with a `DATA_CORRUPTION` error, because
+  `checkFullyDecoded` cross-checks the decoded length against the recorded `objectfs-original-size`.
+  That guard was compensating for a dispatch that could have succeeded — every codec was already
+  linked into the same binary. The decoder table is built from
+  `pkg/compression.SupportedAlgorithms` rather than listed by hand, so an algorithm added there is
+  readable without a second edit; that derivation is what stops the defect's actual shape, which was
+  a set of encoders and a set of decoders maintained independently. Pinned by the full
+  write-algorithm × read-configuration matrix, including a disabled reader, and the fail-closed
+  behavior still holds for the cases no dispatch can help: a `Content-Encoding` naming a coding
+  ObjectFS does not implement, and a header stripped after the write by a `CopyObject` or a tier
+  transition. A body its own declared codec rejects is now reported as non-retryable corruption
+  rather than a bare error the retry layer would take at face value.
+
 - **A mount on `STANDARD_IA`, `ONEZONE_IA`, or `GLACIER_IR` could not create anything at all.**
   `mkdir` and `touch` both failed, and so did writing any file smaller than 128 KiB ([#154]). AWS's
   per-tier minimum object size is a *billing* floor — S3 stores a zero-byte `STANDARD_IA` object and
@@ -216,6 +239,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#164]: https://github.com/scttfrdmn/objectfs/issues/164
 [#181]: https://github.com/scttfrdmn/objectfs/issues/181
 [#205]: https://github.com/scttfrdmn/objectfs/issues/205
+[#230]: https://github.com/scttfrdmn/objectfs/issues/230
 
 ## [0.10.3] - 2026-08-02
 

--- a/docs/features/compression.md
+++ b/docs/features/compression.md
@@ -243,11 +243,12 @@ latency — what else does it provide?* Less than you would expect.
 - **It does not speed up writes.** It costs CPU on the write path, and until [#184](https://github.com/scttfrdmn/objectfs/issues/184)
   lands it costs that CPU even on data that cannot compress.
 - **It does not make small objects cheap.** See the billing minimums above.
-- **It adds a failure mode.** An object whose stored encoding this mount cannot decode fails closed with
-  an integrity error. That is the correct behavior — v0.10.0 returned the raw compressed frame with exit
+- **It adds a failure mode.** An object whose stored encoding cannot be decoded fails closed with an
+  integrity error. That is the correct behavior — v0.10.0 returned the raw compressed frame with exit
   status 0, which is audit finding C2 — but it is a way for a read to fail that an uncompressed object
-  does not have. The way to reach it is to change `algorithm` after data has been written — see below,
-  a mount decodes only its configured algorithm.
+  does not have. Changing `algorithm` no longer reaches it ([#230](https://github.com/scttfrdmn/objectfs/issues/230)),
+  so what is left is an object whose `Content-Encoding` names a coding ObjectFS does not implement, or
+  one whose header was stripped after the write — a `CopyObject` or a tier transition does not carry it.
 
 ---
 
@@ -266,19 +267,24 @@ write_buffer:
 is reasonable. On `STANDARD_IA`, `ONEZONE_IA`, or `GLACIER_IR`, nothing below 128 KB can reduce your
 bill, so a `min_size` at or above `128KB` skips the objects where compression is pure cost.
 
-**Do not change `algorithm` once a bucket holds compressed objects.** A mount decodes only the one
-algorithm it is configured for, so switching from zstd to gzip makes every existing zstd object
-unreadable — the read fails with a `DATA_CORRUPTION` integrity error naming the encoding it could not
-handle. Verified against the in-process endpoint: an object written with `algorithm: zstd` reads
-correctly under `zstd` and fails under each of `gzip`, `lz4`, and `none`.
+**`algorithm` is safe to change.** A mount decodes every algorithm ObjectFS can write — `zstd`, `lz4`,
+and `gzip` — whichever one it is configured to write, because the codec is chosen from the object's
+stored `Content-Encoding` rather than from the configuration. Setting `enabled: false` is safe for the
+same reason: it stops new objects being compressed and still decodes the ones already in the bucket.
+Verified against the in-process endpoint as a full matrix — every writable algorithm read back by every
+algorithm and by a disabled mount — in `TestEveryConfiguredAlgorithmReadsEveryStoredEncoding`.
 
-Failing is the right behavior — v0.10.0 returned the raw compressed frame with exit status 0 — but it
-means the algorithm is effectively a property of the bucket, not a knob to tune. If you must change it,
-rewrite the objects through the new configuration. There is no in-place migration, and ObjectFS does not
-detect the situation in advance. Tracked as
-[#230](https://github.com/scttfrdmn/objectfs/issues/230): every codec is compiled in, so dispatching on
-each object's stored `Content-Encoding` would make this work, and only the single-codec `Compressor`
-prevents it.
+This is new in v0.11.0. Through v0.10.x a mount decoded only its configured algorithm, so switching
+from zstd to gzip made every existing zstd object unreadable, and so did turning compression off. That
+read failed closed with a `DATA_CORRUPTION` error rather than returning the raw frame, which was the
+correct half of it, but it meant the algorithm was effectively a property of the bucket rather than a
+knob to tune. Fixed in [#230](https://github.com/scttfrdmn/objectfs/issues/230); every codec was
+already compiled into the same binary, and only the single-codec `Compressor` stood between them and
+the read path.
+
+What remains a one-way door is the **format**, not the algorithm: a compressed object is still only
+readable by something that understands its `Content-Encoding`, which is cost #1 at the top of this
+page.
 
 Compression applies to whole objects on the write path. It does not compress the read cache, and it does
 not change what the persistent cache stores on local disk.

--- a/internal/compression/decoders_test.go
+++ b/internal/compression/decoders_test.go
@@ -1,0 +1,226 @@
+package compression
+
+// The decoder table is the fix for #230, and what makes it a fix rather than a workaround is that it
+// is derived from pkg/compression.SupportedAlgorithms rather than listed by hand. The defect was that
+// the set of algorithms ObjectFS can *write* and the set it can *read* were maintained
+// independently — one codec on the read side, three on the write side — so these tests assert the
+// derivation, not a snapshot of today's three codecs.
+
+import (
+	"bytes"
+	"testing"
+
+	comprpkg "github.com/scttfrdmn/objectfs/pkg/compression"
+)
+
+// TestEveryWritableAlgorithmIsDecodable is the property the fix rests on: whatever a Compressor can
+// produce, any Compressor can read back.
+//
+// Written as a matrix over SupportedAlgorithms in both directions so that adding an algorithm to that
+// list and forgetting the read side fails here rather than in production, where it presents as
+// objects written last week being unreadable today.
+func TestEveryWritableAlgorithmIsDecodable(t *testing.T) {
+	t.Parallel()
+
+	original := bytes.Repeat([]byte("decoder table\n"), 500)
+
+	for _, writeAlgo := range comprpkg.SupportedAlgorithms() {
+		if writeAlgo == comprpkg.AlgorithmNone {
+			// Stores nothing encoded, so there is no token to dispatch on. Covered by
+			// TestDisabledCompressorStillDecodes, which is the case that matters.
+			continue
+		}
+
+		t.Run("written_with_"+string(writeAlgo), func(t *testing.T) {
+			t.Parallel()
+
+			writer, err := NewCompressor(makeConfig(true, string(writeAlgo), "0", 0))
+			if err != nil {
+				t.Fatalf("NewCompressor(%q): %v", writeAlgo, err)
+			}
+
+			encoded, wasCompressed, err := writer.Compress(original)
+			if err != nil {
+				t.Fatalf("Compress with %q: %v", writeAlgo, err)
+			}
+
+			if !wasCompressed {
+				t.Fatalf("%q did not compress %d bytes of repetitive text, so there is no encoded "+
+					"object for a reader to decode", writeAlgo, len(original))
+			}
+
+			encoding := writer.ContentEncoding()
+			if encoding == "" {
+				t.Fatalf("%q reports an empty Content-Encoding while compressing; an object stored "+
+					"this way records nothing a reader could dispatch on", writeAlgo)
+			}
+
+			for _, readAlgo := range comprpkg.SupportedAlgorithms() {
+				t.Run("read_by_"+string(readAlgo), func(t *testing.T) {
+					t.Parallel()
+
+					// enabled follows the algorithm: "none" is only reachable as a disabled
+					// compressor, since NewCompressor with Enabled true and AlgorithmNone is a
+					// configuration nothing produces.
+					enabled := readAlgo != comprpkg.AlgorithmNone
+
+					reader, err := NewCompressor(makeConfig(enabled, string(readAlgo), "0", 0))
+					if err != nil {
+						t.Fatalf("NewCompressor(%q): %v", readAlgo, err)
+					}
+
+					got, decoded, err := reader.Decompress(encoded, encoding)
+					if err != nil {
+						t.Fatalf("a %q-configured compressor could not decode %q: %v",
+							readAlgo, encoding, err)
+					}
+
+					if !decoded {
+						t.Fatalf("a %q-configured compressor declined to decode %q, which it has a "+
+							"codec for. Its decodable set is %v", readAlgo, encoding,
+							reader.DecodableEncodings())
+					}
+
+					if !bytes.Equal(got, original) {
+						t.Errorf("decoding %q with a %q-configured compressor returned %d bytes "+
+							"that differ from the %d written", encoding, readAlgo, len(got),
+							len(original))
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestDisabledCompressorStillDecodes is the configuration change an operator is most likely to make,
+// and the one that used to orphan a bucket outright.
+func TestDisabledCompressorStillDecodes(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCompressor(makeConfig(false, "none", "0", 0))
+	if err != nil {
+		t.Fatalf("NewCompressor: %v", err)
+	}
+
+	if c.Enabled() {
+		t.Fatal("a compressor built from disabled settings reports Enabled")
+	}
+
+	if got := len(c.DecodableEncodings()); got == 0 {
+		t.Fatal("a disabled compressor decodes nothing. Turning compression off stops new objects " +
+			"being compressed; it does not make the objects already in the bucket uncompressed")
+	}
+
+	original := bytes.Repeat([]byte("still decodable\n"), 500)
+
+	writer, err := NewCompressor(makeConfig(true, "zstd", "0", 0))
+	if err != nil {
+		t.Fatalf("NewCompressor(zstd): %v", err)
+	}
+
+	encoded, wasCompressed, err := writer.Compress(original)
+	if err != nil || !wasCompressed {
+		t.Fatalf("Compress: err=%v, wasCompressed=%v", err, wasCompressed)
+	}
+
+	got, decoded, err := c.Decompress(encoded, "zstd")
+	if err != nil {
+		t.Fatalf("a disabled compressor could not decode a zstd object: %v", err)
+	}
+
+	if !decoded || !bytes.Equal(got, original) {
+		t.Errorf("decoded=%v, got %d bytes, want %d", decoded, len(got), len(original))
+	}
+
+	// It must still not compress, or "disabled" means nothing.
+	out, wasCompressed, err := c.Compress(original)
+	if err != nil {
+		t.Fatalf("Compress on a disabled compressor: %v", err)
+	}
+
+	if wasCompressed || !bytes.Equal(out, original) {
+		t.Error("a disabled compressor compressed its input")
+	}
+}
+
+// TestDecodableEncodingsMatchesSupportedAlgorithms pins the derivation itself.
+//
+// A list of decoders maintained separately from the list of algorithms would reintroduce #230's whole
+// class of gap, so the assertion is against SupportedAlgorithms rather than against {gzip, lz4, zstd}.
+func TestDecodableEncodingsMatchesSupportedAlgorithms(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCompressor(makeConfig(true, "zstd", "0", 0))
+	if err != nil {
+		t.Fatalf("NewCompressor: %v", err)
+	}
+
+	decodable := make(map[string]bool)
+	for _, token := range c.DecodableEncodings() {
+		if token == "" {
+			t.Error("the decoder table contains an empty Content-Encoding token; an empty encoding " +
+				"means \"not encoded\" rather than naming a codec, and Decompress handles it before " +
+				"consulting the table")
+		}
+
+		decodable[token] = true
+	}
+
+	for _, algo := range comprpkg.SupportedAlgorithms() {
+		codec, err := New(algo, comprpkg.DefaultLevel)
+		if err != nil {
+			t.Fatalf("New(%q): %v", algo, err)
+		}
+
+		token := codec.ContentEncoding()
+		if token == "" {
+			continue
+		}
+
+		if !decodable[token] {
+			t.Errorf("%q writes Content-Encoding %q and no decoder claims it, so an object written "+
+				"with it cannot be read back. DecodableEncodings is %v",
+				algo, token, c.DecodableEncodings())
+		}
+	}
+
+	// Sorted, because callers put this in error messages and log fields.
+	tokens := c.DecodableEncodings()
+	for i := 1; i < len(tokens); i++ {
+		if tokens[i-1] > tokens[i] {
+			t.Errorf("DecodableEncodings is not sorted: %v", tokens)
+
+			break
+		}
+	}
+}
+
+// TestDecompressReportsACorruptFrame separates the two failure modes a caller has to tell apart: a
+// token nothing claims (bytes through, decoded false, no error — another tool's format) and a token a
+// codec claims over a body it rejects (an error — the stored bytes are damaged).
+func TestDecompressReportsACorruptFrame(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCompressor(makeConfig(true, "zstd", "0", 0))
+	if err != nil {
+		t.Fatalf("NewCompressor: %v", err)
+	}
+
+	garbage := []byte("this is not a zstd frame, whatever the header says")
+
+	got, decoded, err := c.Decompress(garbage, "zstd")
+	if err == nil {
+		t.Fatalf("Decompress accepted %d bytes of non-zstd data labeled zstd and returned %d bytes "+
+			"with decoded=%v; a caller cannot tell that from a successful decode",
+			len(garbage), len(got), decoded)
+	}
+
+	if decoded {
+		t.Error("Decompress reported decoded=true alongside an error")
+	}
+
+	if got != nil {
+		t.Errorf("Decompress returned %d bytes alongside an error; a caller that checks the error "+
+			"second would use them", len(got))
+	}
+}

--- a/internal/compression/s3_integration.go
+++ b/internal/compression/s3_integration.go
@@ -2,6 +2,7 @@ package compression
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -34,20 +35,39 @@ type Settings struct {
 // Compressor wraps a Codec with minimum-size enforcement for transparent S3
 // object compression.  A Compressor whose codec is AlgorithmNone acts as a
 // pass-through and reports Enabled() == false.
+//
+// Writing and reading are deliberately asymmetric. One codec is used to write, chosen by
+// configuration, and *every* codec is available to read, chosen by the object. A bucket accumulates
+// objects across configuration changes and across the tools that wrote them, so the algorithm a
+// mount is set to says nothing about the algorithm the object in front of it used.
 type Compressor struct {
 	codec   comprpkg.Codec
 	minSize int64
+
+	// decoders holds a codec per Content-Encoding token, built once at construction.
+	//
+	// Keyed on the token rather than on the [comprpkg.Algorithm] name because the token is what the
+	// object carries and what the read path has in hand. They happen to be the same strings for all
+	// three codecs, and that is a coincidence of naming rather than a guarantee — ContentEncoding is a
+	// separate method from Algorithm precisely because a codec is free to have them differ.
+	decoders map[string]comprpkg.Codec
 }
 
 // NewCompressor builds a Compressor from Settings.
-// When cfg.Enabled is false a nop compressor is returned (no-overhead
-// pass-through).
+// When cfg.Enabled is false a nop compressor is returned: it writes nothing compressed, and still
+// decodes every algorithm, because objects already in the bucket do not stop being compressed when a
+// mount turns compression off.
 //
 // Calling this is also how a caller validates a compression configuration: it is the only check that
 // cannot drift from what the codecs actually support, because it is the code that builds them.
 func NewCompressor(cfg Settings) (*Compressor, error) {
+	decoders, err := buildDecoders()
+	if err != nil {
+		return nil, err
+	}
+
 	if !cfg.Enabled {
-		return &Compressor{codec: &nopCodec{}, minSize: 0}, nil
+		return &Compressor{codec: &nopCodec{}, minSize: 0, decoders: decoders}, nil
 	}
 
 	codec, err := New(comprpkg.Algorithm(cfg.Algorithm), cfg.Level)
@@ -60,7 +80,43 @@ func NewCompressor(cfg Settings) (*Compressor, error) {
 		return nil, fmt.Errorf("invalid min_size %q: %w", cfg.MinSize, err)
 	}
 
-	return &Compressor{codec: codec, minSize: minSize}, nil
+	// The write codec is used for its own token rather than a second instance of the same algorithm,
+	// so a configured level is not silently a different level on the way back in. It makes no
+	// difference to the output — decoding does not consult the level — but two codecs for one
+	// algorithm is two things that can be made to disagree.
+	decoders[codec.ContentEncoding()] = codec
+
+	return &Compressor{codec: codec, minSize: minSize, decoders: decoders}, nil
+}
+
+// buildDecoders constructs one codec per algorithm that has a Content-Encoding token.
+//
+// Built from [comprpkg.SupportedAlgorithms] rather than from a list here, so an algorithm added
+// there is readable without a second edit. That matters more than it looks: the reason this map
+// exists is that the read path had exactly one codec, and a list of decoders maintained separately
+// from the list of algorithms would reintroduce the same class of gap — an algorithm ObjectFS can
+// write and cannot read.
+//
+// Every codec is constructed at its default level. A level is an encoder parameter; all three
+// formats are self-describing on the way back, so it has no bearing on decoding.
+func buildDecoders() (map[string]comprpkg.Codec, error) {
+	decoders := make(map[string]comprpkg.Codec)
+
+	for _, algo := range comprpkg.SupportedAlgorithms() {
+		codec, err := New(algo, comprpkg.DefaultLevel)
+		if err != nil {
+			return nil, fmt.Errorf("build decoder for %s: %w", algo, err)
+		}
+
+		// AlgorithmNone's token is empty, and an empty Content-Encoding means "not encoded" rather
+		// than naming a codec. Registering it would make the map answer for a case Decompress handles
+		// before it ever looks here.
+		if token := codec.ContentEncoding(); token != "" {
+			decoders[token] = codec
+		}
+	}
+
+	return decoders, nil
 }
 
 // Enabled returns true when an active (non-nop) codec is in use.
@@ -91,19 +147,54 @@ func (c *Compressor) Compress(data []byte) ([]byte, bool, error) {
 	return compressed, true, nil
 }
 
-// Decompress decompresses data when contentEncoding matches the codec's
-// Content-Encoding token.  Returns data unchanged when contentEncoding is
-// empty or does not match.
-func (c *Compressor) Decompress(data []byte, contentEncoding string) ([]byte, error) {
-	if contentEncoding == "" || contentEncoding != c.codec.ContentEncoding() {
-		return data, nil
+// Decompress decodes data according to contentEncoding, which is the object's own
+// Content-Encoding — not the algorithm this Compressor writes with.
+//
+// The second return reports whether a codec was found and applied. False with a nil error means the
+// data came back untouched, either because contentEncoding was empty or because no codec here claims
+// that token; the caller decides what that means, since only the caller can see whether the object
+// is one ObjectFS compressed. Passing a foreign encoding through is right — an object another tool
+// wrote with `Content-Encoding: br` is that tool's format, and `aws s3 cp` hands back the same
+// bytes — while an ObjectFS-compressed object arriving undecoded is an integrity failure, which is
+// what `checkFullyDecoded` in the S3 backend exists to catch.
+//
+// Dispatching on the object rather than on the configuration is the whole point. This used to
+// compare contentEncoding against the single configured codec's token and return the data unchanged
+// on any mismatch (audit finding C2), which meant a mount could read back only what it was currently
+// configured to write: switching `algorithm: zstd` to `lz4` — or to `enabled: false` — made every
+// existing compressed object unreadable, with the code to read them linked into the same binary.
+func (c *Compressor) Decompress(data []byte, contentEncoding string) ([]byte, bool, error) {
+	if contentEncoding == "" {
+		return data, false, nil
 	}
 
-	decompressed, err := c.codec.Decompress(data)
-	if err != nil {
-		return nil, fmt.Errorf("decompress: %w", err)
+	codec, ok := c.decoders[contentEncoding]
+	if !ok {
+		return data, false, nil
 	}
-	return decompressed, nil
+
+	decompressed, err := codec.Decompress(data)
+	if err != nil {
+		return nil, false, fmt.Errorf("decompress %s: %w", contentEncoding, err)
+	}
+
+	return decompressed, true, nil
+}
+
+// DecodableEncodings lists the Content-Encoding tokens this Compressor can decode, sorted.
+//
+// For error messages and for logging: an object that cannot be decoded is worth reporting alongside
+// what could have been, since the two most likely explanations — a foreign tool's encoding and an
+// ObjectFS object whose header was mangled — are told apart by exactly that comparison.
+func (c *Compressor) DecodableEncodings() []string {
+	tokens := make([]string, 0, len(c.decoders))
+	for token := range c.decoders {
+		tokens = append(tokens, token)
+	}
+
+	sort.Strings(tokens)
+
+	return tokens
 }
 
 // ContentEncoding returns the HTTP Content-Encoding token set on compressed

--- a/internal/compression/s3_integration_test.go
+++ b/internal/compression/s3_integration_test.go
@@ -143,9 +143,12 @@ func TestCompressor_DecompressMatchingEncoding(t *testing.T) {
 		t.Fatalf("Compress: err=%v, wasCompressed=%v", err, wasCompressed)
 	}
 
-	got, err := c.Decompress(compressed, "zstd")
+	got, decoded, err := c.Decompress(compressed, "zstd")
 	if err != nil {
 		t.Fatalf("Decompress: %v", err)
+	}
+	if !decoded {
+		t.Error("Decompress reported it did not decode an object encoded with its own algorithm")
 	}
 	if !bytes.Equal(got, original) {
 		t.Errorf("roundtrip mismatch: got len %d, want len %d", len(got), len(original))
@@ -160,30 +163,42 @@ func TestCompressor_DecompressNoEncoding(t *testing.T) {
 	}
 
 	data := []byte("not compressed")
-	got, err := c.Decompress(data, "")
+	got, decoded, err := c.Decompress(data, "")
 	if err != nil {
 		t.Fatalf("Decompress: %v", err)
+	}
+	if decoded {
+		t.Error("Decompress claimed to decode an object with no Content-Encoding")
 	}
 	if !bytes.Equal(got, data) {
 		t.Error("Decompress with no encoding should return data unchanged")
 	}
 }
 
-func TestCompressor_DecompressMismatchEncoding(t *testing.T) {
+// TestCompressor_DecompressUnknownEncoding covers a token no codec in this build claims.
+//
+// Passing the bytes through is deliberate: an object another tool wrote with `Content-Encoding: br`
+// is that tool's format, and returning it unchanged is what every other S3 client does. What must
+// not happen is a silent pass-through that the caller cannot detect — hence the second return, which
+// is how the S3 backend knows to cross-check against objectfs-original-size and fail closed for an
+// object ObjectFS itself compressed.
+func TestCompressor_DecompressUnknownEncoding(t *testing.T) {
 	t.Parallel()
 	c, err := NewCompressor(makeConfig(true, "zstd", "0", 0))
 	if err != nil {
 		t.Fatalf("NewCompressor: %v", err)
 	}
 
-	data := []byte("gzip encoded data (pretend)")
-	got, err := c.Decompress(data, "gzip")
+	data := []byte("brotli encoded data (pretend)")
+	got, decoded, err := c.Decompress(data, "br")
 	if err != nil {
 		t.Fatalf("Decompress: %v", err)
 	}
-	// encoding doesn't match our codec → pass through unchanged
+	if decoded {
+		t.Error("Decompress claimed to decode \"br\", which no codec in this build implements")
+	}
 	if !bytes.Equal(got, data) {
-		t.Error("Decompress with mismatched encoding should return data unchanged")
+		t.Error("an encoding this build does not implement should pass through unchanged")
 	}
 }
 

--- a/internal/storage/s3/backend.go
+++ b/internal/storage/s3/backend.go
@@ -456,16 +456,51 @@ func (b *Backend) GetObject(ctx context.Context, key string, offset, size int64)
 		return nil, err
 	}
 
-	// Decompress if the object was stored with transparent compression. The encoding comes from the
-	// object's own header rather than the write config, so objects stay readable across a config
-	// change (audit finding C2 is the opposite: dispatching on the configured codec silently returned
-	// the raw frame for anything else).
+	// Decompress if the object was stored with transparent compression.
+	//
+	// Both the decision to decode and the codec used come from the object's own header rather than
+	// from the write config, so objects stay readable across a config change — including a change to
+	// `enabled: false`, which does not make what is already in the bucket uncompressed. Audit finding
+	// C2 was that only the *decision* worked this way: the codec came from the configuration, so a
+	// mount could read back only the algorithm it was currently set to write, and anything else came
+	// through as a raw frame with a successful status (#230).
 	data := read.data
 	if b.compressor != nil && read.contentEncoding != "" {
-		decompressed, decompErr := b.compressor.Decompress(data, read.contentEncoding)
+		decompressed, decoded, decompErr := b.compressor.Decompress(data, read.contentEncoding)
 		if decompErr != nil {
-			return nil, fmt.Errorf("decompress object %q: %w", key, decompErr)
+			// The codec claimed the encoding and then rejected the body. That is corruption of the
+			// stored bytes, not a transient fault: a retry decodes the same frame and fails the same
+			// way, so this is reported structured and non-retryable rather than as a bare wrapped
+			// error the retry layer would take at face value.
+			corrupt := errors.NewError(errors.ErrCodeDataCorruption,
+				"stored object could not be decompressed by the codec its Content-Encoding names").
+				WithComponent("s3-backend").
+				WithOperation("GetObject").
+				WithContext("key", key).
+				WithContext("content_encoding", read.contentEncoding).
+				WithDetail("stored_size", len(data)).
+				WithDetail("cause", decompErr.Error()).
+				WithDetail("suggestion", "The body is not a valid "+read.contentEncoding+" frame. "+
+					"Either the object was truncated or overwritten in place, or its Content-Encoding "+
+					"names a different codec than the one that wrote it.")
+
+			b.metricsCollector.RecordError(corrupt)
+			b.healthTracker.RecordError("s3-reads", corrupt)
+
+			return nil, corrupt
 		}
+
+		if !decoded {
+			// A token no codec here claims. Not an error on its own — another tool may have written a
+			// coding ObjectFS does not implement, and handing those bytes back unchanged is what every
+			// other S3 client does. checkFullyDecoded below is what refuses it if the object is one
+			// ObjectFS compressed, and it can tell because only those carry objectfs-original-size.
+			b.logger.Warn("object has a Content-Encoding this build cannot decode",
+				"key", key,
+				"content_encoding", read.contentEncoding,
+				"decodable", b.compressor.DecodableEncodings())
+		}
+
 		data = decompressed
 	}
 
@@ -474,13 +509,17 @@ func (b *Backend) GetObject(ctx context.Context, key string, offset, size int64)
 	// objectfs-original-size is written only for objects that were actually compressed, so its
 	// presence is an assertion by the writer that the caller must receive that many bytes. If the
 	// data on hand is shorter, decompression did not happen — either the stored Content-Encoding was
-	// lost (which is what CargoShip's metadata-only upload did), or it names a codec this build
-	// cannot decode, or compression was reconfigured since the write.
+	// lost (which is what CargoShip's metadata-only upload did, and what a CopyObject or tier
+	// transition still does), or it names a coding ObjectFS does not implement. A change of configured
+	// algorithm is no longer on that list: since #230 every algorithm ObjectFS can write is decoded
+	// regardless of what this mount writes.
 	//
 	// Returning the bytes anyway is the worst option available: HeadObject reports the uncompressed
 	// size, so the kernel pads the shortfall with zeros and the caller gets a silently corrupt file
-	// with a successful exit status. Compressor.Decompress does exactly that today for an encoding it
-	// does not recognize, which is why the check lives here rather than there.
+	// with a successful exit status. Compressor.Decompress hands back unrecognized encodings unchanged
+	// by design — a foreign coding is the other tool's format, not an error — so this is the check that
+	// distinguishes those from an ObjectFS object that failed to decode, and it can only be made here,
+	// where objectfs-original-size is in hand.
 	if err := checkFullyDecoded(read.metadata, data, offset, size, read.contentEncoding, key); err != nil {
 		b.metricsCollector.RecordError(err)
 
@@ -2263,9 +2302,20 @@ func checkFullyDecoded(metadata map[string]string, data []byte, offset, size int
 		return nil
 	}
 
+	// Two different causes reach here, and they want different advice. Since #230 the read path
+	// decodes every algorithm ObjectFS can write, whatever the mount is configured to write, so a
+	// codec change is no longer one of them.
 	detail := "the stored Content-Encoding was lost, so the object was never decompressed"
+	suggestion := "The object was written by a build that stored the encoding as user metadata " +
+		"instead of the Content-Encoding header. Rewrite it, or read it with a build that " +
+		"recognizes that layout."
+
 	if contentEncoding != "" {
 		detail = fmt.Sprintf("the object is encoded as %q, which this build cannot decode", contentEncoding)
+		suggestion = "No codec in this build claims that Content-Encoding. Since ObjectFS decodes " +
+			"every algorithm it can write regardless of configuration, the encoding was most likely " +
+			"set by another tool, or altered after the write — a CopyObject or a tier transition " +
+			"does not carry the header. Changing this mount's compression settings will not help."
 	}
 
 	return errors.NewError(errors.ErrCodeDataCorruption,
@@ -2277,9 +2327,7 @@ func checkFullyDecoded(metadata map[string]string, data []byte, offset, size int
 		WithDetail("recorded_size", want).
 		WithDetail("decoded_size", len(data)).
 		WithDetail("cause", detail).
-		WithDetail("suggestion", "The object was written by a build that stored the encoding as user "+
-			"metadata instead of the Content-Encoding header. Rewrite it, or read it with a build "+
-			"that recognizes that layout.")
+		WithDetail("suggestion", suggestion)
 }
 
 // verifyChecksum recomputes the SHA-256 of a whole object's uncompressed content and compares it

--- a/internal/storage/s3/compression_algorithm_change_test.go
+++ b/internal/storage/s3/compression_algorithm_change_test.go
@@ -1,0 +1,257 @@
+package s3_test
+
+// A bucket outlives its configuration. Objects accumulate across mounts, across releases, and across
+// whatever the operator had `algorithm` set to at the time, so the algorithm a mount is configured to
+// *write* says nothing about the algorithm of the object in front of it.
+//
+// Through v0.11.0 the read path did not accept that. `Compressor.Decompress` compared the object's
+// stored `Content-Encoding` against the single configured codec's token and returned the data
+// unchanged on any mismatch, so a mount could read back only what it was currently set to write.
+// Changing `algorithm: zstd` to `lz4` — or turning compression off entirely — made every existing
+// compressed object unreadable, with the code to read them linked into the same binary. Measured
+// before the fix, one object written under zstd and read by four backends differing only in that
+// field: zstd returned the 22,000 bytes; gzip, lz4, and `enabled: false` each returned a
+// DATA_CORRUPTION error (#230, audit finding C2).
+//
+// Failing closed was the correct half of that. `checkFullyDecoded` compares the decoded length
+// against the recorded `objectfs-original-size`, so nobody got a raw frame with exit status 0. But it
+// was compensating for a dispatch that could have succeeded.
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/scttfrdmn/objectfs/internal/storage/s3"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	comprpkg "github.com/scttfrdmn/objectfs/pkg/compression"
+)
+
+// writableAlgorithms returns the algorithms that produce an encoded object, read from
+// pkg/compression rather than listed here so an algorithm added there is covered without an edit.
+//
+// AlgorithmNone is excluded on the write side because it stores nothing encoded, and there is
+// therefore no encoding for a reader to dispatch on. It appears on the *read* side below as the
+// `enabled: false` backend, which is the configuration that actually matters: turning compression
+// off must not make what is already in the bucket unreadable.
+func writableAlgorithms(t *testing.T) []comprpkg.Algorithm {
+	t.Helper()
+
+	var algos []comprpkg.Algorithm
+
+	for _, algo := range comprpkg.SupportedAlgorithms() {
+		if algo != comprpkg.AlgorithmNone {
+			algos = append(algos, algo)
+		}
+	}
+
+	if len(algos) < 2 {
+		t.Fatalf("pkg/compression reports %d writable algorithms; a cross-algorithm read test needs "+
+			"at least two to prove anything", len(algos))
+	}
+
+	return algos
+}
+
+// compressorBackend builds a backend whose compression settings are the only thing that varies.
+//
+// Level is left at the codec default deliberately: the valid range differs per algorithm (zstd 0-22,
+// gzip 0-9), so a fixed non-zero level would be invalid for some of the codecs this test enumerates.
+func compressorBackend(t *testing.T, ts *testaws.TestServer, algo string, enabled bool) *s3.Backend {
+	t.Helper()
+
+	return ts.Backend(func(cfg *s3.Config) {
+		cfg.Compression.Enabled = enabled
+		cfg.Compression.Algorithm = algo
+		cfg.Compression.Level = 0
+		cfg.Compression.MinSize = "1KB"
+		// The transporter has its own upload path with its own encoding handling; this test is about
+		// the read side, so keep the write side to the one path whose header behavior is asserted in
+		// compression_integrity_test.go.
+		cfg.EnableCargoShipOptimization = false
+	})
+}
+
+// TestEveryConfiguredAlgorithmReadsEveryStoredEncoding is the issue's failure table, generalized: for
+// each algorithm an object may have been written with, every reader configuration must return the
+// original bytes.
+//
+// The matrix is every writable algorithm × (every writable algorithm + compression disabled). It is
+// built from comprpkg.SupportedAlgorithms in both directions, so an algorithm added to that list is
+// covered as a writer and as a reader with no edit here — which is the point, since the defect was
+// precisely that the set of decoders and the set of encoders were maintained independently.
+func TestEveryConfiguredAlgorithmReadsEveryStoredEncoding(t *testing.T) {
+	t.Parallel()
+
+	algos := writableAlgorithms(t)
+
+	// Big enough to clear MinSize by a margin and to compress under all three codecs, so a pass
+	// cannot come from an object that was never encoded in the first place.
+	want := compressible(22000)
+
+	for _, writeAlgo := range algos {
+		t.Run("written_with_"+string(writeAlgo), func(t *testing.T) {
+			t.Parallel()
+
+			ts := testaws.Start(t)
+			ctx := context.Background()
+
+			key := "cross-algorithm/" + string(writeAlgo)
+
+			writer := compressorBackend(t, ts, string(writeAlgo), true)
+			if err := writer.PutObject(ctx, key, want, nil); err != nil {
+				t.Fatalf("PutObject with algorithm %q: %v", writeAlgo, err)
+			}
+
+			// Without this the whole subtest is vacuous: an object stored uncompressed reads back
+			// correctly under every configuration for reasons that have nothing to do with the fix.
+			stored := ts.ObjectSize(key)
+			if stored >= int64(len(want)) {
+				t.Fatalf("algorithm %q stored %d bytes for a %d-byte object, so it did not compress "+
+					"and no reader has anything to dispatch on", writeAlgo, stored, len(want))
+			}
+
+			// Readers: every algorithm, plus compression off.
+			readers := make([]struct {
+				name    string
+				algo    string
+				enabled bool
+			}, 0, len(algos)+1)
+
+			for _, readAlgo := range algos {
+				readers = append(readers, struct {
+					name    string
+					algo    string
+					enabled bool
+				}{name: "algorithm_" + string(readAlgo), algo: string(readAlgo), enabled: true})
+			}
+
+			readers = append(readers, struct {
+				name    string
+				algo    string
+				enabled bool
+			}{name: "compression_disabled", algo: string(comprpkg.AlgorithmNone), enabled: false})
+
+			for _, reader := range readers {
+				t.Run(reader.name, func(t *testing.T) {
+					t.Parallel()
+
+					backend := compressorBackend(t, ts, reader.algo, reader.enabled)
+
+					got, err := backend.GetObject(ctx, key, 0, int64(len(want)))
+					if err != nil {
+						t.Fatalf("an object written with %q could not be read by a mount configured "+
+							"%s: %v\nEvery codec is linked into this binary, so the object is "+
+							"decodable and the configuration is the only thing refusing it. A mount "+
+							"that cannot read what an earlier configuration wrote orphans the bucket",
+							writeAlgo, reader.name, err)
+					}
+
+					if !bytes.Equal(got, want) {
+						t.Errorf("an object written with %q read back under %s as %d bytes that "+
+							"differ from the %d written", writeAlgo, reader.name, len(got), len(want))
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestDisablingCompressionStillReadsCompressedObjects is the case above that an operator is most
+// likely to hit, pulled out on its own because it is the one that reads as a *configuration* change
+// rather than a format change.
+//
+// Setting `enabled: false` is how someone turns compression off after deciding it was not worth the
+// read amplification. It stops new objects being compressed. It cannot make the existing ones
+// uncompressed, and before #230 it made them all unreadable — which is a considerably worse outcome
+// than the setting they were trying to leave.
+func TestDisablingCompressionStillReadsCompressedObjects(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	ctx := context.Background()
+
+	const key = "disabled-reader/object"
+
+	want := compressible(22000)
+
+	writer := compressorBackend(t, ts, "zstd", true)
+	if err := writer.PutObject(ctx, key, want, nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	reader := compressorBackend(t, ts, "none", false)
+
+	got, err := reader.GetObject(ctx, key, 0, int64(len(want)))
+	if err != nil {
+		t.Fatalf("a mount with compression disabled could not read a compressed object: %v\n"+
+			"Turning compression off stops new objects being compressed; it does not make the "+
+			"existing ones uncompressed", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("read %d bytes, want %d", len(got), len(want))
+	}
+
+	// And it must still write uncompressed, or "disabled" would not mean anything.
+	const plain = "disabled-reader/written-after"
+
+	if err := reader.PutObject(ctx, plain, want, nil); err != nil {
+		t.Fatalf("PutObject with compression disabled: %v", err)
+	}
+
+	if stored := ts.ObjectSize(plain); stored != int64(len(want)) {
+		t.Errorf("a mount with compression disabled stored %d bytes for a %d-byte object; it is "+
+			"still compressing", stored, len(want))
+	}
+}
+
+// TestPartialReadSurvivesAnAlgorithmChange covers the same fix on the other read shape.
+//
+// A compressed object cannot serve a range from a range of the stored bytes, so the backend fetches
+// the whole body and slices after decoding. That slice is arithmetic on the decoded buffer, so it is
+// only correct if the decode happened — and a ranged read is where a silent failure hides best,
+// because `checkFullyDecoded` deliberately does not fire on one: a short range is legitimately short,
+// and the length alone cannot distinguish it from a still-encoded body.
+func TestPartialReadSurvivesAnAlgorithmChange(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	ctx := context.Background()
+
+	const key = "cross-algorithm/ranged"
+
+	want := compressible(22000)
+
+	writer := compressorBackend(t, ts, "zstd", true)
+	if err := writer.PutObject(ctx, key, want, nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	// Offset chosen away from any boundary, so a decode that silently did not happen produces bytes
+	// from the middle of a zstd frame rather than something that could coincide with the plaintext.
+	const (
+		offset = 9001
+		length = 4096
+	)
+
+	for _, readAlgo := range []string{"gzip", "lz4", "none"} {
+		t.Run("read_as_"+readAlgo, func(t *testing.T) {
+			t.Parallel()
+
+			backend := compressorBackend(t, ts, readAlgo, readAlgo != "none")
+
+			got, err := backend.GetObject(ctx, key, offset, length)
+			if err != nil {
+				t.Fatalf("ranged read of a zstd object by a %q-configured mount: %v", readAlgo, err)
+			}
+
+			if !bytes.Equal(got, want[offset:offset+length]) {
+				t.Errorf("ranged read at offset %d returned %d bytes that are not the object's "+
+					"content there. A range is sliced out of the decoded buffer, so this is what a "+
+					"decode that silently did not happen looks like — and checkFullyDecoded cannot "+
+					"catch it, because a short range is legitimately short", offset, len(got))
+			}
+		})
+	}
+}

--- a/internal/storage/s3/compression_integrity_test.go
+++ b/internal/storage/s3/compression_integrity_test.go
@@ -203,13 +203,18 @@ func TestHeadObjectAgreesWithGetObject(t *testing.T) {
 	}
 }
 
-// TestUndecodableObjectFailsClosed covers the objects the write-path fix cannot help: ones already
-// stored with the encoding in user metadata by an earlier build.
+// TestUndecodableObjectFailsClosed covers the objects no read-path fix can decode: ones whose stored
+// Content-Encoding is missing or names a coding this build does not implement.
 //
-// Compressor.Decompress returns data *unchanged* when the encoding is empty or unrecognized (audit
-// finding C2), so without a guard the read path hands back a raw zstd frame with exit status 0. The
-// backend now cross-checks the decoded length against the recorded objectfs-original-size and
-// refuses.
+// Compressor.Decompress returns the data *unchanged* in both cases — correctly, since a coding
+// ObjectFS does not implement belongs to whatever tool wrote it — so without a guard the read path
+// hands back a raw zstd frame with exit status 0 (audit finding C2). The backend cross-checks the
+// decoded length against the recorded objectfs-original-size and refuses.
+//
+// Note what is deliberately *not* here any more. Through #230 a third case belonged on this list: an
+// encoding naming a codec ObjectFS implements but the mount was not configured to write. That was
+// never undecodable — every codec is linked into the binary — so it is now decoded rather than
+// refused, and TestEveryConfiguredAlgorithmReadsEveryStoredEncoding covers it.
 func TestUndecodableObjectFailsClosed(t *testing.T) {
 	t.Parallel()
 
@@ -244,11 +249,13 @@ func TestUndecodableObjectFailsClosed(t *testing.T) {
 			},
 		},
 		{
-			// Audit finding C2: the header is correct, but names a codec this build is not
-			// configured for — which is what a change of compression algorithm leaves behind.
-			// Decompress returns the data *unchanged* on a mismatch rather than failing.
-			name:   "encoding names a codec this build cannot decode",
-			header: "lz4",
+			// A registered HTTP content coding ObjectFS does not implement. Chosen over a nonsense
+			// token because it is the realistic version: a bucket shared with a tool that writes
+			// brotli. "lz4" used to sit here, and it does not belong any more — since #230 lz4 is
+			// decodable regardless of what the mount writes, so this case would have been asserting
+			// that a readable object is refused.
+			name:   "encoding names a coding this build does not implement",
+			header: "br",
 			metadata: map[string]string{
 				metaOriginalSizeKey: "8192",
 			},

--- a/internal/storage/s3/fuzz_roundtrip_test.go
+++ b/internal/storage/s3/fuzz_roundtrip_test.go
@@ -263,11 +263,15 @@ func TestRoundTripAcrossACodecChange(t *testing.T) {
 
 			got, err := reader.GetObject(context.Background(), key, 0, -1)
 			if err != nil {
-				// Failing closed is acceptable: an integrity error tells the user their data needs a
-				// build that can decode it. Returning wrong bytes is not.
-				t.Logf("read failed closed, which is acceptable: %v", err)
-
-				return
+				// This used to accept a fail-closed read: an integrity error at least told the user
+				// their data needed a build that could decode it, which beat returning wrong bytes.
+				// It is a failure now. Every codec ObjectFS can write is linked into the same binary
+				// and the read path dispatches on the object's own encoding (#230), so there is no
+				// configuration of this mount that legitimately cannot read this object.
+				t.Fatalf("an object written with %s could not be read by a mount configured %s: %v\n"+
+					"Failing closed was acceptable while the read path decoded only its configured "+
+					"algorithm. Since #230 it decodes all of them, so this is a regression rather "+
+					"than a safe refusal", tc.wroteWith, tc.readWith, err)
 			}
 
 			if !bytes.Equal(got, content) {

--- a/internal/vfs/errors.go
+++ b/internal/vfs/errors.go
@@ -62,7 +62,9 @@ var (
 	// This is deliberately distinct from a generic I/O error. Integrity failures must fail closed:
 	// v0.10.0 returned raw compressed bytes with exit status 0 when an object's Content-Encoding
 	// did not match the configured codec, which is worse than any error, because the caller cannot
-	// tell that it happened.
+	// tell that it happened. That particular mismatch is no longer reachable — the read path decodes
+	// every algorithm ObjectFS can write, whatever a mount is configured to write — but a coding
+	// ObjectFS does not implement, and a header lost after the write, still are.
 	ErrIntegrity = errors.New("vfs: integrity check failed")
 
 	// ErrBackend reports a storage-backend failure whose cause is not otherwise classified.


### PR DESCRIPTION
Closes #230.

## The defect

A bucket outlives its configuration. `Compressor` held exactly one codec and `Decompress` compared the object's stored `Content-Encoding` against that codec's token, returning the data unchanged on any mismatch — so a mount could read back only what it was currently configured to write.

The issue's verified table, one object written `algorithm: zstd` and read by four backends differing only in that field:

| reader config | before | after |
|---|---|---|
| `algorithm: zstd` | 22,000 bytes, correct | correct |
| `algorithm: gzip` | `DATA_CORRUPTION` | correct |
| `algorithm: lz4` | `DATA_CORRUPTION` | correct |
| `enabled: false` | `DATA_CORRUPTION` | correct |

The last row is the one that matters most. Setting `enabled: false` is how an operator turns compression off after deciding the read amplification was not worth it — the change most likely to be made and least likely to be expected to break anything. Turning compression off stops new objects being compressed; it does not make the existing ones uncompressed.

Nobody got wrong bytes: `checkFullyDecoded` cross-checks the decoded length against `objectfs-original-size` and fails closed. But that guard was compensating for a dispatch that could have succeeded — every codec was already linked into the same binary.

## The fix

`Compressor` holds a decoder per Content-Encoding token, built at construction from `pkg/compression.SupportedAlgorithms` **rather than listed by hand**. The derivation is the fix rather than the map: #230's actual shape was a set of encoders and a set of decoders maintained independently, and a hand-listed table would reintroduce exactly that. Adding an algorithm to `SupportedAlgorithms` makes it readable with no second edit.

`Decompress` gained a second return reporting whether a codec was found, because two cases have to be told apart and only the caller can do it:

- **Unknown token** → bytes through, `decoded=false`, no error. A coding ObjectFS does not implement belongs to whatever tool wrote it, and `aws s3 cp` hands back the same bytes. `checkFullyDecoded` is what refuses it *if* the object is one ObjectFS compressed, and it can tell, because only those carry `objectfs-original-size`.
- **Claimed token over a body the codec rejects** → non-retryable `DATA_CORRUPTION`, rather than the bare wrapped error the retry layer would previously have taken at face value. Retrying decodes the same frame and fails the same way.

## Tests, at both layers

`internal/compression/decoders_test.go` — the write × read matrix from `SupportedAlgorithms` in both directions; a disabled compressor that still decodes; the derivation itself (every writable token has a decoder, sorted, no empty token); the two failure modes separated.

`internal/storage/s3/compression_algorithm_change_test.go` — the issue's table generalized to every writable algorithm × (every algorithm + disabled), through a real HTTP endpoint. It asserts the stored object actually compressed before reading it back, so a pass cannot come from an object that was never encoded. Plus the ranged-read shape, which is where a silent failure hides best: `checkFullyDecoded` deliberately does not fire on a partial read, because a short range is legitimately short and the length alone cannot distinguish it from a still-encoded body.

Two existing tests **changed rather than added to**, both asserting the old behavior:

- `TestUndecodableObjectFailsClosed`'s "cannot decode" case used `lz4`, now decodable — it would have asserted that a readable object is refused. Replaced with `br`: a registered coding ObjectFS does not implement, which is the realistic version (a bucket shared with a tool that writes brotli).
- `TestRoundTripAcrossACodecChange` accepted a fail-closed read as acceptable. It is a failure now. There is no configuration of this mount that legitimately cannot read an object this mount's codecs can decode.

## Mutation verification

Per the project's practice of breaking the code and watching the test fail rather than predicting a signature. Five mutants, all caught:

| mutant | failures |
|---|---|
| M1 dispatch on the configured codec (the original defect) | 32 subtests |
| M2 decoder table hand-listed as zstd only | 19 subtests |
| M3 swallow a corrupt frame, return the bytes | 1 |
| M4 a disabled compressor decodes nothing | 7 subtests |
| M5 backend gates the decode on its own configured encoding | 14 subtests |

M5 is the one that matters for test placement: it confirms the S3-layer tests are not riding on the compression package's coverage.

## Documentation

`docs/features/compression.md` said **"do not change `algorithm` once a bucket holds compressed objects"** and named the fail-closed error as the consequence. It now says the algorithm is safe to change and `enabled: false` is safe, dates that to v0.11.0, and keeps the one-way door that is real: the **format**, not the algorithm — a compressed object is still only readable by something that understands its `Content-Encoding`, which is cost #1 on that page.

Three stale comments corrected in the same pass — `backend.go`'s fail-closed rationale, `vfs/errors.go`'s `ErrIntegrity`, and the compression package's own doc. A codec mismatch is no longer among the ways to reach an integrity error, and saying it is would send an operator to change a setting that cannot help. What *can* still reach it: a coding ObjectFS does not implement, and a header stripped after the write — a `CopyObject` or a tier transition does not carry it.

## Gates

- `go build ./...`, `go vet ./...` clean
- `go test -race ./internal/... ./pkg/...` all pass
- `golangci-lint run --new-from-merge-base=origin/main` → **0 issues**
- coverage: `internal/compression` 88.6% (floor raised 87 → 88), `internal/storage/s3` 82.3% (floor 81)