### PR TITLE
fix: the cluster.redis block selects the cache a mount actually uses (#178)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -44,7 +44,11 @@
 internal/analytics       96
 internal/archive         90
 internal/awsname         100
-internal/cache/redis     87
+# internal/cache/redis goes 87 → 88 with the shared conformance suite (#178). The gain is small and
+# what it bought is not: the suite is the test that found Get answering a ten-byte request with two
+# bytes, which ten implementation-specific tests had missed because none of them asked for a range
+# longer than the value stored.
+internal/cache/redis     88
 internal/circuit         96
 # internal/compression goes from 87 to 88 with the decoder-table tests #230 added: a matrix over
 # every writable algorithm read back by every algorithm and by a disabled compressor.
@@ -163,7 +167,11 @@ internal/fuse            59
 # `EnablePrefetch: false`, so the prefetcher's queue, workers, rate limiter, and shutdown path had no
 # coverage at all, and three defects lived there — a panic on close racing a read, a token bucket that
 # never refilled, and a Close nothing called. Switching prefetch on in tests is what found them.
-internal/cache           82
+#
+# 82 → 85 with #178: the four in-process implementations are now enrolled in the shared conformance
+# suite in internal/cache/cachetest, and NewFromConfig has a caller and therefore tests that assert
+# which implementation a configuration selects rather than only that one was returned.
+internal/cache           85
 
 pkg/api                  73
 pkg/errors               48

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   succeeds and that the resulting object is whole, so a lossy reclaim fails rather than passing
   quietly.
 
+- **A cache that answered a ten-byte request with two bytes now reports a miss ([#178]).** The
+  `types.Cache` contract is that a partial hit is a miss, and it is a contract about data integrity
+  rather than about return values: `internal/fuse` passes a non-nil hit to the kernel verbatim as file
+  content, so a short answer is a truncated read reported as a successful one, and the caller cannot
+  distinguish a short cache entry from a short file. The Redis implementation used `GETRANGE`, which
+  clamps to the stored value's length and returns what it can — `GETRANGE k 8 17` over a ten-byte value
+  answers with two bytes and no indication that eight are missing. It had ten tests of its own, all
+  passing, none of which asked for a range longer than what was stored.
+
+  What found it is the durable part: **`internal/cache/cachetest` is a shared conformance suite that
+  every `types.Cache` implementation is now run against.** There were five implementations, one
+  contract, and no test in common — each was checked against the questions its own author thought to
+  ask, which is why four of them satisfied a rule the fifth violated in the most consequential
+  direction. Ten cases, each stating in its failure message what a caller would observe: exact-range
+  hits, straddling and past-the-end reads as misses, a request longer than the entry as a miss, the
+  open-ended `size <= 0` form, the returned slice not aliasing the cache's own storage, a newer `Put`
+  winning where it overlaps, and `Delete` removing the key it names and nothing that merely shares a
+  prefix with it. A sixth implementation is one enrollment away from being held to the same contract.
+
 ### Changed
 
 - **Each listener's address is one setting, beside the `enabled` flag that governs it
@@ -395,12 +414,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior at the default configuration, which wants a measurement rather than a number nudged in
   passing, so it is filed as [#247] and documented where the setting is.
 
+- **The `cluster.redis` block selects the cache a mount uses, and the `cache` block reaches it
+  ([#178]).** `cache.NewFromConfig` — the only reader of `cluster.redis.*` anywhere — had no caller.
+  The adapter built a `MultiLevelConfig` literal of its own instead, so seven `cluster` keys plus a
+  seven-key `redis` sub-block were decoded, defaulted, validated and documented while no mount
+  consulted any of them: a deployment that configured a shared Redis cache got a private in-process
+  one, with no error and no warning, and looked correct until two nodes disagreed about a file.
+
+  Both halves of that mistake are fixed together, because they are the same mistake. `NewFromConfig`'s
+  other arm passed a literal `nil` to `NewMultiLevelCache`, discarding the L1/L2 sizing, the TTL, the
+  persistent-cache directory and the eviction policy its argument carried — so even with a caller, most
+  of the `cache` block would still have been ignored. The mapping now lives in `internal/cache` beside
+  the selection rather than in the adapter, since a second copy of it is how the two came to disagree
+  in the first place, and `Adapter.cache` is typed as `types.Cache`: naming the concrete
+  `*cache.MultiLevelCache` there is what made the function uncallable, as the field could not hold what
+  it returns.
+
+  **An unreachable Redis now fails the mount** rather than falling back to an in-process cache. Falling
+  back is this same defect one layer out — both nodes come up, both believe the cache is shared, and
+  nothing in either log explains the disagreement — so the error names `cluster.redis` and the mount
+  does not start. This is the third instance of the shape [#156] and [#176] were: a config block whose
+  every layer worked except the one that had to call it.
+
 [#154]: https://github.com/scttfrdmn/objectfs/issues/154
+[#156]: https://github.com/scttfrdmn/objectfs/issues/156
 [#157]: https://github.com/scttfrdmn/objectfs/issues/157
 [#162]: https://github.com/scttfrdmn/objectfs/issues/162
 [#163]: https://github.com/scttfrdmn/objectfs/issues/163
 [#164]: https://github.com/scttfrdmn/objectfs/issues/164
 [#176]: https://github.com/scttfrdmn/objectfs/issues/176
+[#178]: https://github.com/scttfrdmn/objectfs/issues/178
 [#181]: https://github.com/scttfrdmn/objectfs/issues/181
 [#192]: https://github.com/scttfrdmn/objectfs/issues/192
 [#202]: https://github.com/scttfrdmn/objectfs/issues/202

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,6 @@ them**. Verified by import graph, not by reading the code:
 | REST API | `pkg/api` | no importer outside itself |
 | Detailed per-file performance metrics | `internal/metrics` detailed collector | constructor has no non-test caller |
 | ML tier prediction driving cache promotion | `internal/analytics` | imported by `internal/cache`, but the `Predictor` field is never set on the mount path, so the size heuristic always runs |
-| Redis-backed distributed cache | `internal/cache/redis` | `cache.NewFromConfig` selects it, but nothing calls `NewFromConfig` — the adapter constructs `NewMultiLevelCache` directly |
 | Multi-node coordination | `internal/distributed` | imported only by tests |
 
 They are listed here rather than deleted from the docs because the code exists and may be wired up;

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -298,8 +298,13 @@ features:
 
 # Multi-node coordination. Experimental and incomplete — the Raft log is not applied and
 # "strong" consistency fans the same PUT to N nodes rather than ordering operations. Do not
-# depend on this for correctness. The Redis block is the one usable part, and it is reached only
-# through cache.NewFromConfig, which currently has no caller.
+# depend on this for correctness.
+#
+# The redis: block is the one part of this section that a mount reaches. Setting both `enabled`
+# here and `redis.enabled` below replaces the in-process cache with a shared Redis one for the
+# whole mount; everything else under cluster: is read only by the experimental coordinator.
+# A Redis that cannot be reached at startup fails the mount rather than falling back, so two
+# nodes cannot both come up believing they share a cache when they do not.
 cluster:
   enabled: false
   node_id: ""                         # empty = derived at startup

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/url"
 	"strings"
@@ -15,17 +16,17 @@ import (
 	"github.com/scttfrdmn/objectfs/internal/storage/s3"
 	"github.com/scttfrdmn/objectfs/internal/vfs"
 	"github.com/scttfrdmn/objectfs/pkg/retry"
+	"github.com/scttfrdmn/objectfs/pkg/types"
 	"github.com/scttfrdmn/objectfs/pkg/utils"
 )
 
-// Fallback sizes for the two cache capacities, used only if a configured value fails to parse here
-// after having passed Configuration.Validate — see sizeOrDefault. They match internal/config's
-// NewDefault so that the fallback is the documented default rather than a third number.
-const (
-	defaultCacheSize           = 2 << 30   // 2 GiB, matching NewDefault's "2GB"
-	defaultPersistentCacheSize = 10 << 30  // 10 GiB, matching NewDefault's "10GB"
-	defaultWriteBufferMemory   = 512 << 20 // 512 MiB, matching NewDefault's "512MB"
-)
+// Fallback used only if a configured size fails to parse here after having passed
+// Configuration.Validate — see sizeOrDefault. It matches internal/config's NewDefault so that the
+// fallback is the documented default rather than a third number.
+//
+// The two cache capacities were here too until the cache construction moved to cache.NewFromConfig
+// (#178); their fallbacks live beside that mapping now, for the same reason the mapping does.
+const defaultWriteBufferMemory = 512 << 20 // 512 MiB, matching NewDefault's "512MB"
 
 // Adapter represents the main ObjectFS adapter
 type Adapter struct {
@@ -33,9 +34,15 @@ type Adapter struct {
 	mountPoint string
 	config     *config.Configuration
 
-	// Core components
+	// Core components.
+	//
+	// cache is the interface and not *cache.MultiLevelCache, because which implementation a mount gets
+	// is a configuration decision: `cluster.redis.enabled` selects a Redis-backed distributed cache
+	// instead. Naming the concrete type here is what kept cache.NewFromConfig from having a caller
+	// (#178) and so left the whole cluster: block unreachable — the field could not hold what the
+	// function returns.
 	backend     *s3.Backend
-	cache       *cache.MultiLevelCache
+	cache       types.Cache
 	writeBuffer *vfs.Writer
 	mountMgr    fuse.PlatformFileSystem
 	metrics     *metrics.Collector
@@ -127,27 +134,19 @@ func (a *Adapter) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize S3 backend: %w", err)
 	}
 
-	// 3. Initialize cache system
-	cacheConfig := &cache.MultiLevelConfig{
-		L1Config: &cache.L1Config{
-			Enabled:    true,
-			Size:       a.sizeOrDefault("performance.cache_size", a.config.Performance.CacheSize, defaultCacheSize),
-			MaxEntries: a.config.Cache.MaxEntries,
-			TTL:        a.config.Cache.TTL,
-			Prefetch:   true,
-		},
-		L2Config: &cache.L2Config{
-			Enabled: a.config.Cache.PersistentCache.Enabled,
-			Size: a.sizeOrDefault("cache.persistent_cache.max_size",
-				a.config.Cache.PersistentCache.MaxSize, defaultPersistentCacheSize),
-			Directory:   a.config.Cache.PersistentCache.Directory,
-			TTL:         a.config.Cache.TTL,
-			Compression: true,
-		},
-		Policy: a.config.Cache.EvictionPolicy,
-	}
-
-	a.cache, err = cache.NewMultiLevelCache(cacheConfig)
+	// 3. Initialize the cache.
+	//
+	// Through NewFromConfig, which is what makes the cluster: block reachable at all: it selects the
+	// Redis-backed distributed cache when cluster.enabled and cluster.redis.enabled are both set, and
+	// otherwise builds the in-process MultiLevelCache from the cache: block.
+	//
+	// This used to be a MultiLevelConfig literal built here, and NewFromConfig had no caller (#178). So
+	// seven cluster keys plus a seven-key redis: sub-block were decoded, defaulted and validated while
+	// no mount consulted any of them: a deployment that configured a shared Redis cache got a private
+	// in-process one, with no error and no warning, and looked correct until two nodes disagreed about
+	// a file. The mapping moved into internal/cache with the selection, because a duplicate of it here
+	// is how the two came to disagree in the first place.
+	a.cache, err = cache.NewFromConfig(ctx, a.config)
 	if err != nil {
 		return fmt.Errorf("failed to initialize cache: %w", err)
 	}
@@ -339,16 +338,28 @@ func (a *Adapter) Stop(ctx context.Context) error {
 
 	// 6. Clear the cache, then release the goroutines behind it.
 	//
-	// The Close is what retires the prefetch workers. Prefetch is enabled unconditionally above, so
-	// every mount wraps L1 in a predictive cache with four workers and a statistics ticker, and until
-	// this call existed nothing ever stopped them: a process that mounted and unmounted repeatedly
-	// accumulated a set per mount, each holding a reference to the cache it was built over.
+	// The Close is what retires the prefetch workers. Prefetch is enabled unconditionally for the
+	// in-process cache, so that mount wraps L1 in a predictive cache with four workers and a statistics
+	// ticker, and until this call existed nothing ever stopped them: a process that mounted and
+	// unmounted repeatedly accumulated a set per mount, each holding a reference to the cache it was
+	// built over.
+	//
+	// Both are type assertions because types.Cache declares neither, and it should not: Clear on a
+	// shared Redis cache would discard every *other* node's cached bytes as well, which is not what
+	// unmounting one mount means, and Close on the interface would oblige every implementation to have
+	// a lifecycle it may not have. So the interface stays the read/write contract and lifecycle is
+	// asked for rather than assumed — the assertion failing is the correct outcome for a cache with no
+	// local state to clear.
 	if a.cache != nil {
-		a.cache.Clear()
+		if clearer, ok := a.cache.(interface{ Clear() }); ok {
+			clearer.Clear()
+		}
 
-		if err := a.cache.Close(); err != nil {
-			slog.Error("error closing cache", "error", err)
-			lastErr = err
+		if closer, ok := a.cache.(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				slog.Error("error closing cache", "error", err)
+				lastErr = err
+			}
 		}
 	}
 

--- a/internal/adapter/cache_selection_test.go
+++ b/internal/adapter/cache_selection_test.go
@@ -1,0 +1,243 @@
+package adapter
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	"github.com/scttfrdmn/objectfs/internal/cache/redis"
+	"github.com/scttfrdmn/objectfs/internal/config"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+)
+
+// TestStartReachesTheCacheTheConfigNames is the mount-path half of #178.
+//
+// internal/cache's own tests can show that NewFromConfig selects a Redis cache; only this one can show
+// that a *mount* does. That distinction is the entire defect: NewFromConfig was correct and had no
+// caller, so every assertion about it passed while `cluster.redis.enabled: true` on a real config
+// produced a private in-process cache. A test that stops at the constructor cannot tell those apart.
+//
+// Start rather than a hand-built Adapter, and a substrate-backed S3 endpoint rather than a mock, for the
+// same reason: the thing under test is the wiring between the config the operator wrote and the object
+// the filesystem ends up holding, and every layer skipped is a layer where the value can be dropped.
+//
+// Start's last step is the mount itself, which most hosts running this suite cannot perform — see
+// startAdapterWithCluster for how that is handled without weakening the assertion.
+func TestStartReachesTheCacheTheConfigNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("redis when configured", func(t *testing.T) {
+		t.Parallel()
+
+		mr := miniredis.RunT(t)
+		a := startAdapterWithCluster(t, func(cfg *config.Configuration) {
+			cfg.Cluster.Enabled = true
+			cfg.Cluster.Redis = config.RedisConfig{
+				Enabled:    true,
+				Address:    mr.Addr(),
+				KeyPrefix:  "mount",
+				TTL:        time.Minute,
+				MaxRetries: 1,
+			}
+		})
+
+		if _, ok := a.cache.(*redis.Cache); !ok {
+			t.Fatalf("a mount configured with cluster.redis.enabled holds a %T, so the whole cluster: "+
+				"block is unreachable from Start and an operator's shared-cache setting does nothing", a.cache)
+		}
+
+		// And the mount's cache is really that Redis, not merely of that type: put through the adapter's
+		// own reference and read the key out of the server.
+		a.cache.Put("obj", 0, []byte("through-the-mount"))
+
+		got, err := mr.Get("mount:obj")
+		if err != nil {
+			t.Fatalf("the key is absent from Redis after a Put through the mount's cache: %v", err)
+		}
+
+		if got != "through-the-mount" {
+			t.Errorf("Redis holds %q, want %q", got, "through-the-mount")
+		}
+	})
+
+	t.Run("the in-process cache by default", func(t *testing.T) {
+		t.Parallel()
+
+		a := startAdapterWithCluster(t, nil)
+
+		if _, ok := a.cache.(*cache.MultiLevelCache); !ok {
+			t.Fatalf("a default mount holds a %T, want the in-process MultiLevelCache", a.cache)
+		}
+	})
+}
+
+// TestStartRefusesAnUnreachableRedis asserts the mount does not come up with the wrong cache.
+//
+// Silently falling back is the failure this whole issue is about, one layer further out: two nodes both
+// start, both believe they share a cache, and disagree about a file with nothing in either log to
+// explain it. Refusing at Start costs a restart and says which setting to fix.
+func TestStartRefusesAnUnreachableRedis(t *testing.T) {
+	t.Parallel()
+
+	cfg := configForSubstrate(t)
+	cfg.Cluster.Enabled = true
+	cfg.Cluster.Redis = config.RedisConfig{
+		Enabled:    true,
+		Address:    "127.0.0.1:1", // nothing listens here
+		MaxRetries: 0,
+	}
+
+	a, err := New(context.Background(), "s3://"+substrateBucket(t), t.TempDir(), cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	err = a.Start(context.Background())
+	if err == nil {
+		_ = a.Stop(context.Background())
+		t.Fatal("Start succeeded with an unreachable Redis, so the mount is serving from a private cache " +
+			"while the configuration says the cache is shared")
+	}
+
+	// Which failure, not just that one occurred. Start's last step is the mount, which fails on a host
+	// with no FUSE helper — so "Start returned an error" alone is satisfied on those hosts by a build
+	// that ignored the Redis setting entirely, and this test would pass while asserting nothing.
+	if !strings.Contains(err.Error(), "cache") {
+		t.Fatalf("Start failed for some other reason than the cache, so nothing here shows the "+
+			"unreachable Redis was refused: %v", err)
+	}
+
+	if a.cache != nil {
+		t.Errorf("Start failed but left a %T on the adapter, so a later call would use a cache the mount "+
+			"was refused permission to use", a.cache)
+	}
+
+	// The backend is built at step 2, before the cache at step 3, so it exists even though Start failed.
+	if a.backend != nil {
+		if err := a.backend.Close(); err != nil {
+			t.Errorf("closing the backend: %v", err)
+		}
+	}
+}
+
+// startAdapterWithCluster runs Adapter.Start against the substrate endpoint, applying mutate to the
+// config first, and returns the adapter however far Start got.
+//
+// Start's seven steps end with the mount, and the mount is the one step a test host may be unable to
+// perform: it needs a FUSE mount helper — fusermount3 on Linux, macFUSE on darwin — plus permission to
+// use it, and CI has neither. So a mount failure is tolerated and every earlier failure is fatal.
+//
+// That tolerance costs nothing here, because the cache is built at step 3 and the mount is step 7: by
+// the time Mount is reached, a.cache holds whatever the configuration selected, which is the entire
+// assertion. Skipping instead would be worse than tolerating — the wiring under test is testable on
+// every host, and a skip would silently retire the test on the machines that run it most.
+//
+// Stop is only called when Start finished, since Stop refuses an adapter that never started. On the
+// partial path the pieces Start did build are closed by hand, so a Redis client and an S3 connection
+// pool are not left behind per subtest.
+func startAdapterWithCluster(t *testing.T, mutate func(*config.Configuration)) *Adapter {
+	t.Helper()
+
+	cfg := configForSubstrate(t)
+	if mutate != nil {
+		mutate(cfg)
+	}
+
+	a, err := New(context.Background(), "s3://"+substrateBucket(t), t.TempDir(), cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	startErr := a.Start(context.Background())
+
+	switch {
+	case startErr == nil:
+		t.Cleanup(func() {
+			if err := a.Stop(context.Background()); err != nil {
+				t.Errorf("Stop: %v", err)
+			}
+		})
+
+	case strings.Contains(startErr.Error(), "failed to mount filesystem"):
+		t.Cleanup(func() { closePartialStart(t, a) })
+
+	default:
+		t.Fatalf("Start failed before reaching the mount, so it failed at a step this test is "+
+			"about: %v", startErr)
+	}
+
+	if a.cache == nil {
+		t.Fatal("Start left no cache on the adapter at all, so step 3 did not run")
+	}
+
+	return a
+}
+
+// closePartialStart releases what Start built before the mount failed.
+func closePartialStart(t *testing.T, a *Adapter) {
+	t.Helper()
+
+	if a.cancelMount != nil {
+		a.cancelMount()
+	}
+
+	if closer, ok := a.cache.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			t.Errorf("closing the cache: %v", err)
+		}
+	}
+
+	if a.writeBuffer != nil {
+		if err := a.writeBuffer.Close(); err != nil {
+			t.Errorf("closing the write path: %v", err)
+		}
+	}
+
+	if a.backend != nil {
+		if err := a.backend.Close(); err != nil {
+			t.Errorf("closing the backend: %v", err)
+		}
+	}
+}
+
+// configForSubstrate returns a default config pointed at the in-process substrate endpoint.
+//
+// Defaults except for the endpoint and the two listeners: NewDefault is what a mount with no config
+// file runs, so starting from it is what makes this a test of the shipped path. The listeners are off
+// because both default to fixed ports, and two Starts on fixed ports cannot coexist under t.Parallel.
+//
+// No credentials are set, and none are needed: buildS3Config deliberately leaves the credential fields
+// empty so the AWS default chain applies (see the note at the end of that function), and the substrate
+// emulator does not verify signatures. Verified — NewBackend, HealthCheck included, succeeds against
+// this endpoint with both credential fields blank.
+func configForSubstrate(t *testing.T) *config.Configuration {
+	t.Helper()
+
+	base := testaws.Shared(t).Config()
+
+	cfg := config.NewDefault()
+	cfg.Storage.S3.Endpoint = base.Endpoint
+	cfg.Storage.S3.ForcePathStyle = base.ForcePathStyle
+	cfg.Storage.S3.Region = base.Region
+	cfg.Monitoring.Metrics.Enabled = false
+	cfg.Monitoring.HealthChecks.Enabled = false
+
+	return cfg
+}
+
+// substrateBucket creates a bucket on the shared substrate endpoint.
+func substrateBucket(t *testing.T) string {
+	t.Helper()
+
+	bucket, err := testaws.Shared(t).Bucket(context.Background())
+	if err != nil {
+		t.Fatalf("testaws: bucket: %v", err)
+	}
+
+	return bucket
+}

--- a/internal/adapter/cache_selection_test.go
+++ b/internal/adapter/cache_selection_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -205,16 +206,38 @@ func closePartialStart(t *testing.T, a *Adapter) {
 	}
 }
 
+// TestMain supplies credentials for the whole package before any test runs.
+//
+// It has to be here rather than in a helper, and the reason is the seam this file is about.
+// buildS3Config deliberately maps no credential fields — a YAML key for a long-lived secret invites it
+// into version control — so an adapter built from a Configuration gets its credentials from the AWS
+// default chain, exactly as a real mount does. With nothing in the environment that chain reaches EC2
+// IMDS and fails, which is what CI does: no credentials, no instance role, and
+// `NewBackend`'s closing HealthCheck fails before the cache is ever built.
+//
+// A developer machine with an AWS profile hides this completely — these tests passed locally with no
+// credentials of their own, because the chain found the ambient ones. So the values are set here, once,
+// for the whole test binary. Not with t.Setenv, which cannot be used from a parallel test and mutates
+// process-wide state that other parallel tests in this package read.
+//
+// The substrate emulator does not verify signatures, so any non-empty pair would do; using testaws's
+// keeps one source for them.
+func TestMain(m *testing.M) {
+	// Errors are impossible for a well-formed name and there is no test scope to report one in.
+	_ = os.Setenv("AWS_ACCESS_KEY_ID", testaws.AccessKeyID)
+	_ = os.Setenv("AWS_SECRET_ACCESS_KEY", testaws.SecretAccessKey)
+
+	os.Exit(m.Run())
+}
+
 // configForSubstrate returns a default config pointed at the in-process substrate endpoint.
 //
 // Defaults except for the endpoint and the two listeners: NewDefault is what a mount with no config
 // file runs, so starting from it is what makes this a test of the shipped path. The listeners are off
 // because both default to fixed ports, and two Starts on fixed ports cannot coexist under t.Parallel.
 //
-// No credentials are set, and none are needed: buildS3Config deliberately leaves the credential fields
-// empty so the AWS default chain applies (see the note at the end of that function), and the substrate
-// emulator does not verify signatures. Verified — NewBackend, HealthCheck included, succeeds against
-// this endpoint with both credential fields blank.
+// Credentials come from the environment, set in TestMain — see there for why they cannot come from the
+// Configuration.
 func configForSubstrate(t *testing.T) *config.Configuration {
 	t.Helper()
 

--- a/internal/cache/cachetest/conformance.go
+++ b/internal/cache/cachetest/conformance.go
@@ -1,0 +1,206 @@
+// Package cachetest holds the shared conformance suite for types.Cache implementations.
+//
+// There are five of them — LRUCache, PersistentCache, MultiLevelCache, PredictiveCache and the
+// Redis-backed cache — and until this package existed each was tested only against itself. That is
+// how the Redis cache came to violate the contract's central promise while passing its own suite: its
+// tests exercised Get(key, 0, 0) and Get(key, 2, 4) against entries long enough to satisfy them, and
+// never asked for a range the cache did not hold in full.
+//
+// It matters because of what the caller does with the answer. internal/fuse hands a cache hit
+// straight to the kernel as file content:
+//
+//	if cachedData := fh.fs.cache.Get(fh.file.path, off, want); cachedData != nil {
+//	    return fuse.ReadResultData(cachedData), 0
+//	}
+//
+// A cache that returns 2 bytes when asked for 10 is therefore not a slow cache or a lossy one — it is
+// a truncated read reported as a successful one, which is audit finding H7's shape arriving through a
+// different door. So "a partial hit is a miss" is not a style rule about return values; it is the only
+// thing that makes that call site safe, and it has to hold for every implementation the mount can be
+// configured to use rather than for the ones whose tests happened to ask.
+//
+// The suite lives in a non-test package so both internal/cache and internal/cache/redis can call it
+// without an import cycle, and so a sixth implementation added anywhere in the tree can be enrolled in
+// one line.
+package cachetest
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// RunContract exercises cache against every promise types.Cache makes about Get, Put and Delete.
+//
+// newCache is called once per subtest rather than a single instance being shared, because several of
+// the cases below depend on a key being absent and a suite that shares state cannot distinguish "this
+// cache missed" from "an earlier subtest already stored it". Implementations that need cleanup should
+// register it with t.Cleanup inside newCache.
+//
+// Deliberately not table-driven over a list of implementations here: each caller enrolls its own, so a
+// package that cannot import another (redis, in particular) still runs the same assertions.
+func RunContract(t *testing.T, newCache func(t *testing.T) types.Cache) {
+	t.Helper()
+
+	t.Run("a hit returns exactly the bytes asked for", func(t *testing.T) {
+		c := newCache(t)
+		c.Put("obj", 0, []byte("0123456789"))
+
+		got := c.Get("obj", 2, 4)
+		if !bytes.Equal(got, []byte("2345")) {
+			t.Errorf("Get(obj,2,4) over a 10-byte entry = %q, want %q", got, "2345")
+		}
+	})
+
+	t.Run("a partial hit is a miss", func(t *testing.T) {
+		c := newCache(t)
+
+		// Ten bytes cached; a read straddling the end of them. The object itself may well be longer —
+		// the cache does not know the object's length and must not guess — so the only safe answer is
+		// nil, leaving the caller to fetch the range it actually needs.
+		c.Put("obj", 0, []byte("0123456789"))
+
+		got := c.Get("obj", 8, 10)
+		if got != nil {
+			t.Errorf("Get(obj,8,10) over a 10-byte entry returned %d bytes (%q) instead of a miss.\n"+
+				"internal/fuse returns a non-nil hit to the kernel verbatim as file content, so a short "+
+				"answer here is a silently truncated read: the caller asked for 10 bytes at offset 8 and "+
+				"has no way to tell a short cache entry from a short file", len(got), got)
+		}
+	})
+
+	t.Run("a read past the end of what is held is a miss", func(t *testing.T) {
+		c := newCache(t)
+		c.Put("obj", 0, []byte("0123456789"))
+
+		if got := c.Get("obj", 100, 10); got != nil {
+			t.Errorf("Get(obj,100,10) returned %d bytes (%q), want a miss", len(got), got)
+		}
+	})
+
+	t.Run("a read longer than what is held is a miss", func(t *testing.T) {
+		c := newCache(t)
+		c.Put("obj", 0, []byte("0123456789"))
+
+		if got := c.Get("obj", 0, 20); got != nil {
+			t.Errorf("Get(obj,0,20) over a 10-byte entry returned %d bytes (%q), want a miss.\n"+
+				"This is the same defect as the straddling case and reads more innocently: offset 0 with "+
+				"a length the entry cannot cover looks like a whole-object read, and answering it with "+
+				"the whole entry hands back a file that is shorter than the one requested", len(got), got)
+		}
+	})
+
+	t.Run("a miss on an absent key is nil", func(t *testing.T) {
+		c := newCache(t)
+
+		if got := c.Get("never-stored", 0, 16); got != nil {
+			t.Errorf("Get on an unstored key returned %d bytes (%q), want nil", len(got), got)
+		}
+	})
+
+	t.Run("an open-ended read returns what is held", func(t *testing.T) {
+		c := newCache(t)
+		c.Put("obj", 0, []byte("0123456789"))
+
+		// size <= 0 means "whatever contiguous bytes are held from offset" — the one form where a short
+		// answer is correct, because the caller has stated it does not know the length. The FUSE
+		// metadata cache is the reason it exists: it stores a marshaled ObjectInfo and cannot state
+		// that value's length at lookup time.
+		if got := c.Get("obj", 0, 0); !bytes.Equal(got, []byte("0123456789")) {
+			t.Errorf("Get(obj,0,0) = %q, want the whole 10-byte entry", got)
+		}
+
+		if got := c.Get("obj", 6, 0); !bytes.Equal(got, []byte("6789")) {
+			t.Errorf("Get(obj,6,0) = %q, want %q", got, "6789")
+		}
+	})
+
+	t.Run("the returned slice is the caller's own", func(t *testing.T) {
+		c := newCache(t)
+		c.Put("obj", 0, []byte("0123456789"))
+
+		got := c.Get("obj", 0, 10)
+		if got == nil {
+			t.Fatal("Get(obj,0,10) missed on bytes just written")
+		}
+
+		// Scribble on it. A cache that handed out a view of its own storage would now hold "XXXXXXXXXX",
+		// and every later reader of this key would see it — the FUSE read path passes the returned slice
+		// to the kernel, which is free to keep it in the page cache.
+		for i := range got {
+			got[i] = 'X'
+		}
+
+		again := c.Get("obj", 0, 10)
+		if !bytes.Equal(again, []byte("0123456789")) {
+			t.Errorf("after a caller wrote to the slice Get returned, the cache holds %q: the returned "+
+				"slice aliases the cache's own storage, so one reader can corrupt every later read of "+
+				"the same key", again)
+		}
+	})
+
+	t.Run("a newer Put wins where it overlaps", func(t *testing.T) {
+		c := newCache(t)
+		c.Put("obj", 0, []byte("OLDOLDOLD!"))
+		c.Put("obj", 0, []byte("NEWNEWNEW!"))
+
+		// This is how an overwrite reaches the cache. Keeping the older copy serves pre-write content,
+		// which is audit finding H5 — read-after-write returning stale bytes for up to the TTL.
+		if got := c.Get("obj", 0, 10); !bytes.Equal(got, []byte("NEWNEWNEW!")) {
+			t.Errorf("Get after an overlapping Put = %q, want %q: the older bytes won, so a read after "+
+				"a write returns pre-write content", got, "NEWNEWNEW!")
+		}
+	})
+
+	t.Run("Delete removes the key", func(t *testing.T) {
+		c := newCache(t)
+		c.Put("obj", 0, []byte("0123456789"))
+
+		if got := c.Get("obj", 0, 10); got == nil {
+			t.Fatal("Get missed on bytes just written, so the Delete below would prove nothing")
+		}
+
+		c.Delete("obj")
+
+		if got := c.Get("obj", 0, 10); got != nil {
+			t.Errorf("Get after Delete returned %d bytes (%q): write invalidation relies on this, so a "+
+				"surviving entry serves pre-write bytes", len(got), got)
+		}
+	})
+
+	t.Run("Delete removes nothing else", func(t *testing.T) {
+		c := newCache(t)
+
+		// The three names that matter: a prefix relationship, and a shared path component. A Delete
+		// implemented by prefix match rather than on the delimiter flushes all three, which is the
+		// over-removal half of the same contract line (audit finding M14).
+		c.Put("logs/app", 0, []byte("aaaaaaaaaa"))
+		c.Put("logs/app2", 0, []byte("bbbbbbbbbb"))
+		c.Put("logs/appendix", 0, []byte("cccccccccc"))
+
+		c.Delete("logs/app")
+
+		for _, tc := range []struct{ key, want string }{
+			{"logs/app2", "bbbbbbbbbb"},
+			{"logs/appendix", "cccccccccc"},
+		} {
+			if got := c.Get(tc.key, 0, 10); !bytes.Equal(got, []byte(tc.want)) {
+				t.Errorf("after Delete(logs/app), Get(%s,0,10) = %q, want %q: the delete matched on a "+
+					"prefix rather than a whole key, so it discarded an unrelated object's bytes",
+					tc.key, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("Size and Stats do not panic on an empty cache", func(t *testing.T) {
+		c := newCache(t)
+
+		// Not asserting values: Size means bytes held for the in-process caches and the server's
+		// used_memory for Redis, which is not a number this suite can predict. That these are callable
+		// on a cache nothing has been written to is still worth pinning — Stats divides by a request
+		// total that is zero here.
+		_ = c.Size()
+		_ = c.Stats()
+	})
+}

--- a/internal/cache/config_mapping_test.go
+++ b/internal/cache/config_mapping_test.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/config"
+)
+
+// TestMultiLevelConfigFromMapsEveryConfiguredValue is the other half of internal/config's cache block.
+//
+// The mapping it checks had two defects at once (#178). cache.NewFromConfig, the only reader of
+// cluster.redis.*, had no caller, so seven cluster keys plus a seven-key redis: sub-block were decoded,
+// defaulted and validated while no mount consulted any of them. And its non-Redis arm passed nil to
+// NewMultiLevelCache, discarding the L1/L2 sizing, TTL, persistent-cache directory and eviction policy
+// its argument carried — so even called, most of cache: would still have been ignored.
+//
+// Every value below is spelled out rather than computed from the input, following
+// TestBuildS3ConfigMapsEveryConfiguredValue in internal/adapter. A test written as
+//
+//	want := utils.ParseBytes(cfg.Performance.CacheSize)
+//
+// agrees with any mapping formula, including one that reads the persistent-cache size into the L1 size.
+// Writing "3GB" as 3221225472 means it fails when the mapping is wrong rather than when it differs.
+//
+// Nothing here is a default: each value differs from what the field would hold if the mapping were
+// absent, which is the only way a mapping test can distinguish a mapped field from a field arriving at
+// a plausible value from somewhere else.
+func TestMultiLevelConfigFromMapsEveryConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewDefault()
+	cfg.Performance.CacheSize = "3GB"
+	cfg.Cache.MaxEntries = 77777
+	cfg.Cache.TTL = 11 * time.Minute
+	cfg.Cache.EvictionPolicy = "lru"
+	cfg.Cache.PersistentCache.Enabled = true
+	cfg.Cache.PersistentCache.Directory = "/tmp/objectfs-mapping-test"
+	cfg.Cache.PersistentCache.MaxSize = "42GB"
+
+	got := multiLevelConfigFrom(cfg)
+
+	if got.L1Config == nil || got.L2Config == nil {
+		t.Fatalf("a nil level config: L1=%v L2=%v", got.L1Config, got.L2Config)
+	}
+
+	wantL1 := L1Config{
+		Enabled:    true,
+		Size:       3221225472, // 3GB
+		MaxEntries: 77777,
+		TTL:        11 * time.Minute,
+		Prefetch:   true,
+	}
+	if *got.L1Config != wantL1 {
+		t.Errorf("L1:\n got: %+v\nwant: %+v", *got.L1Config, wantL1)
+	}
+
+	wantL2 := L2Config{
+		Enabled:     true,
+		Size:        45097156608, // 42GB
+		Directory:   "/tmp/objectfs-mapping-test",
+		TTL:         11 * time.Minute,
+		Compression: true,
+	}
+	if *got.L2Config != wantL2 {
+		t.Errorf("L2:\n got: %+v\nwant: %+v", *got.L2Config, wantL2)
+	}
+
+	if got.Policy != "lru" {
+		t.Errorf("Policy = %q, want %q: the eviction policy is a documented key and reached nothing",
+			got.Policy, "lru")
+	}
+}
+
+// TestMultiLevelConfigFromFallsBackOnAnUnparseableSize pins the warn-and-continue behavior.
+//
+// Zero is the failure that matters: a zero-capacity cache evicts on every write and presents as a 0%
+// hit rate rather than as a misconfiguration, so an operator sees a performance problem where they have
+// a typo. Falling back to the documented default and logging the setting by name is the trade — the
+// mount still comes up, and the reason it is not using the configured size is in the log.
+func TestMultiLevelConfigFromFallsBackOnAnUnparseableSize(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewDefault()
+	cfg.Performance.CacheSize = "2 gigabytes"
+	cfg.Cache.PersistentCache.MaxSize = "tpyo"
+
+	got := multiLevelConfigFrom(cfg)
+
+	if got.L1Config.Size != defaultCacheSize {
+		t.Errorf("L1 size = %d, want the %d fallback: an unparseable size must not reach the cache as a "+
+			"capacity, and zero is the value that would", got.L1Config.Size, int64(defaultCacheSize))
+	}
+
+	if got.L2Config.Size != defaultPersistentCacheSize {
+		t.Errorf("L2 size = %d, want the %d fallback", got.L2Config.Size, int64(defaultPersistentCacheSize))
+	}
+}
+
+// TestMultiLevelConfigFromLeavesTheL2OffWhenTheConfigDoes asserts the one L2 field that is a decision
+// rather than a value.
+//
+// Enabled is not derived from the directory being set, and must not be: a config that names a cache
+// directory without enabling persistence is asking for the directory to be remembered, not for a
+// 10 GiB on-disk cache to appear.
+func TestMultiLevelConfigFromLeavesTheL2OffWhenTheConfigDoes(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewDefault()
+	cfg.Cache.PersistentCache.Enabled = false
+	cfg.Cache.PersistentCache.Directory = "/var/cache/objectfs"
+
+	if got := multiLevelConfigFrom(cfg); got.L2Config.Enabled {
+		t.Error("the L2 level is enabled while cache.persistent_cache.enabled is false, so a mount " +
+			"creates an on-disk cache the configuration declines")
+	}
+}

--- a/internal/cache/conformance_test.go
+++ b/internal/cache/conformance_test.go
@@ -1,0 +1,112 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	"github.com/scttfrdmn/objectfs/internal/cache/cachetest"
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// The four in-process implementations, each against the same contract. See internal/cache/cachetest
+// for why the suite is shared rather than per-implementation.
+//
+// Sizes are generous relative to the suite's ten-byte payloads: an eviction mid-subtest would look
+// like a contract violation and would be one of the few failures here that is the test's fault rather
+// than the cache's.
+
+func TestLRUCacheHonorsTheCacheContract(t *testing.T) {
+	t.Parallel()
+
+	cachetest.RunContract(t, func(t *testing.T) types.Cache {
+		return cache.NewLRUCache(&cache.CacheConfig{
+			MaxSize:    1 << 20,
+			MaxEntries: 1000,
+			TTL:        time.Hour,
+		})
+	})
+}
+
+func TestPersistentCacheHonorsTheCacheContract(t *testing.T) {
+	t.Parallel()
+
+	cachetest.RunContract(t, func(t *testing.T) types.Cache {
+		// Compression on, which is what the mount path sets unconditionally: adapter.Start builds its
+		// L2Config with Compression: true and no way to turn it off. A conformance run against the
+		// uncompressed path would not be testing the code any mount uses.
+		c, err := cache.NewPersistentCache(&cache.PersistentCacheConfig{
+			Directory:   t.TempDir(),
+			MaxSize:     1 << 20,
+			TTL:         time.Hour,
+			Compression: true,
+		})
+		if err != nil {
+			t.Fatalf("NewPersistentCache: %v", err)
+		}
+
+		t.Cleanup(func() { _ = c.Close() })
+
+		return c
+	})
+}
+
+func TestMultiLevelCacheHonorsTheCacheContract(t *testing.T) {
+	t.Parallel()
+
+	cachetest.RunContract(t, func(t *testing.T) types.Cache {
+		// Both levels on, as on a mount with persistent_cache.enabled — a promotion between them is the
+		// one path where a partial answer could be assembled from two sources, so a single-level
+		// configuration would miss the interesting case.
+		c, err := cache.NewMultiLevelCache(&cache.MultiLevelConfig{
+			L1Config: &cache.L1Config{
+				Enabled:    true,
+				Size:       1 << 20,
+				MaxEntries: 1000,
+				TTL:        time.Hour,
+			},
+			L2Config: &cache.L2Config{
+				Enabled:     true,
+				Size:        1 << 20,
+				Directory:   t.TempDir(),
+				TTL:         time.Hour,
+				Compression: true,
+			},
+			Policy: "weighted_lru",
+		})
+		if err != nil {
+			t.Fatalf("NewMultiLevelCache: %v", err)
+		}
+
+		t.Cleanup(func() { _ = c.Close() })
+
+		return c
+	})
+}
+
+func TestPredictiveCacheHonorsTheCacheContract(t *testing.T) {
+	t.Parallel()
+
+	cachetest.RunContract(t, func(t *testing.T) types.Cache {
+		// No Backend, so nothing can prefetch: a prefetch would issue a GET against a nil backend, and
+		// the contract this suite checks is about what Get returns for bytes already held. Prediction
+		// stays on because it runs on the Get path and must not change the answer.
+		c, err := cache.NewPredictiveCache(&cache.PredictiveCacheConfig{
+			BaseCache: cache.NewLRUCache(&cache.CacheConfig{
+				MaxSize:    1 << 20,
+				MaxEntries: 1000,
+				TTL:        time.Hour,
+			}),
+			EnablePrediction:    true,
+			PredictionWindow:    100,
+			ConfidenceThreshold: 0.7,
+		})
+		if err != nil {
+			t.Fatalf("NewPredictiveCache: %v", err)
+		}
+
+		t.Cleanup(func() { _ = c.Close() })
+
+		return c
+	})
+}

--- a/internal/cache/interface.go
+++ b/internal/cache/interface.go
@@ -1,20 +1,127 @@
 package cache
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
+
 	"github.com/scttfrdmn/objectfs/internal/cache/redis"
 	"github.com/scttfrdmn/objectfs/internal/config"
 	"github.com/scttfrdmn/objectfs/pkg/types"
+	"github.com/scttfrdmn/objectfs/pkg/utils"
 )
 
-// NewFromConfig constructs the appropriate cache backend from cfg.
+// Fallback sizes for the two cache capacities, used only when a configured value cannot be parsed.
 //
-// When cfg.Cluster.Enabled && cfg.Cluster.Redis.Enabled, a Redis-backed distributed
-// cache is returned; connectivity is verified during construction.
+// Same values and same reasoning as the adapter's, which is where this construction used to live: a
+// size that fails to parse must not silently become zero, because a zero-capacity cache evicts
+// everything on the next write and looks like a cache with a 0% hit rate rather than like a
+// misconfiguration.
+const (
+	defaultCacheSize           = 2 << 30 // 2 GiB, matching NewDefault's "2GB"
+	defaultPersistentCacheSize = 10 << 30
+)
+
+// NewFromConfig constructs the cache a mount should use from cfg.
 //
-// Otherwise the standard in-process MultiLevelCache is returned with default settings.
-func NewFromConfig(cfg *config.Configuration) (types.Cache, error) {
+// Two shapes, chosen by `cluster.enabled && cluster.redis.enabled`: a Redis-backed distributed cache,
+// whose connectivity is verified during construction, or the in-process MultiLevelCache built from the
+// `cache:` block.
+//
+// This function existed for a release with **no caller** (#178), which made the whole `cluster:` block
+// — seven keys plus a seven-key `redis:` sub-block — unreachable on every path a mount takes. The
+// adapter built a MultiLevelConfig by hand and called NewMultiLevelCache directly, so a deployment
+// that set `cluster.redis.enabled: true` got an in-process cache with no error and no warning. It
+// looked correct until two nodes disagreed about a file.
+//
+// Its second arm was lossy in its own right: it passed nil to NewMultiLevelCache, discarding the L1/L2
+// sizing, TTL, persistent-cache directory and eviction policy the caller's config carries. So even had
+// it been called, the non-Redis path would have ignored most of `cache:` too. Both halves are fixed
+// here, and the mapping lives in one place rather than being duplicated between this function and the
+// adapter — which is the condition that let the two drift apart unnoticed.
+//
+// ctx bounds the Redis connectivity check and nothing else: neither cache retains it. A cache lives for
+// as long as the mount does, so a startup context stored inside one would cancel every later operation
+// the moment startup returned.
+func NewFromConfig(ctx context.Context, cfg *config.Configuration) (types.Cache, error) {
 	if cfg.Cluster.Enabled && cfg.Cluster.Redis.Enabled {
-		return redis.NewCache(cfg.Cluster.Redis)
+		c, err := redis.NewCache(ctx, cfg.Cluster.Redis)
+		if err != nil {
+			// Returned rather than logged and swallowed. A mount that asked for a shared cache and
+			// silently got a private one is the defect this function's disuse produced; falling back on a
+			// connection failure would reintroduce it at a different layer.
+			return nil, fmt.Errorf("cluster.redis: %w", err)
+		}
+
+		slog.Info("using the Redis-backed distributed cache",
+			"address", cfg.Cluster.Redis.Address, "key_prefix", cfg.Cluster.Redis.KeyPrefix,
+			"ttl", cfg.Cluster.Redis.TTL)
+
+		return c, nil
 	}
-	return NewMultiLevelCache(nil)
+
+	// nolint:contextcheck // ctx deliberately does not reach the in-process cache. What it would reach
+	// is the predictive layer's prefetch workers, which outlive this call by design — they run for as
+	// long as the mount does, and are stopped by MultiLevelCache.Close on the unmount path rather than
+	// by a context. Passing a startup context down to them would cancel every prefetch the moment
+	// startup returned, so the goroutines would still be running and would simply never fetch anything.
+	// Each prefetch already bounds itself with its own 5-second timeout, which is the right scope for a
+	// speculative background read.
+	return NewMultiLevelCache(multiLevelConfigFrom(cfg))
+}
+
+// multiLevelConfigFrom maps the cache: block onto the in-process cache's own configuration.
+//
+// Separate from NewFromConfig so the mapping is assertable without constructing a cache — the same
+// reasoning as the adapter's buildS3Config and buildWriterOptions, and for the same reason: a mapping
+// only reachable through a constructor is a mapping tests do not check field by field, which is how
+// six of thirty S3 fields went unmapped for a release.
+func multiLevelConfigFrom(cfg *config.Configuration) *MultiLevelConfig {
+	return &MultiLevelConfig{
+		L1Config: &L1Config{
+			Enabled:    true,
+			Size:       sizeOrDefault("performance.cache_size", cfg.Performance.CacheSize, defaultCacheSize),
+			MaxEntries: cfg.Cache.MaxEntries,
+			TTL:        cfg.Cache.TTL,
+
+			// Prefetch is on for every mount and is not a configuration key. `features.prefetching` and
+			// `performance.predictive_caching` both exist and neither reaches here; wiring one of them is
+			// its own change, since turning the predictive layer off changes what Close has to stop.
+			Prefetch: true,
+		},
+		L2Config: &L2Config{
+			Enabled: cfg.Cache.PersistentCache.Enabled,
+			Size: sizeOrDefault("cache.persistent_cache.max_size",
+				cfg.Cache.PersistentCache.MaxSize, defaultPersistentCacheSize),
+			Directory: cfg.Cache.PersistentCache.Directory,
+			TTL:       cfg.Cache.TTL,
+
+			// Compression is likewise unconditional and has no key. Note it is not the same setting as
+			// storage.s3.compression, which governs the stored object; this one only affects bytes on the
+			// local cache disk and is invisible to anything reading the bucket.
+			Compression: true,
+		},
+		Policy: cfg.Cache.EvictionPolicy,
+	}
+}
+
+// sizeOrDefault parses a configured size, falling back with a warning rather than to zero.
+//
+// The warning is the point. `cache_size: 2G` and `cache_size: tpyo` both configured a 1 GiB cache with
+// no message at all before this logged, so an operator who mistyped a capacity had no way to learn it
+// from the process they were running.
+func sizeOrDefault(path, value string, fallback int64) int64 {
+	if value == "" {
+		return fallback
+	}
+
+	n, err := utils.ParseBytes(value)
+	if err != nil {
+		slog.Warn("configured size is not parseable; using the built-in default",
+			"setting", path, "value", value, "default", fallback, "error", err)
+
+		return fallback
+	}
+
+	return n
 }

--- a/internal/cache/interface_test.go
+++ b/internal/cache/interface_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,13 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/scttfrdmn/objectfs/internal/cache/redis"
 	"github.com/scttfrdmn/objectfs/internal/config"
 )
 
 func TestNewFromConfig_DefaultsToMultiLevel(t *testing.T) {
 	t.Parallel()
 	cfg := config.NewDefault()
-	c, err := NewFromConfig(cfg)
+	c, err := NewFromConfig(context.Background(), cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }
@@ -33,7 +35,7 @@ func TestNewFromConfig_RedisWhenEnabled(t *testing.T) {
 		MaxRetries: 1,
 	}
 
-	c, err := NewFromConfig(cfg)
+	c, err := NewFromConfig(context.Background(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
@@ -48,7 +50,114 @@ func TestNewFromConfig_ClusterEnabledButRedisDisabled(t *testing.T) {
 	cfg.Cluster.Enabled = true
 	cfg.Cluster.Redis.Enabled = false
 
-	c, err := NewFromConfig(cfg)
+	c, err := NewFromConfig(context.Background(), cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
+}
+
+// TestNewFromConfigReturnsTheImplementationTheConfigNames asserts the *type*, not just non-nil.
+//
+// The three tests above all passed while this function had no caller, and two of them would still pass
+// if the Redis arm were deleted: `assert.NotNil` holds for either implementation, and the round-trip in
+// RedisWhenEnabled holds for any working cache. So they establish that NewFromConfig returns something
+// usable and say nothing about *which* cache a configuration selects, which is the entire question
+// cluster.redis.enabled asks.
+//
+// The Redis case additionally proves the bytes went to Redis rather than to memory, by reading the key
+// out of miniredis directly. A cache that ignored the config and returned a MultiLevelCache would
+// satisfy every assertion above and leave the Redis server empty.
+func TestNewFromConfigReturnsTheImplementationTheConfigNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("redis when the cluster and redis are both enabled", func(t *testing.T) {
+		t.Parallel()
+
+		mr := miniredis.RunT(t)
+
+		cfg := config.NewDefault()
+		cfg.Cluster.Enabled = true
+		cfg.Cluster.Redis = config.RedisConfig{
+			Enabled:    true,
+			Address:    mr.Addr(),
+			KeyPrefix:  "selection",
+			TTL:        time.Minute,
+			MaxRetries: 1,
+		}
+
+		c, err := NewFromConfig(context.Background(), cfg)
+		require.NoError(t, err)
+
+		if _, ok := c.(*redis.Cache); !ok {
+			t.Fatalf("cluster.redis.enabled selected %T, so a deployment that configured a shared cache "+
+				"got a private in-process one — with no error, and no way to notice until two nodes "+
+				"disagreed about a file", c)
+		}
+
+		// The bytes must be in Redis, not merely in something that answers Get.
+		c.Put("obj", 0, []byte("stored-in-redis"))
+
+		got, err := mr.Get("selection:obj")
+		require.NoError(t, err, "the key is absent from Redis, so the cache is not the one it claims")
+		assert.Equal(t, "stored-in-redis", got)
+	})
+
+	for _, tc := range []struct {
+		name    string
+		cluster bool
+		redis   bool
+	}{
+		{"neither enabled", false, false},
+		{"cluster enabled, redis not", true, false},
+		// cluster: false with redis: true is the interesting one. Enabling a distributed cache without
+		// enabling the cluster is contradictory, and the resolution is to stay in-process: a Redis cache
+		// on a node that is not in a cluster is a remote cache with one participant, which is slower than
+		// memory and buys nothing.
+		{"redis enabled, cluster not", false, true},
+	} {
+		t.Run(tc.name+" gives the in-process cache", func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.NewDefault()
+			cfg.Cluster.Enabled = tc.cluster
+			cfg.Cluster.Redis.Enabled = tc.redis
+			// A live address, so a config that wrongly took the Redis arm would fail on connect rather
+			// than accidentally passing this assertion.
+			cfg.Cluster.Redis.Address = miniredis.RunT(t).Addr()
+
+			c, err := NewFromConfig(context.Background(), cfg)
+			require.NoError(t, err)
+
+			if _, ok := c.(*MultiLevelCache); !ok {
+				t.Fatalf("got %T, want the in-process MultiLevelCache", c)
+			}
+		})
+	}
+}
+
+// TestNewFromConfigFailsWhenRedisIsUnreachable pins the refusal.
+//
+// A mount that asked for a shared cache and silently got a private one is the defect this function's
+// disuse produced, so falling back on a connection failure would reintroduce it one layer up: two nodes
+// would both come up, both believe they are sharing a cache, and disagree about file contents with
+// nothing in either log to say why.
+func TestNewFromConfigFailsWhenRedisIsUnreachable(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewDefault()
+	cfg.Cluster.Enabled = true
+	cfg.Cluster.Redis = config.RedisConfig{
+		Enabled:    true,
+		Address:    "127.0.0.1:1", // nothing listens here
+		MaxRetries: 0,
+	}
+
+	c, err := NewFromConfig(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("an unreachable Redis produced a working cache (%T) instead of an error, so the mount "+
+			"comes up with a private cache while the configuration says it is shared", c)
+	}
+
+	assert.Nil(t, c, "a cache was returned alongside the error, and a caller checking only one of them "+
+		"gets the wrong implementation")
+	assert.Contains(t, err.Error(), "cluster.redis", "the error does not name the config block to fix")
 }

--- a/internal/cache/redis/client.go
+++ b/internal/cache/redis/client.go
@@ -26,18 +26,29 @@ type Cache struct {
 }
 
 // NewCache creates a new Redis-backed Cache and verifies connectivity.
-func NewCache(cfg config.RedisConfig) (*Cache, error) {
+//
+// ctx bounds the connectivity check only, and is deliberately not retained. The cache outlives the
+// call that builds it — it is held for the life of the mount — so storing a startup context here would
+// mean every later Get and Put ran under a context canceled the moment startup finished. The
+// per-operation contexts are a separate question and are noted at [Cache.Get].
+//
+// The check is not optional. It is what makes `cluster.redis.enabled` a setting a mount can refuse: an
+// address nothing listens on has to fail startup rather than produce a cache whose every operation
+// quietly misses, because the alternative is two nodes both coming up believing they share a cache.
+func NewCache(ctx context.Context, cfg config.RedisConfig) (*Cache, error) {
 	client := goredis.NewClient(&goredis.Options{
 		Addr:       cfg.Address,
 		Password:   cfg.Password,
 		DB:         cfg.DB,
 		MaxRetries: cfg.MaxRetries,
 	})
-	ctx := context.Background()
+
 	if err := client.Ping(ctx).Err(); err != nil {
 		_ = client.Close()
+
 		return nil, fmt.Errorf("redis: ping failed: %w", err)
 	}
+
 	return &Cache{client: client, cfg: cfg}, nil
 }
 
@@ -49,9 +60,24 @@ func (c *Cache) rkey(key string) string {
 	return key
 }
 
-// Get retrieves up to size bytes of key starting at offset.
-// If offset == 0 and size == 0 the full value is returned.
-// Returns nil on cache miss.
+// Get returns the cached bytes for [offset, offset+size), or nil if this cache does not hold all of
+// them.
+//
+// All of them: a partial hit is a miss, per the types.Cache contract. That is not a preference about
+// return values — internal/fuse hands a non-nil hit to the kernel verbatim as file content, so a short
+// answer is a truncated read reported as a successful one, and the caller cannot tell a short cache
+// entry from a short file.
+//
+// GETRANGE does not have those semantics. It clamps to the value's length and returns what it can, so
+// `GETRANGE k 8 17` over a ten-byte value answers with two bytes and no indication that eight are
+// missing — which is what this cache used to return. The length check below is therefore not
+// defensive tidiness; it is the whole difference between a cache miss and a silently short file. Found
+// by the shared conformance suite in internal/cache/cachetest, which the four in-process
+// implementations already passed.
+//
+// A size of zero or less means "whatever contiguous bytes are held from offset", which is the one form
+// where a short answer is correct: the caller has said it does not know the length. GETRANGE's clamp is
+// exactly right there, so that path is unchanged.
 func (c *Cache) Get(key string, offset, size int64) []byte {
 	ctx := context.Background()
 	rk := c.rkey(key)
@@ -60,21 +86,36 @@ func (c *Cache) Get(key string, offset, size int64) []byte {
 		data []byte
 		err  error
 	)
-	if offset == 0 && size == 0 {
-		data, err = c.client.Get(ctx, rk).Bytes()
-	} else {
-		end := int64(-1)
-		if size > 0 {
-			end = offset + size - 1
+
+	switch {
+	case size <= 0:
+		// Open-ended: from offset to the end of whatever is stored. -1 is GETRANGE's "last byte".
+		if offset == 0 {
+			data, err = c.client.Get(ctx, rk).Bytes()
+		} else {
+			data, err = c.client.GetRange(ctx, rk, offset, -1).Bytes()
 		}
-		data, err = c.client.GetRange(ctx, rk, offset, end).Bytes()
+	default:
+		data, err = c.client.GetRange(ctx, rk, offset, offset+size-1).Bytes()
+
+		// The clamp. A shorter answer than asked for means the stored value does not cover the request,
+		// whether because the object was cached before it grew, because only a prefix was ever stored, or
+		// because the request starts past the end. In all three the caller must fetch the range itself.
+		if err == nil && int64(len(data)) != size {
+			c.misses.Add(1)
+
+			return nil
+		}
 	}
 
 	if err != nil || len(data) == 0 {
 		c.misses.Add(1)
+
 		return nil
 	}
+
 	c.hits.Add(1)
+
 	return data
 }
 

--- a/internal/cache/redis/client_test.go
+++ b/internal/cache/redis/client_test.go
@@ -1,6 +1,7 @@
 package redis_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -24,7 +25,7 @@ func newTestCache(t *testing.T) (*redis.Cache, *miniredis.Miniredis) {
 		TTL:        5 * time.Minute,
 		MaxRetries: 1,
 	}
-	c, err := redis.NewCache(cfg)
+	c, err := redis.NewCache(context.Background(), cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 	return c, mr
@@ -43,7 +44,7 @@ func TestNewCache_BadAddress(t *testing.T) {
 		Address:    "localhost:1", // nothing listening here
 		MaxRetries: 0,
 	}
-	_, err := redis.NewCache(cfg)
+	_, err := redis.NewCache(context.Background(), cfg)
 	assert.Error(t, err)
 }
 
@@ -136,7 +137,7 @@ func TestTTLExpiry(t *testing.T) {
 		TTL:        100 * time.Millisecond,
 		MaxRetries: 1,
 	}
-	c, err := redis.NewCache(cfg)
+	c, err := redis.NewCache(context.Background(), cfg)
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 
@@ -155,11 +156,11 @@ func TestKeyPrefix(t *testing.T) {
 	cfg1 := config.RedisConfig{Enabled: true, Address: mr.Addr(), KeyPrefix: "ns1", MaxRetries: 1}
 	cfg2 := config.RedisConfig{Enabled: true, Address: mr.Addr(), KeyPrefix: "ns2", MaxRetries: 1}
 
-	c1, err := redis.NewCache(cfg1)
+	c1, err := redis.NewCache(context.Background(), cfg1)
 	require.NoError(t, err)
 	defer func() { _ = c1.Close() }()
 
-	c2, err := redis.NewCache(cfg2)
+	c2, err := redis.NewCache(context.Background(), cfg2)
 	require.NoError(t, err)
 	defer func() { _ = c2.Close() }()
 

--- a/internal/cache/redis/conformance_test.go
+++ b/internal/cache/redis/conformance_test.go
@@ -1,0 +1,52 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/scttfrdmn/objectfs/internal/cache/cachetest"
+	"github.com/scttfrdmn/objectfs/internal/cache/redis"
+	"github.com/scttfrdmn/objectfs/internal/config"
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// TestCacheHonorsTheCacheContract runs the same suite as the four in-process implementations.
+//
+// It is in this package rather than beside them because internal/cache cannot import
+// internal/cache/redis — redis imports internal/config, which the parent's own tests use — so the
+// contract lives in internal/cache/cachetest and both sides call it.
+//
+// This is the test that found the truncation. Before it existed the Redis cache had ten tests of its
+// own, all passing, none of which asked for a range longer than what was stored: Get(k,0,0) and
+// Get(k,2,4) over a six- or ten-byte value are both satisfiable, so GETRANGE's clamp-to-length
+// behavior never showed. A shared suite asks every implementation the same questions rather than the
+// ones its author thought of.
+func TestCacheHonorsTheCacheContract(t *testing.T) {
+	t.Parallel()
+
+	cachetest.RunContract(t, func(t *testing.T) types.Cache {
+		// miniredis, not a real server: the contract is about what Get returns for what Put stored, and
+		// nothing here depends on Redis internals miniredis abstains from. A KeyPrefix is set because
+		// the mount path defaults to one, and prefixing is where the Delete-removes-nothing-else case
+		// could plausibly go wrong.
+		mr := miniredis.RunT(t)
+
+		c, err := redis.NewCache(context.Background(), config.RedisConfig{
+			Enabled:    true,
+			Address:    mr.Addr(),
+			KeyPrefix:  "conformance",
+			TTL:        time.Hour,
+			MaxRetries: 1,
+		})
+		if err != nil {
+			t.Fatalf("NewCache: %v", err)
+		}
+
+		t.Cleanup(func() { _ = c.Close() })
+
+		return c
+	})
+}

--- a/internal/cache/redis/invalidation_test.go
+++ b/internal/cache/redis/invalidation_test.go
@@ -23,7 +23,7 @@ func newTestCacheAndInvalidator(t *testing.T, mr *miniredis.Miniredis, nodeID st
 		TTL:        5 * time.Minute,
 		MaxRetries: 1,
 	}
-	c, err := redis.NewCache(cfg)
+	c, err := redis.NewCache(context.Background(), cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 


### PR DESCRIPTION
Closes #178.

## The defect

`cache.NewFromConfig` — the only reader of `cluster.redis.*` anywhere in the repository — **had no caller.** `Adapter.Start` built a `MultiLevelConfig` literal of its own instead, so seven `cluster` keys plus a seven-key `redis` sub-block were decoded, defaulted, validated and documented while no mount consulted any of them. A deployment that configured a shared Redis cache got a private in-process one, with no error and no warning, and looked correct until two nodes disagreed about a file.

Third instance of the shape #156 and #176 were: a config block whose every layer worked except the one that had to call it.

Both halves are fixed together, because they are the same mistake. `NewFromConfig`'s other arm passed a literal `nil` to `NewMultiLevelCache`, discarding the L1/L2 sizing, the TTL, the persistent-cache directory and the eviction policy its argument carried — so even with a caller, most of the `cache:` block would still have been ignored. The mapping now lives in `internal/cache` beside the selection rather than in the adapter, since a second copy of it is how the two came to disagree in the first place. `Adapter.cache` is typed `types.Cache`: naming the concrete `*cache.MultiLevelCache` there is what made the function uncallable, as the field could not hold what it returns.

**An unreachable Redis fails the mount** rather than falling back. Falling back is this same defect one layer out — both nodes come up, both believe the cache is shared, and nothing in either log explains the disagreement.

## What wiring it up would have shipped

A contract-violating cache on the read path. So the conformance suite came first, and it found one.

**`internal/cache/cachetest` is a shared suite every `types.Cache` implementation is now run against.** There were five implementations, one contract, and no test in common — each checked against the questions its own author thought to ask. That is why four of them satisfied a rule the fifth violated in the most consequential direction: **the Redis cache answered a ten-byte request with two bytes.** `GETRANGE` clamps to the stored value's length, so `GETRANGE k 8 17` over a ten-byte value returns two bytes and no indication that eight are missing. `internal/fuse` passes a non-nil hit to the kernel verbatim as file content, so that is a truncated read reported as a successful one — audit finding H7's shape arriving through a different door. It had ten tests of its own, all passing, none of which asked for a range longer than what was stored.

Ten cases, each stating in its failure message what a caller would observe: exact-range hits, straddling and past-the-end reads as misses, a request longer than the entry as a miss, the open-ended `size <= 0` form, the returned slice not aliasing the cache's own storage, a newer `Put` winning where it overlaps, and `Delete` removing the key it names and nothing that merely shares a prefix with it. A sixth implementation is one enrollment away.

## Tests

| Test | What only it can show |
|---|---|
| `TestStartReachesTheCacheTheConfigNames` | that a **mount** gets the configured cache — drives `Adapter.Start` against a substrate-backed S3 endpoint plus miniredis, and reads the stored key back out of the Redis server rather than asserting the type alone |
| `TestStartRefusesAnUnreachableRedis` | the mount does not come up with the wrong cache; asserts *which* failure, since Start's last step fails anyway on a host with no FUSE helper |
| `TestCacheHonorsTheCacheContract` ×5 | the contract, asked identically of every implementation |
| `TestNewFromConfigReturnsTheImplementationTheConfigNames` | which implementation a config selects — the three pre-existing tests asserted `NotNil`, which holds for either |
| `TestMultiLevelConfigFromMapsEveryConfiguredValue` | the `cache:` block reaching the cache, values spelled out rather than recomputed from the input |

Mutation-verified, all four ways: reverting `Start` to the hand-built literal fails both adapter tests; removing the length check in `redis.Cache.Get` fails exactly the two conformance cases about short answers.

`Adapter.Start`'s mount step is tolerated because a host without a FUSE mount helper cannot perform it, and the cache is built four steps earlier. Skipping would be worse — the wiring under test is testable on every host, and a skip would silently retire the test on the machines that run it most.

## Gates

`go build` · `go vet` · full `go test -race ./...` clean · coverage gate 30 packages at or above their floor, with `internal/cache` ratcheted 82 → 85 and `internal/cache/redis` 87 → 88 · `golangci-lint --new-from-merge-base=origin/main` 0 issues · markdownlint on the touched docs.

`NewCache` and `NewFromConfig` take a context for the connectivity check, which neither cache retains — a cache lives as long as the mount does, so a startup context stored inside one would cancel every later operation the moment startup returned. The `contextcheck` finding on the in-process arm is suppressed with the reason at the call site: what `ctx` would reach there is the prefetch workers, which are stopped by `Close` on the unmount path and would otherwise never fetch anything.

## Docs

`docs/index.md`'s **Not yet wired up** table loses its Redis row. `examples/config.yaml`'s `cluster:` comment no longer says `NewFromConfig` "currently has no caller" and states what setting both flags does, including the refusal.