### PR TITLE
fix: compression is configured where the compression happens

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -54,7 +54,15 @@ internal/compression     88
 # value was accepted" but "a bad value was accepted, replaced with something plausible, and never
 # mentioned again" — an unrecognized storage class became STANDARD, and any unparseable size became
 # 1 GiB. An error that says "invalid configuration" leaves the operator exactly as stuck.
-internal/config          86
+#
+# 86 → 88 with #157's move of the compression block to storage.s3. The two points are in the
+# rejection cases rather than the move: `write_buffer.compression` and
+# `performance.compression_enabled` are removed rather than kept as ignored fields, and the tests that
+# hold that decision assert the loader *refuses* a file still setting either, naming the key. A key
+# kept in the schema and read by nothing is what produced the defect — a shipped
+# `compression_enabled: true` over a feature that was off — so a test that only checked the new path
+# worked would leave the old one free to come back as a silent no-op.
+internal/config          88
 internal/cost            98
 internal/difftest        75
 internal/distributed     67

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,7 +233,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   succeeds and that the resulting object is whole, so a lossy reclaim fails rather than passing
   quietly.
 
+### Changed
+
+- **Compression is configured under `storage.s3.compression`, not `write_buffer.compression`
+  ([#157]).** Nothing has ever compressed a write buffer. The block always configured the codec the
+  S3 backend applies to a whole object on its way to the wire, and the misplacement mattered in both
+  directions: an operator tuning the write buffer was changing how objects were stored, and an
+  operator looking for how objects are stored had no reason to read the write-buffer section. It now
+  sits under the backend that applies it. Defaults are unchanged — `enabled: false`, `zstd`, level 3,
+  `min_size: 4KB`.
+
+  `write_buffer.compression` and `performance.compression_enabled` are **removed rather than
+  deprecated**, so a configuration file still setting either fails to load with the offending key
+  named. That is deliberate, and follows the precedent set by the `security.encryption` booleans
+  removed in v0.10.1: a key kept as an ignored field means an operator's compression settings
+  silently stop applying on upgrade, which is the same failure as the unknown keys strict decoding was
+  introduced to catch, arrived at by a different route.
+
+  `performance.compression_enabled` is the more instructive of the two. It defaulted to **true**, was
+  read by nothing, and sat two sections away from the real setting that defaulted to **false** — so
+  the shipped configuration contained a prominent `compression_enabled: true` while no object was ever
+  compressed, and anyone who read the file to find out came away with the opposite of the truth. It is
+  removed rather than wired up because compression happens in the S3 backend, on the object, and a
+  second boolean over one feature can only ever disagree with the first. `OBJECTFS_COMPRESSION_ENABLED`
+  survives and now assigns `storage.s3.compression.enabled`: the variable's name was never wrong, only
+  what it assigned to, and exporting it previously had no effect on whether anything was compressed.
+
+  One assertion in the mapping test had to change with it, for a reason worth recording: it asserted
+  `Algorithm: "zstd"`, which is also the default — so a `buildS3Config` that hardcoded `"zstd"` and
+  ignored the configuration passed. Verified by making exactly that mutation. The test now uses `lz4`,
+  because every value in a mapping test has to differ from the value the field would hold if the
+  mapping were absent. That is the shape of the original config-plumbing defect: a field nothing mapped
+  still arriving at a plausible value from somewhere else.
+
 [#154]: https://github.com/scttfrdmn/objectfs/issues/154
+[#157]: https://github.com/scttfrdmn/objectfs/issues/157
 [#162]: https://github.com/scttfrdmn/objectfs/issues/162
 [#163]: https://github.com/scttfrdmn/objectfs/issues/163
 [#164]: https://github.com/scttfrdmn/objectfs/issues/164

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A data race between `ConsensusEngine.Stop` and an inbound heartbeat.** `Stop` read
+  `ce.electionTimer` without holding `ce.mu` while `resetElectionTimer` was replacing it from the
+  gossip receiver goroutine, which is where an `AppendEntries` RPC is handled. Neither shutdown signal
+  ordered the two: the receiver does not watch the consensus engine's `stopCh`, and although
+  `ClusterManager.Stop` stops gossip first, `GossipProtocol.Stop` closes the socket without waiting
+  for the receiver, so a message already inside a handler keeps running. `Start`'s unlocked call to the
+  same function was the second instance. The regression test drives `handleNetworkAppendEntries`
+  concurrently with `Stop` rather than over UDP, because the two tests that caught this in CI hit it
+  only when a heartbeat happened to land inside `Stop`'s window — reproducible under CI's load and not
+  locally, which is the flake shape a `-race` gate is worst at.
 - **Changing `compression.algorithm` no longer orphans every object already in the bucket.** A mount
   now decodes any algorithm ObjectFS can write, chosen from the object's stored `Content-Encoding`
   rather than from the configuration ([#230]). Before this, `Compressor` held exactly one codec and

--- a/README.md
+++ b/README.md
@@ -331,12 +331,13 @@ compressed object is not readable by `aws s3 cp`, boto3, or the S3 console, whic
 compressed bytes with a successful exit status.
 
 ```yaml
-write_buffer:
-  compression:
-    enabled: true
-    algorithm: zstd     # none, zstd, lz4, gzip
-    level: 3            # zstd 0-22, gzip 0-9; 0 selects the codec default
-    min_size: 4KB       # smaller objects are stored as-is
+storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: zstd   # none, zstd, lz4, gzip
+      level: 3          # zstd 0-22, gzip 0-9; 0 selects the codec default
+      min_size: 4KB     # smaller objects are stored as-is
 ```
 
 Read [docs/features/compression.md](docs/features/compression.md) first. It covers what compresses

--- a/cmd/objectfs/doc.go
+++ b/cmd/objectfs/doc.go
@@ -102,7 +102,6 @@ Configuration file usage:
 	performance:
 	  cache_size: "8GB"
 	  max_concurrency: 300
-	  compression_enabled: true
 	cache:
 	  ttl: 300s
 	  eviction_policy: "weighted_lru"
@@ -199,7 +198,6 @@ YAML configuration with comprehensive options:
 	  write_buffer_size: "64MB"
 	  max_concurrency: 200
 	  read_ahead_size: "128MB"
-	  compression_enabled: true
 	  connection_pool_size: 8
 
 	cache:

--- a/docs/features/compression.md
+++ b/docs/features/compression.md
@@ -5,13 +5,20 @@ applications see ordinary bytes and S3 stores fewer of them. It is **off by defa
 exists because turning it on costs you four things that are not obvious from the configuration key.
 
 ```yaml
-write_buffer:
-  compression:
-    enabled: false        # the default
-    min_size: 4KB         # smaller objects are stored as-is
-    algorithm: zstd       # none, zstd, lz4, gzip
-    level: 3              # zstd 0-22, gzip 0-9; 0 selects the codec's default
+storage:
+  s3:
+    compression:
+      enabled: false      # the default
+      min_size: 4KB       # smaller objects are stored as-is
+      algorithm: zstd     # none, zstd, lz4, gzip
+      level: 3            # zstd 0-22, gzip 0-9; 0 selects the codec's default
 ```
+
+This block was under `write_buffer` before v0.11.0. Nothing ever compressed a write buffer — it has
+always configured the codec the S3 backend applies to the whole object — so it now sits under the
+backend that stores the object. A config file still setting `write_buffer.compression`, or the
+`performance.compression_enabled` key that defaulted to `true` and was read by nothing, fails to load
+with the offending key named rather than being silently ignored.
 
 The short version:
 
@@ -255,12 +262,13 @@ latency — what else does it provide?* Less than you would expect.
 ## If you do enable it
 
 ```yaml
-write_buffer:
-  compression:
-    enabled: true
-    algorithm: zstd       # gzip only if HTTP clients must read the objects; see above
-    level: 3              # 3 is a good ratio-per-CPU point; above ~9 the returns are small
-    min_size: 4KB         # below this, framing overhead and the tier floor dominate
+storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: zstd     # gzip only if HTTP clients must read the objects; see above
+      level: 3            # 3 is a good ratio-per-CPU point; above ~9 the returns are small
+      min_size: 4KB       # below this, framing overhead and the tier floor dominate
 ```
 
 `min_size` deserves a thought rather than the default. On `STANDARD` there is no billing floor, so 4 KB

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -59,6 +59,23 @@ storage:
       chunk_size: 16MB                # bytes per part; S3 rejects a non-final part under 5MB
       concurrency: 8                  # parts in flight at once
 
+    # Transparent object compression. Off by default, and worth understanding before turning on: a
+    # compressed object is an opaque frame to `aws s3 cp`, boto3, and every other S3 client, so
+    # enabling this revokes the "my data is just objects in S3" property. A ranged read of a
+    # compressed object must also fetch the whole object, because a compression frame cannot be
+    # sliced.
+    #
+    # This block was under `write_buffer` until v0.11.0, which was wrong in both directions: nothing
+    # ever compressed a write buffer, and an operator tuning the write buffer was changing how objects
+    # were stored on the wire. It lives here because the S3 backend is what applies it, to the object.
+    compression:
+      enabled: false
+      min_size: 4KB                   # smaller objects are stored as-is
+      # Safe to change on a bucket that already holds compressed objects: the read path decodes every
+      # algorithm ObjectFS can write, whatever this says. Changing the stored *format* is not.
+      algorithm: zstd                 # none, zstd, lz4, gzip
+      level: 3                        # zstd 0-22, gzip 0-9; 0 = codec default
+
     cost_optimization:                # not yet wired — none of this block reaches the backend
       enabled: false
       tiering_enabled: false
@@ -72,7 +89,6 @@ performance:
   write_buffer_size: 16MB             # not yet wired — write_buffer.max_memory is the live setting
   max_concurrency: 150
   read_ahead_size: 64MB               # not yet wired — see read_ahead below
-  compression_enabled: true           # not yet wired — write_buffer.compression is the live setting
   # Pooled S3 clients. Also the batch concurrency in GetObjects/PutObjects and MaxIdleConnsPerHost
   # on the HTTP transport, so it bounds three things at once. Must be > 0: zero reached the batch
   # paths as an unbuffered channel and blocked forever.
@@ -126,28 +142,18 @@ cache:
     directory: /var/cache/objectfs
     max_size: 10GB
 
-# Write buffering.
+# Write buffering — the bounds on dirty bytes held in memory before they are durable.
 #
-# Not yet wired: vfs.NewWriter takes no configuration, so none of the three sizes below is read.
-# What actually happens is that dirty ranges accumulate per open file until the kernel flushes, and
-# nothing bounds the total — a large enough write set is bounded by available memory rather than by
-# max_memory. Fixing that means backpressure in the writer, not a wider mapping, so these keys stay
-# marked rather than being plumbed to a component that cannot honour them.
+# This block no longer configures compression; that moved to storage.s3.compression, because nothing
+# here ever compressed anything (#157).
 write_buffer:
   flush_interval: 30s                 # not yet wired — flushes happen when the kernel asks
-  max_buffers: 1000                   # not yet wired
-  max_memory: 512MB                   # not yet wired — nothing bounds dirty bytes today
-
-  # Transparent object compression. Off by default, and worth understanding before turning on: a
-  # compressed object is an opaque frame to `aws s3 cp`, boto3, and every other S3 client, so
-  # enabling this revokes the "my data is just objects in S3" property. A ranged read of a
-  # compressed object must also fetch the whole object, because a compression frame cannot be
-  # sliced.
-  compression:
-    enabled: false
-    min_size: 4KB                     # smaller objects are stored as-is
-    algorithm: zstd                   # none, zstd, lz4, gzip
-    level: 3                          # zstd 0-22, gzip 0-9; 0 = codec default
+  max_buffers: 1000                   # maximum files with dirty ranges held at once
+  # Total dirty bytes across all open files. Reaching it flushes to make room rather than failing the
+  # write, and only a flush that could not release enough returns ENOSPC. Set to 0 for unbounded,
+  # which is what the process had for three releases while this key was declared, defaulted, and
+  # validated but read by nothing.
+  max_memory: 512MB
 
 # Network behavior.
 #

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -455,11 +455,15 @@ func (a *Adapter) buildS3Config() *s3.Config {
 
 		StorageTier: s3cfg.StorageTier,
 
+		// Read from storage.s3.compression, not write_buffer.compression (#157). Nothing ever
+		// compressed a write buffer; the block always configured the codec the S3 backend applies to
+		// whole objects, and reading it from two sections away meant an operator tuning the write
+		// buffer changed how objects were stored on the wire.
 		Compression: s3.CompressionConfig{
-			Enabled:   a.config.WriteBuffer.Compression.Enabled,
-			Algorithm: a.config.WriteBuffer.Compression.Algorithm,
-			Level:     a.config.WriteBuffer.Compression.Level,
-			MinSize:   a.config.WriteBuffer.Compression.MinSize,
+			Enabled:   s3cfg.Compression.Enabled,
+			Algorithm: s3cfg.Compression.Algorithm,
+			Level:     s3cfg.Compression.Level,
+			MinSize:   s3cfg.Compression.MinSize,
 		},
 
 		CongestionAlgorithm: a.config.Network.CongestionAlgorithm,

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -394,6 +394,12 @@ func createTestConfig() *config.Configuration {
 				Profile:         "",
 				UseAcceleration: false,
 				ForcePathStyle:  false,
+				Compression: config.CompressionConfig{
+					Enabled:   true,
+					MinSize:   "1KB",
+					Algorithm: "gzip",
+					Level:     6,
+				},
 			},
 		},
 		Performance: config.PerformanceConfig{
@@ -401,7 +407,6 @@ func createTestConfig() *config.Configuration {
 			WriteBufferSize:    "16MB",
 			MaxConcurrency:     100,
 			ReadAheadSize:      "4MB",
-			CompressionEnabled: true,
 			ConnectionPoolSize: 8,
 			PredictiveCaching:  false,
 			MLModelPath:        "",
@@ -425,12 +430,6 @@ func createTestConfig() *config.Configuration {
 			FlushInterval: 30 * time.Second,
 			MaxBuffers:    1000,
 			MaxMemory:     "512MB",
-			Compression: config.CompressionConfig{
-				Enabled:   true,
-				MinSize:   "1KB",
-				Algorithm: "gzip",
-				Level:     6,
-			},
 		},
 		Network: config.NetworkConfig{
 			Timeouts: config.TimeoutConfig{

--- a/internal/adapter/config_mapping_test.go
+++ b/internal/adapter/config_mapping_test.go
@@ -72,10 +72,14 @@ func TestBuildS3ConfigMapsEveryConfiguredValue(t *testing.T) {
 	cfg.Network.CircuitBreaker.FailureThreshold = 13
 	cfg.Network.CircuitBreaker.Timeout = 45 * time.Second
 
-	cfg.WriteBuffer.Compression.Enabled = true
-	cfg.WriteBuffer.Compression.Algorithm = "zstd"
-	cfg.WriteBuffer.Compression.Level = 5
-	cfg.WriteBuffer.Compression.MinSize = "8KB"
+	// lz4 rather than zstd. Every value in this test has to differ from the default it would take if
+	// the mapping were absent, and zstd *is* the default — so `Algorithm: "zstd"` hardcoded in
+	// buildS3Config passes an assertion written against zstd. That is the exact shape of D12, where a
+	// field the mapping never touched still arrived at a plausible value from somewhere else.
+	cfg.Storage.S3.Compression.Enabled = true
+	cfg.Storage.S3.Compression.Algorithm = "lz4"
+	cfg.Storage.S3.Compression.Level = 5
+	cfg.Storage.S3.Compression.MinSize = "8KB"
 
 	// sse-kms with bucket keys because it is the only mode that populates all three fields, so a
 	// mapping that carried the mode and dropped the key — the shape of P-7 that is hardest to see,
@@ -184,7 +188,13 @@ func TestBuildS3ConfigMapsEveryConfiguredValue(t *testing.T) {
 		{field: "CongestionAlgorithm", got: got.CongestionAlgorithm, want: "bbr"},
 
 		{field: "Compression.Enabled", got: got.Compression.Enabled, want: true},
-		{field: "Compression.Algorithm", got: got.Compression.Algorithm, want: "zstd"},
+		{
+			field: "Compression.Algorithm",
+			got:   got.Compression.Algorithm,
+			want:  "lz4",
+			why: "deliberately not zstd, which is the default this field would hold anyway if the " +
+				"mapping dropped it",
+		},
 		{field: "Compression.Level", got: got.Compression.Level, want: 5},
 		{
 			field: "Compression.MinSize",

--- a/internal/adapter/fuzz_config_test.go
+++ b/internal/adapter/fuzz_config_test.go
@@ -244,61 +244,67 @@ var configSeeds = []struct {
 	{
 		name: "C1 itself",
 		why:  "the v0.10.0 default: gzip named where no gzip codec existed",
-		yaml: `write_buffer:
-  compression:
-    enabled: true
-    algorithm: gzip
-    level: 6
-    min_size: 4KB
+		yaml: `storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: gzip
+      level: 6
+      min_size: 4KB
 `,
 	},
 	{
 		name: "every supported algorithm's name",
 		why:  "each must either validate and construct, or be rejected by Validate — never neither",
-		yaml: `write_buffer:
-  compression:
-    enabled: true
-    algorithm: zstd
-    level: 3
+		yaml: `storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: zstd
+      level: 3
 `,
 	},
 	{
 		name: "a level valid for one algorithm and not another",
 		why:  "zstd takes 0-22 and gzip only 0-9, so a name-matching validator cannot catch this",
-		yaml: `write_buffer:
-  compression:
-    enabled: true
-    algorithm: gzip
-    level: 19
+		yaml: `storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: gzip
+      level: 19
 `,
 	},
 	{
 		name: "an algorithm no codec exists for",
 		why:  "must be refused by Validate, with the supported set named",
-		yaml: `write_buffer:
-  compression:
-    enabled: true
-    algorithm: brotli
+		yaml: `storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: brotli
 `,
 	},
 	{
 		name: "a stale algorithm in a disabled block",
 		why:  "a setting with no effect must not refuse the mount",
-		yaml: `write_buffer:
-  compression:
-    enabled: false
-    algorithm: brotli
-    level: 99
+		yaml: `storage:
+  s3:
+    compression:
+      enabled: false
+      algorithm: brotli
+      level: 99
 `,
 	},
 	{
 		name: "an unparseable min_size",
 		why:  "parsed by internal/compression, not by the validator's own arithmetic",
-		yaml: `write_buffer:
-  compression:
-    enabled: true
-    algorithm: zstd
-    min_size: "4 gigglebytes"
+		yaml: `storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: zstd
+      min_size: "4 gigglebytes"
 `,
 	},
 	{
@@ -335,10 +341,33 @@ global:
 		name:             "a key that does not exist",
 		why:              "P-10: this exact document was silently accepted before v0.10.1, setting nothing",
 		rejectedByLoader: true,
+		yaml: `storage:
+  s3:
+    compression:
+      enable: true
+      zstd_level: 3
+`,
+	},
+	{
+		name: "the compression block at its pre-v0.11.0 path",
+		why: "#157 moved compression from write_buffer to storage.s3, and removed the key rather " +
+			"than keeping it as an ignored field. An operator upgrading with this in their file has " +
+			"to be told, because the alternative is their compression settings silently ceasing to " +
+			"apply — which is the same failure P-10 was about, arrived at by a different route",
+		rejectedByLoader: true,
 		yaml: `write_buffer:
   compression:
-    enable: true
-    zstd_level: 3
+    enabled: true
+    algorithm: zstd
+`,
+	},
+	{
+		name: "the dead performance.compression_enabled key",
+		why: "removed by #157. It defaulted to true and was read by nothing, so a file setting it " +
+			"was written by someone who believed compression was on when it was off",
+		rejectedByLoader: true,
+		yaml: `performance:
+  compression_enabled: true
 `,
 	},
 
@@ -635,10 +664,10 @@ func TestValidateRejectsWhatTheCodecFactoryRejects(t *testing.T) {
 			t.Parallel()
 
 			cfg := config.NewDefault()
-			cfg.WriteBuffer.Compression.Enabled = true
-			cfg.WriteBuffer.Compression.Algorithm = tc.algorithm
-			cfg.WriteBuffer.Compression.Level = tc.level
-			cfg.WriteBuffer.Compression.MinSize = tc.minSize
+			cfg.Storage.S3.Compression.Enabled = true
+			cfg.Storage.S3.Compression.Algorithm = tc.algorithm
+			cfg.Storage.S3.Compression.Level = tc.level
+			cfg.Storage.S3.Compression.MinSize = tc.minSize
 
 			err := cfg.Validate()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,13 +45,20 @@ type GlobalConfig struct {
 	ProfilePort int    `yaml:"profile_port"`
 }
 
-// PerformanceConfig represents performance-related settings
+// PerformanceConfig represents performance-related settings.
+//
+// Its `compression_enabled` key is gone (#157). It defaulted to **true**, was read by nothing, and
+// sat two sections away from the `compression` block that actually controlled compression and
+// defaulted to false — so the configuration contained a prominent `compression_enabled: true` that
+// meant nothing, next to the real setting that said otherwise. It is removed rather than wired
+// because there is nothing to wire it to: compression happens in the S3 backend, on the object, and
+// is configured by `storage.s3.compression`. A second boolean over the same feature could only
+// disagree with the first.
 type PerformanceConfig struct {
-	CacheSize          string `yaml:"cache_size"`
-	WriteBufferSize    string `yaml:"write_buffer_size"`
-	MaxConcurrency     int    `yaml:"max_concurrency"`
-	ReadAheadSize      string `yaml:"read_ahead_size"`
-	CompressionEnabled bool   `yaml:"compression_enabled"`
+	CacheSize       string `yaml:"cache_size"`
+	WriteBufferSize string `yaml:"write_buffer_size"`
+	MaxConcurrency  int    `yaml:"max_concurrency"`
+	ReadAheadSize   string `yaml:"read_ahead_size"`
 	// ConnectionPoolSize is the number of pooled S3 clients, and also the batch concurrency in
 	// GetObjects/PutObjects and MaxIdleConnsPerHost on the HTTP transport. Validated > 0 below:
 	// zero reached the batch paths as an unbuffered semaphore and blocked forever.
@@ -124,20 +131,41 @@ type ReadAheadConfig struct {
 	ModelUpdateInterval string `yaml:"model_update_interval"` // ML model update frequency
 }
 
-// WriteBufferConfig represents write buffer configuration
+// WriteBufferConfig represents write buffer configuration.
+//
+// Its `compression` subsection moved to `storage.s3.compression`, where the thing it configures
+// lives (#157). It is gone rather than deprecated, and the loader is strict, so a file still setting
+// `write_buffer.compression` fails to load with the key named — the same reasoning as the removed
+// encryption booleans above. Silently accepting it under the old path would leave an operator
+// believing they had configured a write buffer when what they had configured was the stored format
+// of every object in their bucket, which is the misunderstanding the move exists to end.
 type WriteBufferConfig struct {
-	FlushInterval time.Duration     `yaml:"flush_interval"`
-	MaxBuffers    int               `yaml:"max_buffers"`
-	MaxMemory     string            `yaml:"max_memory"`
-	Compression   CompressionConfig `yaml:"compression"`
+	FlushInterval time.Duration `yaml:"flush_interval"`
+	MaxBuffers    int           `yaml:"max_buffers"`
+	MaxMemory     string        `yaml:"max_memory"`
 }
 
-// CompressionConfig represents compression settings
+// CompressionConfig configures transparent compression of stored S3 objects. See
+// [S3Config.Compression], its only user.
 type CompressionConfig struct {
-	Enabled   bool   `yaml:"enabled"`
-	MinSize   string `yaml:"min_size"`
+	// Enabled turns compression on. Off by default: it is a storage-format decision rather than a
+	// performance knob, and a compressed object is an opaque frame to every S3 client but ObjectFS.
+	Enabled bool `yaml:"enabled"`
+	// MinSize is the smallest object worth compressing, e.g. "4KB". Below it, framing overhead and
+	// any per-tier billing floor dominate whatever the codec saves.
+	MinSize string `yaml:"min_size"`
+	// Algorithm names the codec: "none", "zstd", "lz4", or "gzip". The authority is
+	// pkg/compression.SupportedAlgorithms, and Validate builds the codec rather than checking a list,
+	// because building it is the only check that cannot drift.
+	//
+	// Safe to change on a bucket that already holds compressed objects: the read path decodes every
+	// algorithm ObjectFS can write, chosen from each object's own Content-Encoding (#230). Through
+	// v0.10.x it was not — a mount decoded only its configured algorithm.
 	Algorithm string `yaml:"algorithm"`
-	Level     int    `yaml:"level"`
+	// Level is the codec-specific compression level; 0 selects the codec's default. The valid range
+	// differs per algorithm — zstd accepts 0-22, gzip only 0-9 — so a level valid for one is often
+	// invalid for another, and changing Algorithm may require changing this too.
+	Level int `yaml:"level"`
 }
 
 // NetworkConfig represents network configuration
@@ -371,6 +399,22 @@ type S3Config struct {
 	// Multipart controls when an upload is split into parts and how those parts are sent.
 	Multipart MultipartConfig `yaml:"multipart"`
 
+	// Compression controls transparent compression of the objects ObjectFS writes to S3.
+	//
+	// It lives here, under the backend that stores the objects, because that is what it decides: the
+	// stored format of an object in a bucket. It used to live under `write_buffer`, where the name
+	// implied it compressed data held in memory before upload and where nothing else in the section
+	// was about storage at all (#157). Nothing compressed a buffer — the setting was mapped straight
+	// into the S3 backend's own compression config and always had been — so the key's location
+	// described a feature that did not exist while the feature it did control was documented nowhere
+	// near the backend it configures.
+	//
+	// That mattered beyond tidiness in two directions. An operator tuning write buffering had no
+	// reason to expect they were changing the on-disk format of every object they wrote, and an
+	// operator looking for object compression had no reason to look under `write_buffer`. Both are
+	// how a storage-format decision gets made by accident.
+	Compression CompressionConfig `yaml:"compression"`
+
 	CostOptimization S3CostOptimization `yaml:"cost_optimization"`
 }
 
@@ -446,6 +490,26 @@ func NewDefault() *Configuration {
 					ChunkSize:   "16MB",
 					Concurrency: 8,
 				},
+				// Compression is off by default. It is a storage-format decision, not a performance
+				// knob: a compressed object is an opaque frame to `aws s3 cp`, boto3, and every other
+				// S3 client, so enabling it by default would silently revoke the "my data is just
+				// objects in S3" property that most users assume. It also makes a ranged read fetch
+				// the whole object, since a compression frame cannot be sliced. Opt in when the
+				// tradeoff is wanted.
+				//
+				// Off here and on in internal/storage/s3.NewDefaultConfig, the same split as
+				// UseCargoShip and for the same reason: that constructor serves the Go SDK, where the
+				// caller chose the S3 backend explicitly, and this file serves a mount.
+				//
+				// The algorithm is named even though compression is disabled, so that flipping
+				// Enabled to true does not also have to supply one. zstd/3/4KB matches what
+				// NewDefaultConfig chooses, so the two entry points agree on everything but Enabled.
+				Compression: CompressionConfig{
+					Enabled:   false,
+					MinSize:   "4KB",
+					Algorithm: "zstd",
+					Level:     3,
+				},
 				CostOptimization: S3CostOptimization{
 					Enabled:             false,
 					TieringEnabled:      false,
@@ -460,7 +524,6 @@ func NewDefault() *Configuration {
 			WriteBufferSize:    "16MB",
 			MaxConcurrency:     150,
 			ReadAheadSize:      "64MB",
-			CompressionEnabled: true,
 			ConnectionPoolSize: 8,
 			PredictiveCaching:  false,
 			MLModelPath:        "",
@@ -506,20 +569,6 @@ func NewDefault() *Configuration {
 			FlushInterval: 30 * time.Second,
 			MaxBuffers:    1000,
 			MaxMemory:     "512MB",
-			// Compression is off by default. It is a storage-format decision, not a performance
-			// knob: a compressed object is an opaque frame to `aws s3 cp`, boto3, and every other
-			// S3 client, so enabling it by default would silently revoke the "my data is just
-			// objects in S3" property that most users assume. It also makes a ranged read fetch the
-			// whole object, since a zstd frame cannot be sliced. Opt in when the tradeoff is wanted.
-			//
-			// The algorithm is named even though compression is disabled, so that flipping Enabled
-			// to true does not also have to supply an algorithm.
-			Compression: CompressionConfig{
-				Enabled:   false,
-				MinSize:   "4KB",
-				Algorithm: "zstd",
-				Level:     3,
-			},
 		},
 		Network: NetworkConfig{
 			Timeouts: TimeoutConfig{
@@ -755,8 +804,11 @@ func getEnvMappings() []envMapping {
 			c.Performance.ReadAheadSize = val
 			return nil
 		}},
+		// Repointed from the removed performance.compression_enabled to the setting that actually
+		// controls compression (#157). The variable's name was never wrong; what it assigned to was
+		// read by nothing, so exporting it had no effect on whether objects were compressed.
 		{"OBJECTFS_COMPRESSION_ENABLED", func(c *Configuration, val string) error {
-			c.Performance.CompressionEnabled = strings.ToLower(val) == TrueValue
+			c.Storage.S3.Compression.Enabled = strings.ToLower(val) == TrueValue
 			return nil
 		}},
 		{"OBJECTFS_CONNECTION_POOL_SIZE", func(c *Configuration, val string) error {
@@ -898,8 +950,8 @@ func (c *Configuration) Validate() error {
 		return fmt.Errorf("read_ahead configuration invalid: %w", err)
 	}
 
-	if err := validateCompressionConfig(c.WriteBuffer.Compression); err != nil {
-		return fmt.Errorf("write_buffer.compression configuration invalid: %w", err)
+	if err := validateCompressionConfig(c.Storage.S3.Compression); err != nil {
+		return fmt.Errorf("storage.s3.compression configuration invalid: %w", err)
 	}
 
 	if err := c.validateSizes(); err != nil {
@@ -1129,7 +1181,7 @@ func (c *Configuration) validateSizes() error {
 		}
 	}
 
-	// write_buffer.compression.min_size is validated by validateCompressionConfig, which builds the
+	// storage.s3.compression.min_size is validated by validateCompressionConfig, which builds the
 	// codec — and only when compression is enabled, since a disabled block is not consulted.
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,8 +34,21 @@ func TestNewDefault(t *testing.T) {
 	if cfg.Performance.MaxConcurrency != 150 {
 		t.Errorf("Expected MaxConcurrency to be 150, got %d", cfg.Performance.MaxConcurrency)
 	}
-	if !cfg.Performance.CompressionEnabled {
-		t.Error("Expected CompressionEnabled to be true")
+	// Object compression lives under the backend that stores the objects (#157), and is off by
+	// default: it is a storage-format decision, not a performance knob — a compressed object is not
+	// readable by `aws s3 cp`. The algorithm and level are still asserted, because they are what a
+	// mount uses the moment an operator flips enabled.
+	if cfg.Storage.S3.Compression.Enabled {
+		t.Error("Expected storage.s3.compression.enabled to default to false")
+	}
+	if cfg.Storage.S3.Compression.Algorithm != "zstd" {
+		t.Errorf("Expected compression algorithm zstd, got %s", cfg.Storage.S3.Compression.Algorithm)
+	}
+	if cfg.Storage.S3.Compression.Level != 3 {
+		t.Errorf("Expected compression level 3, got %d", cfg.Storage.S3.Compression.Level)
+	}
+	if cfg.Storage.S3.Compression.MinSize != "4KB" {
+		t.Errorf("Expected compression min_size 4KB, got %s", cfg.Storage.S3.Compression.MinSize)
 	}
 
 	// Test cache defaults
@@ -146,7 +159,12 @@ global:
 performance:
   cache_size: 4GB
   max_concurrency: 200
-  compression_enabled: false
+
+storage:
+  s3:
+    compression:
+      enabled: true
+      algorithm: lz4
 
 features:
   prefetching: false
@@ -177,8 +195,18 @@ features:
 	if cfg.Performance.MaxConcurrency != 200 {
 		t.Errorf("Expected MaxConcurrency to be 200, got %d", cfg.Performance.MaxConcurrency)
 	}
-	if cfg.Performance.CompressionEnabled {
-		t.Error("Expected CompressionEnabled to be false")
+	if !cfg.Storage.S3.Compression.Enabled {
+		t.Error("Expected storage.s3.compression.enabled to be true")
+	}
+	if cfg.Storage.S3.Compression.Algorithm != "lz4" {
+		t.Errorf("Expected compression algorithm lz4, got %s", cfg.Storage.S3.Compression.Algorithm)
+	}
+	// Not set in the file, so the default survives the overlay. This is the half of the loader a
+	// partial section can break: yaml.Unmarshal into an already-defaulted struct leaves absent keys
+	// alone, and a file that names only `algorithm` must not zero the level to an invalid 0.
+	if cfg.Storage.S3.Compression.Level != 3 {
+		t.Errorf("Expected compression level to keep its default 3, got %d",
+			cfg.Storage.S3.Compression.Level)
 	}
 	if cfg.Features.Prefetching {
 		t.Error("Expected Prefetching to be false")
@@ -203,7 +231,7 @@ func TestLoadFromEnv(t *testing.T) {
 		"OBJECTFS_METRICS_PORT":        "9090",
 		"OBJECTFS_CACHE_SIZE":          TestCacheSize,
 		"OBJECTFS_MAX_CONCURRENCY":     "300",
-		"OBJECTFS_COMPRESSION_ENABLED": "false",
+		"OBJECTFS_COMPRESSION_ENABLED": "true",
 		"OBJECTFS_PREFETCHING":         "false",
 		"OBJECTFS_BATCH_OPERATIONS":    "false",
 		"OBJECTFS_OFFLINE_MODE":        "true",
@@ -234,8 +262,12 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.Performance.MaxConcurrency != 300 {
 		t.Errorf("Expected MaxConcurrency to be 300, got %d", cfg.Performance.MaxConcurrency)
 	}
-	if cfg.Performance.CompressionEnabled {
-		t.Error("Expected CompressionEnabled to be false")
+	// OBJECTFS_COMPRESSION_ENABLED assigns storage.s3.compression.enabled as of #157. It previously
+	// assigned performance.compression_enabled, which was read by nothing — so exporting this
+	// variable had no effect on whether objects were compressed. Asserted as true against a default
+	// of false: "false" would pass whether or not the handler ran at all.
+	if !cfg.Storage.S3.Compression.Enabled {
+		t.Error("OBJECTFS_COMPRESSION_ENABLED=true did not reach storage.s3.compression.enabled")
 	}
 	if cfg.Features.Prefetching {
 		t.Error("Expected Prefetching to be false")

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -114,8 +114,15 @@ Configuration file format:
 	  write_buffer_size: "16MB"
 	  max_concurrency: 150
 	  read_ahead_size: "64MB"
-	  compression_enabled: true
 	  connection_pool_size: 8
+
+	storage:
+	  s3:
+	    compression:
+	      enabled: false
+	      algorithm: "zstd"
+	      level: 3
+	      min_size: "4KB"
 
 	cache:
 	  ttl: 5m
@@ -221,12 +228,16 @@ no way to be told it is stale. As of writing:
 	Cache.EvictionPolicy          "weighted_lru"
 	Features.Prefetching          true
 
-Two defaults are worth knowing because they are not what the name suggests:
+Two settings are worth knowing because their names have misled before:
 
-  - Performance.CompressionEnabled is true, but this is the *write-buffer* compression switch and is
-    separate from WriteBuffer.Compression.Enabled, which is false. Object compression is off by
-    default: it is a storage-format decision rather than a performance knob, and a compressed object
-    is not readable by `aws s3 cp`.
+  - Storage.S3.Compression is the only compression switch, and it defaults to off. There were two
+    others until v0.11.0 — Performance.CompressionEnabled, which defaulted to *true* and was read by
+    nothing, and WriteBuffer.Compression, which is where this block used to live despite nothing ever
+    compressing a write buffer. Both are removed rather than deprecated, so a config file that still
+    sets either fails to load with the key named. Compression is off by default because it is a
+    storage-format decision rather than a performance knob: a compressed object is not readable by
+    `aws s3 cp`. Algorithm is safe to change on an existing bucket — the read path decodes every
+    algorithm ObjectFS can write, whatever this is set to (#230).
   - Global.ProfilePort is 6060 but is read by nothing — no pprof listener is started at any port.
 
 # Security Considerations

--- a/internal/config/strict_test.go
+++ b/internal/config/strict_test.go
@@ -38,15 +38,32 @@ func TestLoadFromFileRejectsUnknownKeys(t *testing.T) {
 		{
 			name:     "a misspelled leaf",
 			why:      "the compression block documented `enable` against the real `enabled`",
-			yaml:     "write_buffer:\n  compression:\n    enable: true\n",
+			yaml:     "storage:\n  s3:\n    compression:\n      enable: true\n",
 			mustName: "enable",
 		},
 		{
 			name: "a leaf named as the wrong type's field",
 			why: "`zstd_level` and `min_file_size` were documented for four releases against the " +
 				"real `level` and `min_size`, and nobody noticed because the block was inert",
-			yaml:     "write_buffer:\n  compression:\n    zstd_level: 3\n",
+			yaml:     "storage:\n  s3:\n    compression:\n      zstd_level: 3\n",
 			mustName: "zstd_level",
+		},
+		{
+			name: "the compression block at its old path",
+			why: "#157 moved compression from write_buffer to storage.s3. Removing the key rather " +
+				"than deprecating it is what makes an upgrade name the file and line to edit; " +
+				"leaving it in the schema as an ignored field would mean an operator's compression " +
+				"settings silently stopped applying on upgrade",
+			yaml:     "write_buffer:\n  compression:\n    enabled: true\n",
+			mustName: "compression",
+		},
+		{
+			name: "the dead performance.compression_enabled key",
+			why: "it defaulted to true, was read by nothing, and sat two sections away from the " +
+				"real setting that defaulted to false (#157). A config still setting it has to be " +
+				"told, because its author believed compression was on",
+			yaml:     "performance:\n  compression_enabled: true\n",
+			mustName: "compression_enabled",
 		},
 		{
 			name:     "a plausible key under a real block",

--- a/internal/config/validate_s3_test.go
+++ b/internal/config/validate_s3_test.go
@@ -131,8 +131,8 @@ func TestValidateRejectsUnusableS3Settings(t *testing.T) {
 		{
 			name: "a compression algorithm no codec implements",
 			mutate: func(c *Configuration) {
-				c.WriteBuffer.Compression.Enabled = true
-				c.WriteBuffer.Compression.Algorithm = "brotli"
+				c.Storage.S3.Compression.Enabled = true
+				c.Storage.S3.Compression.Algorithm = "brotli"
 			},
 			wantText: "brotli",
 			why: "this is audit finding C1's shape — the shipped default named an algorithm the " +
@@ -247,8 +247,8 @@ func TestValidateIgnoresACompressionAlgorithmInADisabledBlock(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewDefault()
-	cfg.WriteBuffer.Compression.Enabled = false
-	cfg.WriteBuffer.Compression.Algorithm = "no-such-codec"
+	cfg.Storage.S3.Compression.Enabled = false
+	cfg.Storage.S3.Compression.Algorithm = "no-such-codec"
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate rejected an unusable algorithm inside a disabled compression block, so a "+

--- a/internal/distributed/consensus.go
+++ b/internal/distributed/consensus.go
@@ -205,8 +205,13 @@ func NewConsensusEngine(cluster *ClusterManager, config *ClusterConfig) (*Consen
 func (ce *ConsensusEngine) Start(ctx context.Context) error {
 	slog.Info("starting consensus engine", "node_id", ce.cluster.GetNodeID())
 
-	// Reset election timer
+	// Under the write lock because resetElectionTimer writes ce.electionTimer and does not lock for
+	// itself — see its doc comment. This call is before any goroutine below exists, but the gossip
+	// receiver started by ClusterManager.Start already does, and an inbound AppendEntries reaches
+	// resetElectionTimer from there.
+	ce.mu.Lock()
 	ce.resetElectionTimer()
+	ce.mu.Unlock()
 
 	// Start background goroutines
 	go ce.electionLoop(ctx)
@@ -217,13 +222,25 @@ func (ce *ConsensusEngine) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops the consensus engine
+// Stop stops the consensus engine.
+//
+// The timer is read under the write lock, not unlocked. A heartbeat arriving from the gossip receiver
+// reaches resetElectionTimer, which replaces ce.electionTimer, and Stop racing that read the field
+// while it was being written — a data race CI caught in TriggerElection's two peer tests and that
+// reproduces locally only under -count on a loaded machine.
+//
+// Neither shutdown signal orders the two. Closing stopCh does not, because the receiver goroutine
+// belongs to GossipProtocol and does not watch it; and although ClusterManager.Stop stops gossip
+// before consensus, GossipProtocol.Stop closes the socket without waiting for the receiver, so a
+// message already in a handler keeps running past it.
 func (ce *ConsensusEngine) Stop() error {
 	close(ce.stopCh)
 
+	ce.mu.Lock()
 	if ce.electionTimer != nil {
 		ce.electionTimer.Stop()
 	}
+	ce.mu.Unlock()
 
 	slog.Info("consensus engine stopped")
 	return nil
@@ -829,11 +846,12 @@ func (ce *ConsensusEngine) executeProposal(proposal *ConsensusProposal) {
 
 // Utility methods
 
+// resetElectionTimer replaces the election timer with a fresh randomized one.
+//
+// ce.mu must be held for writing. It writes ce.electionTimer, which electionLoop reads under the read
+// lock and Stop reads under the write lock; every caller — Start, startElection, and
+// handleNetworkAppendEntries — holds it.
 func (ce *ConsensusEngine) resetElectionTimer() {
-	if ce.electionTimer != nil {
-		ce.electionTimer.Stop()
-	}
-
 	// Random timeout between 150ms and 300ms (scaled by ElectionTimeout)
 	timeoutMs := 150 + (rand.Intn(150))
 	timeout := time.Duration(timeoutMs) * time.Millisecond

--- a/internal/distributed/consensus_test.go
+++ b/internal/distributed/consensus_test.go
@@ -2,6 +2,7 @@ package distributed
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -308,4 +309,53 @@ func TestConsensusEngine_StartStop(t *testing.T) {
 	if err := cm.consensus.Stop(); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
+}
+
+// TestConsensusEngine_StopRacesAnInboundHeartbeat is the regression test for the data race CI caught
+// in TriggerElection's two peer tests.
+//
+// Stop read ce.electionTimer without holding ce.mu while resetElectionTimer replaces it — reached from
+// handleNetworkAppendEntries, which runs on the gossip receiver goroutine. Closing stopCh does not
+// order the two: the receiver belongs to GossipProtocol, which ClusterManager.Stop shuts down *after*
+// the consensus engine, so a heartbeat in flight is still being handled while Stop runs.
+//
+// Driving handleNetworkAppendEntries directly rather than over UDP is what makes this deterministic.
+// The peer tests hit it only when a heartbeat happened to land inside Stop's window, which is why it
+// showed up under CI's load and not locally; here the write is guaranteed to be concurrent with the
+// read, so -race reports it on every run without the fix.
+func TestConsensusEngine_StopRacesAnInboundHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig("stop-race")
+	cfg.ElectionTimeout = time.Hour // no election fires on its own during this test
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	ce := cm.consensus
+
+	if err := ce.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// A heartbeat from a leader at a term above ours, which is the arm that resets the timer. The
+	// sender is not a known node, so the response send is skipped and no socket is needed.
+	body, err := json.Marshal(&AppendEntriesMessage{Term: 99, LeaderID: "leader"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	msg := &GossipMessage{Type: MessageTypeAppendEntries, From: "leader", Data: body}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			ce.handleNetworkAppendEntries(msg)
+		}
+	}()
+
+	if err := ce.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	<-done
 }

--- a/internal/storage/s3/default_config_test.go
+++ b/internal/storage/s3/default_config_test.go
@@ -48,10 +48,10 @@ func TestShippedDefaultsConstructABackend(t *testing.T) {
 	// The compression block comes from the application defaults verbatim. Assembling it by hand
 	// would be the mistake that let C1 ship: the value under test is the one the user actually gets.
 	cfg.Compression = s3.CompressionConfig{
-		Enabled:   defaults.WriteBuffer.Compression.Enabled,
-		Algorithm: defaults.WriteBuffer.Compression.Algorithm,
-		Level:     defaults.WriteBuffer.Compression.Level,
-		MinSize:   defaults.WriteBuffer.Compression.MinSize,
+		Enabled:   defaults.Storage.S3.Compression.Enabled,
+		Algorithm: defaults.Storage.S3.Compression.Algorithm,
+		Level:     defaults.Storage.S3.Compression.Level,
+		MinSize:   defaults.Storage.S3.Compression.MinSize,
 	}
 
 	backend, err := s3.NewBackend(context.Background(), ts.Bucket, cfg)
@@ -154,19 +154,19 @@ func TestCompressionValidationRejectsWhatTheCodecsCannotBuild(t *testing.T) {
 			t.Parallel()
 
 			cfg := config.NewDefault()
-			tc.mutate(&cfg.WriteBuffer.Compression)
+			tc.mutate(&cfg.Storage.S3.Compression)
 
 			err := cfg.Validate()
 
 			if tc.wantErr && err == nil {
 				t.Fatalf("Validate accepted %+v; the failure would surface at mount time as "+
-					"\"Failed to start adapter\"", cfg.WriteBuffer.Compression)
+					"\"Failed to start adapter\"", cfg.Storage.S3.Compression)
 			}
 
 			if !tc.wantErr {
 				if err != nil {
 					t.Fatalf("Validate rejected a usable configuration %+v: %v",
-						cfg.WriteBuffer.Compression, err)
+						cfg.Storage.S3.Compression, err)
 				}
 
 				return

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -352,7 +352,6 @@ func (suite *IntegrationTestSuite) TestEndToEndFileOperations() {
 			CacheSize:          "50MB",
 			WriteBufferSize:    "10MB",
 			MaxConcurrency:     10,
-			CompressionEnabled: true,
 			ConnectionPoolSize: 8,
 		},
 		Cache: config.CacheConfig{


### PR DESCRIPTION
Closes #157.

`write_buffer.compression` configured the codec the S3 backend applies to a whole object on its way to the wire. **Nothing has ever compressed a write buffer.** The misplacement mattered in both directions: an operator tuning the write buffer was changing how every object in the bucket was stored, and an operator asking how objects are stored had no reason to read the write-buffer section. It now lives under `storage.s3.compression`, next to the backend that applies it. Defaults are unchanged — off, zstd, level 3, 4KB.

`performance.compression_enabled` is deleted. It defaulted to **true**, was read by nothing, and sat two sections away from the setting that defaulted to **false** — so the shipped configuration carried a prominent `compression_enabled: true` while no object was ever compressed, and anyone who read the file to find out came away with the opposite of the truth. Removed rather than wired up: compression happens in the backend, on the object, and a second boolean over one feature can only disagree with the first. `OBJECTFS_COMPRESSION_ENABLED` is kept and repointed at `storage.s3.compression.enabled` — the variable's name was never wrong, only what it assigned to.

Both keys are **removed, not deprecated**, so the strict loader fails a file that still sets either and names the key. That follows the precedent of the encryption booleans removed in v0.10.1. A key kept as an ignored field means an operator's compression settings silently stop applying on upgrade, which is the same failure strict decoding was introduced to catch, arrived at by a different route.

## The issue's acceptance criteria

Two need restating rather than checking, because the premises moved between filing and now:

- [x] `Storage.S3.Compression` exists and defaults to zstd / level 3 / 4KB
- [x] `buildS3Config()` yields zstd/3/4KB — **but not "not gzip/6/1KB"**: that half self-corrected before this PR. `internal/config` already defaulted to zstd/3/4KB, matching `s3.NewDefaultConfig` on everything except `Enabled`, which is deliberately false for a mount and true for the Go SDK
- [x] ~~Changing `WriteBuffer.Compression` no longer affects the S3 object compression config~~ — vacuous now: `WriteBuffer.Compression` does not exist, and a file setting it fails to load
- [x] Previously-written gzip objects still read back correctly — **satisfied by #230, not by this change.** #157's claim that "reads are unaffected — `GetObject` dispatches on the stored `Content-Encoding` per object" was false when filed and became true only with #230
- [x] The example config documents the section — **one section, not both**: the write-buffer one is being removed, so documenting both would document a key that no longer loads
- [x] `go test -race ./internal/adapter/... ./internal/config/...` passes

## Verified by mutation

Each applied to the code, the failing test watched, then reverted:

| | mutation | result |
|---|---|---|
| M1 | mapping drops `enabled` | caught |
| M2 | compression defaults on | caught |
| M3 | env handler assigns nothing | caught |
| M4 | old key kept in the schema as an ignored field | caught (4 tests) |
| M5 | compression key typo in `examples/config.yaml` | caught (4 tests) |
| M6 | `Algorithm` hardcoded to `"zstd"` | **MISSED**, then caught |
| M7 | `min_size` dropped from the mapping | caught |
| M8 | `level` dropped from the mapping | caught |

**M6 is the finding.** The mapping test asserted `Algorithm: "zstd"` — which is also the default — so a `buildS3Config` that ignored the configuration entirely passed it. It now asserts `lz4`, because every value in a mapping test has to differ from the one the field would hold if the mapping were absent. That is precisely the shape of the D12 config-plumbing defect: a field nothing mapped still arriving at a plausible value from somewhere else.

## Also here

`examples/config.yaml` marked all three `write_buffer` keys "not yet wired", with a comment stating that nothing bounds dirty bytes. `max_memory` and `max_buffers` reach `vfs.Writer` through `buildWriterOptions` as of #205, and the bound flushes to make room before it refuses a write. `flush_interval` is genuinely unwired and stays marked. Corrected here because it is a false claim in the block this PR edits.

## Gates

- `go build`, `go vet` — clean
- `go test -race ./...` — passes
- `golangci-lint run --new-from-merge-base=origin/main` — **0 issues**
- coverage gate green; `internal/config` floor 86 → 88, the two points being the rejection tests that hold the removal rather than the move itself