### PR TITLE
fix: one address per listener, beside the flag that enables it

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -29,8 +29,9 @@
 #   cmd/objectfs        no tests — argument parsing and signal handling, currently untestable
 #                       because main() calls log.Fatalf directly
 #   internal/testhttp   no tests, deliberately: it is test support, and every statement in it runs
-#                       under the suites that use it. A test for FreePort would assert that a port
-#                       is free by binding it, which is what the function does — a tautology. Its
+#                       under the suites that use it. A test for FreeAddr would assert that an
+#                       address is free by binding it, which is what the function does — a
+#                       tautology. Its
 #                       real check is that deleting adapter.Start's metrics call fails the tests
 #                       built on it, which it does, with the message it exists to print
 #   pkg/archive         no tests — metadata types; dead code pending a decision (Part 4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Each listener's address is one setting, beside the `enabled` flag that governs it
+  ([#202], [#211], [#212]).** `global.metrics_port`, `global.health_port`, `global.profile_port`,
+  `monitoring.metrics_addr`, `monitoring.health_check_addr` and `monitoring.enable_pprof` are all
+  removed, replaced by `monitoring.metrics.addr` and `monitoring.health_checks.addr`, both defaulting
+  to **loopback** — `127.0.0.1:8080` and `127.0.0.1:8081`. Same ports, so an existing same-host
+  Prometheus scrape keeps working; the host is what changed.
+
+  A port and an address were never two settings. `monitoring` declared the two addresses, defaulted
+  them, documented them — and read neither, while the ports two sections away were what the listeners
+  used. So an operator who set `health_check_addr: 127.0.0.1:8081` to keep an unauthenticated
+  diagnostic endpoint off the network got a wildcard bind and no warning: the setting that would have
+  changed it was inert, and the setting that was live could not express a host at all, because the bind
+  was `fmt.Sprintf(":%d", port)`. Both endpoints are on by default, so a stock
+  `objectfs s3://bucket /mnt` published per-operation counts, error rates, sizes and timings — and, on
+  `/health`, component names and error strings — to anything that could route to the host.
+
+  An address subsumes a port, so keeping both would have preserved the disagreement. It also settles
+  what a port could not: `health_port: 0` disabled the health endpoint while `metrics_port: 0` was
+  treated as unset and defaulted back to 8080 and bound it, so two adjacent fields spelled "off"
+  differently and the metrics one failed in the direction that leaves a port open. There is no `0` in
+  an address, and each listener already has an `enabled` flag next to its new `addr`.
+
+  `global.enable_pprof` and `global.profile_port` are removed rather than wired. Nothing read either.
+  The one pprof server in the tree is `pkg/profiling`'s, which has no importer, also binds every
+  interface, and serves *mutating* `/memory/gc` and `/memory/free` handlers with no authentication —
+  binding a third unauthenticated listener inside the change that stops binding two of them was the
+  wrong trade to make on the strength of a boolean nothing read. Its fate is [#245].
+
+  Three further consequences:
+
+  - **A bind failure now fails startup and names the address.** Both servers used to bind on a
+    goroutine and log, so a mount whose metrics port was taken came up with no endpoint and one line
+    in the log to say why — an operator finds that out when a probe starts failing. This deliberately
+    contradicts [#192]'s reasoning that non-fatal was "the right call for observability":
+    `enabled: false` is already how you ask for no endpoint.
+  - **Validation catches what a listener reports badly.** `net.SplitHostPort` accepts `"99999"`, so
+    the port range is checked explicitly and the error names the field. `health_port: 99999` used to
+    reach `net.Listen` from YAML unchecked.
+  - **`OBJECTFS_METRICS_PORT`/`OBJECTFS_HEALTH_PORT` become `OBJECTFS_METRICS_ADDR`/`_HEALTH_ADDR`,**
+    and `OBJECTFS_METRICS_ENABLED` — documented in two places and assigned by nothing, which is
+    [#202]'s shape in the setting that *closes* an endpoint rather than the one that moves it — is now
+    wired, along with a new `OBJECTFS_HEALTH_ENABLED`. Both parse strictly: a value that is not a
+    boolean fails startup naming the variable, where the feature-flag variables coerce anything but
+    `"true"` to false. These two govern unauthenticated endpoints that default to on, so silent
+    coercion is wrong in whichever direction it picks.
+
+  The test gap is the more interesting half. `TestStartMetricsBindsTheEndpoint` scraped `127.0.0.1`
+  and passed against a wildcard bind, because a wildcard bind answers on loopback too — so the tests
+  asserted that *something* was listening and never that it was listening where the configuration
+  said. `Collector.Addr()` now reports the bound address, and the regression tests assert two things:
+  that it equals what was configured (a wildcard bind reports `0.0.0.0` or `[::]` here), and that the
+  endpoint does *not* answer on a routable non-loopback address of the host. Verified by mutation —
+  restoring the `":"+port` bind fails both halves while the old-shaped test stays green.
+
 - **Compression is configured under `storage.s3.compression`, not `write_buffer.compression`
   ([#157]).** Nothing has ever compressed a write buffer. The block always configured the codec the
   S3 backend applies to a whole object on its way to the wire, and the misplacement mattered in both
@@ -282,8 +336,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#163]: https://github.com/scttfrdmn/objectfs/issues/163
 [#164]: https://github.com/scttfrdmn/objectfs/issues/164
 [#181]: https://github.com/scttfrdmn/objectfs/issues/181
+[#192]: https://github.com/scttfrdmn/objectfs/issues/192
+[#202]: https://github.com/scttfrdmn/objectfs/issues/202
 [#205]: https://github.com/scttfrdmn/objectfs/issues/205
+[#211]: https://github.com/scttfrdmn/objectfs/issues/211
+[#212]: https://github.com/scttfrdmn/objectfs/issues/212
 [#230]: https://github.com/scttfrdmn/objectfs/issues/230
+[#245]: https://github.com/scttfrdmn/objectfs/issues/245
 
 ## [0.10.3] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     boolean fails startup naming the variable, where the feature-flag variables coerce anything but
     `"true"` to false. These two govern unauthenticated endpoints that default to on, so silent
     coercion is wrong in whichever direction it picks.
+  - **The endpoints are documented.** `grep -rn health_port docs/ README.md configs/ examples/` used to
+    return nothing: the knobs existed, were read, changed behavior, and appeared in no shipped
+    documentation or example config ([#192]). The README now has a *Metrics and health endpoints*
+    section with both addresses, the `curl` that reaches each, the environment overrides, and why the
+    defaults are loopback; `docs/index.md` names the addresses beside the features rather than listing
+    "health monitoring" with nowhere to point a probe.
 
   The test gap is the more interesting half. `TestStartMetricsBindsTheEndpoint` scraped `127.0.0.1`
   and passed against a wildcard bind, because a wildcard bind answers on loopback too — so the tests

--- a/OBJECTFS.md
+++ b/OBJECTFS.md
@@ -852,9 +852,6 @@ ObjectFS uses a hierarchical configuration system:
 global:
   log_level: INFO
   log_file: /var/log/objectfs.log
-  metrics_port: 8080
-  health_port: 8081
-  profile_port: 6060  # pprof debugging
 
 # Performance settings
 performance:
@@ -922,16 +919,25 @@ security:
     kms_key_id: arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012
     bucket_keys: true
 
-# Monitoring configuration
+# Monitoring configuration.
+#
+# Each listener's address sits beside the enabled flag that governs it, and defaults to loopback:
+# both endpoints are unauthenticated, and /health reports component names and error strings. These
+# replaced global.metrics_port/health_port, which were what the listeners read, and
+# monitoring.metrics_addr/health_check_addr, which were read by nothing — so a port was the only way
+# to move an endpoint and a port cannot name an interface (#211). There is no profile_port: no pprof
+# listener is started at any address (#245).
 monitoring:
   metrics:
     enabled: true
+    addr: 127.0.0.1:8080
     prometheus: true
     custom_labels:
       environment: production
       service: objectfs
   health_checks:
     enabled: true
+    addr: 127.0.0.1:8081
     interval: 30s
     timeout: 5s
   logging:
@@ -1024,11 +1030,12 @@ export OBJECTFS_OFFLINE_CACHE="/mnt/ssd/objectfs-cache"
 export OBJECTFS_TLS_VERIFY="true"
 export OBJECTFS_ENCRYPTION_ENABLED="true"
 
-# Monitoring
+# Monitoring. Addresses, not ports: a port cannot name an interface (#211). There is no pprof
+# variable — no pprof listener is started at any address (#245).
 export OBJECTFS_METRICS_ENABLED="true"
-export OBJECTFS_METRICS_PORT="8080"
-export OBJECTFS_HEALTH_PORT="8081"
-export OBJECTFS_PPROF_PORT="6060"
+export OBJECTFS_METRICS_ADDR="127.0.0.1:8080"
+export OBJECTFS_HEALTH_ENABLED="true"
+export OBJECTFS_HEALTH_ADDR="127.0.0.1:8081"
 
 # Feature flags
 export OBJECTFS_COMPRESSION_ENABLED="true"

--- a/README.md
+++ b/README.md
@@ -345,6 +345,47 @@ Read [docs/features/compression.md](docs/features/compression.md) first. It cove
 transfers the whole object, which storage tiers make the saving zero, and why compression inside the
 file format is usually the better answer.
 
+### Metrics and health endpoints
+
+A mount starts two HTTP listeners with the built-in defaults. Both are on, and neither is
+authenticated, which is why both default to loopback:
+
+```yaml
+monitoring:
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:8080    # /metrics, /health, /debug/metrics, /debug/operations
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081    # /health
+    interval: 30s
+    timeout: 5s
+```
+
+There are no `objectfs metrics` or `objectfs health` subcommands — the mount process serves both, so
+`curl` is the interface:
+
+```bash
+curl -s 127.0.0.1:8080/metrics
+curl -s 127.0.0.1:8081/health
+```
+
+`enabled: false` is the only way to turn a listener off. A port of `0` is rejected rather than read as
+"off" — through v0.10.x `health_port: 0` disabled its listener while `metrics_port: 0` defaulted back
+to 8080 and bound it, so the same value meant opposite things in adjacent blocks. Those port keys are
+gone: a port cannot name an interface, so `:8080` — every interface the host has — was the only bind
+either setting could produce, whatever it was set to. Prometheus scraping `localhost:8080` needs no
+change; a scraper on another host needs an address written here deliberately, and
+[SECURITY.md](SECURITY.md) covers what it then exposes.
+
+An address that cannot be bound fails the mount and names the field, rather than logging and leaving a
+mount up with a probe endpoint that answers nothing. `OBJECTFS_METRICS_ENABLED`,
+`OBJECTFS_METRICS_ADDR`, `OBJECTFS_HEALTH_ENABLED`, and `OBJECTFS_HEALTH_ADDR` override all four
+without a config file; a non-boolean in either `_ENABLED` fails startup instead of being coerced.
+
+There is no pprof listener at any address. See
+[#245](https://github.com/scttfrdmn/objectfs/issues/245).
+
 ### The two shipped config files
 
 - [`configs/example.yaml`](configs/example.yaml) — a short, copyable starting point. Every key in it is read on the mount path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,29 +46,38 @@ enforces no authorization of its own. `mount.options.allow_other` (`false` by de
 that widens the mountpoint beyond the mounting user; turning it on hands every local user the
 bucket. Scope this at the IAM policy, not in ObjectFS.
 
-**Two HTTP listeners bind on all interfaces by default.** With the shipped defaults
+**Two HTTP listeners are on by default, on loopback.** With the shipped defaults
 (`monitoring.metrics.enabled: true`, `monitoring.health_checks.enabled: true`) a mount listens on
-`:8080` and `:8081`:
+`127.0.0.1:8080` and `127.0.0.1:8081`:
 
-| Port | Path | Serves | How to turn it off |
+| Address | Path | Serves | How to turn it off |
 |---|---|---|---|
-| `global.metrics_port` (8080) | `/metrics`, `/health`, `/debug/metrics`, `/debug/operations` | Prometheus counters, latencies, cache statistics; per-operation counts, errors, sizes and timings | `monitoring.metrics.enabled: false` |
-| `global.health_port` (8081) | `/health` | Component health status | `monitoring.health_checks.enabled: false`, or `global.health_port: 0` |
+| `monitoring.metrics.addr` (127.0.0.1:8080) | `/metrics`, `/health`, `/debug/metrics`, `/debug/operations` | Prometheus counters, latencies, cache statistics; per-operation counts, errors, sizes and timings | `monitoring.metrics.enabled: false` |
+| `monitoring.health_checks.addr` (127.0.0.1:8081) | `/health` | Component health status, including component names and error strings | `monitoring.health_checks.enabled: false` |
 
-Neither is authenticated, and both bind `:port` — all interfaces — rather than a loopback address.
-Verified by dialling a mount's metrics port on a non-loopback address of the host. They expose
-operational telemetry, not object contents, keys, or credentials, but the volumes and error rates are
-enough to characterize a workload. On a multi-tenant or internet-facing host, disable them or
-firewall the ports. The bind address is not configurable today; that is
-[#211](https://github.com/scttfrdmn/objectfs/issues/211).
+Neither is authenticated. They expose operational telemetry, not object contents, keys, or
+credentials, but the volumes and error rates are enough to characterize a workload — and `/health`
+names components and repeats their error strings. Set `enabled: false`, or point the address
+somewhere deliberate. Anything wider than loopback is now something an operator writes down: through
+v0.10.x both listeners bound `:port` — every interface — whatever the configuration said, because the
+setting was a port and a port cannot name an interface
+([#211](https://github.com/scttfrdmn/objectfs/issues/211)).
 
-**`metrics_port: 0` does not disable the metrics listener** — `metrics.NewCollector` treats any
-non-positive port as unset and defaults it back to 8080, so an operator who sets `0` meaning "off"
-gets a listener on the default port. Use `monitoring.metrics.enabled: false`. This is
-[#212](https://github.com/scttfrdmn/objectfs/issues/212). `health_port: 0` *does* disable the health
-listener; setting both ports to `0` fails validation, because they would then be equal.
+**Turning a listener off is `enabled: false`, and only that.** `metrics_port: 0` used to read as
+"unset" and default back to 8080, so an operator who wrote `0` meaning "off" got a listener on the
+default port ([#212](https://github.com/scttfrdmn/objectfs/issues/212)); `health_port: 0` disabled its
+listener, so the same value meant opposite things in the two blocks. An address cannot be overloaded
+that way, and there is no second spelling of "off". Setting both addresses equal fails validation
+rather than starting one listener and losing the other.
 
-`global.profile_port` is read by nothing — no pprof listener is started at any port.
+A bind failure is now fatal to startup and names the address. Both servers used to bind on a goroutine
+and log the error, so a mount whose metrics port was taken came up with no endpoint and one line in the
+log to say why — an operator finds that out when a probe starts failing.
+
+No pprof listener is started at any address. `global.enable_pprof` and `global.profile_port` were
+removed rather than wired: the server they would have started serves mutating `/memory/gc` and
+`/memory/free` handlers with no authentication. See
+[#245](https://github.com/scttfrdmn/objectfs/issues/245).
 
 ## Credentials
 

--- a/cmd/objectfs/doc.go
+++ b/cmd/objectfs/doc.go
@@ -190,8 +190,6 @@ YAML configuration with comprehensive options:
 	global:
 	  log_level: INFO
 	  log_file: /var/log/objectfs.log
-	  metrics_port: 8080
-	  health_port: 8081
 
 	performance:
 	  cache_size: "4GB"
@@ -209,7 +207,15 @@ YAML configuration with comprehensive options:
 	    directory: "/var/cache/objectfs"
 	    max_size: "10GB"
 
-	# Additional sections: write_buffer, network, security, monitoring, features
+	monitoring:
+	  metrics:
+	    enabled: true
+	    addr: 127.0.0.1:8080   # unauthenticated; loopback by default
+	  health_checks:
+	    enabled: true
+	    addr: 127.0.0.1:8081   # unauthenticated; loopback by default
+
+	# Additional sections: write_buffer, network, security, features
 
 # Environment Variables
 
@@ -238,9 +244,14 @@ AWS Settings:
 
 Monitoring:
 
-	OBJECTFS_METRICS_ENABLED        Enable metrics collection
-	OBJECTFS_METRICS_PORT           Metrics HTTP server port
-	OBJECTFS_HEALTH_PORT            Health check HTTP server port
+	OBJECTFS_METRICS_ENABLED        Serve the metrics endpoint (true/false)
+	OBJECTFS_METRICS_ADDR           Metrics listener address (host:port)
+	OBJECTFS_HEALTH_ENABLED         Serve the health endpoint (true/false)
+	OBJECTFS_HEALTH_ADDR            Health listener address (host:port)
+
+Both endpoints are unauthenticated and both are on by default, so the two _ENABLED variables are how
+a mount closes one without editing a config file. Unlike the feature-flag variables above, a value
+that is not a boolean fails startup and names the variable rather than being coerced to false.
 
 # Validation and Safety
 

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -25,8 +25,6 @@
 global:
   log_level: INFO                     # DEBUG, INFO, WARN, ERROR
   log_file: ""                        # empty = stderr
-  metrics_port: 8080                  # Prometheus /metrics; must differ from health_port
-  health_port: 8081                   # health endpoint; 0 disables it
 
 storage:
   s3:
@@ -78,10 +76,15 @@ network:
     base_delay: 1s
     max_delay: 30s
 
+# Each endpoint's address sits beside the flag that enables it, and both default to loopback because
+# neither has any authentication. Set enabled: false to turn one off — there is no port value that
+# means "off".
 monitoring:
   metrics:
     enabled: true
+    addr: 127.0.0.1:8080              # /metrics and /debug/*
   health_checks:
     enabled: true
+    addr: 127.0.0.1:8081              # /health
     interval: 30s
     timeout: 5s

--- a/docs-platform/guide/getting-started.md
+++ b/docs-platform/guide/getting-started.md
@@ -247,9 +247,12 @@ performance:
   predictive_caching: true
 
 monitoring:
-  enabled: true
-  metrics_addr: :9090
-  health_check_addr: :8081
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:9090
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
 ```
 
 </CodeRunner>
@@ -278,17 +281,19 @@ Two HTTP endpoints, both served by the mount process itself. There is no `object
 <CodeRunner language="bash">
 
 ```bash
-# Health, on monitoring.health_check_addr (:8081 by default)
-curl http://localhost:8081/health
+# Health, on monitoring.health_checks.addr (127.0.0.1:8081 by default)
+curl http://127.0.0.1:8081/health
 
-# Prometheus metrics, on monitoring.metrics_addr (:9090 in the config above)
-curl http://localhost:9090/metrics
+# Prometheus metrics, on monitoring.metrics.addr (127.0.0.1:9090 in the config above)
+curl http://127.0.0.1:9090/metrics
 ```
 
 </CodeRunner>
 
-Both listeners bind all interfaces and are unauthenticated. [SECURITY.md](https://github.com/scttfrdmn/objectfs/blob/main/SECURITY.md)
-documents that and the switches that turn each off.
+Both listeners are unauthenticated, which is why each defaults to loopback: set `addr` to
+`0.0.0.0:8080` to reach one from another host, and understand that anything that can route to you can
+then read it. `enabled: false` is how you turn one off — there is no address value that means "off".
+[SECURITY.md](https://github.com/scttfrdmn/objectfs/blob/main/SECURITY.md) has the details.
 
 ## Unmounting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,9 +56,17 @@ which names them rather than leaving them mixed in with the list above.
 ### 🔧 Operations
 
 - **Systemd integration**: service templates under `deployments/`
-- **Health monitoring**: health endpoint and internal checks
-- **Metrics export**: Prometheus-compatible metrics endpoint
+- **Health monitoring**: `/health` on `monitoring.health_checks.addr`, plus internal component checks
+- **Metrics export**: Prometheus-compatible `/metrics` on `monitoring.metrics.addr`
 - **Structured logging**: JSON logs with configurable levels
+
+Both listeners are on by default, both default to loopback (`127.0.0.1:8080` and `127.0.0.1:8081`),
+and neither is authenticated. `enabled: false` beside the address is the only way to turn one off; a
+port of `0` is rejected rather than read as "off". [Metrics and health
+endpoints](https://github.com/scttfrdmn/objectfs#metrics-and-health-endpoints) in the README has the
+configuration, and
+[SECURITY.md](https://github.com/scttfrdmn/objectfs/blob/main/SECURITY.md) has what publishing one
+exposes.
 
 ---
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -21,9 +21,6 @@
 global:
   log_level: INFO                     # DEBUG, INFO, WARN, ERROR
   log_file: ""                        # empty = stderr
-  metrics_port: 8080                  # Prometheus /metrics; must differ from health_port
-  health_port: 8081                   # health endpoint; 0 disables it
-  profile_port: 6060                  # not yet wired — pprof is not served on this port
 
 # Storage backend. The bucket comes from the s3:// command-line argument, not from here.
 storage:
@@ -242,11 +239,14 @@ security:
     bucket_keys: false
 
 # Metrics, health and logging.
+#
+# Each listener's address lives beside the `enabled` flag that governs it. There used to be a port
+# under `global` and an address here, for each of the two endpoints; the ports were what the listeners
+# read and the addresses were read by nothing, so an operator who set `metrics_addr` to move the
+# endpoint off every interface got the wildcard anyway. Both endpoints are unauthenticated, which is
+# why the defaults are loopback: publishing them further is a choice you write down.
 monitoring:
   enabled: false                      # not yet wired — see metrics.enabled below
-  metrics_addr: ":9090"               # not yet wired — global.metrics_port is the live setting
-  enable_pprof: false                 # not yet wired
-  health_check_addr: ":8081"          # not yet wired — global.health_port is the live setting
 
   # Not yet wired: no OpenTelemetry exporter is constructed.
   opentelemetry:
@@ -256,12 +256,14 @@ monitoring:
 
   metrics:
     enabled: true
+    addr: 127.0.0.1:8080              # /metrics, /debug/metrics, /debug/operations. No auth
     prometheus: true
     custom_labels:                    # attached to every exported metric
       service: objectfs
 
   health_checks:
     enabled: true
+    addr: 127.0.0.1:8081              # /health. No auth: reports component names and error strings
     interval: 30s
     timeout: 5s
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -205,9 +205,15 @@ func (a *Adapter) Start(ctx context.Context) error {
 				CheckInterval: a.config.Monitoring.HealthChecks.Interval,
 				Timeout:       a.config.Monitoring.HealthChecks.Timeout,
 				MaxFailures:   3,
-				HTTPEnabled:   a.config.Global.HealthPort > 0,
-				HTTPPort:      a.config.Global.HealthPort,
-				HTTPPath:      "/health",
+				// monitoring.health_checks.addr, which is a real setting as of #202 — global.health_port
+				// was, and monitoring.health_check_addr, the one an operator would reach for to move
+				// this listener off the wildcard, was declared, defaulted, documented and read by
+				// nothing. HTTPEnabled is the enclosing `if`, not a second switch derived from a port
+				// being non-zero: `health_port: 0` was how the endpoint got disabled, which is exactly
+				// the overload an address cannot express and no longer has to.
+				HTTPEnabled: true,
+				HTTPAddr:    a.config.Monitoring.HealthChecks.Addr,
+				HTTPPath:    "/health",
 			},
 		}
 		a.monitor, err = health.NewMonitor(monCfg)
@@ -257,7 +263,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 		if err := a.monitor.Start(ctx); err != nil {
 			return fmt.Errorf("failed to start health monitor: %w", err)
 		}
-		slog.Info("health monitor started", "port", a.config.Global.HealthPort)
+		slog.Info("health monitor started", "addr", a.config.Monitoring.HealthChecks.Addr)
 	}
 
 	// 7. Mount filesystem
@@ -374,8 +380,11 @@ func (a *Adapter) startMetrics(ctx context.Context) error {
 	var err error
 	a.metrics, err = metrics.NewCollector(&metrics.Config{
 		Enabled: a.config.Monitoring.Metrics.Enabled,
-		Port:    a.config.Global.MetricsPort,
-		Labels:  a.config.Monitoring.Metrics.CustomLabels,
+		// monitoring.metrics.addr, live as of #202. This read global.metrics_port, and an operator who
+		// wanted the endpoint on loopback only had no way to say so: monitoring.metrics_addr existed for
+		// exactly that and reached nothing.
+		Addr:   a.config.Monitoring.Metrics.Addr,
+		Labels: a.config.Monitoring.Metrics.CustomLabels,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize metrics collector: %w", err)
@@ -388,7 +397,9 @@ func (a *Adapter) startMetrics(ctx context.Context) error {
 	}
 
 	if a.config.Monitoring.Metrics.Enabled {
-		slog.Info("metrics server started", "port", a.config.Global.MetricsPort, "path", "/metrics")
+		// The bound address, not the configured one. They differ when the configured port is 0, and a
+		// log line naming a port nothing is listening on is how the missing bind went unnoticed before.
+		slog.Info("metrics server started", "addr", a.metrics.Addr(), "path", "/metrics")
 	}
 
 	return nil

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -381,11 +381,8 @@ func TestAdapterStopNotStarted(t *testing.T) {
 func createTestConfig() *config.Configuration {
 	return &config.Configuration{
 		Global: config.GlobalConfig{
-			LogLevel:    "INFO",
-			LogFile:     "",
-			MetricsPort: 9090,
-			HealthPort:  8080,
-			ProfilePort: 6060,
+			LogLevel: "INFO",
+			LogFile:  "",
 		},
 		Storage: config.StorageConfig{
 			S3: config.S3Config{
@@ -467,22 +464,24 @@ func createTestConfig() *config.Configuration {
 			},
 		},
 		Monitoring: config.MonitoringConfig{
-			Enabled:         true,
-			MetricsAddr:     ":9090",
-			EnablePprof:     false,
-			HealthCheckAddr: ":8081",
+			Enabled: true,
 			OpenTelemetry: config.OpenTelemetryConfig{
 				Enabled:     false,
 				Endpoint:    "localhost:4317",
 				ServiceName: "objectfs",
 			},
+			// Each listener's address sits inside the block whose enabled flag governs it. Both are
+			// non-default and loopback: a fixture equal to the default cannot show that the mapping ran,
+			// and the wildcard is what this change stopped doing.
 			Metrics: config.MetricsConfig{
 				Enabled:      true,
+				Addr:         "127.0.0.1:19090",
 				Prometheus:   true,
 				CustomLabels: map[string]string{"env": "test"},
 			},
 			HealthChecks: config.HealthChecksConfig{
 				Enabled:  true,
+				Addr:     "127.0.0.1:19091",
 				Interval: 30 * time.Second,
 				Timeout:  5 * time.Second,
 			},

--- a/internal/adapter/fuzz_config_test.go
+++ b/internal/adapter/fuzz_config_test.go
@@ -333,8 +333,13 @@ network:
   connection_pool_size: 1
 global:
   log_level: DEBUG
-  metrics_port: 9090
-  health_port: 8080
+monitoring:
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:19090
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:19091
 `,
 	},
 	{

--- a/internal/adapter/metrics_wiring_test.go
+++ b/internal/adapter/metrics_wiring_test.go
@@ -2,7 +2,7 @@ package adapter
 
 import (
 	"context"
-	"strconv"
+	"net"
 	"strings"
 	"testing"
 
@@ -14,23 +14,28 @@ import (
 //
 // This is the regression test for the defect that everything else about the metrics chain was
 // downstream of: internal/metrics.Collector was constructed here and Start was never called on it, so
-// the registry was correct and unreachable. `monitoring.metrics.enabled: true` and
-// `global.metrics_port: 8080` were both honored as far as building the counters, the mount logged
-// nothing amiss, and a scrape of the port got connection refused. Both SDKs' get_metrics(), the
-// Prometheus examples in docs/monitoring, and every dashboard anybody built against a mount were
-// describing an endpoint that did not exist.
+// the registry was correct and unreachable. `monitoring.metrics.enabled: true` and a metrics port
+// were both honored as far as building the counters, the mount logged nothing amiss, and a scrape of
+// the port got connection refused. Both SDKs' get_metrics(), the Prometheus examples in
+// docs/monitoring, and every dashboard anybody built against a mount were describing an endpoint that
+// did not exist.
 //
 // It scrapes over a socket rather than inspecting a.metrics, because that distinction *is* the defect.
 // A collector with no listener gathers exactly like one with a listener; the field is non-nil either
 // way. Only a request can tell them apart, which is why nothing in this package noticed for a whole
 // release — mutation-testing the fix by deleting the Start call left `go test ./internal/adapter/`
 // entirely green before this test existed.
+//
+// The address is a non-default one, and that is deliberate. A fixture equal to the default passes
+// whether the mapping happened or not, since the field would hold that value anyway.
 func TestStartMetricsBindsTheEndpoint(t *testing.T) {
 	t.Parallel()
 
+	addr := testhttp.FreeAddr(t)
+
 	cfg := config.NewDefault()
 	cfg.Monitoring.Metrics.Enabled = true
-	cfg.Global.MetricsPort = testhttp.FreePort(t)
+	cfg.Monitoring.Metrics.Addr = addr
 
 	a := &Adapter{config: cfg}
 
@@ -39,8 +44,16 @@ func TestStartMetricsBindsTheEndpoint(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = a.metrics.Stop(context.Background()) })
 
-	body := testhttp.Get(t, cfg.Global.MetricsPort, "/metrics",
-		"the adapter bound no metrics listener")
+	// The address the listener reports, which is the value the consumer received — not a recomputation
+	// of the mapping. #211's whole point is that "something is listening" and "the listener is where
+	// the configuration said" are different assertions, and only the second one fails for a wildcard
+	// bind: a wildcard answers on loopback too.
+	if got := a.metrics.Addr(); got != addr {
+		t.Errorf("the collector bound %s; monitoring.metrics.addr was %s. A wildcard bind reports "+
+			"0.0.0.0 or [::] here and publishes an unauthenticated endpoint on every interface", got, addr)
+	}
+
+	body := testhttp.Get(t, addr, "/metrics", "the adapter bound no metrics listener")
 
 	// The prefix and the operator label, both over the wire. Between them they cover the two other
 	// live-path defects in the same chain: an empty Namespace exported every series unprefixed, and
@@ -56,16 +69,20 @@ func TestStartMetricsBindsTheEndpoint(t *testing.T) {
 // TestStartMetricsHonorsDisabled asserts a disabled collector binds nothing.
 //
 // The pairing matters: without it, a Start that unconditionally bound would satisfy the test above
-// while ignoring the setting. metrics.Collector.Start returns nil early when disabled, so the port
-// must stay free — an operator who turns metrics off should not find a listener on 8080.
+// while ignoring the setting. metrics.Collector.Start returns nil early when disabled, so the address
+// must stay free — an operator who turns metrics off should not find a listener on it.
+//
+// This is also the only way to turn the endpoint off now. `metrics_port: 0` used to look like a way,
+// and it was the worst of both: zero read as "unset" to the collector's defaulting, came back as 8080,
+// and got bound (#212). An address has no value that quietly means something else.
 func TestStartMetricsHonorsDisabled(t *testing.T) {
 	t.Parallel()
 
-	port := testhttp.FreePort(t)
+	addr := testhttp.FreeAddr(t)
 
 	cfg := config.NewDefault()
 	cfg.Monitoring.Metrics.Enabled = false
-	cfg.Global.MetricsPort = port
+	cfg.Monitoring.Metrics.Addr = addr
 
 	a := &Adapter{config: cfg}
 
@@ -77,8 +94,8 @@ func TestStartMetricsHonorsDisabled(t *testing.T) {
 	// Waits out the same budget a successful scrape is allowed, rather than dialing once: a single
 	// immediate failure would also be what a listener that is merely slow to bind looks like, so a test
 	// written that way passes whether the setting is honored or not.
-	if !testhttp.Unreachable(t, strconv.Itoa(port), "/metrics") {
-		t.Errorf("something is serving /metrics on port %d with monitoring.metrics.enabled false", port)
+	if !testhttp.Unreachable(t, addr, "/metrics") {
+		t.Errorf("something is serving /metrics on %s with monitoring.metrics.enabled false", addr)
 	}
 }
 
@@ -93,7 +110,7 @@ func TestStartMetricsRejectsAnUnusableLabel(t *testing.T) {
 
 	cfg := config.NewDefault()
 	cfg.Monitoring.Metrics.Enabled = true
-	cfg.Global.MetricsPort = testhttp.FreePort(t)
+	cfg.Monitoring.Metrics.Addr = testhttp.FreeAddr(t)
 	// "operation" is a variable label on operations_total, errors_total and both histograms.
 	cfg.Monitoring.Metrics.CustomLabels = map[string]string{"operation": "read"}
 
@@ -106,5 +123,43 @@ func TestStartMetricsRejectsAnUnusableLabel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "operation") {
 		t.Errorf("the error does not name the offending label, so an operator cannot find it: %v", err)
+	}
+}
+
+// TestStartMetricsFailsWhenTheAddressIsTaken asserts a bind failure fails the mount.
+//
+// It used to be logged with fmt.Printf from inside the goroutine that served, and nothing propagated:
+// an address already in use left the mount running with no endpoint and one line of output on stdout
+// that an operator had no reason to be watching. #192 called the non-fatal behavior "the right call
+// for observability", and it is the opposite — `enabled: false` is already how you ask for no
+// endpoint, so an operator who asked for one and silently did not get it learns from a scrape failing
+// days later.
+//
+// A live listener rather than a malformed address, because malformed is rejected earlier now, by
+// Configuration.Validate. What reaches the bind is a real conflict.
+func TestStartMetricsFailsWhenTheAddressIsTaken(t *testing.T) {
+	t.Parallel()
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving an address: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	cfg := config.NewDefault()
+	cfg.Monitoring.Metrics.Enabled = true
+	cfg.Monitoring.Metrics.Addr = ln.Addr().String()
+
+	a := &Adapter{config: cfg}
+
+	err = a.startMetrics(context.Background())
+	if err == nil {
+		t.Fatal("startMetrics succeeded against an address already in use; the mount would come up " +
+			"with no metrics endpoint and nothing but a log line to say so")
+	}
+	if !strings.Contains(err.Error(), ln.Addr().String()) {
+		t.Errorf("the error does not name the address that could not be bound, which is the one piece "+
+			"of information the operator needs: %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1187,17 +1187,18 @@ func validateEncryptionConfig(cfg EncryptionConfig) error {
 
 // validateListenAddr rejects a monitoring listen address the runtime cannot bind.
 //
-// The check is here rather than at the listener because of where the failure lands otherwise. Both
-// servers bind on a goroutine and log the error: metrics from inside a `go func()` in Collector.Start
-// that nothing reads the result of, health from startHTTPServer, which logs and returns. So a
-// malformed address leaves the mount up and working with no endpoint, and the only report is one line
-// in a log the operator has no reason to be reading — the config parsed, the mount succeeded, and
-// `curl` gets connection refused.
+// Both listeners now bind synchronously and return the error, so a malformed address does fail the
+// mount without this check. What this adds is where the failure is reported: net.Listen can only say
+// "address 127.0.0.1:99999: invalid port", naming neither the setting nor the file. Validation here
+// names the field an operator has to edit, and does it before the backend is constructed and a bucket
+// is contacted. Both servers used to bind on a goroutine and log — metrics from inside a `go func()`
+// whose result nothing read, health from startHTTPServer, which logged and returned — so the mount
+// came up working with no endpoint and one line in a log the operator had no reason to be reading.
 //
-// port is what this most needs to catch and what a listener cannot report well. `health_port: 99999`
-// was a config an operator could write; it reached net.Listen as "[::]:99999", failed in the address
-// parse, and produced exactly the silent-no-endpoint above (#192). net.SplitHostPort accepts it —
-// "99999" is a syntactically fine port string — so the range is checked here explicitly.
+// port is what this most needs to catch. `health_port: 99999` was a config an operator could write;
+// it reached net.Listen as "[::]:99999" and failed there, producing exactly that silent
+// no-endpoint (#192). net.SplitHostPort accepts it — "99999" is a syntactically fine port string —
+// so the range is checked here explicitly.
 //
 // A name is allowed to fail resolution: "localhost" is the address an operator is most likely to
 // write, and refusing anything that does not parse as an IP would reject it. What is checked is the
@@ -1219,9 +1220,8 @@ func validateListenAddr(field, addr string) error {
 
 	n, err := strconv.Atoi(port)
 	if err != nil {
-		return fmt.Errorf("%s has a non-numeric port: %q. A service name is not resolved here, because "+
-			"the listener would fail at bind time on a goroutine and the mount would come up with no "+
-			"endpoint and no error", field, port)
+		return fmt.Errorf("%s has a non-numeric port: %q. A service name is not looked up in "+
+			"/etc/services here; write the number", field, port)
 	}
 	if n < 1 || n > 65535 {
 		return fmt.Errorf("%s port %d is outside 1-65535. Port 0 is not how these endpoints are "+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -22,6 +23,20 @@ const (
 	TrueValue = "true"
 )
 
+// Default bind addresses for the two monitoring listeners.
+//
+// Loopback, not the wildcard. Both endpoints are on by default, so a stock `objectfs s3://bucket /mnt`
+// used to open two unauthenticated ports to every host that could route to it (#211); neither serves
+// object contents, but between them they report per-operation counts, error rates, sizes and timings.
+// Loopback keeps a same-host Prometheus scrape working and makes a cross-host one explicit.
+//
+// The ports are unchanged from the global.metrics_port and global.health_port these replaced, so an
+// existing same-host scrape keeps working across the upgrade.
+const (
+	DefaultMetricsAddr = "127.0.0.1:8080"
+	DefaultHealthAddr  = "127.0.0.1:8081"
+)
+
 // Configuration represents the complete application configuration
 type Configuration struct {
 	Global      GlobalConfig      `yaml:"global"`
@@ -36,13 +51,37 @@ type Configuration struct {
 	Cluster     ClusterConfig     `yaml:"cluster"`
 }
 
-// GlobalConfig represents global application settings
+// GlobalConfig represents global application settings.
+//
+// Its three port keys are gone as of v0.11.0, replaced by an address per listener beside that
+// listener's own `enabled` flag (#202, #211, #212):
+//
+//	global.metrics_port  →  monitoring.metrics.addr
+//	global.health_port   →  monitoring.health_checks.addr
+//	global.profile_port  →  removed outright
+//
+// A port and an address were never two settings. `monitoring` already declared `metrics_addr` and
+// `health_check_addr`, defaulted them, documented them — and read neither, while the ports two
+// sections away were what the listeners used. So an operator who set `health_check_addr:
+// 127.0.0.1:8081` to keep a diagnostic endpoint off the network got a wildcard bind and no warning:
+// the setting that would have changed it was inert and the setting that was live could not express a
+// host at all.
+//
+// An address subsumes a port, so keeping both would have preserved the disagreement. It also settles
+// what a port could not: `health_port: 0` disabled the health endpoint while `metrics_port: 0`
+// defaulted back to 8080 and bound it, so the two adjacent fields spelled "off" differently and the
+// metrics one failed in the direction that leaves a port open. There is no `0` in an address, and each
+// listener already has an `enabled` flag next to its new `addr` — one way to disable, per listener.
+//
+// global.profile_port is removed rather than wired. It defaulted to 6060 and started nothing; the one
+// pprof server in the tree is pkg/profiling's, which has no importer, also binds every interface, and
+// serves mutating /memory/gc and /memory/free endpoints with no authentication. Binding a third
+// unauthenticated listener inside the change that stops binding two of them was the wrong trade to
+// make on the strength of a boolean nothing read. Tracked as #245, where the profiling package's fate
+// is decided with it.
 type GlobalConfig struct {
-	LogLevel    string `yaml:"log_level"`
-	LogFile     string `yaml:"log_file"`
-	MetricsPort int    `yaml:"metrics_port"`
-	HealthPort  int    `yaml:"health_port"`
-	ProfilePort int    `yaml:"profile_port"`
+	LogLevel string `yaml:"log_level"`
+	LogFile  string `yaml:"log_file"`
 }
 
 // PerformanceConfig represents performance-related settings.
@@ -288,28 +327,62 @@ const (
 	EncryptionModeKMS = awsname.SSEModeKMS
 )
 
-// MonitoringConfig represents monitoring settings
+// MonitoringConfig represents monitoring settings.
+//
+// Its `metrics_addr`, `health_check_addr` and `enable_pprof` keys are gone as of v0.11.0. The first
+// two moved to `monitoring.metrics.addr` and `monitoring.health_checks.addr`, beside the `enabled`
+// flag each governs — an address belongs to the listener it binds, and at the top of this block they
+// were two sections away from the ports the listeners actually used, which is how both came to be
+// read by nothing. `enable_pprof` is removed outright; see [GlobalConfig] for why no pprof listener
+// was started in its place.
+//
+// `enabled` remains read by nothing. It is not the switch for this block — `metrics.enabled` and
+// `health_checks.enabled` are, one per listener, and both are honored. Left in place rather than
+// removed with the others because deciding whether a whole-block switch should exist is a design
+// question, not a plumbing one.
 type MonitoringConfig struct {
-	Enabled         bool                `yaml:"enabled"`
-	MetricsAddr     string              `yaml:"metrics_addr"`
-	EnablePprof     bool                `yaml:"enable_pprof"`
-	HealthCheckAddr string              `yaml:"health_check_addr"`
-	OpenTelemetry   OpenTelemetryConfig `yaml:"opentelemetry"`
-	Metrics         MetricsConfig       `yaml:"metrics"`
-	HealthChecks    HealthChecksConfig  `yaml:"health_checks"`
-	Logging         LoggingConfig       `yaml:"logging"`
+	Enabled       bool                `yaml:"enabled"`
+	OpenTelemetry OpenTelemetryConfig `yaml:"opentelemetry"`
+	Metrics       MetricsConfig       `yaml:"metrics"`
+	HealthChecks  HealthChecksConfig  `yaml:"health_checks"`
+	Logging       LoggingConfig       `yaml:"logging"`
 }
 
 // MetricsConfig represents metrics settings
 type MetricsConfig struct {
-	Enabled      bool              `yaml:"enabled"`
+	Enabled bool `yaml:"enabled"`
+
+	// Addr is the host:port the Prometheus endpoint binds, default "127.0.0.1:8080".
+	//
+	// Loopback by default. /metrics and /debug/operations between them report per-operation counts,
+	// error rates, sizes and timings — enough to characterize what a bucket is used for and when — and
+	// neither has any authentication, so a wildcard bind exposed that to every host that could route
+	// to the mount. A same-host Prometheus scrape still works; a cross-host one is now something an
+	// operator writes down.
+	//
+	// Set "0.0.0.0:8080" for every interface, or ":8080", which means the same thing. Setting Enabled
+	// false is how the endpoint is disabled — there is no port 0 to write, which is deliberate: this
+	// field replaced global.metrics_port, where 0 read as "off" and defaulted back to 8080.
+	Addr string `yaml:"addr"`
+
 	Prometheus   bool              `yaml:"prometheus"`
 	CustomLabels map[string]string `yaml:"custom_labels"`
 }
 
 // HealthChecksConfig represents health check settings
 type HealthChecksConfig struct {
-	Enabled  bool          `yaml:"enabled"`
+	Enabled bool `yaml:"enabled"`
+
+	// Addr is the host:port the health endpoint binds, default "127.0.0.1:8081".
+	//
+	// Loopback by default, for the reason [MetricsConfig.Addr] gives: /health reports component names,
+	// error strings and check timings with no authentication. This was found the hard way — a test
+	// asserting a bind *collision* held 127.0.0.1:8081 and watched the server come up on [::]:8081 and
+	// serve happily (#192).
+	//
+	// Setting Enabled false disables the endpoint and the checks behind it.
+	Addr string `yaml:"addr"`
+
 	Interval time.Duration `yaml:"interval"`
 	Timeout  time.Duration `yaml:"timeout"`
 }
@@ -468,11 +541,8 @@ type RedisConfig struct {
 func NewDefault() *Configuration {
 	return &Configuration{
 		Global: GlobalConfig{
-			LogLevel:    "INFO",
-			LogFile:     "",
-			MetricsPort: 8080,
-			HealthPort:  8081,
-			ProfilePort: 6060,
+			LogLevel: "INFO",
+			LogFile:  "",
 		},
 		Storage: StorageConfig{
 			S3: S3Config{
@@ -615,10 +685,7 @@ func NewDefault() *Configuration {
 			},
 		},
 		Monitoring: MonitoringConfig{
-			Enabled:         false,
-			MetricsAddr:     ":9090",
-			EnablePprof:     false,
-			HealthCheckAddr: ":8081",
+			Enabled: false,
 			OpenTelemetry: OpenTelemetryConfig{
 				Enabled:     false,
 				Endpoint:    "localhost:4317",
@@ -626,6 +693,7 @@ func NewDefault() *Configuration {
 			},
 			Metrics: MetricsConfig{
 				Enabled:    true,
+				Addr:       DefaultMetricsAddr,
 				Prometheus: true,
 				CustomLabels: map[string]string{
 					"service": "objectfs",
@@ -633,6 +701,7 @@ func NewDefault() *Configuration {
 			},
 			HealthChecks: HealthChecksConfig{
 				Enabled:  true,
+				Addr:     DefaultHealthAddr,
 				Interval: 30 * time.Second,
 				Timeout:  5 * time.Second,
 			},
@@ -778,10 +847,50 @@ func getEnvMappings() []envMapping {
 			c.Global.LogFile = val
 			return nil
 		}},
-		{"OBJECTFS_METRICS_PORT", func(c *Configuration, val string) error {
-			if port, err := strconv.Atoi(val); err == nil {
-				c.Global.MetricsPort = port
+		// Repointed from the removed global.metrics_port, and renamed with it: the variable assigns an
+		// address now, so a name saying PORT would be the same two-names-one-setting problem the ports
+		// had. Both endpoints get one, because an operator who moves one listener off loopback usually
+		// has to move the other.
+		//
+		// Assigned verbatim rather than parsed. Validate rejects a malformed address naming the field,
+		// which is more use than a handler that swallows the error and leaves the default in place —
+		// what OBJECTFS_METRICS_PORT did, so `OBJECTFS_METRICS_PORT=eighty` was silently ignored.
+		{"OBJECTFS_METRICS_ADDR", func(c *Configuration, val string) error {
+			c.Monitoring.Metrics.Addr = val
+			return nil
+		}},
+		{"OBJECTFS_HEALTH_ADDR", func(c *Configuration, val string) error {
+			c.Monitoring.HealthChecks.Addr = val
+			return nil
+		}},
+		// OBJECTFS_METRICS_ENABLED was documented in cmd/objectfs/doc.go and OBJECTFS.md and assigned
+		// nothing — the same defect as the addresses above, in the setting that turns the listener off
+		// rather than the one that moves it. It is the only way to close an unauthenticated endpoint
+		// without editing a config file, so it is wired rather than undocumented.
+		//
+		// strconv.ParseBool, and the error is returned, unlike the feature-flag handlers below which
+		// coerce anything that is not "true" to false. That asymmetry is deliberate: these two govern
+		// listeners that default to on, so a typo coerced to false silently removes an endpoint a probe
+		// depends on, and coerced to true silently keeps one an operator asked to close. Both are worse
+		// than refusing to start and naming the variable.
+		{"OBJECTFS_METRICS_ENABLED", func(c *Configuration, val string) error {
+			enabled, err := strconv.ParseBool(val)
+			if err != nil {
+				return fmt.Errorf("OBJECTFS_METRICS_ENABLED=%q is not a boolean: %w", val, err)
 			}
+
+			c.Monitoring.Metrics.Enabled = enabled
+
+			return nil
+		}},
+		{"OBJECTFS_HEALTH_ENABLED", func(c *Configuration, val string) error {
+			enabled, err := strconv.ParseBool(val)
+			if err != nil {
+				return fmt.Errorf("OBJECTFS_HEALTH_ENABLED=%q is not a boolean: %w", val, err)
+			}
+
+			c.Monitoring.HealthChecks.Enabled = enabled
+
 			return nil
 		}},
 
@@ -934,8 +1043,29 @@ func (c *Configuration) Validate() error {
 		return fmt.Errorf("connection_pool_size must be greater than 0")
 	}
 
-	if c.Global.MetricsPort == c.Global.HealthPort {
-		return fmt.Errorf("metrics_port and health_port cannot be the same")
+	// Only the enabled listener's address is checked. Refusing to start over a malformed address in a
+	// block that binds nothing would fail a mount over a setting with no effect — the same reasoning as
+	// the disabled-compression arm in validateCompressionConfig.
+	if c.Monitoring.Metrics.Enabled {
+		if err := validateListenAddr("monitoring.metrics.addr", c.Monitoring.Metrics.Addr); err != nil {
+			return err
+		}
+	}
+	if c.Monitoring.HealthChecks.Enabled {
+		if err := validateListenAddr("monitoring.health_checks.addr", c.Monitoring.HealthChecks.Addr); err != nil {
+			return err
+		}
+	}
+
+	// Two listeners on one address is a startup failure with no error, not a conflict the OS resolves:
+	// whichever binds second logs from a goroutine and returns, leaving the mount up with one endpoint
+	// missing. Compared as strings deliberately — "127.0.0.1:8080" and ":8080" are different addresses
+	// and do not collide, since the first binds one interface and the second every interface, so
+	// normalizing them together would reject a pair that works.
+	if c.Monitoring.Metrics.Enabled && c.Monitoring.HealthChecks.Enabled &&
+		c.Monitoring.Metrics.Addr == c.Monitoring.HealthChecks.Addr {
+		return fmt.Errorf("monitoring.metrics.addr and monitoring.health_checks.addr are both %q; "+
+			"two listeners cannot share one address", c.Monitoring.Metrics.Addr)
 	}
 
 	validLogLevels := []string{"DEBUG", "INFO", "WARN", "ERROR"}
@@ -1050,6 +1180,52 @@ func validateEncryptionConfig(cfg EncryptionConfig) error {
 	if cfg.BucketKeys && cfg.Mode != EncryptionModeKMS {
 		return fmt.Errorf("security.encryption: bucket_keys is set but mode is %q; bucket keys reduce "+
 			"SSE-KMS's per-object KMS calls and do nothing without mode %q", cfg.Mode, EncryptionModeKMS)
+	}
+
+	return nil
+}
+
+// validateListenAddr rejects a monitoring listen address the runtime cannot bind.
+//
+// The check is here rather than at the listener because of where the failure lands otherwise. Both
+// servers bind on a goroutine and log the error: metrics from inside a `go func()` in Collector.Start
+// that nothing reads the result of, health from startHTTPServer, which logs and returns. So a
+// malformed address leaves the mount up and working with no endpoint, and the only report is one line
+// in a log the operator has no reason to be reading — the config parsed, the mount succeeded, and
+// `curl` gets connection refused.
+//
+// port is what this most needs to catch and what a listener cannot report well. `health_port: 99999`
+// was a config an operator could write; it reached net.Listen as "[::]:99999", failed in the address
+// parse, and produced exactly the silent-no-endpoint above (#192). net.SplitHostPort accepts it —
+// "99999" is a syntactically fine port string — so the range is checked here explicitly.
+//
+// A name is allowed to fail resolution: "localhost" is the address an operator is most likely to
+// write, and refusing anything that does not parse as an IP would reject it. What is checked is the
+// shape, which is the part a typo breaks.
+func validateListenAddr(field, addr string) error {
+	if addr == "" {
+		return fmt.Errorf("%s must be set to a host:port; leave it at its default or set enabled: false "+
+			"to turn the endpoint off", field)
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("%s is not a host:port address: %q (%w)", field, addr, err)
+	}
+
+	// An empty host is the wildcard, which is legal and is what this change stopped doing by default.
+	// Written explicitly it is a choice, so it is accepted.
+	_ = host
+
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("%s has a non-numeric port: %q. A service name is not resolved here, because "+
+			"the listener would fail at bind time on a goroutine and the mount would come up with no "+
+			"endpoint and no error", field, port)
+	}
+	if n < 1 || n > 65535 {
+		return fmt.Errorf("%s port %d is outside 1-65535. Port 0 is not how these endpoints are "+
+			"disabled — set the enabled flag beside this field to false", field, n)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,11 +20,17 @@ func TestNewDefault(t *testing.T) {
 	if cfg.Global.LogLevel != "INFO" {
 		t.Errorf("Expected LogLevel to be INFO, got %s", cfg.Global.LogLevel)
 	}
-	if cfg.Global.MetricsPort != 8080 {
-		t.Errorf("Expected MetricsPort to be 8080, got %d", cfg.Global.MetricsPort)
+	// Loopback, not the wildcard, and inside the block whose enabled flag governs the listener. Both
+	// endpoints are unauthenticated: /metrics and /debug/operations report per-operation counts, error
+	// rates and timings, /health reports component names and error strings. The ports are the ones
+	// global.metrics_port and global.health_port defaulted to, so a scrape config keeps working; the
+	// host is what changed (#211).
+	if cfg.Monitoring.Metrics.Addr != DefaultMetricsAddr {
+		t.Errorf("monitoring.metrics.addr = %q, want %q", cfg.Monitoring.Metrics.Addr, DefaultMetricsAddr)
 	}
-	if cfg.Global.HealthPort != 8081 {
-		t.Errorf("Expected HealthPort to be 8081, got %d", cfg.Global.HealthPort)
+	if cfg.Monitoring.HealthChecks.Addr != DefaultHealthAddr {
+		t.Errorf("monitoring.health_checks.addr = %q, want %q",
+			cfg.Monitoring.HealthChecks.Addr, DefaultHealthAddr)
 	}
 
 	// Test performance defaults
@@ -106,15 +112,17 @@ func TestValidate(t *testing.T) {
 			errMsg:  "connection_pool_size must be greater than 0",
 		},
 		{
-			name: "same metrics and health ports",
+			name: "same metrics and health addresses",
 			config: func() *Configuration {
 				cfg := NewDefault()
-				cfg.Global.MetricsPort = 8080
-				cfg.Global.HealthPort = 8080
+				cfg.Monitoring.Metrics.Enabled = true
+				cfg.Monitoring.HealthChecks.Enabled = true
+				cfg.Monitoring.Metrics.Addr = "127.0.0.1:8080"
+				cfg.Monitoring.HealthChecks.Addr = "127.0.0.1:8080"
 				return cfg
 			},
 			wantErr: true,
-			errMsg:  "metrics_port and health_port cannot be the same",
+			errMsg:  "two listeners cannot share one address",
 		},
 		{
 			name: "invalid log level",
@@ -153,8 +161,12 @@ func TestLoadFromFile(t *testing.T) {
 	configContent := `
 global:
   log_level: DEBUG
-  metrics_port: 9090
-  health_port: 9091
+
+monitoring:
+  metrics:
+    addr: 127.0.0.1:9090
+  health_checks:
+    addr: 127.0.0.1:9091
 
 performance:
   cache_size: 4GB
@@ -186,8 +198,12 @@ features:
 	if cfg.Global.LogLevel != TestDebugLevel {
 		t.Errorf("Expected LogLevel to be DEBUG, got %s", cfg.Global.LogLevel)
 	}
-	if cfg.Global.MetricsPort != 9090 {
-		t.Errorf("Expected MetricsPort to be 9090, got %d", cfg.Global.MetricsPort)
+	if cfg.Monitoring.Metrics.Addr != "127.0.0.1:9090" {
+		t.Errorf("monitoring.metrics.addr = %q, want 127.0.0.1:9090", cfg.Monitoring.Metrics.Addr)
+	}
+	if cfg.Monitoring.HealthChecks.Addr != "127.0.0.1:9091" {
+		t.Errorf("monitoring.health_checks.addr = %q, want 127.0.0.1:9091",
+			cfg.Monitoring.HealthChecks.Addr)
 	}
 	if cfg.Performance.CacheSize != "4GB" {
 		t.Errorf("Expected CacheSize to be 4GB, got %s", cfg.Performance.CacheSize)
@@ -228,7 +244,8 @@ func TestLoadFromEnv(t *testing.T) {
 	// Set up environment variables
 	testEnvVars := map[string]string{
 		"OBJECTFS_LOG_LEVEL":           "ERROR",
-		"OBJECTFS_METRICS_PORT":        "9090",
+		"OBJECTFS_METRICS_ADDR":        "127.0.0.1:9090",
+		"OBJECTFS_HEALTH_ADDR":         "127.0.0.1:9091",
 		"OBJECTFS_CACHE_SIZE":          TestCacheSize,
 		"OBJECTFS_MAX_CONCURRENCY":     "300",
 		"OBJECTFS_COMPRESSION_ENABLED": "true",
@@ -253,8 +270,13 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.Global.LogLevel != "ERROR" {
 		t.Errorf("Expected LogLevel to be ERROR, got %s", cfg.Global.LogLevel)
 	}
-	if cfg.Global.MetricsPort != 9090 {
-		t.Errorf("Expected MetricsPort to be 9090, got %d", cfg.Global.MetricsPort)
+	if cfg.Monitoring.Metrics.Addr != "127.0.0.1:9090" {
+		t.Errorf("OBJECTFS_METRICS_ADDR did not reach monitoring.metrics.addr: got %q",
+			cfg.Monitoring.Metrics.Addr)
+	}
+	if cfg.Monitoring.HealthChecks.Addr != "127.0.0.1:9091" {
+		t.Errorf("OBJECTFS_HEALTH_ADDR did not reach monitoring.health_checks.addr: got %q",
+			cfg.Monitoring.HealthChecks.Addr)
 	}
 	if cfg.Performance.CacheSize != TestCacheSize {
 		t.Errorf("Expected CacheSize to be 8GB, got %s", cfg.Performance.CacheSize)
@@ -280,6 +302,179 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.Cache.TTL != 10*time.Minute {
 		t.Errorf("Expected Cache TTL to be 10 minutes, got %v", cfg.Cache.TTL)
+	}
+}
+
+// TestValidateRejectsEachWayAListenAddressCanBeWrong covers validateListenAddr's arms individually.
+//
+// This validation is [#192]'s half of the listener change, and each arm has a distinct failure it
+// prevents. The reason it is here rather than left to the bind is that the bind used to happen on a
+// goroutine that logged and returned, so every one of these produced a mount that came up with no
+// endpoint and one line in the log — the operator finds out when a probe starts failing.
+//
+// The range arm is the load-bearing one. net.SplitHostPort accepts "99999" — it is a syntactically
+// fine port string — so nothing before this caught a config an operator could plausibly write.
+func TestValidateRejectsEachWayAListenAddressCanBeWrong(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		addr    string
+		mustSay string
+	}{
+		{
+			name:    "empty",
+			addr:    "",
+			mustSay: "must be set to a host:port",
+		},
+		{
+			name:    "a bare host with no port",
+			addr:    "127.0.0.1",
+			mustSay: "is not a host:port address",
+		},
+		{
+			name:    "a service name rather than a number",
+			addr:    "127.0.0.1:http",
+			mustSay: "non-numeric port",
+		},
+		{
+			// Accepted by net.SplitHostPort, refused by the kernel at bind time. This is the exact value
+			// #192 reported: health_port: 99999 reached net.Listen as "[::]:99999" and failed in the
+			// address parse.
+			name:    "a port above 65535",
+			addr:    "127.0.0.1:99999",
+			mustSay: "outside 1-65535",
+		},
+		{
+			// Port 0 is a real thing to write — it asks the kernel for any free port — which is why it is
+			// refused explicitly rather than accepted: a listener on a port nobody can predict is
+			// indistinguishable from no listener to whatever was meant to scrape it, and "off" is the
+			// enabled flag.
+			name:    "port zero",
+			addr:    "127.0.0.1:0",
+			mustSay: "Port 0 is not how these endpoints are disabled",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Both fields, because they are validated by two separate call sites and an omission in
+			// either is silent: the block would accept any address and the endpoint would land wherever.
+			for field, set := range map[string]func(*Configuration){
+				"monitoring.metrics.addr": func(c *Configuration) {
+					c.Monitoring.Metrics.Enabled = true
+					c.Monitoring.Metrics.Addr = tc.addr
+				},
+				"monitoring.health_checks.addr": func(c *Configuration) {
+					c.Monitoring.HealthChecks.Enabled = true
+					c.Monitoring.HealthChecks.Addr = tc.addr
+				},
+			} {
+				cfg := NewDefault()
+				set(cfg)
+
+				err := cfg.Validate()
+				if err == nil {
+					t.Errorf("%s = %q validated. The bind fails and the mount comes up with no endpoint",
+						field, tc.addr)
+
+					continue
+				}
+				if !contains(err.Error(), tc.mustSay) {
+					t.Errorf("%s = %q: the error does not explain what is wrong (want %q): %v",
+						field, tc.addr, tc.mustSay, err)
+				}
+				if !contains(err.Error(), field) {
+					t.Errorf("%s = %q: the error does not name the field at fault: %v",
+						field, tc.addr, err)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateIgnoresTheAddressOfADisabledListener pins the other half of that contract.
+//
+// A block that binds nothing must not fail a mount over a setting with no effect. This is the same
+// reasoning as validateCompressionConfig's disabled arm, and it is what makes `enabled: false` a
+// usable answer to a bad address rather than a second thing to fix.
+func TestValidateIgnoresTheAddressOfADisabledListener(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewDefault()
+	cfg.Monitoring.Metrics.Enabled = false
+	cfg.Monitoring.Metrics.Addr = "this is not an address"
+	cfg.Monitoring.HealthChecks.Enabled = false
+	cfg.Monitoring.HealthChecks.Addr = ""
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("a malformed address in a block whose enabled flag is false failed validation, so "+
+			"turning an endpoint off is not on its own a way to stop caring about its address: %v", err)
+	}
+}
+
+// TestLoadFromEnvGovernsTheListeners covers the four monitoring variables together.
+//
+// OBJECTFS_METRICS_ENABLED was documented in cmd/objectfs/doc.go and OBJECTFS.md and assigned nothing,
+// which is #202's shape in the setting that *closes* an unauthenticated endpoint rather than the one
+// that moves it. An operator who exported it meaning "off" got a listener.
+//
+// Both _ENABLED cases assert false against a default of true. The direction matters: "false" is the
+// only value whose effect a defaulted-true field can distinguish from the handler never running at
+// all, so asserting true here would pass with the mapping deleted.
+func TestLoadFromEnvGovernsTheListeners(t *testing.T) {
+	// t.Setenv forbids t.Parallel.
+
+	t.Run("each variable reaches the field the listener reads", func(t *testing.T) {
+		t.Setenv("OBJECTFS_METRICS_ENABLED", "false")
+		t.Setenv("OBJECTFS_METRICS_ADDR", "10.0.0.1:19090")
+		t.Setenv("OBJECTFS_HEALTH_ENABLED", "false")
+		t.Setenv("OBJECTFS_HEALTH_ADDR", "10.0.0.1:19091")
+
+		cfg := NewDefault()
+		if !cfg.Monitoring.Metrics.Enabled || !cfg.Monitoring.HealthChecks.Enabled {
+			t.Fatal("both listeners must default to enabled for the assertions below to mean anything")
+		}
+
+		if err := cfg.LoadFromEnv(); err != nil {
+			t.Fatalf("LoadFromEnv() error = %v", err)
+		}
+
+		if cfg.Monitoring.Metrics.Enabled {
+			t.Error("OBJECTFS_METRICS_ENABLED=false did not close the metrics listener, so an operator " +
+				"who exported it to stop publishing an unauthenticated endpoint still has one")
+		}
+		if cfg.Monitoring.HealthChecks.Enabled {
+			t.Error("OBJECTFS_HEALTH_ENABLED=false did not close the health listener")
+		}
+		if cfg.Monitoring.Metrics.Addr != "10.0.0.1:19090" {
+			t.Errorf("monitoring.metrics.addr = %q, want the exported address", cfg.Monitoring.Metrics.Addr)
+		}
+		if cfg.Monitoring.HealthChecks.Addr != "10.0.0.1:19091" {
+			t.Errorf("monitoring.health_checks.addr = %q, want the exported address",
+				cfg.Monitoring.HealthChecks.Addr)
+		}
+	})
+
+	// A value that is not a boolean must fail startup and name the variable, not be coerced. These two
+	// govern endpoints that are on by default, so silent coercion fails in whichever direction the
+	// coercion happens to pick: to false it removes an endpoint a probe depends on, to true it keeps one
+	// the operator asked to close. The feature-flag variables coerce, and that asymmetry is the point.
+	for _, v := range []string{"OBJECTFS_METRICS_ENABLED", "OBJECTFS_HEALTH_ENABLED"} {
+		t.Run(v+" refuses a non-boolean", func(t *testing.T) {
+			t.Setenv(v, "yes-please")
+
+			err := NewDefault().LoadFromEnv()
+			if err == nil {
+				t.Fatalf("%s=yes-please was accepted; whichever way it coerced, an unauthenticated "+
+					"listener is in a state nobody asked for and nothing reported", v)
+			}
+			if !contains(err.Error(), v) {
+				t.Errorf("the error does not name the variable at fault: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -105,9 +105,6 @@ Configuration file format:
 	global:
 	  log_level: INFO
 	  log_file: "/var/log/objectfs.log"
-	  metrics_port: 8080
-	  health_port: 8081
-	  profile_port: 6060
 
 	performance:
 	  cache_size: "2GB"
@@ -133,12 +130,28 @@ Configuration file format:
 	    directory: "/var/cache/objectfs"
 	    max_size: "10GB"
 
+	monitoring:
+	  metrics:
+	    enabled: true
+	    addr: 127.0.0.1:8080
+	  health_checks:
+	    enabled: true
+	    addr: 127.0.0.1:8081
+
 Environment variable mapping:
 
 	# Global settings
 	OBJECTFS_LOG_LEVEL="DEBUG"
 	OBJECTFS_LOG_FILE="/var/log/objectfs.log"
-	OBJECTFS_METRICS_PORT="9090"
+
+	# Listeners. OBJECTFS_METRICS_PORT and OBJECTFS_HEALTH_PORT no longer exist; a port could not
+	# name an interface, so every value of them bound all of them (#211). The two _ENABLED variables
+	# take a boolean and refuse anything else, because they govern unauthenticated endpoints that
+	# default to on: a typo coerced to false silently removes an endpoint a probe depends on.
+	OBJECTFS_METRICS_ENABLED="false"
+	OBJECTFS_METRICS_ADDR="127.0.0.1:9090"
+	OBJECTFS_HEALTH_ENABLED="true"
+	OBJECTFS_HEALTH_ADDR="127.0.0.1:9091"
 
 	# Performance settings
 	OBJECTFS_CACHE_SIZE="4GB"
@@ -219,8 +232,8 @@ Read the current values from [NewDefault] rather than trusting a list here; a ta
 no way to be told it is stale. As of writing:
 
 	Global.LogLevel               "INFO"
-	Global.MetricsPort            8080
-	Global.HealthPort             8081
+	Monitoring.Metrics.Addr       "127.0.0.1:8080"
+	Monitoring.HealthChecks.Addr  "127.0.0.1:8081"
 	Performance.CacheSize         "2GB"
 	Performance.MaxConcurrency    150
 	Performance.ConnectionPoolSize 8      // also the batch concurrency and MaxIdleConnsPerHost
@@ -238,7 +251,15 @@ Two settings are worth knowing because their names have misled before:
     storage-format decision rather than a performance knob: a compressed object is not readable by
     `aws s3 cp`. Algorithm is safe to change on an existing bucket — the read path decodes every
     algorithm ObjectFS can write, whatever this is set to (#230).
-  - Global.ProfilePort is 6060 but is read by nothing — no pprof listener is started at any port.
+  - Monitoring.Metrics.Addr and Monitoring.HealthChecks.Addr are loopback, and each sits beside the
+    `enabled` flag that governs its listener. They replaced Global.MetricsPort/HealthPort and the
+    never-read Monitoring.MetricsAddr/HealthCheckAddr in v0.11.0: the ports were what the listeners
+    bound, the addresses were read by nothing, and a port cannot name an interface — so every value of
+    metrics_port bound all of them (#211). Both endpoints are unauthenticated, which is why the default
+    is the narrowest thing that still lets a same-host scrape work. To turn one off, set its `enabled`
+    to false; there is no `0`-means-off spelling to get wrong (#212).
+  - No pprof listener is started at any address. Global.EnablePprof and Global.ProfilePort are removed
+    rather than wired; see [GlobalConfig] and #245.
 
 # Security Considerations
 

--- a/internal/config/strict_test.go
+++ b/internal/config/strict_test.go
@@ -174,9 +174,9 @@ func TestLoadFromFileLeavesUnmentionedKeysAtTheirDefaults(t *testing.T) {
 
 	def := NewDefault()
 
-	if cfg.Global.MetricsPort != def.Global.MetricsPort {
-		t.Errorf("a key the document does not mention lost its default: metrics_port = %d, want %d",
-			cfg.Global.MetricsPort, def.Global.MetricsPort)
+	if cfg.Monitoring.Metrics.Addr != def.Monitoring.Metrics.Addr {
+		t.Errorf("a key the document does not mention lost its default: monitoring.metrics.addr = %q, "+
+			"want %q", cfg.Monitoring.Metrics.Addr, def.Monitoring.Metrics.Addr)
 	}
 
 	if cfg.Cache.TTL != def.Cache.TTL {

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -42,9 +42,19 @@ type Config struct {
 	MetricsEnabled bool `yaml:"metrics_enabled"`
 
 	// HTTP endpoint settings
-	HTTPEnabled bool   `yaml:"http_enabled"`
-	HTTPPort    int    `yaml:"http_port"`
-	HTTPPath    string `yaml:"http_path"`
+	HTTPEnabled bool `yaml:"http_enabled"`
+
+	// HTTPAddr is the host:port the endpoint binds, default "127.0.0.1:8081".
+	//
+	// This was HTTPPort, an int, which could only ever produce ":%d" — the wildcard. /health reports
+	// component names, error strings and check timings with no authentication, and it is on by default,
+	// so a stock mount published that to anything that could route to it (#211). The port range is also
+	// checked at config load now rather than at bind: 99999 is a config an operator could write, and it
+	// failed in the address parse on this goroutine, logged, and returned, leaving the mount up with no
+	// endpoint (#192).
+	HTTPAddr string `yaml:"http_addr"`
+
+	HTTPPath string `yaml:"http_path"`
 }
 
 // Check represents a health check function
@@ -141,7 +151,7 @@ func NewChecker(config *Config) (*Checker, error) {
 			AlertThreshold:   2,
 			MetricsEnabled:   true,
 			HTTPEnabled:      true,
-			HTTPPort:         8081,
+			HTTPAddr:         "127.0.0.1:8081",
 			HTTPPath:         "/health",
 		}
 	}
@@ -201,13 +211,30 @@ func (c *Checker) Start(ctx context.Context) error {
 	// Start background check loop
 	go c.checkLoop()
 
-	// Start HTTP server if enabled.
+	// Start the HTTP endpoint if enabled.
+	//
+	// The bind happens here, before returning, and its error fails Start. It used to happen on a
+	// goroutine that logged and returned, which left the mount running with no health endpoint and one
+	// line in the log to say why — and #192, which reported the unvalidated port, called that
+	// non-fatal behavior "the right call for observability". It is the opposite: an operator who asked
+	// for the endpoint and did not get it learns from a scrape failing later, and `enabled: false` is
+	// already how you ask for no endpoint. Config validation now rejects a malformed or out-of-range
+	// address at load naming the field, so what reaches here is a real bind failure — the address is
+	// taken, or the OS refused it — which is worth a startup error the operator can act on immediately.
 	//
 	// context.WithoutCancel: the listener outlives the Start call, and this ctx is the caller's
 	// request-scoped one. Binding it directly would tear the endpoint down the moment the caller
 	// canceled — Stop is what ends this server.
 	if c.config.HTTPEnabled {
-		go c.startHTTPServer(context.WithoutCancel(ctx))
+		serveCtx := context.WithoutCancel(ctx)
+
+		ln, err := c.listenHealth(serveCtx)
+		if err != nil {
+			c.started = false
+			return err
+		}
+
+		go c.serveHealth(serveCtx, ln)
 	}
 
 	return nil
@@ -467,25 +494,27 @@ func (c *Checker) updateStats() {
 	c.stats.SystemUptime = time.Since(c.lastUpdate)
 }
 
-// startHTTPServer binds the configured port and serves the health endpoint until Stop.
+// listenHealth binds the configured address for the health endpoint.
 //
-// The bind is separated from the serving so that each half is testable. Before that split the only
-// coverage this function had came from tests *failing* to bind: eight tests in this package start a
-// Monitor with the default Config, which enables the endpoint on the fixed port 8081, so the first
-// one to reach it won and the rest took the error arm below. How many did was a matter of goroutine
-// scheduling — the package measured 45.0% coverage on an idle machine and 44.7% under CI's load,
-// which is how a per-package floor came to be set half a statement above what the tests reliably
-// reach. The handler itself, meanwhile, had never served a request in a test at all.
-func (c *Checker) startHTTPServer(ctx context.Context) {
+// The bind is separated from the serving so that each half is testable, and so that Start can return
+// the bind error rather than log it from a goroutine. Before the split the only coverage this had came
+// from tests *failing* to bind: eight tests in this package start a Monitor with the default Config,
+// which enabled the endpoint on the fixed port 8081, so the first to reach it won and the rest took
+// the error arm. How many did was a matter of goroutine scheduling — the package measured 45.0%
+// coverage on an idle machine and 44.7% under CI's load, which is how a per-package floor came to be
+// set half a statement above what the tests reliably reach.
+//
+// The address, not a port. fmt.Sprintf(":%d", HTTPPort) could only bind every interface; see
+// Config.HTTPAddr.
+func (c *Checker) listenHealth(ctx context.Context) (net.Listener, error) {
 	var lc net.ListenConfig
 
-	ln, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", c.config.HTTPPort))
+	ln, err := lc.Listen(ctx, "tcp", c.config.HTTPAddr)
 	if err != nil {
-		slog.Error("health: failed to bind HTTP server", "port", c.config.HTTPPort, "error", err)
-		return
+		return nil, fmt.Errorf("binding the health endpoint on %s: %w", c.config.HTTPAddr, err)
 	}
 
-	c.serveHealth(ctx, ln)
+	return ln, nil
 }
 
 // serveHealth serves the health endpoint on ln, returning when Stop closes stopCh.

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -231,27 +230,46 @@ func TestHealthEndpointStopsServingAfterStop(t *testing.T) {
 	}
 }
 
-// TestStartHTTPServerSurvivesAnUnbindablePort covers the bind-failure arm deliberately.
+// TestStartFailsWhenTheHealthAddressCannotBeBound pins the bind-failure contract.
 //
-// This arm had coverage before only because parallel tests collided on port 8081 — it was exercised
-// by accident, in tests written to assert something else, a variable number of times per run. That is
-// what made this package's coverage percentage depend on the scheduler.
+// The contract is the opposite of what it was. The bind used to happen on a goroutine that logged the
+// error and returned, so the mount came up with no health endpoint and one line in the log to say
+// why — and #192, reporting the unvalidated port, called that non-fatal behavior "the right call for
+// observability". It is the inversion: an operator who asked for the endpoint and did not get it finds
+// out when a liveness probe starts failing, and `enabled: false` is already how you ask for no
+// endpoint. So Start binds before returning and returns the error.
 //
-// The port numbers here are out of range rather than merely occupied, and that is not laziness: an
-// occupied port does not reliably fail. startHTTPServer binds the wildcard (fmt.Sprintf(":%d")), so
-// a listener already holding 127.0.0.1:N does not stop it from binding [::]:N — the first draft of
-// this test asserted a collision and watched the server come up on [::] instead. An out-of-range
-// port fails in the address parse, before any of that, on every platform.
+// Two cases, and they fail at different depths on purpose. An occupied address is a real conflict that
+// reaches the bind. A malformed one is rejected by net.Listen's address parse — the same class as
+// health_port: 99999, which used to reach here from YAML unchecked and now cannot, because
+// config.Validate range-checks the port at load. Both must reach the caller as an error naming the
+// address.
 //
-// It is also the realistic failure: Global.HealthPort comes from YAML and nothing range-checks it,
-// so health_port: 99999 is a config an operator can actually write. The contract is that it logs and
-// returns. A health endpoint that cannot bind must not be fatal — it is observability, and taking a
-// mount down because a diagnostic port is unusable inverts the priority.
-func TestStartHTTPServerSurvivesAnUnbindablePort(t *testing.T) {
+// Note the occupied case has to be occupied on the *same host*, not merely the same port. The previous
+// implementation bound fmt.Sprintf(":%d") — the wildcard — so a listener holding 127.0.0.1:N did not
+// stop it coming up on [::]:N, and the first draft of the old test asserted a collision and watched
+// exactly that happen. That is #211 seen from the test's side.
+func TestStartFailsWhenTheHealthAddressCannotBeBound(t *testing.T) {
 	t.Parallel()
 
-	for _, port := range []int{-1, 99999} {
-		t.Run(fmt.Sprintf("port %d", port), func(t *testing.T) {
+	var lc net.ListenConfig
+
+	held, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen on loopback in this environment: %v", err)
+	}
+	t.Cleanup(func() { _ = held.Close() })
+
+	cases := []struct {
+		name string
+		addr string
+	}{
+		{name: "the address is already in use", addr: held.Addr().String()},
+		{name: "the address is not a host:port", addr: "127.0.0.1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			checker, err := NewChecker(&Config{
@@ -259,29 +277,124 @@ func TestStartHTTPServerSurvivesAnUnbindablePort(t *testing.T) {
 				CheckInterval: time.Hour,
 				Timeout:       5 * time.Second,
 				HTTPEnabled:   true,
-				HTTPPort:      port,
+				HTTPAddr:      tc.addr,
 				HTTPPath:      "/health",
 			})
 			if err != nil {
 				t.Fatalf("NewChecker() error = %v", err)
 			}
 
-			returned := make(chan struct{})
+			err = checker.Start(t.Context())
+			if err == nil {
+				t.Fatalf("Start succeeded with health_checks.addr %q. The mount would run with no "+
+					"health endpoint, so every probe against it fails and nothing says why", tc.addr)
+			}
+			if !strings.Contains(err.Error(), tc.addr) {
+				t.Errorf("the error does not name the address that could not be bound, which is the "+
+					"one thing the operator has to change: %v", err)
+			}
 
-			go func() {
-				defer close(returned)
-				checker.startHTTPServer(t.Context())
-			}()
-
-			select {
-			case <-returned:
-			case <-time.After(10 * time.Second):
-				t.Fatalf("startHTTPServer did not return after failing to bind port %d. It must log "+
-					"and give up: a goroutine wedged here would hold whatever it acquired for the "+
-					"life of the mount", port)
+			// Start must not leave the checker looking started when it failed, or Stop is unreachable
+			// and a caller retrying gets "already started" for a checker that never ran.
+			if checker.started {
+				t.Error("Start reported an error but left started true; Stop would then be the only " +
+					"way to clear it and Stop is not reachable from a failed Start")
 			}
 		})
 	}
+}
+
+// TestStartServesTheEndpointWhereConfigured is the regression test for #211 on the health side.
+//
+// Nothing asserted where this listener was, only that requests to it succeeded — and a wildcard bind
+// answers on loopback, so a test that scrapes 127.0.0.1 passes either way. /health reports component
+// names, error strings and check timings with no authentication and is on by default, so a stock
+// mount published that to anything that could route to it.
+func TestStartServesTheEndpointWhereConfigured(t *testing.T) {
+	t.Parallel()
+
+	// A reserved-then-released address, because the address has to be known before Start binds it.
+	var lc net.ListenConfig
+
+	probe, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen on loopback in this environment: %v", err)
+	}
+	addr := probe.Addr().String()
+	if err := probe.Close(); err != nil {
+		t.Fatalf("releasing the reserved address: %v", err)
+	}
+
+	checker, err := NewChecker(&Config{
+		Enabled:       true,
+		CheckInterval: time.Hour,
+		Timeout:       5 * time.Second,
+		HTTPEnabled:   true,
+		HTTPAddr:      addr,
+		HTTPPath:      "/health",
+	})
+	if err != nil {
+		t.Fatalf("NewChecker() error = %v", err)
+	}
+
+	if err := checker.Start(t.Context()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = checker.Stop() })
+
+	if code, _ := get(t, "http://"+addr+"/health"); code != http.StatusOK &&
+		code != http.StatusServiceUnavailable {
+		t.Fatalf("the endpoint answered %d on the configured address; it should be serving", code)
+	}
+
+	// And not on an address that is this host but is not the configured one.
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("splitting %s: %v", addr, err)
+	}
+
+	routable := routableIPv4(t)
+	if routable == "" {
+		t.Log("no non-loopback IPv4 address on this host; only the configured-address half of this " +
+			"test ran")
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"http://"+net.JoinHostPort(routable, port)+"/health", nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Errorf("/health answered on %s, which is not the configured %s — an unauthenticated "+
+			"endpoint is reachable from anything that can route to this host", routable, addr)
+	}
+}
+
+// routableIPv4 returns a non-loopback IPv4 address of this host, or "" if it has none.
+func routableIPv4(t *testing.T) string {
+	t.Helper()
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Fatalf("enumerating interface addresses: %v", err)
+	}
+
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() {
+			continue
+		}
+		if v4 := ipnet.IP.To4(); v4 != nil {
+			return v4.String()
+		}
+	}
+
+	return ""
 }
 
 // TestCheckerAccessorsReflectRegisteredChecks covers GetStats, EnableCheck, and DisableCheck.

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -2,7 +2,10 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -32,12 +35,26 @@ type Collector struct {
 
 	// HTTP server for metrics endpoint
 	server *http.Server
+
+	// boundAddr is what the listener actually bound, read through Addr. Guarded by mu: Start writes it
+	// before the serving goroutine exists, and a test reads it from another goroutine.
+	boundAddr string
 }
 
 // Config represents metrics configuration
 type Config struct {
-	Enabled        bool              `yaml:"enabled"`
-	Port           int               `yaml:"port"`
+	Enabled bool `yaml:"enabled"`
+
+	// Addr is the host:port the endpoint binds, default "127.0.0.1:8080".
+	//
+	// This was Port, an int, and the change is not cosmetic. A port cannot express an interface, so
+	// Start built "fmt.Sprintf(\":%d\", Port)" and bound every one of them — /metrics and
+	// /debug/operations, unauthenticated, on any host that could route to the mount (#211). Nor could a
+	// port say "off": zero meant "unset" to the defaulting below and came back as 8080, so an operator
+	// writing 0 to close the port got it opened on the default (#212). Enabled is the only disable
+	// switch now, and there is no value of this field that quietly means something else.
+	Addr string `yaml:"addr"`
+
 	Path           string            `yaml:"path"`
 	Labels         map[string]string `yaml:"labels"`
 	Namespace      string            `yaml:"namespace"`
@@ -63,7 +80,7 @@ type OperationMetrics struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Enabled:        true,
-		Port:           8080,
+		Addr:           "127.0.0.1:8080",
 		Path:           "/metrics",
 		Namespace:      "objectfs",
 		Subsystem:      "",
@@ -92,8 +109,8 @@ func NewCollector(config *Config) (*Collector, error) {
 	}
 
 	defaults := DefaultConfig()
-	if config.Port <= 0 {
-		config.Port = defaults.Port
+	if config.Addr == "" {
+		config.Addr = defaults.Addr
 	}
 	if config.Path == "" {
 		config.Path = defaults.Path
@@ -132,7 +149,13 @@ func NewCollector(config *Config) (*Collector, error) {
 	return collector, nil
 }
 
-// Start starts the metrics collection server
+// Start binds the metrics endpoint and starts the periodic-update loop.
+//
+// The listener is created here and not on the goroutine below, so a bind failure is returned to the
+// caller. It used to be inside the goroutine, where the error went to stdout with fmt.Printf and
+// nothing propagated: a port already in use, or an address the OS refused, left the mount running with
+// no endpoint and one line of output the operator had no reason to be watching. Returning it lets
+// adapter.Start fail the mount, which is the only place that can say which setting was at fault.
 func (c *Collector) Start(ctx context.Context) error {
 	if !c.config.Enabled {
 		return nil
@@ -151,8 +174,15 @@ func (c *Collector) Start(ctx context.Context) error {
 	mux.HandleFunc("/debug/metrics", c.debugMetricsHandler)
 	mux.HandleFunc("/debug/operations", c.debugOperationsHandler)
 
+	// Addr, not a port. fmt.Sprintf(":%d", Port) bound every interface, and there was no way to ask for
+	// one — see Config.Addr.
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", c.config.Addr)
+	if err != nil {
+		return fmt.Errorf("binding the metrics endpoint on %s: %w", c.config.Addr, err)
+	}
+
 	c.server = &http.Server{
-		Addr:              fmt.Sprintf(":%d", c.config.Port),
 		Handler:           mux,
 		ReadHeaderTimeout: 30 * time.Second, // Prevent Slowloris attacks
 		ReadTimeout:       60 * time.Second,
@@ -160,10 +190,14 @@ func (c *Collector) Start(ctx context.Context) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
+	// The bound address, which is not necessarily the configured one: a test asking for port 0 gets
+	// whatever the kernel assigned, and Addr is how it finds out.
+	c.boundAddr = ln.Addr().String()
+
 	// Start server in background
 	go func() {
-		if err := c.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			fmt.Printf("Metrics server error: %v\n", err)
+		if err := c.server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("metrics server stopped serving", "addr", c.config.Addr, "error", err)
 		}
 	}()
 
@@ -171,6 +205,17 @@ func (c *Collector) Start(ctx context.Context) error {
 	go c.updateLoop(ctx)
 
 	return nil
+}
+
+// Addr returns the address the endpoint is bound to, or "" if Start has not bound one.
+//
+// It exists so a test can assert *where* the listener is rather than that a listener exists. The
+// distinction is the whole of #211: the previous wiring test scraped 127.0.0.1 and passed identically
+// against a loopback bind and a wildcard bind, because a wildcard bind answers on loopback too.
+func (c *Collector) Addr() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.boundAddr
 }
 
 // Stop stops the metrics collection server

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -13,7 +13,7 @@ func TestNewCollector(t *testing.T) {
 	t.Run("with valid config", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9090,
+			Addr:      "127.0.0.1:0",
 			Path:      "/metrics",
 			Namespace: "objectfs",
 			Subsystem: "test",
@@ -47,8 +47,10 @@ func TestNewCollector(t *testing.T) {
 		if collector.config == nil {
 			t.Fatal("default config is nil")
 		}
-		if collector.config.Port != 8080 {
-			t.Errorf("default port = %d, want 8080", collector.config.Port)
+		// Loopback, not the wildcard. The default is what a mount with no monitoring block in its
+		// config file gets, and this endpoint is unauthenticated (#211).
+		if collector.config.Addr != "127.0.0.1:8080" {
+			t.Errorf("default addr = %q, want %q", collector.config.Addr, "127.0.0.1:8080")
 		}
 		if collector.config.Path != "/metrics" {
 			t.Errorf("default path = %q, want %q", collector.config.Path, "/metrics")
@@ -81,7 +83,7 @@ func TestRecordOperation(t *testing.T) {
 	t.Run("record successful operation", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9091,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -120,7 +122,7 @@ func TestRecordOperation(t *testing.T) {
 	t.Run("record failed operation", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9092,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -140,7 +142,7 @@ func TestRecordOperation(t *testing.T) {
 	t.Run("record multiple operations", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9093,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -195,7 +197,7 @@ func TestRecordCacheOperations(t *testing.T) {
 	t.Run("record cache hit", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9094,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -210,7 +212,7 @@ func TestRecordCacheOperations(t *testing.T) {
 	t.Run("record cache miss", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9095,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -243,7 +245,7 @@ func TestRecordError(t *testing.T) {
 	t.Run("record error", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9096,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -274,7 +276,7 @@ func TestClassifyError(t *testing.T) {
 
 	config := &Config{
 		Enabled:   true,
-		Port:      9097,
+		Addr:      "127.0.0.1:0",
 		Namespace: "test",
 	}
 	collector, err := NewCollector(config)
@@ -335,7 +337,7 @@ func TestUpdateCacheSize(t *testing.T) {
 	t.Run("update cache size", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9098,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -366,7 +368,7 @@ func TestUpdateActiveConnections(t *testing.T) {
 	t.Run("update active connections", func(t *testing.T) {
 		config := &Config{
 			Enabled:   true,
-			Port:      9099,
+			Addr:      "127.0.0.1:0",
 			Namespace: "test",
 		}
 		collector, err := NewCollector(config)
@@ -396,7 +398,7 @@ func TestGetMetrics(t *testing.T) {
 
 	config := &Config{
 		Enabled:   true,
-		Port:      9100,
+		Addr:      "127.0.0.1:0",
 		Namespace: "test",
 	}
 	collector, err := NewCollector(config)
@@ -449,7 +451,7 @@ func TestResetMetrics(t *testing.T) {
 
 	config := &Config{
 		Enabled:   true,
-		Port:      9101,
+		Addr:      "127.0.0.1:0",
 		Namespace: "test",
 	}
 	collector, err := NewCollector(config)
@@ -491,7 +493,7 @@ func TestStopWithoutStart(t *testing.T) {
 
 	config := &Config{
 		Enabled:   true,
-		Port:      9102,
+		Addr:      "127.0.0.1:0",
 		Namespace: "test",
 	}
 	collector, err := NewCollector(config)

--- a/internal/metrics/doc.go
+++ b/internal/metrics/doc.go
@@ -32,7 +32,7 @@ operation tracking (for debugging).
 
 	collector, err := metrics.NewCollector(&metrics.Config{
 		Enabled:   true,
-		Port:      8080,
+		Addr:      "127.0.0.1:8080",
 		Path:      "/metrics",
 		Namespace: "objectfs",
 	})
@@ -108,20 +108,27 @@ Regenerate with:
 
 # HTTP Endpoints
 
-The metrics server exposes several endpoints:
+The metrics server exposes several endpoints. None of them is authenticated, which is why Addr
+defaults to loopback and why Start binds exactly what it is given: through v0.10.x this was a Port
+and the bind was fmt.Sprintf(":%d"), so every configured value published these to every interface
+(#211). Start also binds synchronously and returns the bind error, rather than logging it on a
+goroutine and leaving the mount running with no endpoint.
+
+Curl the address the collector reports from Addr, not a hardcoded one — Config.Addr may name port 0,
+in which case the kernel chose the port.
 
 /metrics - Prometheus-formatted metrics (for scraping)
 
-	curl http://localhost:8080/metrics
+	curl http://127.0.0.1:8080/metrics
 
 /health - Health check endpoint
 
-	curl http://localhost:8080/health
+	curl http://127.0.0.1:8080/health
 	{"status":"healthy","service":"objectfs-metrics"}
 
 /debug/metrics - Human-readable metrics summary
 
-	curl http://localhost:8080/debug/metrics
+	curl http://127.0.0.1:8080/debug/metrics
 	{
 	  "uptime": "2h15m30s",
 	  "operations": {
@@ -136,7 +143,7 @@ The metrics server exposes several endpoints:
 
 /debug/operations - Tabular operations summary
 
-	curl http://localhost:8080/debug/operations
+	curl http://127.0.0.1:8080/debug/operations
 	Operation            Count     Errors   Avg Duration      Avg Size
 	----------           -----     ------   ------------      --------
 	read                 15234         12         45ms        524288
@@ -148,7 +155,7 @@ The Config struct controls metrics behavior:
 
 	config := &metrics.Config{
 		Enabled:        true,              // Enable/disable metrics collection
-		Port:           8080,              // HTTP server port
+		Addr:           "127.0.0.1:8080",  // listener address; Start returns an error if it cannot bind
 		Path:           "/metrics",        // Prometheus metrics endpoint path
 		Namespace:      "objectfs",        // Prometheus namespace
 		Subsystem:      "",                // Optional subsystem prefix
@@ -205,7 +212,7 @@ Prometheus Setup:
 	scrape_configs:
 	  - job_name: 'objectfs'
 	    static_configs:
-	      - targets: ['localhost:8080']
+	      - targets: ['127.0.0.1:8080']
 	    metrics_path: '/metrics'
 	    scrape_interval: 15s
 
@@ -235,7 +242,7 @@ Complete example of metrics integration:
 		// Create metrics collector
 		collector, err := metrics.NewCollector(&metrics.Config{
 			Enabled:   true,
-			Port:      8080,
+			Addr:      "127.0.0.1:8080",
 			Namespace: "objectfs",
 			Labels: map[string]string{
 				"instance": "primary",

--- a/internal/metrics/fixture_test.go
+++ b/internal/metrics/fixture_test.go
@@ -76,7 +76,7 @@ func TestSDKFixtureMatchesTheLiveScrape(t *testing.T) {
 func liveScrape(t *testing.T) string {
 	t.Helper()
 
-	c, err := NewCollector(exactAdapterConfig(testhttp.FreePort(t)))
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
 	if err != nil {
 		t.Fatalf("NewCollector: %v", err)
 	}
@@ -98,5 +98,5 @@ func liveScrape(t *testing.T) string {
 	}
 	t.Cleanup(func() { _ = c.Stop(context.Background()) })
 
-	return testhttp.Get(t, c.config.Port, c.config.Path, "Start bound no listener")
+	return testhttp.Get(t, c.Addr(), c.config.Path, "Start bound no listener")
 }

--- a/internal/metrics/wiring_test.go
+++ b/internal/metrics/wiring_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -14,17 +15,25 @@ import (
 
 // exactAdapterConfig is the Config internal/adapter builds, field-for-field.
 //
-// Nothing here is illustrative. adapter.go sets Enabled, Port and Labels and stops, which leaves
+// Nothing here is illustrative. adapter.go sets Enabled, Addr and Labels and stops, which leaves
 // Path, Namespace, Subsystem and UpdateInterval at their zero values — and two of those zeroes used
 // to panic inside Start. Reproducing the shape rather than a plausible one is the point: every test
-// in this package before it passed a Namespace and a Port, which is why nothing noticed.
-func exactAdapterConfig(port int) *Config {
+// in this package before it passed a Namespace and an address, which is why nothing noticed.
+func exactAdapterConfig(addr string) *Config {
 	return &Config{
 		Enabled: true,
-		Port:    port,
+		Addr:    addr,
 		Labels:  map[string]string{"service": "objectfs"},
 	}
 }
+
+// anyLoopbackAddr is the address to configure when the test does not care which port it gets.
+//
+// Port 0 rather than a fixed number, and rather than testhttp.FreeAddr: the kernel picks a port that
+// is free at the moment of the bind, where FreeAddr picks one that was free a moment earlier and
+// leaves a window. Collector.Addr reports what was chosen, so a scrape still knows where to go. Use
+// FreeAddr only where the address must be known before the server starts.
+const anyLoopbackAddr = "127.0.0.1:0"
 
 // TestStartSurvivesTheConfigTheAdapterBuilds is the regression test for two panics on the live path.
 //
@@ -35,7 +44,7 @@ func exactAdapterConfig(port int) *Config {
 func TestStartSurvivesTheConfigTheAdapterBuilds(t *testing.T) {
 	t.Parallel()
 
-	c, err := NewCollector(exactAdapterConfig(testhttp.FreePort(t)))
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
 	if err != nil {
 		t.Fatalf("NewCollector rejected the config the adapter builds: %v", err)
 	}
@@ -66,9 +75,9 @@ func TestNewCollectorFillsEachUnsetFieldIndividually(t *testing.T) {
 	}{
 		{name: "nil", in: nil},
 		{name: "only enabled", in: &Config{Enabled: true}},
-		{name: "only a port", in: &Config{Enabled: true, Port: 19001}},
+		{name: "only an addr", in: &Config{Enabled: true, Addr: anyLoopbackAddr}},
 		{name: "only labels", in: &Config{Enabled: true, Labels: map[string]string{"a": "b"}}},
-		{name: "the adapter's shape", in: exactAdapterConfig(19002)},
+		{name: "the adapter's shape", in: exactAdapterConfig(anyLoopbackAddr)},
 		{
 			name: "disabled",
 			in:   &Config{Enabled: false},
@@ -100,8 +109,15 @@ func TestNewCollectorFillsEachUnsetFieldIndividually(t *testing.T) {
 				t.Errorf("UpdateInterval = %v, want %v — a non-positive interval panics in time.NewTicker",
 					c.config.UpdateInterval, want.UpdateInterval)
 			}
-			if c.config.Port <= 0 {
-				t.Errorf("Port = %d, want a positive port", c.config.Port)
+			// The addr is the one case where a caller-set value is not the default, so it is compared
+			// against what the case asked for rather than against want.Addr.
+			wantAddr := want.Addr
+			if tc.in != nil && tc.in.Addr != "" {
+				wantAddr = tc.in.Addr
+			}
+			if c.config.Addr != wantAddr {
+				t.Errorf("Addr = %q, want %q — an empty address binds every interface, which is what "+
+					"the port form could only ever do", c.config.Addr, wantAddr)
 			}
 		})
 	}
@@ -113,7 +129,7 @@ func TestNewCollectorKeepsWhatTheCallerSet(t *testing.T) {
 
 	in := &Config{
 		Enabled:        true,
-		Port:           19003,
+		Addr:           "127.0.0.1:19003",
 		Path:           "/internal/metrics",
 		Namespace:      "research",
 		Subsystem:      "objectfs",
@@ -127,7 +143,7 @@ func TestNewCollectorKeepsWhatTheCallerSet(t *testing.T) {
 
 	if c.config.Path != "/internal/metrics" || c.config.Namespace != "research" ||
 		c.config.Subsystem != "objectfs" || c.config.UpdateInterval != 5*time.Second ||
-		c.config.Port != 19003 {
+		c.config.Addr != "127.0.0.1:19003" {
 		t.Errorf("defaulting overwrote a value the caller set: %+v", c.config)
 	}
 }
@@ -141,7 +157,7 @@ func TestNewCollectorKeepsWhatTheCallerSet(t *testing.T) {
 func TestExportedNamesAreTheOnesDocumentedAndScraped(t *testing.T) {
 	t.Parallel()
 
-	c, err := NewCollector(exactAdapterConfig(19004))
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
 	if err != nil {
 		t.Fatalf("NewCollector: %v", err)
 	}
@@ -184,7 +200,7 @@ func TestCustomLabelsReachEveryMetric(t *testing.T) {
 
 	c, err := NewCollector(&Config{
 		Enabled: true,
-		Port:    19005,
+		Addr:    anyLoopbackAddr,
 		Labels:  map[string]string{"service": "objectfs", "cluster": "research-west"},
 	})
 	if err != nil {
@@ -233,7 +249,7 @@ func TestUnusableCustomLabelFailsTheMount(t *testing.T) {
 
 	_, err := NewCollector(&Config{
 		Enabled: true,
-		Port:    19006,
+		Addr:    anyLoopbackAddr,
 		// "operation" is a variable label on operations_total, errors_total and both histograms.
 		Labels: map[string]string{"operation": "read"},
 	})
@@ -254,7 +270,7 @@ func TestUnusableCustomLabelFailsTheMount(t *testing.T) {
 func TestCacheCounterCarriesBothHitAndMiss(t *testing.T) {
 	t.Parallel()
 
-	c, err := NewCollector(exactAdapterConfig(19007))
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
 	if err != nil {
 		t.Fatalf("NewCollector: %v", err)
 	}
@@ -288,14 +304,13 @@ func TestCacheCounterCarriesBothHitAndMiss(t *testing.T) {
 // TestScrapeServesTheDocumentedPath closes the loop over real HTTP.
 //
 // Every other test in this file reads the registry directly, which cannot see whether anything is
-// bound to a port. This one scrapes, because the defect it guards is precisely that: the registry
+// bound to an address. This one scrapes, because the defect it guards is precisely that: the registry
 // was correct and unreachable, since internal/adapter never called Start. A test that gathers
 // in-process agrees with a collector that serves nothing.
 func TestScrapeServesTheDocumentedPath(t *testing.T) {
 	t.Parallel()
 
-	port := testhttp.FreePort(t)
-	c, err := NewCollector(exactAdapterConfig(port))
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
 	if err != nil {
 		t.Fatalf("NewCollector: %v", err)
 	}
@@ -308,7 +323,7 @@ func TestScrapeServesTheDocumentedPath(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = c.Stop(context.Background()) })
 
-	body := testhttp.Get(t, port, "/metrics", "Start bound no listener")
+	body := testhttp.Get(t, c.Addr(), "/metrics", "Start bound no listener")
 
 	for _, want := range []string{
 		"objectfs_cache_requests_total",
@@ -320,6 +335,79 @@ func TestScrapeServesTheDocumentedPath(t *testing.T) {
 			t.Errorf("a scrape of /metrics does not contain %q; body:\n%s", want, body)
 		}
 	}
+}
+
+// TestStartBindsWhereConfiguredAndNowhereElse is the regression test for #211.
+//
+// The distinction it draws is the whole issue. Config.Port could only produce fmt.Sprintf(":%d"),
+// which binds every interface, and no test noticed — because a wildcard bind answers on loopback,
+// so scraping 127.0.0.1 passes identically either way. Asserting that something is listening is not
+// the same as asserting where.
+//
+// Two checks, because either alone is weak. The bound address is what the kernel reports for the
+// listener, so a wildcard bind reads back as 0.0.0.0 or [::] rather than the configured host. And a
+// request to a routable address on this machine must be refused, which is the property an operator
+// actually cares about: that the unauthenticated /metrics and /debug/operations endpoints are not
+// reachable from the network.
+func TestStartBindsWhereConfiguredAndNowhereElse(t *testing.T) {
+	t.Parallel()
+
+	addr := testhttp.FreeAddr(t) // fixed port: the assertion is about the host half
+	c, err := NewCollector(exactAdapterConfig(addr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	if got := c.Addr(); got != addr {
+		t.Errorf("bound %s, configured %s — a wildcard bind reports 0.0.0.0 or [::] here, and it "+
+			"publishes an unauthenticated endpoint on every interface", got, addr)
+	}
+
+	// Confirm it over a socket too, from an address that is this host but is not loopback.
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("splitting %s: %v", addr, err)
+	}
+
+	routable := routableIPv4(t)
+	if routable == "" {
+		t.Log("no non-loopback IPv4 address on this host; the socket half of this test is skipped " +
+			"and only the bound-address check ran")
+
+		return
+	}
+
+	if !testhttp.Unreachable(t, net.JoinHostPort(routable, port), "/metrics") {
+		t.Errorf("/metrics answered on %s, which is not the configured %s — the endpoint is exposed "+
+			"to anything that can route to this host", routable, addr)
+	}
+}
+
+// routableIPv4 returns a non-loopback IPv4 address of this host, or "" if it has none.
+func routableIPv4(t *testing.T) string {
+	t.Helper()
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Fatalf("enumerating interface addresses: %v", err)
+	}
+
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() {
+			continue
+		}
+		if v4 := ipnet.IP.To4(); v4 != nil {
+			return v4.String()
+		}
+	}
+
+	return ""
 }
 
 func gather(t *testing.T, c *Collector) []*dto.MetricFamily {

--- a/internal/testhttp/testhttp.go
+++ b/internal/testhttp/testhttp.go
@@ -6,11 +6,18 @@
 // way, and only a request over a socket tells them apart. So the missing bind survived a release,
 // and deleting the call left every test in the package green.
 //
-// A test that wants that guarantee needs two unglamorous things — a port nothing else is using, and
-// a fetch that tolerates a listener still coming up — and both were copied into
+// A test that wants that guarantee needs two unglamorous things — an address nothing else is using,
+// and a fetch that tolerates a listener still coming up — and both were copied into
 // internal/metrics/wiring_test.go and internal/adapter/metrics_wiring_test.go, where they had
 // already drifted apart in their failure messages. One copy, in one place, is what keeps the
 // message that explains the failure attached to the check that finds it.
+//
+// Addresses, not ports. The settings these helpers exercise are host:port now — a port could not
+// name an interface, so every value of monitoring.metrics_port bound all of them (#211) — and a
+// helper that takes a port cannot express the assertion those issues turn on: not that something is
+// listening, but that it is listening *where the configuration said*. Get dials the host it is
+// given, so scraping a loopback address proves a wildcard bind was not what happened; the old
+// port-only form dialed 127.0.0.1 unconditionally and passed against either.
 package testhttp
 
 import (
@@ -18,7 +25,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -32,50 +38,50 @@ const (
 	maxPolls     = 50
 )
 
-// FreePort returns a TCP port on the loopback interface that is currently unused.
+// FreeAddr returns a loopback host:port that is currently unused.
 //
 // Tests run in parallel with each other and with whatever else is on the machine, and the ports
 // these servers default to are the popular ones: 8080 for ObjectFS's metrics endpoint, 9090 for the
 // Prometheus a developer may well have running. Asking the kernel is the only way to be sure.
 //
 // There is a window between the close here and the bind by the caller, which nothing can eliminate
-// without handing over the listener itself. Where that matters — a server that can accept a
-// net.Listener — pass one instead; the servers here take a port.
-func FreePort(t *testing.T) int {
+// without handing over the listener itself. Prefer configuring "127.0.0.1:0" and reading back where
+// the server bound — [metrics.Collector.Addr] reports it — and use this only where the address has
+// to be known before the server starts, which is every test that supplies it through a config file
+// or a Configuration.
+func FreeAddr(t *testing.T) string {
 	t.Helper()
 
 	var lc net.ListenConfig
 	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("reserving a port: %v", err)
+		t.Fatalf("reserving an address: %v", err)
 	}
 
-	addr, ok := ln.Addr().(*net.TCPAddr)
-	if !ok {
-		t.Fatalf("a TCP listener reported a %T address", ln.Addr())
-	}
-	port := addr.Port
+	addr := ln.Addr().String()
 
 	if err := ln.Close(); err != nil {
-		t.Fatalf("releasing the reserved port: %v", err)
+		t.Fatalf("releasing the reserved address %s: %v", addr, err)
 	}
 
-	return port
+	return addr
 }
 
-// Get fetches a path from a server on the loopback interface, retrying until it answers, and fails
-// the test if nothing ever does.
+// Get fetches a path from a server at addr, retrying until it answers, and fails the test if nothing
+// ever does.
 //
-// whatBound describes what the caller expected to bind the listener, and is quoted in the failure:
-// "nothing ever answered … — the adapter bound no metrics listener" is a sentence someone reading a
-// CI log can act on, where a bare dial error is a sentence they have to go and interpret.
+// addr is a host:port, and the host is dialed as given — that is the point of taking an address
+// rather than a port. whatBound describes what the caller expected to bind the listener, and is
+// quoted in the failure: "nothing ever answered … — the adapter bound no metrics listener" is a
+// sentence someone reading a CI log can act on, where a bare dial error is a sentence they have to
+// go and interpret.
 //
 // A non-200 is fatal immediately rather than retried. A server that answers with a status is up, so
 // retrying only delays the report by a second and buries the status behind a timeout.
-func Get(t *testing.T, port int, path, whatBound string) string {
+func Get(t *testing.T, addr, path, whatBound string) string {
 	t.Helper()
 
-	url := "http://127.0.0.1:" + strconv.Itoa(port) + path
+	url := "http://" + addr + path
 	client := &http.Client{Timeout: time.Second}
 
 	var lastErr error
@@ -96,16 +102,17 @@ func Get(t *testing.T, port int, path, whatBound string) string {
 	return ""
 }
 
-// Unreachable reports whether nothing is listening, having waited out the same budget [Get] allows.
+// Unreachable reports whether nothing is listening at addr, having waited out the same budget [Get]
+// allows.
 //
 // This is the assertion for a disabled configuration, and it is worth having as its own function
 // because the naive version of it is wrong: a single immediate dial fails against a listener that is
 // merely slow to bind, so a test written that way passes whether the feature is off or just late.
 // Waiting the full budget is the cost of the distinction.
-func Unreachable(t *testing.T, port, path string) bool {
+func Unreachable(t *testing.T, addr, path string) bool {
 	t.Helper()
 
-	url := "http://127.0.0.1:" + port + path
+	url := "http://" + addr + path
 	client := &http.Client{Timeout: time.Second}
 
 	for range maxPolls {

--- a/sdks/go/objectfs/client.go
+++ b/sdks/go/objectfs/client.go
@@ -75,8 +75,12 @@ func validateOptions(o clientOptions) error {
 			WithComponent("objectfs-sdk").
 			WithOperation("New")
 	}
-	if o.metricsPort == o.healthPort {
-		return pkgerrors.NewError(pkgerrors.ErrCodeInvalidConfig, "metrics_port and health_port cannot be the same").
+	// Addresses, not ports, and only equality is checked here. Their shape is checked by
+	// Configuration.Validate, which Mount reaches — one implementation, so the SDK and a config file
+	// cannot come to different conclusions about what a valid address is.
+	if o.metricsAddr == o.healthAddr {
+		return pkgerrors.NewError(pkgerrors.ErrCodeInvalidConfig,
+			"metrics_addr and health_addr cannot be the same; two listeners cannot share one address").
 			WithComponent("objectfs-sdk").
 			WithOperation("New")
 	}
@@ -91,8 +95,8 @@ func (c *Client) buildConfig() *config.Configuration {
 	cfg.Performance.CacheSize = c.opts.cacheSize
 	cfg.Performance.MaxConcurrency = c.opts.maxConcurrency
 	cfg.Global.LogLevel = c.opts.logLevel
-	cfg.Global.MetricsPort = c.opts.metricsPort
-	cfg.Global.HealthPort = c.opts.healthPort
+	cfg.Monitoring.Metrics.Addr = c.opts.metricsAddr
+	cfg.Monitoring.HealthChecks.Addr = c.opts.healthAddr
 	cfg.Security.TLSEnabled = c.opts.tlsEnabled
 	return cfg
 }

--- a/sdks/go/objectfs/client_test.go
+++ b/sdks/go/objectfs/client_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/scttfrdmn/objectfs/internal/config"
 )
 
 // requireAWS skips the test unless AWS credentials are available.
@@ -41,11 +44,14 @@ func TestDefaultOptions(t *testing.T) {
 	if o.logLevel != "INFO" {
 		t.Errorf("logLevel: got %q, want %q", o.logLevel, "INFO")
 	}
-	if o.metricsPort != 8080 {
-		t.Errorf("metricsPort: got %d, want 8080", o.metricsPort)
+	// Loopback, and the same value internal/config defaults the file-based setting to, read from
+	// there rather than restated: two constants for one default is how the ports these replaced came
+	// to disagree with the config loader in the first place.
+	if o.metricsAddr != config.DefaultMetricsAddr {
+		t.Errorf("metricsAddr: got %q, want %q", o.metricsAddr, config.DefaultMetricsAddr)
 	}
-	if o.healthPort != 8081 {
-		t.Errorf("healthPort: got %d, want 8081", o.healthPort)
+	if o.healthAddr != config.DefaultHealthAddr {
+		t.Errorf("healthAddr: got %q, want %q", o.healthAddr, config.DefaultHealthAddr)
 	}
 	if o.tlsEnabled {
 		t.Error("tlsEnabled: got true, want false")
@@ -97,21 +103,21 @@ func TestWithLogLevel(t *testing.T) {
 	}
 }
 
-func TestWithMetricsPort(t *testing.T) {
+func TestWithMetricsAddr(t *testing.T) {
 	t.Parallel()
 	o := defaultOptions()
-	WithMetricsPort(9090)(&o)
-	if o.metricsPort != 9090 {
-		t.Errorf("metricsPort: got %d, want 9090", o.metricsPort)
+	WithMetricsAddr("0.0.0.0:9090")(&o)
+	if o.metricsAddr != "0.0.0.0:9090" {
+		t.Errorf("metricsAddr: got %q, want %q", o.metricsAddr, "0.0.0.0:9090")
 	}
 }
 
-func TestWithHealthPort(t *testing.T) {
+func TestWithHealthAddr(t *testing.T) {
 	t.Parallel()
 	o := defaultOptions()
-	WithHealthPort(9091)(&o)
-	if o.healthPort != 9091 {
-		t.Errorf("healthPort: got %d, want 9091", o.healthPort)
+	WithHealthAddr("0.0.0.0:9091")(&o)
+	if o.healthAddr != "0.0.0.0:9091" {
+		t.Errorf("healthAddr: got %q, want %q", o.healthAddr, "0.0.0.0:9091")
 	}
 }
 
@@ -150,17 +156,106 @@ func TestValidateOptions_ZeroConcurrency(t *testing.T) {
 	}
 }
 
-func TestValidateOptions_SamePorts(t *testing.T) {
+func TestValidateOptions_SameAddrs(t *testing.T) {
 	t.Parallel()
 	o := defaultOptions()
-	o.metricsPort = 9000
-	o.healthPort = 9000
+	o.metricsAddr = "127.0.0.1:9000"
+	o.healthAddr = "127.0.0.1:9000"
 	err := validateOptions(o)
 	if err == nil {
-		t.Fatal("expected error for same metrics/health port")
+		t.Fatal("expected error for the same metrics and health address")
 	}
 	if !errors.Is(err, ErrInvalidConfig) {
 		t.Errorf("expected ErrInvalidConfig, got %v", err)
+	}
+}
+
+// TestBuildConfigCarriesEveryOptionToWhereItIsRead asserts the values the consumers receive.
+//
+// Not that buildConfig was called, and not by recomputing its mapping — a test that restates
+// `cfg.X = o.x` cannot fail. It asserts each field of the *output*, against a value that differs from
+// the default the field would hold if the mapping were absent. That distinction is what #202 turns
+// on: `monitoring.metrics_addr` was declared, defaulted, documented and mapped nowhere, and a test
+// asserting it equalled its own default would have passed throughout.
+//
+// The two addresses in particular go through this function to reach a listener. WithMetricsAddr sets
+// an option; only this mapping makes the option a bind address, and only Configuration.Validate makes
+// a malformed one an error rather than a mount with a missing endpoint.
+func TestBuildConfigCarriesEveryOptionToWhereItIsRead(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{opts: clientOptions{
+		region:         "eu-west-1",
+		endpoint:       "https://minio.example.internal:9000",
+		cacheSize:      "7GB",
+		maxConcurrency: 77,
+		logLevel:       "WARN",
+		metricsAddr:    "0.0.0.0:19090",
+		healthAddr:     "0.0.0.0:19091",
+		tlsEnabled:     true,
+	}}
+
+	cfg := c.buildConfig()
+
+	cases := []struct {
+		field string
+		got   any
+		want  any
+	}{
+		{"storage.s3.region", cfg.Storage.S3.Region, "eu-west-1"},
+		{"storage.s3.endpoint", cfg.Storage.S3.Endpoint, "https://minio.example.internal:9000"},
+		{"performance.cache_size", cfg.Performance.CacheSize, "7GB"},
+		{"performance.max_concurrency", cfg.Performance.MaxConcurrency, 77},
+		{"global.log_level", cfg.Global.LogLevel, "WARN"},
+		{"monitoring.metrics.addr", cfg.Monitoring.Metrics.Addr, "0.0.0.0:19090"},
+		{"monitoring.health_checks.addr", cfg.Monitoring.HealthChecks.Addr, "0.0.0.0:19091"},
+		{"security.tls_enabled", cfg.Security.TLSEnabled, true},
+	}
+
+	def := config.NewDefault()
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s = %v, want %v — the option never reached the configuration the mount reads",
+				tc.field, tc.got, tc.want)
+		}
+	}
+
+	// And the fixtures must not equal the defaults, or the assertions above prove nothing.
+	if cfg.Monitoring.Metrics.Addr == def.Monitoring.Metrics.Addr ||
+		cfg.Monitoring.HealthChecks.Addr == def.Monitoring.HealthChecks.Addr {
+		t.Error("a fixture in this test equals the value the field would hold with no mapping at all, " +
+			"so the assertion for it cannot fail; pick a different one")
+	}
+
+	// The result has to survive the validation Mount performs, or the SDK builds a Configuration the
+	// adapter rejects — which is how the SDK and the config loader would come to disagree about what a
+	// valid address is.
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("the configuration built from valid options does not validate: %v", err)
+	}
+}
+
+// TestBuildConfigRejectsAMalformedAddressThroughValidate pins where SDK address checking happens.
+//
+// validateOptions deliberately checks only that the two addresses differ. Their shape is
+// Configuration.Validate's job, so there is one implementation of "what is a valid listen address"
+// and the SDK cannot come to a different conclusion than a config file would. This asserts the
+// error does arrive, and names the field.
+func TestBuildConfigRejectsAMalformedAddressThroughValidate(t *testing.T) {
+	t.Parallel()
+
+	o := defaultOptions()
+	o.metricsAddr = "127.0.0.1:99999" // accepted by net.SplitHostPort; out of range for a port
+
+	c := &Client{opts: o}
+
+	err := c.buildConfig().Validate()
+	if err == nil {
+		t.Fatal("a port outside 1-65535 validated; the bind would fail on a goroutine and the mount " +
+			"would come up with no metrics endpoint")
+	}
+	if !strings.Contains(err.Error(), "monitoring.metrics.addr") {
+		t.Errorf("the error does not name the setting at fault: %v", err)
 	}
 }
 

--- a/sdks/go/objectfs/options.go
+++ b/sdks/go/objectfs/options.go
@@ -1,5 +1,7 @@
 package objectfs
 
+import "github.com/scttfrdmn/objectfs/internal/config"
+
 // Option is a functional option for configuring a Client.
 type Option func(*clientOptions)
 
@@ -10,8 +12,8 @@ type clientOptions struct {
 	cacheSize      string // memory cache size (e.g. "512MB"); default: "512MB"
 	maxConcurrency int    // max concurrent S3 operations; default: 32
 	logLevel       string // log verbosity: DEBUG|INFO|WARN|ERROR; default: "INFO"
-	metricsPort    int    // Prometheus metrics port; default: 8080
-	healthPort     int    // health check port; default: 8081
+	metricsAddr    string // Prometheus endpoint address; default: "127.0.0.1:8080"
+	healthAddr     string // health endpoint address; default: "127.0.0.1:8081"
 	tlsEnabled     bool   // enable TLS; default: false
 }
 
@@ -22,8 +24,8 @@ func defaultOptions() clientOptions {
 		cacheSize:      "512MB",
 		maxConcurrency: 32,
 		logLevel:       "INFO",
-		metricsPort:    8080,
-		healthPort:     8081,
+		metricsAddr:    config.DefaultMetricsAddr,
+		healthAddr:     config.DefaultHealthAddr,
 		tlsEnabled:     false,
 	}
 }
@@ -63,17 +65,27 @@ func WithLogLevel(l string) Option {
 	}
 }
 
-// WithMetricsPort sets the port on which Prometheus metrics are served.
-func WithMetricsPort(p int) Option {
+// WithMetricsAddr sets the host:port on which Prometheus metrics are served.
+//
+// Defaults to loopback. The endpoint has no authentication and reports per-operation counts, error
+// rates, sizes and timings, so exposing it beyond the host is an explicit choice: pass "0.0.0.0:8080"
+// to make it reachable from elsewhere.
+//
+// This replaces WithMetricsPort, which could not express an interface — every value of it bound all of
+// them. Passing an address that is malformed or has a port outside 1-65535 is an error from Mount,
+// naming the field.
+func WithMetricsAddr(addr string) Option {
 	return func(o *clientOptions) {
-		o.metricsPort = p
+		o.metricsAddr = addr
 	}
 }
 
-// WithHealthPort sets the port on which the health check endpoint is served.
-func WithHealthPort(p int) Option {
+// WithHealthAddr sets the host:port on which the health check endpoint is served.
+//
+// Loopback by default, for the reason [WithMetricsAddr] gives. Replaces WithHealthPort.
+func WithHealthAddr(addr string) Option {
 	return func(o *clientOptions) {
-		o.healthPort = p
+		o.healthAddr = addr
 	}
 }
 

--- a/sdks/javascript/README.md
+++ b/sdks/javascript/README.md
@@ -292,10 +292,10 @@ uploadObject(
 // Get health status
 getHealth(endpoint?: string): Promise<HealthStatus>
 
-// Get metrics from the mount's Prometheus endpoint (global.metrics_port, default 8080;
-// requires monitoring.metrics.enabled: true). Returns cache, io, operations, errors and
-// connections sections plus the parsed raw samples. A section is absent when the mount has
-// not recorded that family -- absent is not zero.
+// Get metrics from the mount's Prometheus endpoint (monitoring.metrics.addr, default
+// 127.0.0.1:8080; requires monitoring.metrics.enabled: true). Returns cache, io, operations,
+// errors and connections sections plus the parsed raw samples. A section is absent when the
+// mount has not recorded that family -- absent is not zero.
 getMetrics(endpoint?: string): Promise<Metrics>
 
 // Not implemented; always throws. It returned fixed constants that looked like

--- a/sdks/javascript/src/monitoring.ts
+++ b/sdks/javascript/src/monitoring.ts
@@ -154,7 +154,7 @@ export class MetricsCollector {
         if (response.headers['content-type']?.includes('application/json')) {
           throw new NetworkError(
             `${metricsUrl} returned JSON, not the Prometheus text format ObjectFS serves. ` +
-            `Check that this is an ObjectFS metrics port (global.metrics_port, default 8080).`
+            `Check that this is an ObjectFS metrics endpoint (monitoring.metrics.addr, default 127.0.0.1:8080).`
           );
         }
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -63,13 +63,13 @@ async def main():
         # Mount filesystem
         mount_id = client.mount('s3://my-bucket', '/mnt/objectfs')
 
-        # Get health status -- global.health_port, default 8081
-        health = await client.get_health('http://localhost:8081')
+        # Get health status -- monitoring.health_checks.addr, default 127.0.0.1:8081
+        health = await client.get_health('http://127.0.0.1:8081')
         print(f"Health: {health['status']}")
 
-        # Collect metrics -- global.metrics_port, default 8080.
+        # Collect metrics -- monitoring.metrics.addr, default 127.0.0.1:8080.
         # Requires monitoring.metrics.enabled: true; nothing is bound otherwise.
-        metrics = await client.get_metrics('http://localhost:8080')
+        metrics = await client.get_metrics('http://127.0.0.1:8080')
 
         # Present once the mount has served at least one cache request. An idle mount
         # reports no hit rate rather than a hit rate of zero, because those are different
@@ -195,8 +195,6 @@ objectfs-python unmount /mnt/objectfs
 global:
   log_level: INFO
   log_file: /var/log/objectfs.log
-  metrics_port: 8080    # where /metrics and /health are served
-  health_port: 8081
 
 storage:
   s3:
@@ -218,11 +216,14 @@ cluster:
   consistency_level: eventual
 
 monitoring:
-  enabled: true
   metrics:
-    enabled: true       # required, or nothing binds the metrics endpoint
+    enabled: true             # required, or nothing binds the metrics endpoint
+    addr: 127.0.0.1:8080      # loopback by default; the endpoint has no authentication
     custom_labels:
-      service: objectfs # attached to every exported series
+      service: objectfs       # attached to every exported series
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
 ```
 
 ### Environment Variables

--- a/sdks/python/objectfs/config.py
+++ b/sdks/python/objectfs/config.py
@@ -115,11 +115,38 @@ class SecurityConfig:
 
 @dataclass
 class MonitoringConfig:
-    """Monitoring and observability configuration."""
+    """Monitoring and observability configuration.
+
+    Each listener's address lives beside the ``enabled`` flag that governs it, matching the Go
+    schema this class serializes to. It previously declared flat ``metrics_addr`` and
+    ``health_check_addr`` keys defaulting to ``:9090``/``:8081``: the Go loader read neither --
+    it read ``global.metrics_port``/``global.health_port`` -- so ``to_yaml`` produced a document
+    that set no listener address, and the empty host meant every interface rather than loopback
+    anyway. Both keys are gone from the Go schema as of v0.11.0, and the loader now rejects
+    unknown keys, so a file written by an older SDK fails at load and names the key to fix.
+
+    ``enable_pprof`` is gone with them. Nothing ever started a pprof listener, and the server it
+    would have started serves mutating ``/memory/gc`` and ``/memory/free`` handlers with no
+    authentication.
+
+    Both endpoints below are unauthenticated -- ``/metrics`` reports per-operation counts and
+    timings, ``/health`` reports component names and error strings -- which is why the defaults
+    are loopback. Publishing them further is a choice you write down.
+    """
     enabled: bool = False
-    metrics_addr: str = ":9090"
-    health_check_addr: str = ":8081"
-    enable_pprof: bool = False
+
+    metrics: Dict[str, Any] = field(default_factory=lambda: {
+        "enabled": True,
+        "addr": "127.0.0.1:8080",
+        "prometheus": True,
+    })
+
+    health_checks: Dict[str, Any] = field(default_factory=lambda: {
+        "enabled": True,
+        "addr": "127.0.0.1:8081",
+        "interval": "30s",
+        "timeout": "5s",
+    })
 
     # OpenTelemetry
     opentelemetry: Dict[str, Any] = field(default_factory=lambda: {

--- a/sdks/python/objectfs/monitoring.py
+++ b/sdks/python/objectfs/monitoring.py
@@ -215,8 +215,8 @@ class MetricsCollector:
                     if response.content_type == 'application/json':
                         raise NetworkError(
                             f"{metrics_url} returned JSON; ObjectFS serves /metrics as a "
-                            "Prometheus text exposition. Check that the port belongs to "
-                            "ObjectFS (global.metrics_port) and not to another service."
+                            "Prometheus text exposition. Check that the address belongs to "
+                            "ObjectFS (monitoring.metrics.addr) and not to another service."
                         )
 
                     text = await response.text()

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -41,8 +41,8 @@ func (s *E2ETestSuite) SetupSuite() {
 	s.config.Performance.MaxConcurrency = 10
 	s.config.WriteBuffer.MaxMemory = "16MB"
 	s.config.Cache.TTL = 30 * time.Second
-	s.config.Global.MetricsPort = 9090
-	s.config.Global.HealthPort = 9091
+	s.config.Monitoring.Metrics.Addr = "127.0.0.1:19090"
+	s.config.Monitoring.HealthChecks.Addr = "127.0.0.1:19091"
 
 	s.T().Logf("✅ E2E test suite initialized")
 }
@@ -113,8 +113,8 @@ func (s *E2ETestSuite) TestConfigurationParsing() {
 
 	// Test configuration values
 	assert.Equal(t, "INFO", defaultConfig.Global.LogLevel)
-	assert.Equal(t, 8080, defaultConfig.Global.MetricsPort)
-	assert.Equal(t, 8081, defaultConfig.Global.HealthPort)
+	assert.Equal(t, config.DefaultMetricsAddr, defaultConfig.Monitoring.Metrics.Addr)
+	assert.Equal(t, config.DefaultHealthAddr, defaultConfig.Monitoring.HealthChecks.Addr)
 	assert.Equal(t, "2GB", defaultConfig.Performance.CacheSize)
 	assert.Equal(t, 150, defaultConfig.Performance.MaxConcurrency)
 	assert.True(t, defaultConfig.Features.Prefetching)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -277,8 +277,11 @@ func (suite *IntegrationTestSuite) TestMetricsIntegration() {
 
 	// Create metrics configuration
 	metricsConfig := &metrics.Config{
-		Enabled:        true,
-		Port:           0, // Use random port for testing
+		Enabled: true,
+		// Port 0 on loopback: the kernel picks a port that is free at the moment of the bind, and
+		// Collector.Addr reports which. The setting is an address rather than a port because a port
+		// could not name an interface, so every value of it bound all of them (#211).
+		Addr:           "127.0.0.1:0",
 		Path:           "/metrics",
 		Namespace:      "objectfs_test",
 		UpdateInterval: time.Second,
@@ -344,9 +347,11 @@ func (suite *IntegrationTestSuite) TestEndToEndFileOperations() {
 	// Create full ObjectFS configuration
 	objectfsConfig := &config.Configuration{
 		Global: config.GlobalConfig{
-			LogLevel:    "info",
-			MetricsPort: 8080,
-			HealthPort:  8081,
+			LogLevel: "info",
+		},
+		Monitoring: config.MonitoringConfig{
+			Metrics:      config.MetricsConfig{Enabled: true, Addr: "127.0.0.1:18080"},
+			HealthChecks: config.HealthChecksConfig{Enabled: true, Addr: "127.0.0.1:18081"},
 		},
 		Performance: config.PerformanceConfig{
 			CacheSize:          "50MB",
@@ -372,7 +377,7 @@ func (suite *IntegrationTestSuite) TestEndToEndFileOperations() {
 	// For now, just verify the configuration is valid
 	assert.NotNil(t, objectfsConfig)
 	assert.Equal(t, "info", objectfsConfig.Global.LogLevel)
-	assert.Equal(t, 8080, objectfsConfig.Global.MetricsPort)
+	assert.Equal(t, "127.0.0.1:18080", objectfsConfig.Monitoring.Metrics.Addr)
 	assert.Equal(t, "50MB", objectfsConfig.Performance.CacheSize)
 }
 

--- a/tests/unit_test.go
+++ b/tests/unit_test.go
@@ -160,7 +160,7 @@ func TestWriteBufferUnit(t *testing.T) {
 func TestMetricsCollectorUnit(t *testing.T) {
 	config := &metrics.Config{
 		Enabled:        true,
-		Port:           0, // Use random port for testing
+		Addr:           "127.0.0.1:0", // the kernel picks a free port; Collector.Addr reports which
 		Path:           "/metrics",
 		Namespace:      "objectfs_test",
 		UpdateInterval: 100 * time.Millisecond,
@@ -247,7 +247,9 @@ func TestConfigUnit(t *testing.T) {
 
 	// Verify default values
 	assert.Equal(t, "INFO", defaultConfig.Global.LogLevel)
-	assert.Equal(t, 8080, defaultConfig.Global.MetricsPort)
+	// Loopback, not the wildcard: both endpoints are unauthenticated, so the default is the narrowest
+	// thing that still works and publishing them further is a choice an operator writes down (#211).
+	assert.Equal(t, config.DefaultMetricsAddr, defaultConfig.Monitoring.Metrics.Addr)
 	assert.Equal(t, "weighted_lru", defaultConfig.Cache.EvictionPolicy)
 
 	// Test configuration validation
@@ -262,9 +264,11 @@ func TestConfigUnit(t *testing.T) {
 	// environment-dependence FuzzConfigConstructsBackend found in the loader.
 	validConfig := &config.Configuration{
 		Global: config.GlobalConfig{
-			LogLevel:    "DEBUG",
-			MetricsPort: 9090,
-			HealthPort:  9091,
+			LogLevel: "DEBUG",
+		},
+		Monitoring: config.MonitoringConfig{
+			Metrics:      config.MetricsConfig{Enabled: true, Addr: "127.0.0.1:19090"},
+			HealthChecks: config.HealthChecksConfig{Enabled: true, Addr: "127.0.0.1:19091"},
 		},
 		Storage: config.StorageConfig{
 			S3: config.S3Config{Region: "us-west-2"},


### PR DESCRIPTION
Closes #202, #211, #212, and #192's validation half.

These are one code path, not four issues. The listener endpoints bound a hardcoded wildcard, *and* the settings that would have changed them were inert.

## Why a port could not be fixed in place

A port cannot name an interface. `fmt.Sprintf(":%d", port)` was the only bind it could produce, so every value of `monitoring.metrics_port` published an unauthenticated endpoint on every interface (#211).

A port also cannot say "off" without overloading zero, and the two blocks overloaded it in opposite directions: `health_port: 0` disabled its listener, while `metrics_port: 0` was treated as unset, defaulted back to 8080, and bound it (#212). Two adjacent fields spelled "off" differently, and the metrics one failed in the direction that leaves a port open.

Meanwhile `monitoring` declared `metrics_addr` and `health_check_addr`, defaulted them, documented them — and read neither (#202). So an operator who set `health_check_addr: 127.0.0.1:8081` to keep a diagnostic endpoint off the network got a wildcard bind and no warning: the live setting could not express a host, and the expressive setting was dead.

An address subsumes a port, so keeping both would preserve the disagreement.

## What changed

**Removed:** `global.metrics_port`, `global.health_port`, `global.profile_port`, `monitoring.metrics_addr`, `monitoring.health_check_addr`, `monitoring.enable_pprof`.

**Added:** `monitoring.metrics.addr` and `monitoring.health_checks.addr` — each *inside* the block whose `enabled` flag governs it, both defaulting to **loopback** (`127.0.0.1:8080`, `127.0.0.1:8081`). Same ports, so an existing same-host Prometheus scrape survives the upgrade; the host is what changed. Both endpoints are on by default and neither is authenticated: between them they report per-operation counts, error rates, sizes and timings, and `/health` reports component names and error strings.

Removed rather than deprecated, because strict decoding then names the key and line to edit. A key kept as an ignored field means an operator's listener settings silently stop applying on upgrade.

**`enable_pprof`/`profile_port` are removed rather than wired.** Nothing read either. The one pprof server in the tree is `pkg/profiling`'s, which has no importer, also binds every interface, and serves *mutating* `/memory/gc` and `/memory/free` with no authentication — binding a third unauthenticated listener inside the change that stops binding two of them was the wrong trade on the strength of a boolean nothing read. Filed as #245.

**Bind errors propagate.** Both servers bound on a goroutine and logged. That deliberately contradicts #192's reasoning that non-fatal was "the right call for observability": `enabled: false` is already how you ask for no endpoint, and an operator who asked for one and did not get it finds out when a liveness probe starts failing.

**Validation catches what a listener reports badly.** `net.SplitHostPort` accepts `"99999"`, so the 1–65535 range is checked explicitly and the error names the field. `health_port: 99999` used to reach `net.Listen` from YAML unchecked. Names like `localhost` are allowed — the shape is checked, not the resolution.

**`OBJECTFS_METRICS_ENABLED` is now wired**, along with a new `OBJECTFS_HEALTH_ENABLED`. The former was documented in `cmd/objectfs/doc.go` and `OBJECTFS.md` and assigned nothing — #202's shape in the setting that *closes* an endpoint rather than the one that moves it. Both parse strictly and fail startup naming the variable, where the feature-flag variables coerce anything but `"true"` to false: these govern unauthenticated endpoints that default to on, so silent coercion is wrong whichever direction it picks.

## The test gap

The more interesting half. `TestStartMetricsBindsTheEndpoint` scraped `127.0.0.1` and passed against a wildcard bind — because a wildcard bind answers on loopback too. The tests asserted that *something* was listening, never that it was listening where the configuration said.

`Collector.Addr()` now reports the bound address, and three new regression tests (metrics, health, adapter) assert two things:

1. the bound address equals the configured one — a wildcard bind reports `0.0.0.0` or `[::]` here;
2. the endpoint does **not** answer on a routable non-loopback IPv4 address of the host.

**Verified by mutation.** Restoring the `":"+port` bind fails both halves (`bound [::]:61260, configured 127.0.0.1:61260`, and `/metrics answered on 192.168.6.94`) while the old-shaped `TestScrapeServesTheDocumentedPath` stays green — demonstrating the gap the issue describes. Deleting the SDK's `cfg.Monitoring.Metrics.Addr = c.opts.metricsAddr` mapping fails the new SDK tests, including the guard that refuses a fixture equal to the field's default.

## Gates

- `go build ./...`, `go vet ./...` (and `-tags=e2e`) clean
- `go test -race ./...` — 33 packages, all green
- `golangci-lint run --new-from-merge-base=origin/main` — 0 issues
- `scripts/coverage-gate.sh` — every floor met; `internal/config` 87.7% → **90.4%**, `validateListenAddr` to 100%

Doc and config surfaces repointed together, so strict decoding does not reject a file this repo ships or documents: `examples/config.yaml`, `configs/example.yaml`, `SECURITY.md`, `OBJECTFS.md`, `cmd/objectfs/doc.go`, `internal/config/doc.go`, `internal/metrics/doc.go`, `docs-platform/guide/getting-started.md`, all three SDKs, and `tests/{unit,integration,e2e}_test.go`.
