### PR TITLE
fix: cost_optimization keeps one key, and it reaches the object (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,6 +436,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does not start. This is the third instance of the shape [#156] and [#176] were: a config block whose
   every layer worked except the one that had to call it.
 
+- **`storage.s3.cost_optimization` keeps one key, and it does what it says ([#203]).** The block had
+  six; five are removed and one is new. `small_objects_on_standard` stores an object on STANDARD when
+  the configured `storage_tier` would bill it as larger than it is *and* STANDARD is genuinely cheaper
+  for it. Defaults to `false`, because it changes the storage class objects are written with, and an
+  operator who set `storage_tier` should get that tier until they ask otherwise.
+
+  Removed, not deprecated — configuration is decoded strictly, so a file still carrying one of these
+  fails at startup naming the key rather than silently ignoring it:
+
+  | Removed key | Why |
+  |---|---|
+  | `enabled` | Gated nothing. The backend has no such field |
+  | `tiering_enabled` | Automatic tier transitions exist in the S3 backend; nothing on the mount path invokes them |
+  | `lifecycle_enabled` | Lifecycle rules are a `PutBucketLifecycleConfiguration` call this backend never makes |
+  | `transition_to_ia` | Same: a lifecycle rule, never written |
+  | `transition_to_glacier` | Same |
+
+  This is the fourth instance of the shape [#156], [#176] and the `cluster.redis` item above were, and
+  the most direct: `internal/config.S3CostOptimization` and `internal/storage/s3.CostOptimization`
+  shared **no field name at all**, so the block could not be mapped even in principle. `buildS3Config`
+  carried a comment saying it was not mappable, which was true and is not a fix — the two types had
+  drifted until the only honest options were to plumb a field that did not exist on both sides or to
+  delete what nothing read.
+
+  Two more `s3.CostOptimization` fields survive as Go struct fields with no YAML key, and the
+  distinction is deliberate: `EnableAutoTiering` and `CostThreshold` are read by code an embedder can
+  call directly, while a *mount* has no path to it. `MonitorAccessPatterns` is likewise unmapped, and
+  for a second reason — the map it populates holds one entry per distinct key read and nothing evicts,
+  so on a bucket with many objects it is unbounded growth for a report no mount displays.
+
+- **The small-object rule compares prices instead of one size.** `HandleStandardTierOverhead` tested
+  `objectSize < 128 KiB` with no reference to the configured tier, so it moved objects to STANDARD from
+  tiers that publish no billing minimum at all — including DEEP_ARCHIVE, at ~23× the storage rate —
+  and from the three that do at sizes where they are still much cheaper. Being under a floor does not
+  make STANDARD cheaper: the crossover is at `minBillable × rateTier / rateStandard`, which at list
+  prices is **69.6 KiB** for STANDARD_IA, **55.7 KiB** for ONEZONE_IA and **22.3 KiB** for GLACIER_IR.
+  A 32 KiB object billed as 128 KiB of GLACIER_IR costs about a third of 32 KiB on STANDARD. Three
+  conditions are now required — the tier publishes a minimum, the object is under it, and STANDARD is
+  cheaper for this object at the prices this deployment pays, discounts and `CustomPricing` included.
+
+  This also keeps GLACIER and DEEP_ARCHIVE out on a second ground that is not about money: their
+  objects cannot be read without a restore, so diverting one to STANDARD would change what a read of
+  that object *does*, not only what it costs. A cost heuristic must not decide retrieval semantics.
+
+  `TierValidator.GetRecommendations` had the identical size-only rule and now uses the same three
+  conditions at list rates. It has no mount-path caller — it is exported API — but advice nobody can
+  act on wrongly is still advice someone will act on.
+
+- **The billing-minimum warning names the tier the object is actually stored on.** `ValidateWrite`
+  ran before the small-object diversion and described the configured tier's floor, so an operator who
+  enabled `small_objects_on_standard` *because of* that warning still saw `billed_size=131072` on a
+  16 KiB object that was about to be stored on STANDARD and billed as 16 KiB. The diversion logs at
+  Debug, so at the default level the misleading half was the only half visible. The tier decision now
+  precedes validation and `ValidateWriteToTier` takes the effective tier. `tier_constraints.min_object_size`
+  deliberately does *not* follow it: that is a floor the operator configured for this mount, and an
+  internal cost optimization is not a reason to stop enforcing it.
+
+- **A per-object storage class bypasses the CargoShip transporter.** `Transporter.optimizeStorageClass`
+  returns the transporter's *own* config storage class — fixed at construction from `storage_tier` — for
+  any archive with no `AccessPattern` and no `RetentionDays`, which is every archive ObjectFS builds. It
+  never reads `Archive.StorageClass`, the field whose comment says "Target storage class". So the
+  diverted class was computed correctly and dropped at the boundary: the object stored fine, read back
+  fine, and only the invoice differed. Objects whose class differs from the configured tier now take the
+  direct `PutObject` path, joining the existing bypasses for compression and for encryption modes the
+  transporter cannot express. The common case is unaffected and keeps CargoShip's throughput
+  optimization. Filed upstream as [scttfrdmn/cargoship#352]; `OptimizedTransporter`, a different type
+  ObjectFS does not construct, already honors the field.
+
+  Found by asserting the storage class recorded at the S3 endpoint rather than the value passed in — the
+  same technique that found the `INTELLIGENT_TIERING` default in v0.10.1, and the reason the seam test
+  exists at all.
+
+[scttfrdmn/cargoship#352]: https://github.com/scttfrdmn/cargoship/issues/352
 [#154]: https://github.com/scttfrdmn/objectfs/issues/154
 [#156]: https://github.com/scttfrdmn/objectfs/issues/156
 [#157]: https://github.com/scttfrdmn/objectfs/issues/157
@@ -447,6 +520,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#181]: https://github.com/scttfrdmn/objectfs/issues/181
 [#192]: https://github.com/scttfrdmn/objectfs/issues/192
 [#202]: https://github.com/scttfrdmn/objectfs/issues/202
+[#203]: https://github.com/scttfrdmn/objectfs/issues/203
 [#205]: https://github.com/scttfrdmn/objectfs/issues/205
 [#211]: https://github.com/scttfrdmn/objectfs/issues/211
 [#212]: https://github.com/scttfrdmn/objectfs/issues/212

--- a/docs-platform/guide/getting-started.md
+++ b/docs-platform/guide/getting-started.md
@@ -237,8 +237,7 @@ storage:
     region: us-east-1
     use_acceleration: true
     cost_optimization:
-      enabled: true
-      tiering_enabled: true
+      small_objects_on_standard: true
 
 performance:
   cache_size: 8GB
@@ -259,10 +258,16 @@ monitoring:
 
 Every key above is one the loader defines, which is checked by
 `TestDocumentedConfigYAMLMatchesTheSchema` — configuration is decoded strictly, so a key the schema
-does not have fails at startup with the key named. Two of them set a value nothing reads:
-`cost_optimization` is not mapped onto the backend (`internal/adapter/adapter.go` records why: the
-config and backend types are disjoint), and `predictive_caching` reaches the cache but the predictor
-it selects is never installed on the mount path.
+does not have fails at startup with the key named. One of them sets a value nothing reads:
+`predictive_caching` reaches the cache, but the predictor it selects is never installed on the mount
+path.
+
+`cost_optimization` had five other keys until v0.11.0 — `enabled`, `tiering_enabled`,
+`lifecycle_enabled`, `transition_to_ia` and `transition_to_glacier` — and none of them reached the
+backend, which read an entirely different set of field names. They are gone rather than deprecated,
+so a file still carrying one fails at startup naming it. `small_objects_on_standard` is what remains:
+it stores an object on STANDARD where `storage_tier` names a class that would bill it as larger than
+it is *and* STANDARD is genuinely cheaper for it.
 
 <CodeRunner language="bash">
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,10 @@ which names them rather than leaving them mixed in with the list above.
 
 - **Universal compatibility**: Works with AWS S3, MinIO, Ceph, and all S3-compatible storage
 - **Multi-region support**: Optimize for your region or cross-region workflows
-- **Lifecycle management**: Automatic tiering to IA, Glacier, Deep Archive
+- **Storage class per mount**: `storage_tier` decides the class every object is written with, and
+  `cost_optimization.small_objects_on_standard` diverts an object to STANDARD when the configured tier
+  would bill it as larger than it is *and* STANDARD is actually cheaper for it. Automatic *transitions*
+  between classes are not a feature — see [Not yet wired up](#not-yet-wired-up)
 - **Multipart uploads**: Efficient handling of large files
 - **Retry logic**: Robust error handling with exponential backoff
 
@@ -86,6 +89,7 @@ them**. Verified by import graph, not by reading the code:
 | Detailed per-file performance metrics | `internal/metrics` detailed collector | constructor has no non-test caller |
 | ML tier prediction driving cache promotion | `internal/analytics` | imported by `internal/cache`, but the `Predictor` field is never set on the mount path, so the size heuristic always runs |
 | Multi-node coordination | `internal/distributed` | imported only by tests |
+| Automatic tier transitions and lifecycle rules | `internal/storage/s3` cost optimizer | `AnalyzeAndOptimize` has no caller on the mount path; lifecycle rules are a bucket-level API call this backend never makes. The five config keys that described them were removed in v0.11.0 rather than left accepting values ([#203](https://github.com/scttfrdmn/objectfs/issues/203)) |
 
 They are listed here rather than deleted from the docs because the code exists and may be wired up;
 what they are not is a feature of the shipping product. Each is tracked as its own issue.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -73,12 +73,32 @@ storage:
       algorithm: zstd                 # none, zstd, lz4, gzip
       level: 3                        # zstd 0-22, gzip 0-9; 0 = codec default
 
-    cost_optimization:                # not yet wired — none of this block reaches the backend
-      enabled: false
-      tiering_enabled: false
-      lifecycle_enabled: false
-      transition_to_ia: 30
-      transition_to_glacier: 90
+    # Cost optimization. One key, and it changes where objects are stored.
+    #
+    # Five keys — `enabled`, `tiering_enabled`, `lifecycle_enabled`, `transition_to_ia`,
+    # `transition_to_glacier` — were removed in v0.11.0, not renamed. None of them ever reached the
+    # backend: it read a different set of field names entirely, and one of them was a list of
+    # transition rules that no YAML here could produce. A file still carrying any of the five now
+    # fails at startup naming the key, which is the only way the setting's absence gets noticed
+    # (#203). Automatic tier transitions and S3 lifecycle rules are not implemented at all — the
+    # backend has the analysis code but nothing on the mount path calls it, and lifecycle rules are a
+    # bucket-level setting ObjectFS never writes.
+    cost_optimization:
+      # Store an object on STANDARD when `storage_tier` above names a class that would bill it as
+      # larger than it is. STANDARD_IA, ONEZONE_IA and GLACIER_IR bill a 128 KB minimum per object.
+      #
+      # The threshold is not 128 KB. STANDARD being cheaper depends on the rate difference as well as
+      # the floor: at list prices the crossover is about 70 KB for STANDARD_IA, 56 KB for ONEZONE_IA
+      # and 22 KB for GLACIER_IR, because a 32 KB object billed as 128 KB of GLACIER_IR still costs a
+      # third of 32 KB of STANDARD. Below the crossover the object moves; between the crossover and
+      # the floor it stays, since moving it would cost more. Custom or discounted rates under
+      # `pricing_config` shift the crossover, and are used in the comparison.
+      #
+      # GLACIER, DEEP_ARCHIVE and INTELLIGENT_TIERING are never affected: AWS publishes no minimum
+      # billable size for any of the three. The archive classes are excluded on a second ground too —
+      # their objects cannot be read without a restore, so quietly storing one on STANDARD would
+      # change what a read of it does and not only what it costs.
+      small_objects_on_standard: false
 
 # Performance tuning.
 performance:

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -513,8 +513,24 @@ func (a *Adapter) buildS3Config() *s3.Config {
 			a.config.Performance.ParallelRead.ChunkSize, defaults.ReadChunkSize)
 	}
 
-	// TierConstraints, CostOptimization, PricingConfig and the credential fields are deliberately
-	// left at their zero values, and each for its own reason rather than by omission:
+	// Cost optimization: one field of the four, and the only one a mount can act on.
+	//
+	// SmallObjectsOnStandard is read on the PutObject path, so it decides the storage class of stored
+	// objects on every mount. The other three — EnableAutoTiering, CostThreshold,
+	// MonitorAccessPatterns — gate AnalyzeAndOptimize and the access-pattern report, and nothing on
+	// the mount path calls either, so a YAML key for them would configure a feature no mount can
+	// invoke. They stay reachable to callers using internal/storage/s3 as a library.
+	//
+	// This block was unmappable rather than merely unmapped until #203: the two structs shared no
+	// field name, and `transition_to_ia: 30` had no reading that produced the []TransitionRule the
+	// backend declared. Reconciling them meant deleting the fields nothing read on both sides, which
+	// is a breaking change to keys that never had an effect — see S3CostOptimization.
+	cfg.CostOptimization = s3.CostOptimization{
+		SmallObjectsOnStandard: a.config.Storage.S3.CostOptimization.SmallObjectsOnStandard,
+	}
+
+	// TierConstraints, PricingConfig and the credential fields are deliberately left at their zero
+	// values, and each for its own reason rather than by omission:
 	//
 	//   - TierConstraints is a policy floor, not a description of S3. Its MinObjectSize is the one
 	//     value in the struct that still refuses a write, and it refuses writes S3 would accept —
@@ -523,16 +539,6 @@ func (a *Adapter) buildS3Config() *s3.Config {
 	//     could be given a floor above zero by default, and a floor above zero rejects the zero-byte
 	//     PUTs that create directories and empty files. If it is ever mapped, it has to stay opt-in
 	//     and unset by default, and the deletion embargo needs the same care for the same reason.
-	//
-	//   - CostOptimization is not mappable. internal/config.S3CostOptimization and
-	//     s3.CostOptimization are disjoint types — {Enabled, TieringEnabled, LifecycleEnabled,
-	//     TransitionToIA, TransitionToGlacier} against {EnableAutoTiering, TransitionRules,
-	//     LifecycleManagement, IntelligentTiering, CostThreshold, MonitorAccessPatterns} — with no
-	//     field in common. Nothing reads either one, and the backend's automatic-tiering machinery
-	//     (AnalyzeAndOptimize, applyOptimization) has no caller either, so mapping the two would
-	//     wire a config block to an unreachable feature. examples/config.yaml says so at the block.
-	//     MonitorAccessPatterns is additionally held back because it writes an unsynchronized map
-	//     from the read path and silently rewrites the storage class of objects under 128 KiB.
 	//
 	//   - PricingConfig's Pricing API path was removed in v0.10.1; what remains is a custom rate
 	//     table, which belongs in a file of its own (configs/discount-config.yaml) rather than in a

--- a/internal/adapter/config_mapping_test.go
+++ b/internal/adapter/config_mapping_test.go
@@ -55,6 +55,10 @@ func TestBuildS3ConfigMapsEveryConfiguredValue(t *testing.T) {
 		Concurrency: 5,
 	}
 
+	// The one cost-optimization key with a live effect. Set to the non-default value so that the check
+	// below fails on a mount that drops it, rather than agreeing with a zero value.
+	cfg.Storage.S3.CostOptimization.SmallObjectsOnStandard = true
+
 	cfg.Performance.ConnectionPoolSize = 11
 	cfg.Performance.ParallelRead = config.ParallelReadConfig{
 		Enabled:   true,
@@ -282,10 +286,22 @@ func TestBuildS3ConfigMapsEveryConfiguredValue(t *testing.T) {
 		t.Error("TierConstraints is non-zero; it overrides what AWS itself enforces for a tier, and " +
 			"lowering a minimum object size produces writes S3 rejects")
 	}
-	if !reflect.DeepEqual(got.CostOptimization, s3.CostOptimization{}) {
-		t.Error("CostOptimization is non-zero. internal/config.S3CostOptimization and " +
-			"s3.CostOptimization share no field, and the backend's tiering machinery has no caller — " +
-			"mapping them would wire a config block to an unreachable feature")
+	// The cost-optimization block has exactly one key and it must arrive. The rest of s3.CostOptimization
+	// stays zero: EnableAutoTiering and CostThreshold are read only by code no mount path invokes, and
+	// MonitorAccessPatterns populates a map that never evicts — so each is deliberately unreachable from
+	// YAML rather than accidentally unmapped (#203).
+	//
+	// Asserted as a whole-struct comparison rather than one field, because the failure that matters here
+	// is a *new* field arriving without a decision: the previous version of this test asserted the whole
+	// struct was zero, which passed for the wrong reason once the mapping existed, since the fixture
+	// never set the key. Set it above and compare against the exact expected struct.
+	wantCost := s3.CostOptimization{SmallObjectsOnStandard: true}
+	if !reflect.DeepEqual(got.CostOptimization, wantCost) {
+		t.Errorf("CostOptimization = %+v, want %+v. small_objects_on_standard is the one key in this "+
+			"block with an effect on the write path, and it decides the storage class objects are "+
+			"stored with — a mount that drops it stores every small object on the configured tier and "+
+			"pays that tier's billing minimum, silently. Any other non-zero field here was mapped "+
+			"without a reader.", got.CostOptimization, wantCost)
 	}
 
 	// write_buffer.max_memory, max_buffers and flush_interval have no reader: vfs.NewWriter takes no

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -533,13 +533,35 @@ type MultipartConfig struct {
 	Concurrency int `yaml:"concurrency"`
 }
 
-// S3CostOptimization represents S3 cost optimization settings
+// S3CostOptimization is the `storage.s3.cost_optimization` block.
+//
+// One key, where there were five. `enabled`, `tiering_enabled`, `lifecycle_enabled`,
+// `transition_to_ia` and `transition_to_glacier` were removed rather than plumbed, and the reason is
+// worth stating because the shape of this block was itself the defect (#203): this type and
+// s3.CostOptimization, the struct the backend reads, shared not one field name. There was no mapping
+// to write. `transition_to_ia: 30` had to become an element of a []TransitionRule carrying a source
+// tier, a destination tier, an access pattern and a size filter, none of which the YAML supplied —
+// and nothing in the repository read TransitionRules either, so the mapping would have invented four
+// values in order to reach code with no caller.
+//
+// Removed, not deprecated, and the loader rejects unknown keys — so a config file still carrying any
+// of the five fails at startup naming the key. That is the only way an operator learns the setting
+// never did anything. A block that had no effect for its entire existence has no behavior to
+// preserve, so the compatibility that matters here is telling the truth about that rather than
+// continuing to accept the words.
 type S3CostOptimization struct {
-	Enabled             bool `yaml:"enabled"`
-	TieringEnabled      bool `yaml:"tiering_enabled"`
-	LifecycleEnabled    bool `yaml:"lifecycle_enabled"`
-	TransitionToIA      int  `yaml:"transition_to_ia"`
-	TransitionToGlacier int  `yaml:"transition_to_glacier"`
+	// SmallObjectsOnStandard writes an object to STANDARD when `storage.s3.storage_tier` names a tier
+	// that would bill the object as larger than it is — the 128 KB minimum billable size on
+	// STANDARD_IA, ONEZONE_IA and GLACIER_IR.
+	//
+	// It is the only setting in this block with an effect, because it is the only cost decision made
+	// on a path a mount takes: the write. Everything else the backend's cost machinery can do runs
+	// through AnalyzeAndOptimize, which no mount calls.
+	//
+	// Off by default. It changes the storage class of stored objects, and a mount that silently
+	// stored objects on a class other than the one `storage_tier` names would be the same kind of
+	// surprise in the other direction.
+	SmallObjectsOnStandard bool `yaml:"small_objects_on_standard"`
 }
 
 // ClusterConfig represents distributed cluster settings
@@ -609,11 +631,7 @@ func NewDefault() *Configuration {
 					Level:     3,
 				},
 				CostOptimization: S3CostOptimization{
-					Enabled:             false,
-					TieringEnabled:      false,
-					LifecycleEnabled:    false,
-					TransitionToIA:      30,
-					TransitionToGlacier: 90,
+					SmallObjectsOnStandard: false,
 				},
 			},
 		},

--- a/internal/storage/s3/backend.go
+++ b/internal/storage/s3/backend.go
@@ -815,23 +815,33 @@ func (b *Backend) PutObject(ctx context.Context, key string, data []byte, meta m
 			WithDetail("suggestion", "System is in read-only mode. Writes will be available once service recovers.")
 	}
 
-	// Validate write operation against tier constraints
-	if err := b.tierValidator.ValidateWrite(key, int64(len(data))); err != nil {
-		b.metricsCollector.RecordError(err)
-		return fmt.Errorf("tier validation failed: %w", err)
-	}
-
-	// Handle Standard tier overhead for cost optimization
+	// The storage class this object is written with, which is the configured tier unless the operator
+	// asked for small objects to be diverted to STANDARD.
+	//
+	// The gate used to be MonitorAccessPatterns — a setting whose name promises observation, deciding
+	// where objects are stored. That is why the class an object was written with depended on a knob
+	// about reporting, and why turning reporting on quietly changed the bill (#203).
+	//
+	// Decided before validation, not after, because the validator's warnings are about what this write
+	// will cost and the diversion is what determines that. The other order warned about the configured
+	// tier's 128 KiB billing minimum on the very objects the diversion was keeping off it.
 	effectiveTier := b.currentTier
-	if b.config.CostOptimization.MonitorAccessPatterns {
+	if b.config.CostOptimization.SmallObjectsOnStandard {
 		effectiveTier = b.costOptimizer.HandleStandardTierOverhead(key, int64(len(data)))
 		if effectiveTier != b.currentTier {
-			b.logger.Debug("Using Standard tier to avoid IA overhead",
+			b.logger.Debug("storing a small object on Standard to avoid the configured tier's "+
+				"minimum billable size",
 				"object", key,
 				"size", len(data),
 				"configured_tier", b.currentTier,
 				"effective_tier", effectiveTier)
 		}
+	}
+
+	// Validate write operation against tier constraints
+	if err := b.tierValidator.ValidateWriteToTier(key, int64(len(data)), effectiveTier); err != nil {
+		b.metricsCollector.RecordError(err)
+		return fmt.Errorf("tier validation failed: %w", err)
 	}
 
 	// Compute SHA-256 of the uncompressed canonical content before any
@@ -942,6 +952,30 @@ func (b *Backend) PutObject(ctx context.Context, key string, data []byte, meta m
 				"key", key,
 				"encryption_mode", b.config.Encryption.Mode,
 				"bucket_keys", b.config.Encryption.BucketKeys)
+
+			transporter = nil
+		}
+
+		// Bypassed a third time when this object's class differs from the configured tier, because the
+		// transporter cannot be told a per-object class.
+		//
+		// Archive.StorageClass looks like it can: it is set below and it is the field the name promises.
+		// But Transporter.optimizeStorageClass ignores it — for an archive with no AccessPattern and no
+		// RetentionDays, which is every archive ObjectFS builds, it returns the *transporter's own*
+		// config.StorageClass, fixed at construction from cfg.StorageTier (client.go). So a
+		// small-objects-on-Standard diversion sent through here would be stored on the configured tier
+		// with nothing reporting the difference, which is the seam this whole change is about: the value
+		// is computed correctly and dropped at a boundary.
+		//
+		// Only the diverging case is bypassed. When effectiveTier equals the configured tier the
+		// transporter's own default is the right answer, so the common path keeps CargoShip's throughput
+		// optimization; a mount that diverts small objects gives it up for those objects only, which
+		// are by definition the small ones. Filed upstream as scttfrdmn/cargoship#352.
+		if transporter != nil && effectiveTier != b.currentTier {
+			b.logger.Debug("Bypassing CargoShip: the transporter cannot carry a per-object storage class",
+				"key", key,
+				"configured_tier", b.currentTier,
+				"effective_tier", effectiveTier)
 
 			transporter = nil
 		}

--- a/internal/storage/s3/config.go
+++ b/internal/storage/s3/config.go
@@ -226,29 +226,53 @@ type TierConstraints struct {
 	TransitionDelay    time.Duration `yaml:"transition_delay"`     // Delay before transitioning to this tier
 }
 
-// CostOptimization defines cost optimization settings
+// CostOptimization defines cost optimization settings.
+//
+// Three fields, where there were six. `TransitionRules []TransitionRule`, `LifecycleManagement` and
+// `IntelligentTiering` were removed rather than plumbed: no code read any of the three, and the two
+// bools were additionally misleading — S3 lifecycle rules and Intelligent-Tiering configuration are
+// bucket-level settings applied with PutBucketLifecycleConfiguration and
+// PutBucketIntelligentTieringConfiguration, neither of which this backend calls, so a `true` there
+// described something ObjectFS has no code to do. `TransitionRules` was the reason
+// internal/config.S3CostOptimization could not be mapped onto this type at all: there is no reading
+// of `transition_to_ia: 30` that produces a []TransitionRule without inventing the rest of a rule
+// (#203).
+//
+// What survives is separated by who can reach it, because that turned out to be the whole question:
+// one field is read on the write path of every mount, and two gate an analyzer that only a caller
+// holding a *Backend can invoke.
 type CostOptimization struct {
-	EnableAutoTiering     bool             `yaml:"enable_auto_tiering"`     // Automatically transition objects between tiers
-	TransitionRules       []TransitionRule `yaml:"transition_rules"`        // Rules for automatic tier transitions
-	LifecycleManagement   bool             `yaml:"lifecycle_management"`    // Enable S3 lifecycle management
-	IntelligentTiering    bool             `yaml:"intelligent_tiering"`     // Use S3 Intelligent Tiering
-	CostThreshold         float64          `yaml:"cost_threshold"`          // Cost threshold for optimization decisions ($/GB/month)
-	MonitorAccessPatterns bool             `yaml:"monitor_access_patterns"` // Monitor and optimize based on access patterns
-}
+	// SmallObjectsOnStandard stores an object on STANDARD when the configured tier would bill it as
+	// larger than it is. Read on the PutObject path, and the one field in this struct a mount
+	// configuration maps (`storage.s3.cost_optimization.small_objects_on_standard`).
+	//
+	// It changes the storage class of stored objects, which is why it is its own field and its own
+	// key. This behavior used to be gated by MonitorAccessPatterns — a name that says the process
+	// observes something, attached to a switch that silently rewrote the storage class of every
+	// object under 128 KiB. See [CostOptimizer.HandleStandardTierOverhead] for which tiers it applies
+	// to and why "under 128 KiB" was the wrong test.
+	SmallObjectsOnStandard bool `yaml:"small_objects_on_standard"`
 
-// TransitionRule defines automatic tier transition rules
-type TransitionRule struct {
-	FromTier         string       `yaml:"from_tier"`          // Source tier
-	ToTier           string       `yaml:"to_tier"`            // Destination tier
-	AfterDays        int          `yaml:"after_days"`         // Days after creation to transition
-	AccessPattern    string       `yaml:"access_pattern"`     // "infrequent", "archive", "cold"
-	ObjectSizeFilter ObjectFilter `yaml:"object_size_filter"` // Filter by object size
-}
+	// EnableAutoTiering lets [CostOptimizer.AnalyzeAndOptimize] issue the CopyObject calls that move
+	// objects between tiers. Off by default and deliberately not mapped from a mount configuration:
+	// nothing on the mount path calls AnalyzeAndOptimize, so a YAML key for it would configure a
+	// feature no mount can invoke. It is reachable through [Backend.OptimizeStorageCosts] for callers
+	// using this package as a library.
+	EnableAutoTiering bool `yaml:"enable_auto_tiering"`
 
-// ObjectFilter defines filters for transition rules
-type ObjectFilter struct {
-	MinSize int64 `yaml:"min_size"` // Minimum object size in bytes
-	MaxSize int64 `yaml:"max_size"` // Maximum object size in bytes (-1 for unlimited)
+	// CostThreshold is the monthly saving in dollars below which a suggested transition is not worth
+	// making. Read only by the analyzer above, so it is unmapped for the same reason.
+	CostThreshold float64 `yaml:"cost_threshold"`
+
+	// MonitorAccessPatterns records an access pattern per object key on every read, which is what
+	// gives [Backend.GetCostOptimizationReport] something to report.
+	//
+	// Also unmapped, and this one for a reason that is not just reachability: the map it fills holds
+	// one entry per distinct key read and nothing ever evicts from it, so on a bucket with many
+	// objects it grows for the life of the mount. A key that trades unbounded memory for a report no
+	// mount can display is not a key worth offering. Library callers that want the report accept that
+	// trade knowingly.
+	MonitorAccessPatterns bool `yaml:"monitor_access_patterns"`
 }
 
 // PricingConfig defines custom pricing configuration for S3 costs
@@ -431,11 +455,12 @@ func NewDefaultConfig() *Config {
 			MinSize:   "4KB", // skip compression for tiny objects
 		},
 		CongestionAlgorithm: "auto",
+		// Every cost-optimization setting off. Two of them change what is stored or how much memory
+		// the process holds, so a default that is on would be a decision made for the operator.
 		CostOptimization: CostOptimization{
-			EnableAutoTiering:     false,
-			LifecycleManagement:   false,
-			IntelligentTiering:    false,
-			MonitorAccessPatterns: false,
+			SmallObjectsOnStandard: false,
+			EnableAutoTiering:      false,
+			MonitorAccessPatterns:  false,
 		},
 		PricingConfig: PricingConfig{
 			UsePricingAPI: false,

--- a/internal/storage/s3/cost_optimizer.go
+++ b/internal/storage/s3/cost_optimizer.go
@@ -509,21 +509,77 @@ type OptimizationReport struct {
 
 // Standard tier overhead handling helpers
 
-// HandleStandardTierOverhead manages Standard tier cost overhead for small objects
+// HandleStandardTierOverhead returns the storage class an object of this size should be written with:
+// the configured tier, or STANDARD where the configured tier would bill the object as larger than it
+// is and STANDARD is therefore cheaper.
+//
+// Three conditions, all required, where there used to be one:
+//
+//   - The configured tier publishes a minimum billable size. Only STANDARD_IA, ONEZONE_IA and
+//     GLACIER_IR do. The old test was `objectSize < minBillableSize128KB` with no reference to the
+//     configured tier at all, so with `storage_tier: STANDARD` it returned STANDARD — harmless — and
+//     with `storage_tier: DEEP_ARCHIVE` it moved every object under 128 KiB onto STANDARD, which is
+//     23× the storage rate. The tier that has no floor cannot be rounding anything up.
+//   - The object is below that minimum. Above it there is nothing to avoid.
+//   - STANDARD actually costs less for this object. Computed, not assumed, and this is the condition
+//     that does the most work: being below the floor does not make STANDARD cheaper. The crossover is
+//     at minBillable × rateTier / rateStandard, which at list prices is 69.6 KiB for STANDARD_IA,
+//     55.7 KiB for ONEZONE_IA and 22.3 KiB for GLACIER_IR — so a 32 KiB object is cheaper on
+//     GLACIER_IR *billed as 128 KiB* than on STANDARD at its own size, by nearly 3×. The old
+//     size-only test moved all three to STANDARD anywhere under 128 KiB and raised the bill across
+//     most of that range. [CostOptimizer.calculateObjectCost] also applies any volume or enterprise
+//     discount and any CustomPricing override, so the comparison is against the prices this
+//     deployment pays rather than list.
+//
+// The archive classes are outside this entirely, by the first condition, and that is deliberate
+// beyond the arithmetic: GLACIER and DEEP_ARCHIVE objects cannot be read without a restore, so
+// silently writing one to STANDARD instead would change what a read of that object does, not only
+// what it costs. A cost heuristic must not decide retrieval semantics.
 func (co *CostOptimizer) HandleStandardTierOverhead(objectKey string, objectSize int64) string {
-	// Below the IA classes' billable minimum, Standard is cheaper than a tier that would round the
-	// object up to 128 KB. Named constant rather than a repeated literal: this file spelled 128*1024
-	// twice while tiers.go spelled it once, and the threshold is the same fact in all three places.
-	if objectSize < minBillableSize128KB {
-		co.logger.Debug("Using Standard tier to avoid IA minimum charges",
-			"object", objectKey,
-			"size", objectSize,
-			"threshold", minBillableSize128KB)
+	configuredTier := co.backend.currentTier
+
+	if configuredTier == TierStandard {
 		return TierStandard
 	}
 
-	// For larger objects, use configured tier
-	return co.backend.currentTier
+	tierInfo, known := StorageTiers[configuredTier]
+	if !known {
+		return configuredTier
+	}
+
+	// No published floor: nothing is being rounded up, so there is no overhead to avoid. This is what
+	// keeps the archive classes and INTELLIGENT_TIERING out — see the doc comment.
+	if tierInfo.MinObjectSize <= 0 || objectSize >= tierInfo.MinObjectSize {
+		return configuredTier
+	}
+
+	configuredCost := co.calculateObjectCost(objectSize, configuredTier)
+	standardCost := co.calculateObjectCost(objectSize, TierStandard)
+
+	if standardCost >= configuredCost {
+		// Below the floor and still no cheaper on STANDARD, which a negotiated rate or a volume
+		// discount can produce. Logged rather than silent: it is the case an operator reading the
+		// setting's name would not predict.
+		co.logger.Debug("object is below the tier's billable minimum but Standard is not cheaper",
+			"object", objectKey,
+			"size", objectSize,
+			"tier", configuredTier,
+			"billable_minimum", tierInfo.MinObjectSize,
+			"tier_cost", configuredCost,
+			"standard_cost", standardCost)
+
+		return configuredTier
+	}
+
+	co.logger.Debug("Using Standard tier to avoid this tier's minimum billable size",
+		"object", objectKey,
+		"size", objectSize,
+		"tier", configuredTier,
+		"billable_minimum", tierInfo.MinObjectSize,
+		"tier_cost", configuredCost,
+		"standard_cost", standardCost)
+
+	return TierStandard
 }
 
 // EstimateStandardTierOverhead calculates potential overhead from using Standard tier

--- a/internal/storage/s3/cost_optimizer_test.go
+++ b/internal/storage/s3/cost_optimizer_test.go
@@ -8,46 +8,186 @@ import (
 	"time"
 )
 
-func TestCostOptimizer_StandardTierOverhead(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+// TestHandleStandardTierOverheadDependsOnTheConfiguredTier covers every storage class, because the
+// bug was that the answer did not depend on the class at all.
+//
+// The old implementation was `if objectSize < 128 KiB { return STANDARD }`. It read no tier, so it was
+// right for the three classes with a 128 KiB billable minimum and wrong for the other five — most
+// expensively for DEEP_ARCHIVE, where every object under 128 KiB was diverted to STANDARD at roughly
+// 23× the storage rate, and where the diversion also silently makes the object readable without a
+// restore. A table over all eight classes is the only shape that catches "the code ignores its input":
+// two IA rows would have passed against the old code as readily as the new.
+func TestHandleStandardTierOverheadDependsOnTheConfiguredTier(t *testing.T) {
+	t.Parallel()
 
-	// Create cost optimizer with monitoring enabled
-	config := CostOptimization{
-		EnableAutoTiering:     false,
-		MonitorAccessPatterns: true,
-		CostThreshold:         0.001, // $0.001/GB/month threshold
+	// The sizes are per-tier, because the size at which STANDARD becomes cheaper is per-tier. It is
+	// minBillable × rateTier / rateStandard, not the minimum itself: at list prices that is 69.6 KiB
+	// for STANDARD_IA, 55.7 KiB for ONEZONE_IA and 22.3 KiB for GLACIER_IR. So there is a band under
+	// every floor where the colder tier is still cheaper *even though the object is billed as
+	// 128 KiB*, and a 32 KiB object moved off GLACIER_IR onto STANDARD costs nearly 3× what it would
+	// have. A table with one shared "small" size cannot express that, which is how "under the minimum"
+	// came to stand in for "cheaper on STANDARD".
+	type sizeCase struct {
+		size int64
+		want string
+		why  string
 	}
 
-	// Create mock backend
-	backend := &Backend{
-		currentTier: TierStandardIA,
-		config: &Config{
-			CostOptimization: config,
+	tiers := []struct {
+		tier  string
+		cases []sizeCase
+	}{
+		{
+			tier: TierStandard,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierStandard,
+					why: "STANDARD has no minimum billable size; there is nothing to divert away from"},
+			},
+		},
+		{
+			tier: TierStandardIA,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierStandard,
+					why: "well under the 69.6 KiB crossover: billed as 128 KiB of STANDARD_IA, this " +
+						"object costs more than 16 KiB of STANDARD"},
+				{size: 96 * 1024, want: TierStandardIA,
+					why: "under the 128 KiB floor but over the crossover — STANDARD_IA billed at the " +
+						"minimum is still cheaper than 96 KiB of STANDARD, so diverting would raise the bill"},
+			},
+		},
+		{
+			tier: TierOneZoneIA,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierStandard, why: "under ONEZONE_IA's 55.7 KiB crossover"},
+				{size: 64 * 1024, want: TierOneZoneIA,
+					why: "over the crossover though under the floor. This is the size the old code " +
+						"diverted for every IA class alike"},
+			},
+		},
+		{
+			tier: TierGlacierIR,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierStandard, why: "under GLACIER_IR's 22.3 KiB crossover"},
+				{size: 32 * 1024, want: TierGlacierIR,
+					why: "GLACIER_IR stores at $0.004/GB against STANDARD's $0.023, so even billed at " +
+						"128 KiB it is ~3× cheaper than 32 KiB of STANDARD"},
+			},
+		},
+		{
+			tier: TierGlacier,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierGlacier,
+					why: "GLACIER publishes no minimum billable size — the 40 KB it bills is per-object " +
+						"overhead, added rather than rounded up to — and its objects cannot be read " +
+						"without a restore, so diverting one to STANDARD would change what a read does " +
+						"and not only what it costs"},
+			},
+		},
+		{
+			tier: TierDeepArchive,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierDeepArchive,
+					why: "DEEP_ARCHIVE likewise publishes no minimum. This is the case the old code got " +
+						"most wrong: every object under 128 KiB went to STANDARD at ~23× the storage rate"},
+			},
+		},
+		{
+			tier: TierIntelligent,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierIntelligent,
+					why: "INTELLIGENT_TIERING publishes no minimum billable size. Its 128 KiB threshold " +
+						"decides whether an object is monitored and auto-tiered, not what it is billed"},
+			},
+		},
+		{
+			tier: TierReducedRedundancy,
+			cases: []sizeCase{
+				{size: 16 * 1024, want: TierReducedRedundancy, why: "RRS has no minimum billable size"},
+			},
 		},
 	}
 
-	// Initialize pricing manager for the backend
-	backend.pricingManager = NewPricingManager(PricingConfig{}, logger)
+	for _, tc := range tiers {
+		t.Run(tc.tier, func(t *testing.T) {
+			t.Parallel()
 
-	optimizer := NewCostOptimizer(backend, config, logger)
+			optimizer := optimizerOnTier(t, tc.tier, CostOptimization{SmallObjectsOnStandard: true})
 
-	t.Run("Small Object Uses Standard Tier", func(t *testing.T) {
-		// Small object (64KB) should use Standard tier to avoid IA minimum charges
-		effectiveTier := optimizer.HandleStandardTierOverhead("small.txt", 64*1024)
+			for _, sc := range tc.cases {
+				if got := optimizer.HandleStandardTierOverhead("small", sc.size); got != sc.want {
+					t.Errorf("a %d-byte object on %s would be stored as %q, want %q: %s",
+						sc.size, tc.tier, got, sc.want, sc.why)
+				}
+			}
 
-		if effectiveTier != TierStandard {
-			t.Errorf("Expected Standard tier for small object, got %s", effectiveTier)
-		}
-	})
+			// Above every published minimum, the configured tier is always the answer — there is no
+			// rounding up left to avoid, whatever the rates are.
+			const largeObject = 1024 * 1024
 
-	t.Run("Large Object Uses Configured Tier", func(t *testing.T) {
-		// Large object (1MB) should use configured tier (Standard-IA)
-		effectiveTier := optimizer.HandleStandardTierOverhead("large.txt", 1024*1024)
+			if got := optimizer.HandleStandardTierOverhead("large", largeObject); got != tc.tier {
+				t.Errorf("a %d-byte object on %s would be stored as %q, want the configured tier %q; "+
+					"this object is above every tier's billable minimum, so nothing is being rounded up",
+					largeObject, tc.tier, got, tc.tier)
+			}
+		})
+	}
+}
 
-		if effectiveTier != TierStandardIA {
-			t.Errorf("Expected Standard-IA tier for large object, got %s", effectiveTier)
-		}
-	})
+// TestHandleStandardTierOverheadRespectsANegotiatedRate is the case the size comparison alone cannot
+// get right.
+//
+// Below the billable minimum, STANDARD is cheaper *at list price*. An operator with a 90% discount on
+// STANDARD_IA is better off staying on STANDARD_IA even for a 1-byte object, and the old code moved
+// them to STANDARD anyway — a cost "optimization" that raised their bill. The decision has to be made
+// against the prices this deployment actually pays, which is what calculateObjectCost reads.
+func TestHandleStandardTierOverheadRespectsANegotiatedRate(t *testing.T) {
+	t.Parallel()
+
+	const smallObject = 64 * 1024
+
+	pricing := PricingConfig{
+		DiscountConfig: DiscountConfig{
+			CustomDiscounts: map[string]float64{TierStandardIA: 90},
+		},
+	}
+
+	optimizer := optimizerOnTierWithPricing(t, TierStandardIA, pricing,
+		CostOptimization{SmallObjectsOnStandard: true})
+
+	if got := optimizer.HandleStandardTierOverhead("small", smallObject); got != TierStandardIA {
+		t.Errorf("with a 90%% discount on STANDARD_IA, a %d-byte object would be stored as %q; want "+
+			"STANDARD_IA, which is cheaper for this operator even billed at the 128 KiB minimum. "+
+			"Diverting it to STANDARD raises the bill the setting exists to lower.", smallObject, got)
+	}
+}
+
+// optimizerOnTier builds a CostOptimizer whose backend is configured for one storage tier, at list
+// prices.
+func optimizerOnTier(t *testing.T, tier string, cfg CostOptimization) *CostOptimizer {
+	t.Helper()
+
+	return optimizerOnTierWithPricing(t, tier, PricingConfig{}, cfg)
+}
+
+// optimizerOnTierWithPricing is optimizerOnTier with the rate table the deployment pays.
+//
+// The backend is assembled by hand rather than through NewBackend because these tests exercise the
+// tier arithmetic and never reach S3; currentTier and pricingManager are the only two fields the
+// arithmetic reads.
+func optimizerOnTierWithPricing(t *testing.T, tier string, pricing PricingConfig,
+	cfg CostOptimization,
+) *CostOptimizer {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	backend := &Backend{
+		currentTier: tier,
+		config:      &Config{CostOptimization: cfg},
+	}
+	backend.pricingManager = NewPricingManager(pricing, logger)
+
+	return NewCostOptimizer(backend, cfg, logger)
 }
 
 func TestCostOptimizer_AccessPatternRecording(t *testing.T) {

--- a/internal/storage/s3/storage_tier_seam_test.go
+++ b/internal/storage/s3/storage_tier_seam_test.go
@@ -136,3 +136,73 @@ func TestDefaultConfigStoresStandard(t *testing.T) {
 			"names STANDARD and charges for something else.", got, s3.TierStandard)
 	}
 }
+
+// TestSmallObjectsOnStandardDecidesTheStoredClass asserts the setting's effect where it is visible:
+// on the object.
+//
+// This is the seam #203 is about. The whole cost-optimization block reached the backend through a
+// config type that shared no field with the one the backend read, so the only setting in it with a
+// live effect was gated by a flag named MonitorAccessPatterns — reporting, deciding storage. A test
+// that checked the flag, or checked HandleStandardTierOverhead's return value, would have passed
+// throughout: what was broken was whether the configuration could arrive at all. Only the stored
+// class can answer that.
+func TestSmallObjectsOnStandardDecidesTheStoredClass(t *testing.T) {
+	t.Parallel()
+
+	// 16 KiB is under STANDARD_IA's crossover (about 70 KiB at list prices), so it is a size where
+	// STANDARD is genuinely cheaper and the setting has something to do.
+	const small = 16 * 1024
+
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		want    string
+	}{
+		{
+			name:    "on stores the small object on Standard",
+			enabled: true,
+			want:    s3.TierStandard,
+		},
+		{
+			// The default. A mount must store objects on the class storage_tier names unless asked
+			// otherwise, which is the half of this that an operator reading their bill depends on.
+			name:    "off stores it on the configured tier",
+			enabled: false,
+			want:    s3.TierStandardIA,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := testaws.Start(t)
+			backend := ts.Backend(func(cfg *s3.Config) {
+				cfg.StorageTier = s3.TierStandardIA
+				cfg.CostOptimization.SmallObjectsOnStandard = tc.enabled
+
+				// Compression off: it changes the stored length, and the length is what the decision
+				// is made on.
+				cfg.Compression.Enabled = false
+			})
+
+			key := "cost/small-" + tc.want
+			body := testaws.DeterministicBytes(key, small)
+
+			if err := backend.PutObject(context.Background(), key, body, nil); err != nil {
+				t.Fatalf("PutObject: %v", err)
+			}
+
+			if got := ts.ObjectStorageClass(key); got != tc.want {
+				t.Errorf("with small_objects_on_standard=%v and storage_tier=STANDARD_IA, a %d-byte "+
+					"object was stored as %q, want %q. Nothing reports this: the object reads back "+
+					"either way and the difference is only on the invoice.",
+					tc.enabled, small, got, tc.want)
+			}
+
+			// The bytes have to survive the path that chose the class. A tier decision that also
+			// truncated the object would pass the assertion above.
+			if got := ts.GetObject(key); string(got) != string(body) {
+				t.Errorf("the stored object holds %d bytes, want %d", len(got), len(body))
+			}
+		})
+	}
+}

--- a/internal/storage/s3/tier_min_size_test.go
+++ b/internal/storage/s3/tier_min_size_test.go
@@ -177,6 +177,113 @@ func TestConfiguredMinimumStillRefusesTheWrite(t *testing.T) {
 	}
 }
 
+// TestBillingWarningFollowsTheTierTheObjectIsStoredOn covers the other direction of the split: the
+// billing warnings describe AWS's charges, so they have to follow the tier the object actually lands
+// on rather than the one configured for the mount.
+//
+// `small_objects_on_standard` diverts an individual object to STANDARD when the configured tier would
+// bill it as larger than it is, and the validator is built once per mount. Validating against the
+// configured tier regardless produced the exactly-backwards message: an operator who enabled the
+// setting *because of* this warning still saw "billed_size 131072" on a 16 KiB object about to be
+// stored on STANDARD and billed as 16 KiB. Worse at the default log level, where the diversion's own
+// Debug line is invisible and the misleading warning is all there is.
+func TestBillingWarningFollowsTheTierTheObjectIsStoredOn(t *testing.T) {
+	t.Parallel()
+
+	// 16 KiB: under STANDARD_IA's 128 KiB floor, so the configured tier would warn.
+	const size = 16 * 1024
+
+	t.Run("diverted to Standard warns about nothing", func(t *testing.T) {
+		t.Parallel()
+
+		validator, logs := captureValidator(t, TierStandardIA, TierConstraints{})
+
+		if err := validator.ValidateWriteToTier("small.bin", size, TierStandard); err != nil {
+			t.Fatalf("ValidateWriteToTier(..., STANDARD) = %v, want nil", err)
+		}
+
+		for _, rec := range logs() {
+			if rec.Level == "WARN" {
+				t.Errorf("an object being stored on STANDARD drew the warning %q naming tier=%q: %+v.\n"+
+					"STANDARD has no minimum billable size, so there is nothing to warn about — this is "+
+					"the configured tier's floor being reported for a write that will not be billed "+
+					"against it.", rec.Msg, rec.Tier, rec)
+			}
+		}
+	})
+
+	t.Run("not diverted still warns about the configured tier", func(t *testing.T) {
+		t.Parallel()
+
+		// The half that must not have been silenced. Passing the configured tier explicitly is what
+		// PutObject does when no diversion happened, and it has to behave exactly like ValidateWrite.
+		validator, logs := captureValidator(t, TierStandardIA, TierConstraints{})
+
+		if err := validator.ValidateWriteToTier("small.bin", size, TierStandardIA); err != nil {
+			t.Fatalf("ValidateWriteToTier(..., STANDARD_IA) = %v, want nil", err)
+		}
+
+		var warned bool
+
+		for _, rec := range logs() {
+			if rec.Level == "WARN" && rec.BilledSize != nil && *rec.BilledSize == StorageTiers[TierStandardIA].MinObjectSize {
+				if rec.Tier != TierStandardIA {
+					t.Errorf("the billing warning reported tier=%q, want %q", rec.Tier, TierStandardIA)
+				}
+
+				warned = true
+			}
+		}
+
+		if !warned {
+			t.Errorf("a %d-byte write to STANDARD_IA with no diversion drew no billing warning naming "+
+				"its 128 KiB floor. Making the warning tier-aware must not silence it for the case it "+
+				"was written for.\nCaptured: %+v", size, logs())
+		}
+	})
+
+	t.Run("an unknown tier name falls back to the configured tier", func(t *testing.T) {
+		t.Parallel()
+
+		// Zero-valued StorageTierInfo means "no minimum, no overhead", so an unrecognized name must not
+		// reach the checks as one: it would silently warn about nothing, which is indistinguishable from
+		// a correct diversion to STANDARD.
+		validator, logs := captureValidator(t, TierStandardIA, TierConstraints{})
+
+		if err := validator.ValidateWriteToTier("small.bin", size, "GLACIER_DEEP_ARCHIVE_XL"); err != nil {
+			t.Fatalf("ValidateWriteToTier with an unknown tier = %v, want nil", err)
+		}
+
+		var warned bool
+
+		for _, rec := range logs() {
+			if rec.Level == "WARN" && rec.Tier == TierStandardIA {
+				warned = true
+			}
+		}
+
+		if !warned {
+			t.Errorf("an unrecognized tier name silenced the billing warning instead of falling back to "+
+				"the configured STANDARD_IA.\nCaptured: %+v", logs())
+		}
+	})
+
+	t.Run("the operator's floor is not relaxed by a diversion", func(t *testing.T) {
+		t.Parallel()
+
+		// tier_constraints.min_object_size is a policy for this mount, not a description of AWS billing.
+		// An internal cost diversion is not a reason to stop enforcing it, and letting it be one would
+		// make the floor quietly conditional on an unrelated setting.
+		validator, _ := captureValidator(t, TierStandardIA, TierConstraints{MinObjectSize: 64 * 1024})
+
+		if err := validator.ValidateWriteToTier("small.bin", size, TierStandard); err == nil {
+			t.Error("a diversion to STANDARD bypassed the configured 64 KiB minimum. The operator's " +
+				"floor applies to the mount; a cost optimization deciding not to enforce it is a policy " +
+				"change nobody asked for")
+		}
+	})
+}
+
 // TestConfiguringTheTierMinimumRestoresTheOldBehavior records the sharp edge the split leaves, so
 // that it is a documented consequence rather than a surprise. Setting the constraint to the tier's
 // own published number is a way to reinstate exactly the gate #154 removed, zero-byte directory

--- a/internal/storage/s3/tier_test.go
+++ b/internal/storage/s3/tier_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -338,14 +339,75 @@ func TestTierValidator(t *testing.T) {
 func TestTierRecommendations(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
+	// The size-based recommendation, on both sides of the crossover and on a tier that has no floor.
+	//
+	// Asserted by whether a Standard recommendation appears, not by matching its exact wording: the
+	// previous version compared against the literal "Consider Standard tier for small objects to avoid
+	// IA minimum charges", which passes for any object under 128 KiB on any tier — including the tiers
+	// with no billing minimum, where the advice was wrong. A string equality check on advice cannot
+	// tell correct advice from incorrect advice with the same phrasing.
 	t.Run("Size-based Recommendations", func(t *testing.T) {
-		validator := NewTierValidator(TierStandardIA, TierConstraints{}, logger)
+		recommendsStandard := func(recs []string) bool {
+			for _, r := range recs {
+				if strings.Contains(r, "Consider Standard") {
+					return true
+				}
+			}
 
-		// Small objects should recommend Standard tier
-		recommendations := validator.GetRecommendations(64*1024, "unknown") // 64KB
-		found := slices.Contains(recommendations, "Consider Standard tier for small objects to avoid IA minimum charges")
-		if !found {
-			t.Error("Should recommend Standard tier for small objects")
+			return false
+		}
+
+		for _, tc := range []struct {
+			name string
+			tier string
+			size int64
+			want bool
+			why  string
+		}{
+			{
+				name: "below the crossover on STANDARD_IA",
+				tier: TierStandardIA,
+				size: 64 * 1024,
+				want: true,
+				why: "64 KiB billed as 128 KiB of STANDARD_IA costs more than 64 KiB of STANDARD; the " +
+					"crossover is about 70 KiB",
+			},
+			{
+				name: "above the crossover but below the floor on GLACIER_IR",
+				tier: TierGlacierIR,
+				size: 64 * 1024,
+				want: false,
+				why: "GLACIER_IR's crossover is about 22 KiB, so 64 KiB billed as 128 KiB there is still " +
+					"far cheaper than 64 KiB on STANDARD. Recommending a move would raise the bill, which " +
+					"is what the old size-only rule did for everything under 128 KiB",
+			},
+			{
+				name: "above the floor on STANDARD_IA",
+				tier: TierStandardIA,
+				size: 1024 * 1024,
+				want: false,
+				why:  "nothing is being rounded up, so there is no minimum to avoid",
+			},
+			{
+				name: "a tier with no billing minimum",
+				tier: TierDeepArchive,
+				size: 4 * 1024,
+				want: false,
+				why: "DEEP_ARCHIVE publishes no minimum billable size — its 40 KB is per-object overhead, " +
+					"which is added rather than rounded up to, and STANDARD is ~23× its storage rate",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				validator := NewTierValidator(tc.tier, TierConstraints{}, logger)
+
+				got := recommendsStandard(validator.GetRecommendations(tc.size, "unknown"))
+				if got != tc.want {
+					t.Errorf("GetRecommendations(%d, unknown) on %s recommends Standard = %v, want %v.\n%s",
+						tc.size, tc.tier, got, tc.want, tc.why)
+				}
+			})
 		}
 	})
 

--- a/internal/storage/s3/tiers.go
+++ b/internal/storage/s3/tiers.go
@@ -312,6 +312,24 @@ func NewTierValidator(tier string, constraints TierConstraints, logger *slog.Log
 // were not minimums at all. Those three now have no minimum, and the two archive classes warn about
 // their per-object overhead instead, which is the real cost and points the other way.
 func (tv *TierValidator) ValidateWrite(key string, dataSize int64) error {
+	return tv.ValidateWriteToTier(key, dataSize, tv.tier)
+}
+
+// ValidateWriteToTier is ValidateWrite for an object that is not going to the configured tier.
+//
+// The cost-optimization setting `small_objects_on_standard` diverts an individual object to STANDARD
+// when the configured tier would bill it as larger than it is, so the class an object is written with
+// is a per-object decision while the validator is constructed once per mount. Validating against the
+// configured tier regardless meant an operator who enabled that setting *because of* the warning
+// below still got the warning: "billed_size 131072" on a 16 KiB object that was about to be stored on
+// STANDARD and billed as 16 KiB. The diversion itself logs at Debug, so at the default level the only
+// thing visible was the part that was wrong.
+//
+// The split between what follows the effective tier and what does not is deliberate. The two billing
+// warnings describe what AWS will charge, so they follow the tier the object is actually stored on.
+// TierConstraints.MinObjectSize does not: it is a floor the operator set for this mount, and an
+// ObjectFS-internal cost diversion is not a reason to stop enforcing a policy someone configured.
+func (tv *TierValidator) ValidateWriteToTier(key string, dataSize int64, tier string) error {
 	// The operator's floor, if there is one: a deliberate policy, still enforced.
 	if minSize := tv.constraints.MinObjectSize; minSize > 0 && dataSize < minSize {
 		return fmt.Errorf("object size %d bytes is below the configured minimum of %d bytes for the "+
@@ -320,11 +338,24 @@ func (tv *TierValidator) ValidateWrite(key string, dataSize int64) error {
 			dataSize, minSize, tv.tier, minSize)
 	}
 
+	// The tier the object is being stored on, which is the configured one unless a caller named
+	// another. An unknown name falls back to the configured tier's info rather than to a zero value:
+	// zero means "no minimum and no overhead", so an unrecognized tier would silently warn about
+	// nothing at all.
+	tierInfo := tv.tierInfo
+	if tier != tv.tier {
+		if info, known := StorageTiers[tier]; known {
+			tierInfo = info
+		} else {
+			tier = tv.tier
+		}
+	}
+
 	// AWS's billing floor: not a reason to refuse, but worth saying out loud, because the object
 	// costs a multiple of what its size suggests and nothing downstream will mention it again.
-	if minBillable := tv.tierInfo.MinObjectSize; minBillable > 0 && dataSize < minBillable {
+	if minBillable := tierInfo.MinObjectSize; minBillable > 0 && dataSize < minBillable {
 		tv.logger.Warn("object is smaller than this tier's minimum billable size",
-			"tier", tv.tier,
+			"tier", tier,
 			"key", key,
 			"size", dataSize,
 			"billed_size", minBillable,
@@ -336,9 +367,9 @@ func (tv *TierValidator) ValidateWrite(key string, dataSize int64) error {
 	// The archive classes bill 40 KB of metadata per object regardless of its size, so a small object
 	// costs a multiple of what its bytes suggest. Worth saying at the point of the write, because the
 	// remedy — pack small files into an archive before storing them — is not available afterward.
-	if overhead := tv.tierInfo.PerObjectOverheadBytes; overhead > 0 && dataSize < overhead {
+	if overhead := tierInfo.PerObjectOverheadBytes; overhead > 0 && dataSize < overhead {
 		tv.logger.Warn("object is smaller than the per-object overhead this tier bills",
-			"tier", tv.tier,
+			"tier", tier,
 			"key", key,
 			"size", dataSize,
 			"per_object_overhead", overhead,
@@ -348,9 +379,9 @@ func (tv *TierValidator) ValidateWrite(key string, dataSize int64) error {
 	}
 
 	// Log tier-specific warnings
-	if tv.tierInfo.RetrievalCost {
+	if tierInfo.RetrievalCost {
 		tv.logger.Debug("Writing to tier with retrieval costs",
-			"tier", tv.tier,
+			"tier", tier,
 			"key", key,
 			"size", dataSize)
 	}
@@ -388,13 +419,37 @@ func (tv *TierValidator) GetTierInfo() StorageTierInfo {
 	return tv.tierInfo
 }
 
-// GetRecommendations returns tier recommendations based on access patterns
+// GetRecommendations returns tier recommendations based on access patterns.
+//
+// The size-based recommendation is the same judgement [CostOptimizer.HandleStandardTierOverhead]
+// makes on the write path, and it used to be wrong in the same way: `objectSize < 128 KiB` with no
+// reference to the configured tier, so it advised moving to STANDARD from tiers that have no billing
+// minimum at all, and from GLACIER_IR at sizes where GLACIER_IR billed at 128 KiB is nearly 3× cheaper
+// than STANDARD at the object's own size. Being below a floor does not make STANDARD cheaper; the
+// crossover is at minBillable × rateTier / rateStandard. Advice nobody can act on wrongly is still
+// advice someone will act on.
+//
+// This is the recommendation form, so it compares list rates from StorageTierInfo.CostPerGBMonth
+// rather than the discounted prices a deployment pays — the CostOptimizer holds the discounts and the
+// validator does not have one. That makes it slightly conservative where an operator has a negotiated
+// rate, which is the safe direction for a suggestion.
 func (tv *TierValidator) GetRecommendations(objectSize int64, accessFrequency string) []string {
 	recommendations := make([]string, 0, 3)
 
-	// Size-based recommendations
-	if objectSize < minBillableSize128KB {
-		recommendations = append(recommendations, "Consider Standard tier for small objects to avoid IA minimum charges")
+	// Size-based recommendation: only when this tier has a billing floor, the object is under it, and
+	// STANDARD is genuinely cheaper at list rates.
+	if minBillable := tv.tierInfo.MinObjectSize; minBillable > 0 && objectSize < minBillable {
+		standardRate := StorageTiers[TierStandard].CostPerGBMonth
+
+		billedOnTier := float64(minBillable) * tv.tierInfo.CostPerGBMonth
+		billedOnStandard := float64(objectSize) * standardRate
+
+		if billedOnStandard < billedOnTier {
+			recommendations = append(recommendations, fmt.Sprintf(
+				"Consider Standard for this object: %s bills a %d-byte object as %d bytes, which costs "+
+					"more than %d bytes on Standard",
+				tv.tier, objectSize, minBillable, objectSize))
+		}
 	}
 
 	// Access pattern recommendations

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -201,8 +201,10 @@ storage:
     region: us-east-1
     use_acceleration: true
     cost_optimization:
-      enabled: true
-      tiering_enabled: true
+      # Store objects too small to be worth the configured tier's 128 KB billing
+      # minimum on STANDARD instead. The four other keys this block used to show
+      # were removed in v0.11.0 — they never reached the backend.
+      small_objects_on_standard: true
 
 performance:
   cache_size: 8GB

--- a/sdks/python/objectfs/config.py
+++ b/sdks/python/objectfs/config.py
@@ -33,13 +33,19 @@ class S3Config:
     max_retries: int = 3
     timeout: int = 30
 
-    # Cost optimization
+    # Cost optimization. One key, matching the Go schema exactly, because ``to_yaml``
+    # writes this dict straight into a document the Go loader decodes strictly: a key
+    # it does not define fails the mount naming the key.
+    #
+    # There were five here -- ``enabled``, ``tiering_enabled``, ``lifecycle_enabled``,
+    # ``transition_to_ia``, ``transition_to_glacier`` -- and they were removed from the
+    # schema in v0.11.0 rather than renamed, having never reached the S3 backend at all.
+    # Three of them also defaulted to True, so this SDK's default configuration wrote a
+    # document asking for automatic tiering and lifecycle management, neither of which
+    # ObjectFS implements. Default False here for the same reason the Go side does: it
+    # changes the storage class objects are written with.
     cost_optimization: Dict[str, Any] = field(default_factory=lambda: {
-        "enabled": True,
-        "tiering_enabled": True,
-        "lifecycle_enabled": True,
-        "transition_to_ia": 30,
-        "transition_to_glacier": 90
+        "small_objects_on_standard": False
     })
 
 
@@ -347,7 +353,6 @@ class Configuration:
         config.performance.max_concurrency = 500
         config.performance.multilevel_caching = True
         config.storage.s3.use_acceleration = True
-        config.storage.s3.cost_optimization["enabled"] = True
         config.monitoring.enabled = True
         return config
 
@@ -365,16 +370,26 @@ class Configuration:
 
     @classmethod
     def _cost_optimized_preset(cls) -> 'Configuration':
-        """Cost optimized preset."""
+        """Cost optimized preset.
+
+        This preset used to set five cost-optimization keys, including a
+        seven-day transition to STANDARD_IA and a thirty-day transition to
+        GLACIER. ObjectFS has never performed either: automatic tier
+        transitions exist in the S3 backend but nothing on the mount path
+        invokes them, and lifecycle rules are a bucket-level configuration it
+        does not write. The keys were removed from the schema in v0.11.0, so
+        setting them now fails the mount.
+
+        What remains is one real saving and it is opt-in for a reason: writing
+        small objects to STANDARD rather than to a tier that would bill them at
+        its 128 KB minimum. Pair it with ``storage_tier`` set to STANDARD_IA or
+        ONEZONE_IA -- on STANDARD it has nothing to do.
+        """
         config = cls()
         config.performance.cache_size = "2GB"
         config.performance.max_concurrency = 100
         config.storage.s3.cost_optimization.update({
-            "enabled": True,
-            "tiering_enabled": True,
-            "lifecycle_enabled": True,
-            "transition_to_ia": 7,
-            "transition_to_glacier": 30
+            "small_objects_on_standard": True
         })
         return config
 


### PR DESCRIPTION
Closes #203.

`storage.s3.cost_optimization` had six keys and no effect on anything. `internal/config.S3CostOptimization` and `internal/storage/s3.CostOptimization` shared **not one field name**, so `buildS3Config` carried a comment saying the block was not mappable — true, and not a fix. There was no mapping to write: `transition_to_ia: 30` had to become an element of a `[]TransitionRule` carrying a source tier, a destination tier, an access pattern and a size filter, none of which the YAML supplied, and nothing read `TransitionRules` either.

## Breaking: five keys removed

Removed, not deprecated. Configuration decodes strictly, so a file still carrying one fails at startup naming the key — which is the only way an operator learns the setting never did anything. A block with no effect for its entire existence has no behavior to preserve.

| Removed | Why |
|---|---|
| `enabled` | Gated nothing; the backend has no such field |
| `tiering_enabled` | Transitions exist in the backend; no mount path invokes them |
| `lifecycle_enabled` | Lifecycle rules are a bucket-level call this backend never makes |
| `transition_to_ia` | Same |
| `transition_to_glacier` | Same |

Same treatment #176 gave the fifteen inert read-ahead keys, and the fourth instance of the shape #156, #176 and the `cluster.redis` fix were — in its worst form, since the two types could not be reconciled without deleting first.

## The surviving key, corrected before being exposed

`small_objects_on_standard` (default `false`) stores an object on STANDARD when the configured tier would bill it as larger than it is *and* STANDARD is genuinely cheaper.

The old rule was `objectSize < 128 KiB` with no reference to the configured tier. It moved objects to STANDARD from tiers with no billing minimum at all — DEEP_ARCHIVE at ~23× the storage rate — and from the three that have one at sizes where they remain far cheaper. **Being under a floor does not make STANDARD cheaper.** The crossover is `minBillable × rateTier / rateStandard`:

| Tier | Crossover at list prices |
|---|---|
| STANDARD_IA | 69.6 KiB |
| ONEZONE_IA | 55.7 KiB |
| GLACIER_IR | 22.3 KiB |

A 32 KiB object billed as 128 KiB of GLACIER_IR costs about a third of 32 KiB on STANDARD. Three conditions are now required, the third computed against the prices this deployment pays (volume/enterprise discounts and `CustomPricing` included).

GLACIER and DEEP_ARCHIVE are excluded on a second, non-monetary ground: their objects cannot be read without a restore, so a diversion would change what a read *does*, not only what it costs. A cost heuristic must not decide retrieval semantics.

## Two seams, both found at the endpoint

Both were found by asserting the storage class S3 recorded, not the value passed in — the technique that found the `INTELLIGENT_TIERING` default in v0.10.1.

**CargoShip drops a per-object class.** `Transporter.optimizeStorageClass` returns its own config's `StorageClass` — fixed at construction from `storage_tier` — for any archive with no `AccessPattern`/`RetentionDays`, which is every archive ObjectFS builds. It never reads `Archive.StorageClass`, the field whose comment says "Target storage class". The class was computed correctly and lost at the boundary: object stored fine, read fine, only the invoice differed. Diverging objects now take the direct `PutObject` path, joining the existing bypasses for compression and for encryption modes the transporter cannot express; the common path keeps CargoShip's throughput optimization. Filed upstream as scttfrdmn/cargoship#352 — `OptimizedTransporter`, a different type ObjectFS does not construct, already honors the field.

**The billing warning described the wrong tier.** `ValidateWrite` ran *before* the diversion, so an operator who enabled the setting *because of* that warning still saw `billed_size=131072` on a 16 KiB object about to be stored on STANDARD and billed as 16 KiB. The diversion logs at Debug, so at the default level the misleading half was the only half visible. The tier decision now precedes validation, via `ValidateWriteToTier`. `tier_constraints.min_object_size` deliberately does **not** follow the effective tier: that is a floor the operator configured for this mount, and an internal cost optimization is not a reason to stop enforcing it.

`TierValidator.GetRecommendations` had the identical size-only rule and is fixed the same way. No mount-path caller — it is exported API — but advice nobody can act on wrongly is still advice someone will act on.

## Tests, each verified by mutation

- Eight-tier table with per-tier sizes on **both sides of each crossover**, so a size-only implementation cannot pass. Restoring the old rule fails 7 of 8 tiers, DEEP_ARCHIVE reporting "every object under 128 KiB went to STANDARD at ~23× the storage rate".
- A negotiated 90% discount on STANDARD_IA must keep a 64 KiB object there.
- The endpoint-level seam test — this is what caught the CargoShip drop, and it failed for real before the bypass landed.
- The billing warning follows the effective tier, stays for the undiverted case, falls back on an unknown tier name (zero-valued `StorageTierInfo` means "no minimum", so an unrecognized name must not reach the checks as one), and does not relax the operator's floor.
- `TestBuildS3ConfigMapsEveryConfiguredValue` asserted `CostOptimization` was the zero value — and kept passing once the mapping existed, **for the wrong reason**, because the fixture never set the key. It now sets it and compares the whole struct, so a new field arriving without a decision fails.
- The rewritten recommendation test asserts behavior on both sides of the crossover rather than matching the old literal advice string, which passed for any object under 128 KiB on any tier including the ones where the advice was wrong.

Two `s3.CostOptimization` fields survive as Go fields with no YAML key, deliberately: `EnableAutoTiering` and `CostThreshold` are reachable to an embedder using the package as a library, while a mount has no path to `AnalyzeAndOptimize`. `MonitorAccessPatterns` is likewise unmapped, and for a second reason — the map it populates holds one entry per distinct key read and nothing evicts.

`docs/index.md` claimed "Lifecycle management: Automatic tiering to IA, Glacier, Deep Archive" as a key feature; it is now in the **Not yet wired up** table with the reason.

## Verification

- `go build ./...`, `go vet ./...`, `go test -race ./...` — all clean
- `golangci-lint run --new-from-merge-base=origin/main` — 0 issues
- `./scripts/coverage-gate.sh` — 30 packages at or above their floors
- markdownlint clean on every changed markdown file

Also updated: `examples/config.yaml`, `docs-platform/guide/getting-started.md`, `sdks/python/README.md` and `sdks/python/objectfs/config.py` — the Python SDK's default config wrote three of the removed keys as `True`, so `to_yaml()` produced a document asking for tiering and lifecycle management that would now fail the Go loader.