### PR TITLE
feat: the FUSE options a config file names reach the kernel (#180)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -155,10 +155,20 @@ internal/adapter         40
 # wrong errno does not fail an operation, it fails it differently: v0.10.0 collapsed every HeadObject
 # error to ENOENT, and Create read that as "absent" and wrote an empty object over a throttled file.
 #
-# 59 rather than 80 because what remains uncovered is mostly what a unit test cannot reach: the mount
-# and unmount lifecycle, the signal handling around it, and the go-fuse option construction. Those
-# need a real mount, which is the live integration suite's job.
-internal/fuse            59
+# 59 → 67, and the seven points that are not the FUSE-options work are a correction rather than a
+# raise. The package measured 66.2% on the commit before it while the floor said 59: several releases
+# raised coverage without moving the number, so the gate had drifted into slack that no longer gated
+# anything. A floor eight points under the code is a floor that permits a real regression silently,
+# which is the one failure mode this file exists to prevent, so it is set to the measurement again.
+#
+# The remaining 1.3 points are #180's four seam tests. They reach one of the two things the note below
+# said a unit test could not: the go-fuse option construction is now covered, because `fs.NewNodeFS`
+# returns a RawFileSystem whose Lookup/Open/Create can be called directly, and rawBridge.Open copies a
+# node's returned fuseFlags into the OpenOut the kernel receives. What is left is genuinely
+# mount-only — the mount and unmount lifecycle and the signal handling around it — plus the kernel's
+# own half of direct I/O and page-cache retention, which is what the fuse_mount build tag and
+# `make test-fuse-mount` are for.
+internal/fuse            67
 
 # internal/cache went 74 → 76 with the re-keying work — the byte-range keying, splitting, coalescing,
 # and coverage checks are now covered by 27 tests and a fuzz target where before they were two copies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Test
         run: go test -race -timeout 20m ./...
 
+      # The fuse_mount tag carries the tests that need a real kernel mount — whether the kernel
+      # re-reads under direct I/O, whether it keeps pages across open(2). They cannot run here:
+      # ubuntu-latest runners have no /dev/fuse. They are compiled anyway, because a build tag
+      # nothing compiles is exactly how four other tags in this repo came to carry code that does
+      # not build (#240). This catches that in one step; #240 generalizes it to the rest.
+      - name: Compile the fuse_mount tag
+        run: go vet -tags=fuse_mount ./internal/fuse/
+
   # ---------------------------------------------------------------------------------------------
   # coverage — a floor per package, ratcheting toward 80%.
   #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CompleteMultipartUpload`, which is how the abort path gets a failure arriving after every part has
   already uploaded.
 
+- **A `fuse:` section in the configuration file, and it is the first one any loader has read**
+  ([#180]). `direct_io`, `keep_cache`, and `sync_read`. Nine fields on `internal/fuse.MountOptions` and
+  `internal/fuse.Config` carried yaml tags for a whole release and were decoded by nothing, because
+  `config.Configuration` had no `fuse` key at all — so a `fuse:` block in a config file was silently
+  discarded, and the two flags that reach the kernel per-open were settable in Go and returned as the
+  literal `0` from every `Open`. All three new fields default to false, false is the kernel's own
+  behavior for each, and `NewDefault` therefore names no `fuse` section: the zero value *is* the
+  default, and a second place for it to live is how the last set drifted.
+
+  Each of the four seams between the YAML key and the value the kernel receives is now asserted by a
+  test verified by mutation — the mapping was deleted or reverted to v0.10.0's code and the intended
+  test watched to fail. That is the point of the change rather than a detail of it: every one of those
+  nine fields was correct at the layer that declared it, and died at a boundary no test crossed. The
+  adapter mapping in particular passed its package's whole suite with the three assignment lines
+  removed, which is why it was extracted into a method that can be called without a mount.
+
+  What the flags do to the *kernel* — whether a second `read(2)` at the same offset reaches the
+  filesystem, whether cached pages survive `open(2)` — cannot be observed without `/dev/fuse`, so it
+  lives behind a `fuse_mount` build tag with a `make test-fuse-mount` target. CI compiles the tag it
+  cannot run, because a build tag nothing compiles is how four others in this repo came to carry code
+  that does not build ([#240]). Those tests fail rather than skip when the device is absent: a test
+  that skips itself reports success.
+
+  Two of the four flags [#180] nominated are **not** plumbable, and both reasons are recorded at the
+  field that would have carried each rather than being dropped in silence. Splice: go-fuse only splices
+  a `ReadResult` backed by a file descriptor, and this filesystem's reads come from S3 or from memory
+  and return `fuse.ReadResultData` at every return site, so `DisableSplice` would disable a path never
+  taken — a config key whose effect is provably nothing. The writeback cache: it maps to
+  `ExplicitDataCacheControl`, which makes the filesystem responsible for invalidating the kernel's data
+  cache, and there is not one `NotifyContent`, `NotifyEntry`, or `NotifyInvalInode` call in the
+  repository — enabling it would convert bounded staleness into permanent staleness.
+
 ### Fixed
 
 - **A data race between `ConsensusEngine.Stop` and an inbound heartbeat.** `Stop` read
@@ -517,6 +549,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#164]: https://github.com/scttfrdmn/objectfs/issues/164
 [#176]: https://github.com/scttfrdmn/objectfs/issues/176
 [#178]: https://github.com/scttfrdmn/objectfs/issues/178
+[#180]: https://github.com/scttfrdmn/objectfs/issues/180
 [#181]: https://github.com/scttfrdmn/objectfs/issues/181
 [#192]: https://github.com/scttfrdmn/objectfs/issues/192
 [#202]: https://github.com/scttfrdmn/objectfs/issues/202
@@ -525,6 +558,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#211]: https://github.com/scttfrdmn/objectfs/issues/211
 [#212]: https://github.com/scttfrdmn/objectfs/issues/212
 [#230]: https://github.com/scttfrdmn/objectfs/issues/230
+[#240]: https://github.com/scttfrdmn/objectfs/issues/240
 [#245]: https://github.com/scttfrdmn/objectfs/issues/245
 [#247]: https://github.com/scttfrdmn/objectfs/issues/247
 

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,18 @@ test-aws:
 test-release-check: test test-aws
 	@echo "$(COLOR_GREEN)Release check complete — unit + AWS integration tests passed.$(COLOR_RESET)"
 
+# Kernel-observable FUSE behavior. Needs /dev/fuse, so it is not part of `make test`.
+#
+# These are the tests that cannot be written without a mount: whether the kernel re-reads under
+# direct I/O, whether it keeps cached pages across open(2). Everything up to the kernel boundary is
+# gated by the ordinary suite; this is the half a userspace test cannot reach.
+#
+# The tag is compile-checked by CI even where it cannot run (see the build-tags job), because a build
+# tag nothing compiles is how four of them came to carry broken code — issue #240.
+test-fuse-mount:
+	@echo "$(COLOR_BLUE)Running kernel-observable FUSE tests (requires /dev/fuse)...$(COLOR_RESET)"
+	@go test -race -tags=fuse_mount -run 'TestDirectIO|TestKeepCache' ./internal/fuse/
+
 # POSIX compliance test using pjdfstest.
 # Requires: pjdfstest in PATH, OBJECTFS_TEST_BUCKET set, and a running mount.
 # Run `make build` first.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -341,3 +341,34 @@ cluster:
     key_prefix: objectfs
     ttl: 5m
     max_retries: 3
+
+# How the kernel caches and dispatches to this mount.
+#
+# This is the first FUSE section any loader has read. Nine settings with names matching real FUSE
+# capabilities — direct_io, keep_cache, big_writes, max_read, async_read, writeback_cache, and three
+# splice flags — existed as struct fields with yaml tags for a whole release and were decoded by
+# nothing, because the schema had no `fuse` key at all (#180). Three of them are here, and each
+# changes what the kernel does.
+#
+# Every default is off, and off is the kernel's own behavior in each case. There is nothing to set
+# here for an ordinary mount.
+fuse:
+  # Ask the kernel not to cache this mount's file data: every read(2) becomes a request ObjectFS
+  # serves, even for bytes read a moment ago. Costs the page cache; buys coherence with a bucket
+  # other clients write, and reads that arrive at the offset and length the application asked for
+  # rather than page-aligned and rounded up.
+  direct_io: false
+
+  # Ask the kernel to keep a file's cached pages across open(2) instead of dropping them.
+  #
+  # Only safe when nothing else writes the bucket. A page the kernel keeps is a page ObjectFS cannot
+  # invalidate — there is no notification path yet — so a stale read is not bounded by cache.ttl the
+  # way an attribute is. Ignored when direct_io is true, which asks for the opposite.
+  keep_cache: false
+
+  # Make the kernel keep at most one read outstanding per file.
+  #
+  # Named for the capability that exists rather than for async_read, its negation, so that `false`
+  # is the ordinary value. Turning it on disables kernel readahead and costs sequential read
+  # throughput; it is here for a backend that cannot serve concurrent reads of one file. S3 can.
+  sync_read: false

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -181,13 +181,8 @@ func (a *Adapter) Start(ctx context.Context) error {
 	// 5. Initialize platform-specific FUSE filesystem
 	mountConfig := &fuse.MountConfig{
 		MountPoint: a.mountPoint,
-		Options: &fuse.MountOptions{
-			FSName:   "objectfs",
-			Subtype:  "s3",
-			MaxWrite: 128 * 1024,
-			Debug:    false,
-		},
-		ReadAhead: a.buildReadAheadConfig(),
+		Options:    a.buildMountOptions(),
+		ReadAhead:  a.buildReadAheadConfig(),
 	}
 
 	a.mountMgr = fuse.CreatePlatformMountManager(a.backend, a.cache, a.writeBuffer, a.metrics, mountConfig)
@@ -574,6 +569,37 @@ func (a *Adapter) buildReadAheadConfig() *fuse.ReadAheadConfig {
 		MinSequential:   ra.MinSequential,
 		ConcurrentReads: ra.ConcurrentReads,
 		TTL:             ra.TTL,
+	}
+}
+
+// buildMountOptions maps the `fuse` config section onto the mount's options.
+//
+// A method rather than a struct literal at the one call site, so the mapping can be asserted without
+// a mount. That is not a stylistic preference: this mapping is the seam #180 is about. Nine fields on
+// fuse.MountOptions and fuse.Config named real FUSE capabilities and reached nothing, and they
+// survived a release because there was no place to put a test — the literal lived inside Start,
+// between initializing the write path and constructing the mount manager, and nothing short of a
+// live mount could observe it.
+//
+// FSName, Subtype and MaxWrite are constants here rather than configuration. Their operator-facing
+// keys were removed by #180 for lack of a reader; giving them one is separate work and neither has a
+// use case behind it. Debug is false rather than mapped to global.log_level: go-fuse's Debug logs
+// every FUSE request and reply, which is a different thing from an application log level and would
+// make DEBUG unusable for anything else.
+func (a *Adapter) buildMountOptions() *fuse.MountOptions {
+	return &fuse.MountOptions{
+		FSName:   "objectfs",
+		Subtype:  "s3",
+		MaxWrite: 128 * 1024,
+		Debug:    false,
+
+		// The three settings the `fuse` section carries — the first FUSE block any loader has read.
+		// DirectIO and KeepCache travel further, to fuse.Config, because they are returned from every
+		// open rather than set at mount time; CreatePlatformMountManager is what carries them. SyncRead
+		// stops here, being a field on go-fuse's own fuse.MountOptions.
+		DirectIO:  a.config.FUSE.DirectIO,
+		KeepCache: a.config.FUSE.KeepCache,
+		SyncRead:  a.config.FUSE.SyncRead,
 	}
 }
 

--- a/internal/adapter/config_mapping_test.go
+++ b/internal/adapter/config_mapping_test.go
@@ -648,3 +648,93 @@ func TestDefaultConfigReachesTheManagerUnchanged(t *testing.T) {
 			*got, fuse.DefaultReadAheadConfig())
 	}
 }
+
+// TestBuildMountOptionsMapsTheFUSESection is the mapping half of #180.
+//
+// The three fields it checks are the ones that survived that issue's audit. Nine others named real FUSE
+// capabilities, carried yaml tags, and reached nothing — and the reason none of them was caught is the
+// reason this test exists: they were set in a struct literal inside Adapter.Start, where no test could
+// reach them, and nothing between there and the kernel ever read them back.
+//
+// Values are written out rather than derived from the input, for the reason
+// TestBuildS3ConfigMapsEveryConfiguredValue documents: an expectation computed from cfg would agree with
+// a mapping that read direct_io into keep_cache. Here that matters more than usual, because all three
+// fields are bools of the same type — a crossed pair is invisible unless the inputs differ.
+func TestBuildMountOptionsMapsTheFUSESection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		fuseCfg config.FUSEConfig
+		want    fuse.MountOptions
+	}{
+		{
+			// All three distinct is impossible with three bools, so each subtest sets exactly one. A
+			// field mapped from the wrong source therefore shows up as the wrong field being true.
+			name:    "direct_io alone",
+			fuseCfg: config.FUSEConfig{DirectIO: true},
+			want:    fuse.MountOptions{DirectIO: true},
+		},
+		{
+			name:    "keep_cache alone",
+			fuseCfg: config.FUSEConfig{KeepCache: true},
+			want:    fuse.MountOptions{KeepCache: true},
+		},
+		{
+			name:    "sync_read alone",
+			fuseCfg: config.FUSEConfig{SyncRead: true},
+			want:    fuse.MountOptions{SyncRead: true},
+		},
+		{
+			// The shipped default, and the one row that would pass on a mapping that dropped the section
+			// entirely — which is why it is not the only row.
+			name:    "the default section",
+			fuseCfg: config.FUSEConfig{},
+			want:    fuse.MountOptions{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := createTestConfig()
+			cfg.FUSE = tc.fuseCfg
+
+			got := (&Adapter{config: cfg}).buildMountOptions()
+
+			if got == nil {
+				t.Fatal("buildMountOptions returned nil, which MountManager would replace with its own " +
+					"defaults and every fuse: key in the config file would be ignored")
+			}
+
+			// Compared whole rather than field by field, so a fourth setting added to the `fuse` section
+			// and not mapped here fails this test instead of silently joining the nine.
+			want := tc.want
+			want.FSName = "objectfs"
+			want.Subtype = "s3"
+			want.MaxWrite = 128 * 1024
+
+			if *got != want {
+				t.Errorf("buildMountOptions() = %+v, want %+v", *got, want)
+			}
+		})
+	}
+}
+
+// TestFUSEZeroValueIsTheDefault is the property NewDefault relies on by omission.
+//
+// Every other section of Configuration is named in NewDefault. `fuse` is not, because all three of its
+// fields default to off and off is both the kernel's behavior and ObjectFS's behavior before the section
+// existed. That omission is only safe while the zero value and the default agree, so this asserts it:
+// otherwise a caller building a Configuration as a literal — which internal/adapter's own tests do —
+// would get a different mount from one built by NewDefault.
+func TestFUSEZeroValueIsTheDefault(t *testing.T) {
+	t.Parallel()
+
+	if got := config.NewDefault().FUSE; got != (config.FUSEConfig{}) {
+		t.Errorf("NewDefault().FUSE = %+v, want the zero value. Either name the section in NewDefault "+
+			"or keep the two in agreement; a config built as a literal must describe the same mount",
+			got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,83 @@ type Configuration struct {
 	Monitoring  MonitoringConfig  `yaml:"monitoring"`
 	Features    FeatureConfig     `yaml:"features"`
 	Cluster     ClusterConfig     `yaml:"cluster"`
+	FUSE        FUSEConfig        `yaml:"fuse"`
+}
+
+// FUSEConfig configures how the kernel is asked to cache and dispatch to this mount.
+//
+// This block is new in v0.11.0 and it is the first FUSE section any loader has ever read. Nine
+// fields on internal/fuse.MountOptions and internal/fuse.Config carried yaml tags for a whole
+// release and were decoded by nothing — Configuration had no `fuse` key, so a `fuse:` block in a
+// config file was silently discarded, and under strict decoding it would now be rejected outright.
+// They are the fields #180 removed.
+//
+// Only settings with a demonstrated effect on the kernel's behavior are here, which is why the block
+// is three keys and not nine. Two of the four #180 nominated turned out not to be plumbable, and the
+// evidence is recorded at the field that would have carried them — see DirectIO's comment for
+// splice, and KeepCache's for the writeback cache.
+//
+// All three default to false, which is both the kernel's behavior in the absence of the flag and
+// ObjectFS's behavior before this block existed. That is why NewDefault does not name this section:
+// the zero value is the default, so a Configuration built as a literal and one built by NewDefault
+// cannot describe different mounts. Each field is also named so that false is the uninteresting
+// value — SyncRead rather than AsyncRead, for one — since a negated name would have made the zero
+// value the surprising one.
+type FUSEConfig struct {
+	// DirectIO asks the kernel not to cache this mount's file data: FOPEN_DIRECT_IO on every open.
+	//
+	// Off by default. It costs the page cache — every read(2) becomes a READ request into
+	// FileHandle.Read even when the same bytes were read a microsecond ago — and buys coherence with a
+	// bucket other clients are writing. The internal byte-range cache still serves those reads, so
+	// what is given up is the kernel's copy, not all caching. It also makes reads land at the offset
+	// and length the application asked for rather than page-aligned and rounded up, which is what
+	// makes it the setting to reach for when a reader does large strided reads of a huge object.
+	//
+	// `splice_read`, the fourth flag #180 named, is not here and is not plumbable as things stand.
+	// go-fuse only splices a ReadResult that carries a file descriptor (fuse.ReadResultFd, via the
+	// seekableResult/statefulResult interfaces in fuse/read.go); FileHandle.Read returns
+	// fuse.ReadResultData at all four of its return sites, because the bytes come from S3 or from an
+	// in-memory cache and there is no fd to splice from. trySplice returns errRecoverSplice for such
+	// a result and go-fuse copies instead. Setting DisableSplice would therefore disable a path this
+	// filesystem never takes — a config key whose effect is provably nothing, which is the defect
+	// #180 exists to stop repeating.
+	DirectIO bool `yaml:"direct_io"`
+
+	// KeepCache asks the kernel to retain cached pages across open(2): FOPEN_KEEP_CACHE.
+	//
+	// Off by default, so an open(2) drops whatever the page cache held for that file and the next
+	// read comes to this filesystem. Turning it on trades that for speed on a workload that opens the
+	// same file repeatedly — and it is only safe when nothing else writes the bucket, because a page
+	// the kernel keeps is a page ObjectFS cannot invalidate: see the writeback-cache note below for
+	// why there is no notification path to invalidate it with.
+	//
+	// Ignored when DirectIO is set. The two are contradictory — one asks the kernel to cache harder
+	// and the other asks it not to cache at all — and go-fuse's own bridge clears FOPEN_KEEP_CACHE
+	// when it takes a passthrough path (fs/bridge.go:805). Which one wins is decided in internal/fuse
+	// rather than left to the kernel; see FileNode.Open.
+	//
+	// `writeback_cache`, also named in #180, is not here. It maps to
+	// fuse.MountOptions.ExplicitDataCacheControl, which asks the kernel *not* to invalidate data
+	// caches automatically and makes the filesystem "fully responsible for invalidating data cache"
+	// (go-fuse's own words). ObjectFS makes no invalidation calls at all: there is not one
+	// NotifyContent, NotifyEntry, or NotifyInvalInode in the tree. Enabling it would hand the mount a
+	// responsibility nothing discharges and turn stale pages into a permanent condition rather than
+	// one bounded by cache.ttl. It needs the notification path first, tracked separately.
+	KeepCache bool `yaml:"keep_cache"`
+
+	// SyncRead makes the kernel keep at most one READ outstanding against a file.
+	//
+	// Off by default, so reads are asynchronous — the kernel's default and ObjectFS's. It reaches
+	// go-fuse's SyncRead field, which go-fuse turns into a disabled CAP_ASYNC_READ at INIT
+	// (fuse/server.go:187). #180 proposed exposing this as `async_read`, the name the removed field
+	// had; it is `sync_read` instead, because AsyncRead is the negation of the flag that exists and a
+	// negated key would make `async_read: false` — the value a half-filled config file produces — the
+	// one that serializes every read on the mount.
+	//
+	// Turning it on costs read throughput on any sequential reader: kernel readahead is exactly the
+	// mechanism CAP_ASYNC_READ enables. It is here for a backend that cannot serve concurrent reads of
+	// one file. S3 can.
+	SyncRead bool `yaml:"sync_read"`
 }
 
 // GlobalConfig represents global application settings.
@@ -775,6 +852,12 @@ func NewDefault() *Configuration {
 				MaxRetries: 3,
 			},
 		},
+		// FUSE is deliberately absent, unlike every other section above.
+		//
+		// All three of its fields are false by default and false is the kernel's own behavior for each,
+		// so the zero value *is* the default and naming it here would only create a second place for
+		// that default to live. TestFUSEZeroValueIsTheDefault pins the property this omission depends
+		// on — that a Configuration built as a literal and one built here describe the same mount.
 	}
 }
 

--- a/internal/config/strict_test.go
+++ b/internal/config/strict_test.go
@@ -249,3 +249,80 @@ func TestTopLevelKeysMatchesTheSchema(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadFromFileReadsTheFUSESection is #180 at the layer where that issue actually began.
+//
+// A `fuse:` block in a config file was silently discarded through v0.10.0 — Configuration had no such
+// key, so non-strict decoding dropped the whole section. That is why nine fields on
+// internal/fuse.MountOptions and internal/fuse.Config carried yaml tags to no effect: the tags were
+// real, the fields were settable, and no document could ever reach them. Under the strict decoding
+// added in v0.11.0 the same file would have been rejected outright, which is better but still not the
+// same as being read.
+//
+// So this asserts the section is read, and asserts it with non-default values: a document setting all
+// three to false would pass against a loader that ignored the block entirely.
+func TestLoadFromFileReadsTheFUSESection(t *testing.T) {
+	t.Parallel()
+
+	const doc = `fuse:
+  direct_io: true
+  keep_cache: true
+  sync_read: true
+`
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg := NewDefault()
+	if err := cfg.LoadFromFile(path); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	want := FUSEConfig{DirectIO: true, KeepCache: true, SyncRead: true}
+	if cfg.FUSE != want {
+		t.Errorf("the fuse section loaded as %+v, want %+v. A section the loader drops is how nine "+
+			"settable-but-inert FUSE fields survived to a release (#180)", cfg.FUSE, want)
+	}
+}
+
+// TestLoadFromFileRejectsTheRemovedFUSEKeys pins the other half of #180's removal.
+//
+// The nine names are gone, and gone means rejected rather than accepted-and-ignored. An operator who
+// had written `fuse: {big_writes: true}` was already getting nothing; the difference now is being
+// told. `async_read` is in this list too, and it is the interesting one: it names a real capability
+// and its replacement is `sync_read`, the inverse — so accepting it silently would invert the setting
+// an operator asked for, which is worse than any of the eight that merely did nothing.
+func TestLoadFromFileRejectsTheRemovedFUSEKeys(t *testing.T) {
+	t.Parallel()
+
+	removed := []string{
+		"big_writes", "max_read", "async_read", "writeback_cache",
+		"splice_read", "splice_write", "splice_move",
+	}
+
+	for _, key := range removed {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			doc := "fuse:\n  " + key + ": true\n"
+
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			err := NewDefault().LoadFromFile(path)
+			if err == nil {
+				t.Fatalf("fuse.%s was accepted. It names no field, so it would be silently discarded — "+
+					"the failure mode the strict loader exists to end", key)
+			}
+
+			if !strings.Contains(err.Error(), key) {
+				t.Errorf("the error for fuse.%s does not name the key, so an operator cannot tell which "+
+					"line to fix: %v", key, err)
+			}
+		})
+	}
+}

--- a/internal/fuse/doc.go
+++ b/internal/fuse/doc.go
@@ -84,6 +84,15 @@ Flexible mount configuration options:
 			AttrTimeout:  5 * time.Second,
 			EntryTimeout: 10 * time.Second,
 
+			// What the kernel is told about caching and dispatch. All three default to off, and off
+			// is the kernel's own behavior in each case, so an ordinary mount sets none of them.
+			// DirectIO and KeepCache are returned from every Open rather than set at mount time, and
+			// DirectIO wins if both are set. SyncRead is go-fuse's field; it withholds
+			// CAP_ASYNC_READ, which is what kernel readahead depends on.
+			DirectIO:  false,
+			KeepCache: false,
+			SyncRead:  false,
+
 			// Platform-specific
 			FSName:       "objectfs",
 			Subtype:      "s3",
@@ -96,17 +105,29 @@ Flexible mount configuration options:
 		},
 	}
 
-Every option above takes effect. That is now a property of the type rather than a claim about this
-example: `MountOptions` and `Config` between them carried fourteen fields — `MaxRead`, `DirectIO`,
+Every option above takes effect, and that is a property of the type rather than a claim about this
+example. `MountOptions` and `Config` between them carried fourteen fields — `MaxRead`, `DirectIO`,
 `KeepCache`, `BigWrites`, `AsyncRead`, `WritebackCache`, the three splice flags, `AllowOther` on
-`Config`, `ReadAhead`, `WriteBuffer`, and `Concurrency` — that were read by nothing, and they are
-gone. `MaxWrite` is the only size that is settable: go-fuse derives `max_read` and `MaxPages` from
-it, so the read size is not independently configurable.
+`Config`, `ReadAhead`, `WriteBuffer`, and `Concurrency` — that were read by nothing. Three of them are
+back, plumbed and tested (#180); the rest are gone. `MaxWrite` is the only size that is settable:
+go-fuse derives `max_read` and `MaxPages` from it, so the read size is not independently configurable.
 
-The yaml tags on these structs bind to nothing, and never did. Configuration is decoded into
-[config.Configuration], which has no FUSE section, so a mount is configured by the code above and by
-`internal/adapter`, not by a `fuse:` block in a config file. #180 tracks plumbing the four removed
-flags that name real go-fuse capabilities, along with the tests that would show they took effect.
+Two of the four #180 nominated were not plumbable, and both reasons are worth stating because each
+would otherwise look like an omission:
+
+  - Splice. go-fuse only splices a [fuse.ReadResult] backed by a file descriptor, and
+    [FileHandle.Read] returns [fuse.ReadResultData] at every return site — the bytes come from S3 or
+    from an in-memory cache, and there is no fd to splice from. Setting `DisableSplice` would disable
+    a path this filesystem never takes.
+  - The writeback cache. It maps to `fuse.MountOptions.ExplicitDataCacheControl`, which asks the
+    kernel to stop invalidating data caches automatically and makes the filesystem responsible for
+    doing it. There is not one `NotifyContent`, `NotifyEntry`, or `NotifyInvalInode` call in this
+    repository, so enabling it would make stale pages permanent rather than bounded.
+
+The yaml tags on these structs still bind to nothing, and that is now deliberate rather than an
+oversight. As of v0.11.0 [config.Configuration] does have a `fuse` section — the first one any loader
+has read — and it reaches these structs through `internal/adapter`, not by being decoded into them.
+The operator-facing names are [config.FUSEConfig]'s.
 
 # Usage Examples
 

--- a/internal/fuse/filesystem.go
+++ b/internal/fuse/filesystem.go
@@ -158,11 +158,14 @@ func (f *inflightFetch) slice(off, length int64) ([]byte, bool) {
 // true: this struct carried AllowOther, DirectIO, KeepCache, BigWrites, MaxRead, MaxWrite, ReadAhead,
 // WriteBuffer, and Concurrency, and not one of them was read by anything. Each carried a yaml tag,
 // which is what made them look plumbed — but no decoder targets this type. Configuration is decoded
-// into [config.Configuration], whose ten top-level keys include no FUSE section, so the tags never
-// bound to anything a user could set.
+// into [config.Configuration], which as of v0.11.0 does have a `fuse` section — and it reaches this
+// struct through internal/adapter and [CreatePlatformMountManager], not by being decoded into it.
 //
-// See [MountOptions] for the same note about the mount-time options, and #180 for the four that
-// name real go-fuse capabilities and are worth having for real.
+// DirectIO and KeepCache below are two of the four #180 nominated, restored with the plumbing and the
+// tests they lacked the first time. They are on this type rather than only on [MountOptions] because
+// [FileNode.Open] is what returns them to the kernel, and Open reads this config.
+//
+// See [MountOptions] for the mount-time options and for why splice is not among them.
 type Config struct {
 	// Mount options
 	MountPoint string `yaml:"mount_point"`
@@ -188,6 +191,21 @@ type Config struct {
 
 	// CacheTTL is how long the kernel may cache an attribute set, as returned by Getattr and Setattr.
 	CacheTTL time.Duration `yaml:"cache_ttl"`
+
+	// DirectIO returns FOPEN_DIRECT_IO from every [FileNode.Open], so the kernel does not cache this
+	// mount's file data and every read(2) becomes a READ reaching [FileHandle.Read].
+	//
+	// KeepCache returns FOPEN_KEEP_CACHE, asking the kernel to keep cached pages across open(2).
+	//
+	// DirectIO wins when both are set. The two ask for opposite things, and sending both leaves the
+	// decision to a kernel version rather than to this configuration; go-fuse's bridge makes the same
+	// choice in the passthrough case, clearing FOPEN_KEEP_CACHE when it sets FOPEN_PASSTHROUGH
+	// (fs/bridge.go:805).
+	//
+	// No yaml tags for the reason given at ReadAhead below. The operator-facing names are
+	// config.FUSEConfig's `direct_io` and `keep_cache`.
+	DirectIO  bool
+	KeepCache bool
 
 	// ReadAhead configures the sequential-read prefetcher; nil takes [DefaultReadAheadConfig].
 	//
@@ -889,7 +907,30 @@ func (f *FileNode) Open(ctx context.Context, flags uint32) (fh fs.FileHandle, fu
 		fs:     f.fs,
 		handle: handle,
 		file:   openFile,
-	}, 0, 0
+	}, f.fs.openFlags(), 0
+}
+
+// openFlags is the FOPEN_* set every open on this mount returns to the kernel.
+//
+// This return value was the literal 0 through v0.10.0 while [Config] carried DirectIO and KeepCache
+// fields — the two flags that belong here — so both were settable and neither reached the kernel.
+// #180 removed them for that reason; this is them coming back with the one line that makes them mean
+// something.
+//
+// DirectIO takes precedence over KeepCache rather than the two being OR'd. FOPEN_DIRECT_IO tells the
+// kernel not to use the page cache for this file and FOPEN_KEEP_CACHE tells it to hold what the page
+// cache already has; sending both asks for opposite things and leaves which one applies to a kernel
+// version. See [Config.DirectIO].
+func (fs *FileSystem) openFlags() uint32 {
+	if fs.config.DirectIO {
+		return fuse.FOPEN_DIRECT_IO
+	}
+
+	if fs.config.KeepCache {
+		return fuse.FOPEN_KEEP_CACHE
+	}
+
+	return 0
 }
 
 // FileHandle represents an open file handle

--- a/internal/fuse/kernel_options_live_test.go
+++ b/internal/fuse/kernel_options_live_test.go
@@ -1,0 +1,216 @@
+//go:build (linux || darwin) && fuse_mount
+
+package fuse
+
+// The kernel's half of the direct-I/O contract, which is the only part of #180 a mount is required to
+// observe.
+//
+// kernel_options_test.go asserts that FOPEN_DIRECT_IO reaches the kernel. That is necessary and it is
+// not sufficient: the flag's whole purpose is to change what the *kernel* does with a second read(2) of
+// bytes it already has, and no amount of inspecting OpenOut can show that. This file reads the same
+// offset twice through a real mount and counts how many READ requests arrive.
+//
+// Behind the fuse_mount build tag, and therefore run by nothing by default, because it needs
+// /dev/fuse — absent on GitHub's ubuntu-latest runners and absent on a macOS host without macFUSE.
+// That is a real coverage gap and it is stated rather than papered over: CI gates the seams, and this
+// runs where a kernel is available. `make test-fuse-mount` is the entry point.
+//
+// A test skipping itself for want of a device would be worse than a build tag: it would report success.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// liveMount brings up a real FUSE mount over a real S3 endpoint and returns the mount point.
+func liveMount(t *testing.T, opts *MountOptions) (string, *MountManager) {
+	t.Helper()
+
+	if _, err := os.Stat("/dev/fuse"); err != nil {
+		t.Fatalf("no /dev/fuse: %v. This file is behind the fuse_mount build tag precisely because it "+
+			"needs one; it fails rather than skipping so a run that cannot test anything does not "+
+			"report success", err)
+	}
+
+	srv := testaws.Start(t)
+
+	writer, err := vfs.NewWriter(context.Background(), srv.Backend())
+	if err != nil {
+		t.Fatalf("vfs.NewWriter: %v", err)
+	}
+
+	mountPoint := t.TempDir()
+
+	pfs := CreatePlatformMountManager(srv.Backend(), nil, writer, nil, &MountConfig{
+		MountPoint: mountPoint,
+		Options:    opts,
+	})
+
+	mm, ok := pfs.(*MountManager)
+	if !ok {
+		t.Fatalf("CreatePlatformMountManager returned %T, want *MountManager", pfs)
+	}
+
+	if err := mm.Mount(context.Background()); err != nil {
+		t.Fatalf("Mount(%s): %v", mountPoint, err)
+	}
+
+	t.Cleanup(func() {
+		if err := mm.Unmount(); err != nil {
+			t.Errorf("Unmount(%s): %v", mountPoint, err)
+		}
+	})
+
+	// Seeded after the mount so the read below is the first thing that touches the object.
+	srv.PutObject("f.dat", bytes.Repeat([]byte("x"), 4096))
+
+	return mountPoint, mm
+}
+
+// TestDirectIOMakesTheKernelReReadFromTheFilesystem is the effect assertion #180 asks for.
+//
+// Two read(2) calls at the same offset on one descriptor. Without FOPEN_DIRECT_IO the kernel serves the
+// second from the page cache and the filesystem sees one READ; with it, the filesystem sees both. The
+// number of READs that arrive is the observable, and it is the thing the flag exists to change.
+func TestDirectIOMakesTheKernelReReadFromTheFilesystem(t *testing.T) {
+	tests := []struct {
+		name        string
+		directIO    bool
+		wantAtLeast int64
+		wantAtMost  int64
+		why         string
+	}{
+		{
+			name:        "direct_io: both reads reach the filesystem",
+			directIO:    true,
+			wantAtLeast: 2,
+			wantAtMost:  64,
+			why:         "the kernel was told not to cache this file's data",
+		},
+		{
+			name:        "without direct_io: the page cache serves the second read",
+			directIO:    false,
+			wantAtLeast: 1,
+			wantAtMost:  1,
+			why:         "the kernel caches by default, and 4096 bytes fit in one readahead window",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Not parallel: each subtest mounts, and a mount is a process-wide resource with a
+			// unmount to sequence against.
+			mountPoint, mm := liveMount(t, &MountOptions{
+				FSName:       "objectfs",
+				MaxWrite:     128 * 1024,
+				AttrTimeout:  time.Second,
+				EntryTimeout: time.Second,
+				DirectIO:     tc.directIO,
+			})
+
+			f, err := os.Open(filepath.Join(mountPoint, "f.dat"))
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			defer func() { _ = f.Close() }()
+
+			before := mm.GetStats().Reads
+
+			// Same offset twice on one descriptor, so nothing but the kernel's caching decision differs
+			// between the two calls.
+			buf := make([]byte, 512)
+			for i := range 2 {
+				if _, err := f.ReadAt(buf, 0); err != nil {
+					t.Fatalf("ReadAt #%d: %v", i+1, err)
+				}
+			}
+
+			// An upper bound as well as a lower one. Direct I/O with no bound would pass on a
+			// filesystem that issued a READ per page for reasons unrelated to the flag, and the
+			// non-direct case is the one that actually pins the behavior: exactly one.
+			got := mm.GetStats().Reads - before
+			if got < tc.wantAtLeast || got > tc.wantAtMost {
+				t.Errorf("two read(2) calls at the same offset produced %d READ requests, want between "+
+					"%d and %d: %s", got, tc.wantAtLeast, tc.wantAtMost, tc.why)
+			}
+		})
+	}
+}
+
+// TestKeepCacheSurvivesReopen is the kernel half of FOPEN_KEEP_CACHE.
+//
+// Read, close, reopen, read the same offset. Without the flag the kernel drops the file's cached pages
+// at open(2) and the second read reaches the filesystem; with it, the pages survive and the filesystem
+// sees nothing. As with direct I/O, the count of arriving READs is the observable.
+func TestKeepCacheSurvivesReopen(t *testing.T) {
+	tests := []struct {
+		name      string
+		keepCache bool
+		wantReads int64
+		why       string
+	}{
+		{
+			name:      "keep_cache: the reopened read is served from the page cache",
+			keepCache: true,
+			wantReads: 0,
+			why:       "the kernel was asked to keep the pages it already had across open(2)",
+		},
+		{
+			name:      "without keep_cache: the reopen drops the cache",
+			keepCache: false,
+			wantReads: 1,
+			why:       "the kernel invalidates a file's pages on open unless told otherwise",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mountPoint, mm := liveMount(t, &MountOptions{
+				FSName:       "objectfs",
+				MaxWrite:     128 * 1024,
+				AttrTimeout:  time.Second,
+				EntryTimeout: time.Second,
+				KeepCache:    tc.keepCache,
+			})
+
+			path := filepath.Join(mountPoint, "f.dat")
+			buf := make([]byte, 512)
+
+			first, err := os.Open(path)
+			if err != nil {
+				t.Fatalf("first open: %v", err)
+			}
+			if _, err := first.ReadAt(buf, 0); err != nil {
+				t.Fatalf("first read: %v", err)
+			}
+			if err := first.Close(); err != nil {
+				t.Fatalf("first close: %v", err)
+			}
+
+			// Counted from after the first read, so what is measured is only what the reopen costs.
+			before := mm.GetStats().Reads
+
+			second, err := os.Open(path)
+			if err != nil {
+				t.Fatalf("second open: %v", err)
+			}
+			defer func() { _ = second.Close() }()
+
+			if _, err := second.ReadAt(buf, 0); err != nil {
+				t.Fatalf("second read: %v", err)
+			}
+
+			if got := mm.GetStats().Reads - before; got != tc.wantReads {
+				t.Errorf("a read after reopen produced %d READ requests, want %d: %s",
+					got, tc.wantReads, tc.why)
+			}
+		})
+	}
+}

--- a/internal/fuse/kernel_options_test.go
+++ b/internal/fuse/kernel_options_test.go
@@ -1,0 +1,296 @@
+//go:build linux || darwin
+
+package fuse
+
+// These tests cover the three kernel-facing settings #180 asked for: direct I/O, the page-cache
+// retention flag, and asynchronous reads.
+//
+// Every assertion here is on a value the kernel receives, not on a field having been copied. That
+// distinction is the whole point of the issue: nine fields with names matching real FUSE capabilities
+// survived to a release because a test asserting `opts.DirectIO == cfg.DirectIO` passes just as well
+// when nothing downstream reads the field. So:
+//
+//   - the open-time flags are read out of a real *fuse.OpenOut, filled by go-fuse's own bridge from a
+//     real OPEN request, which is byte-for-byte what the kernel gets back;
+//   - the mount-time flag is read out of the *fs.Options that go-fuse is handed at mount, and then
+//     out of the DisabledCapabilities mask go-fuse itself derives from it — so the assertion is on
+//     the capability being withheld from the kernel, not on the intermediate boolean.
+//
+// What is deliberately not asserted here, and cannot be: that a second read(2) of the same offset
+// reaches FileHandle.Read under direct I/O. That is the kernel's half of the contract and it needs a
+// real mount; there is no /dev/fuse in CI and none on the macOS development host. It belongs in the
+// live-mount smoke suite. What these tests pin is everything up to the kernel boundary, which is
+// where all nine of the removed fields failed.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gofs "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// openThroughBridge issues one OPEN through go-fuse's raw bridge and returns what the kernel would
+// receive, which is the OpenOut the bridge filled.
+//
+// Going through the bridge rather than calling FileNode.Open directly is what makes this a seam test.
+// FileNode.Open returns the flags as its second result and the bridge is what copies them into
+// OpenOut.OpenFlags (fs/bridge.go:756) — a return value nothing forwards would be exactly the defect
+// class under test, so the forwarding is included rather than assumed.
+func openThroughBridge(t *testing.T, fsys *FileSystem, key string) *fuse.OpenOut {
+	t.Helper()
+
+	sec := time.Second
+	raw := gofs.NewNodeFS(fsys.Root(), &gofs.Options{
+		AttrTimeout:  &sec,
+		EntryTimeout: &sec,
+	})
+
+	// Node id 1 is the root, per go-fuse's bridge. Look the file up first so the bridge holds an
+	// inode for it and can dispatch OPEN — the kernel does the same two calls in the same order.
+	var entry fuse.EntryOut
+	if status := raw.Lookup(nil, &fuse.InHeader{NodeId: 1}, key, &entry); !status.Ok() {
+		t.Fatalf("Lookup(%q) through the bridge: %v", key, status)
+	}
+
+	var out fuse.OpenOut
+	if status := raw.Open(nil, &fuse.OpenIn{InHeader: fuse.InHeader{NodeId: entry.NodeId}}, &out); !status.Ok() {
+		t.Fatalf("Open(%q) through the bridge: %v", key, status)
+	}
+
+	return &out
+}
+
+// newOptionsFixture is a FileSystem over a real S3 endpoint and a real write path, configured by the
+// caller. No mocks: mount options are a seam, and a mock on the far side of one agrees by
+// construction.
+func newOptionsFixture(t *testing.T, configure func(*Config)) (*FileSystem, *testaws.TestServer) {
+	t.Helper()
+
+	srv := testaws.Start(t)
+
+	writer, err := vfs.NewWriter(context.Background(), srv.Backend())
+	if err != nil {
+		t.Fatalf("vfs.NewWriter: %v", err)
+	}
+
+	cfg := &Config{
+		DefaultMode:    0o644,
+		DefaultDirMode: 0o755,
+		DefaultUID:     1000,
+		DefaultGID:     1000,
+		CacheTTL:       time.Minute,
+	}
+	if configure != nil {
+		configure(cfg)
+	}
+
+	return NewFileSystem(srv.Backend(), nil, writer, nil, cfg), srv
+}
+
+// TestOpenFlagsReachTheKernel is the assertion the nine removed fields never had.
+//
+// DirectIO and KeepCache existed on Config through v0.10.0 while FileNode.Open returned a literal 0
+// for its fuseFlags, so both were settable and neither reached the kernel. Mutating openFlags to
+// return 0 unconditionally — which is exactly what v0.10.0 did — fails the first two subtests.
+func TestOpenFlagsReachTheKernel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		directIO  bool
+		keepCache bool
+		want      uint32
+		why       string
+	}{
+		{
+			name:     "direct_io sets FOPEN_DIRECT_IO",
+			directIO: true,
+			want:     fuse.FOPEN_DIRECT_IO,
+			why:      "the kernel must be told not to cache this mount's data",
+		},
+		{
+			name:      "keep_cache sets FOPEN_KEEP_CACHE",
+			keepCache: true,
+			want:      fuse.FOPEN_KEEP_CACHE,
+			why:       "the kernel must be told it may keep cached pages across open(2)",
+		},
+		{
+			name:      "direct_io wins over keep_cache",
+			directIO:  true,
+			keepCache: true,
+			want:      fuse.FOPEN_DIRECT_IO,
+			why: "the two ask for opposite things; sending both would leave which one applies to a " +
+				"kernel version rather than to this configuration",
+		},
+		{
+			name: "neither set sends no flags",
+			want: 0,
+			why:  "the default must be the kernel's own behavior, which is what a zero value means",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fsys, srv := newOptionsFixture(t, func(c *Config) {
+				c.DirectIO = tc.directIO
+				c.KeepCache = tc.keepCache
+			})
+			srv.PutObject("f.dat", []byte("contents"))
+
+			out := openThroughBridge(t, fsys, "f.dat")
+
+			if out.OpenFlags != tc.want {
+				t.Errorf("OpenOut.OpenFlags = %#x, want %#x: %s", out.OpenFlags, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestCreateReturnsTheSameOpenFlagsAsOpen pins the second path that hands flags to the kernel.
+//
+// A create is an open too — CREATE returns an OpenOut and the kernel caches whatever flags come back
+// with it — so a direct-io mount whose Create returned 0 would cache the data of every file written
+// through it while honoring the setting for every file merely read. Create delegates to Open for
+// exactly this reason; this test is what would notice if it stopped.
+func TestCreateReturnsTheSameOpenFlagsAsOpen(t *testing.T) {
+	t.Parallel()
+
+	fsys, _ := newOptionsFixture(t, func(c *Config) { c.DirectIO = true })
+
+	sec := time.Second
+	raw := gofs.NewNodeFS(fsys.Root(), &gofs.Options{AttrTimeout: &sec, EntryTimeout: &sec})
+
+	var out fuse.CreateOut
+	status := raw.Create(nil, &fuse.CreateIn{
+		InHeader: fuse.InHeader{NodeId: 1},
+		Mode:     0o644,
+	}, "made.dat", &out)
+	if !status.Ok() {
+		t.Fatalf("Create through the bridge: %v", status)
+	}
+
+	// out.OpenFlags is CreateOut's embedded OpenOut's field. CreateOut embeds both EntryOut and
+	// OpenOut, and only OpenOut carries OpenFlags, so this is the same field rawBridge.Create writes.
+	if out.OpenFlags != fuse.FOPEN_DIRECT_IO {
+		t.Errorf("CreateOut.OpenFlags = %#x, want FOPEN_DIRECT_IO (%#x): a file created on a "+
+			"direct-io mount would have its data cached by the kernel",
+			out.OpenFlags, fuse.FOPEN_DIRECT_IO)
+	}
+}
+
+// TestMountOptionsReachTheOpenFlags covers the middle seam, which is the one that was empty.
+//
+// The kernel-facing flags are produced by FileSystem.openFlags from Config, but Config is not what a
+// caller sets — internal/adapter builds a MountOptions and CreatePlatformMountManager derives the
+// Config from it. That derivation is where nine fields died: it hardcoded uid, gid and mode for a whole
+// release and discarded MountConfig.Permissions entirely, and DirectIO and KeepCache were on Config
+// with nothing assigning them.
+//
+// So this starts where an operator's configuration arrives and asserts what the kernel receives, with
+// no intermediate value trusted along the way.
+func TestMountOptionsReachTheOpenFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts MountOptions
+		want uint32
+	}{
+		{
+			name: "direct_io",
+			opts: MountOptions{DirectIO: true},
+			want: fuse.FOPEN_DIRECT_IO,
+		},
+		{
+			name: "keep_cache",
+			opts: MountOptions{KeepCache: true},
+			want: fuse.FOPEN_KEEP_CACHE,
+		},
+		{
+			name: "neither",
+			opts: MountOptions{},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := testaws.Start(t)
+			srv.PutObject("f.dat", []byte("contents"))
+
+			writer, err := vfs.NewWriter(context.Background(), srv.Backend())
+			if err != nil {
+				t.Fatalf("vfs.NewWriter: %v", err)
+			}
+
+			opts := tc.opts
+			opts.FSName = "objectfs"
+			opts.MaxWrite = 128 * 1024
+
+			pfs := CreatePlatformMountManager(srv.Backend(), nil, writer, nil, &MountConfig{
+				MountPoint: t.TempDir(),
+				Options:    &opts,
+			})
+
+			// The manager holds the filesystem it built; this test is in-package so it can ask. Nothing
+			// is mounted — the assertion is on what an OPEN would return, and openThroughBridge issues a
+			// real one through go-fuse's bridge without a kernel.
+			mm, ok := pfs.(*MountManager)
+			if !ok {
+				t.Fatalf("CreatePlatformMountManager returned %T, want *MountManager", pfs)
+			}
+
+			out := openThroughBridge(t, mm.filesystem, "f.dat")
+
+			if out.OpenFlags != tc.want {
+				t.Errorf("OpenOut.OpenFlags = %#x, want %#x: the flag was set on MountOptions and did "+
+					"not reach the kernel", out.OpenFlags, tc.want)
+			}
+		})
+	}
+}
+
+// TestSyncReadReachesGoFuse is the one assertion in this file that is a copy check, and the reason is
+// worth recording because #180 explicitly rejects copy checks.
+//
+// SyncRead's effect is a capability withheld from the kernel at INIT: go-fuse ORs CAP_ASYNC_READ into
+// DisabledCapabilities in MountOptions.setDefaults (fuse/server.go:187). That method is unexported and
+// NewServer runs it on a private copy of the options, so the derived mask is not reachable from a test
+// without a mount — and Server.KernelSettings, the one exported window onto INIT, returns the kernel's
+// *request*, not the server's reply, so it does not show it either.
+//
+// The effect assertion therefore lives in kernel_options_live_test.go, which mounts and reads INIT
+// through the debug log. This test covers the remaining half: that the value arrives at the field
+// go-fuse derives the mask from. It is not sufficient on its own, which is exactly why the live test
+// exists — a mount is what tells the kernel, and the kernel is what has to be told.
+func TestSyncReadReachesGoFuse(t *testing.T) {
+	t.Parallel()
+
+	for _, syncRead := range []bool{true, false} {
+		t.Run(map[bool]string{true: "on", false: "off"}[syncRead], func(t *testing.T) {
+			t.Parallel()
+
+			mm := NewMountManager(nil, &MountConfig{
+				MountPoint: t.TempDir(),
+				Options: &MountOptions{
+					FSName:   "objectfs",
+					MaxWrite: 128 * 1024,
+					SyncRead: syncRead,
+				},
+			})
+
+			if got := mm.buildFUSEOptions().SyncRead; got != syncRead {
+				t.Errorf("fuse.MountOptions.SyncRead = %v, want %v", got, syncRead)
+			}
+		})
+	}
+}

--- a/internal/fuse/mount.go
+++ b/internal/fuse/mount.go
@@ -66,11 +66,15 @@ type MountConfig struct {
 // MaxWrite, so the read size is not separately settable. BigWrites named a FUSE capability that has
 // been unconditional since kernel 4.20.
 //
-// The yaml tags are what made the whole set look plumbed, and they were never bound to anything:
-// configuration is decoded into [config.Configuration], whose top-level keys include no FUSE
-// section, so nothing has ever decoded YAML into this type. Removing a tag no user could set breaks
-// no config file. #180 tracks the four that name genuine go-fuse capabilities (direct I/O, the
-// writeback cache, splice, and async read) for plumbing with the tests that would show they work.
+// The yaml tags on this type are still bound to nothing, and that is now deliberate rather than an
+// oversight: the operator-facing names live on [config.FUSEConfig], which is the type a config file
+// decodes into, and this type is reached from it through internal/adapter. Two names for one setting
+// is the drift #180 and #176 were both about, so the tags below are kept only because they predate
+// that discovery and nothing decodes them.
+//
+// Three of the four capabilities #180 nominated for plumbing are the DirectIO, KeepCache, and
+// AsyncRead fields below. The fourth, splice, is not plumbable — see [Config.DirectIO] for why, and
+// [config.FUSEConfig] for the same note in operator-facing terms.
 type MountOptions struct {
 	// Basic options
 	ReadOnly     bool `yaml:"read_only"`
@@ -81,6 +85,27 @@ type MountOptions struct {
 	// MaxWrite is the largest WRITE the kernel may send, and go-fuse derives max_read and MaxPages
 	// from it. It is the one size that is settable.
 	MaxWrite uint32 `yaml:"max_write"`
+
+	// DirectIO and KeepCache are the two open-time flags, carried through to [Config] by
+	// [CreatePlatformMountManager] because [FileNode.Open] is what returns them to the kernel — they
+	// are not mount-time options and are not on go-fuse's [fuse.MountOptions] at all. See
+	// [Config.DirectIO] for the precedence between them.
+	DirectIO  bool `yaml:"direct_io"`
+	KeepCache bool `yaml:"keep_cache"`
+
+	// SyncRead makes the kernel keep at most one READ outstanding against one file.
+	//
+	// Named for go-fuse's field rather than for the AsyncRead the removed struct had, because
+	// AsyncRead is the negation and SyncRead is the thing that exists: go-fuse turns SyncRead into a
+	// disabled CAP_ASYNC_READ at INIT (fuse/server.go:187) and there is no field going the other way.
+	// Keeping the negated name would also have made false the interesting value, so a zero-valued
+	// MountOptions would have serialized every read on the mount. Off is asynchronous reads, which is
+	// both the kernel's default and this one's.
+	//
+	// Turning it on costs read throughput on any sequential reader: kernel readahead is precisely the
+	// mechanism CAP_ASYNC_READ enables. It is here for a backend that cannot serve concurrent reads
+	// of one file. S3 can.
+	SyncRead bool `yaml:"sync_read"`
 
 	// Advanced options
 	Debug        bool          `yaml:"debug"`
@@ -449,6 +474,12 @@ func (m *MountManager) buildFUSEOptions() *fs.Options {
 			Debug:       m.config.Options.Debug,
 			AllowOther:  m.config.Options.AllowOther,
 			MaxWrite:    int(m.config.Options.MaxWrite),
+
+			// go-fuse's own field, and the reason MountOptions.SyncRead is not named AsyncRead. This
+			// is the whole of that setting's plumbing: go-fuse ORs CAP_ASYNC_READ into
+			// DisabledCapabilities at INIT when it is set (fuse/server.go:187), so the capability is
+			// never negotiated with the kernel.
+			SyncRead: m.config.Options.SyncRead,
 		},
 
 		// Attribute caching

--- a/internal/fuse/platform.go
+++ b/internal/fuse/platform.go
@@ -77,6 +77,11 @@ func CreatePlatformMountManager(backend types.Backend, cache types.Cache, writeB
 	if o := config.Options; o != nil {
 		fuseConfig.ReadOnly = o.ReadOnly
 
+		// The two open-time flags. Copied rather than defaulted, because false is the meaningful
+		// "off" for both — see FileSystem.openFlags, which is the one place they are read.
+		fuseConfig.DirectIO = o.DirectIO
+		fuseConfig.KeepCache = o.KeepCache
+
 		// The attribute timeout the nodes report and the one in fs.Options must be the same duration.
 		// buildFUSEOptions passes Options.AttrTimeout to go-fuse as the bridge's default; if Getattr
 		// reported a different one the kernel would cache for a period no configuration named.


### PR DESCRIPTION
Closes #180.

Nine fields on `internal/fuse.MountOptions` and `internal/fuse.Config` carried yaml tags for a whole release and were decoded by nothing, because `config.Configuration` had no `fuse` key at all. Three of them name real go-fuse capabilities and are back, plumbed end to end: `direct_io`, `keep_cache`, `sync_read`.

## What reaches what

| YAML key | plumbing | where it lands |
|---|---|---|
| `fuse.direct_io` | `Configuration.FUSE` → `Adapter.buildMountOptions` → `CreatePlatformMountManager` → `FileSystem.openFlags` | `FOPEN_DIRECT_IO` in every `Open`'s and `Create`'s returned `fuseFlags` |
| `fuse.keep_cache` | same chain | `FOPEN_KEEP_CACHE`, unless `direct_io` is also set — see below |
| `fuse.sync_read` | `Configuration.FUSE` → `buildMountOptions` → `MountManager.buildFUSEOptions` | `fuse.MountOptions.SyncRead`, which go-fuse ORs into `DisabledCapabilities` as `CAP_ASYNC_READ` at INIT |

`direct_io` takes precedence over `keep_cache` rather than the two being OR'd. They are contradictory instructions — one says do not cache this file's data, the other says keep the cache you have across `open(2)` — and the kernel's behavior when handed both is not something to leave to the kernel.

## Why each seam is tested, and how each test was checked

Every one of the nine dead fields was correct at the layer that declared it and died at a boundary no test crossed. So the assertions are on the four boundaries, and each was verified by mutation — the mapping deleted or reverted to v0.10.0's actual code, and the intended test watched to fail with its intended message:

| mutation | result |
|---|---|
| `openFlags()` → the literal `0, 0` that shipped through v0.10.0 | 4 subtests fail |
| the three assignment lines deleted from `Adapter.buildMountOptions` | 3 subtests fail — and **passed** the whole package before this test existed |
| the `platform.go` copy deleted | 2 subtests fail |
| `yaml:"fuse"` → `yaml:"-"` | `TestLoadFromFileReadsTheFUSESection` fails |

The adapter mapping is the one that makes the case for the extraction: `internal/adapter`'s entire suite passed with those lines removed, because the literal lived inside `Start`, between initializing the write path and constructing the mount manager, where nothing short of a live mount could observe it.

The kernel-facing assertions go through `fs.NewNodeFS`, which returns a `RawFileSystem` whose `Lookup`/`Open`/`Create` can be called without a mount. `rawBridge.Open` copies the node's returned `fuseFlags` into `out.OpenFlags` byte for byte, so what the test reads is what the kernel receives.

## `sync_read`, not `async_read`

The issue proposed `async_read`. `AsyncRead` is the negation of the field go-fuse actually has, and a negated key makes `async_read: false` — the value a half-filled config file produces — the one that serializes every read. Naming the field that exists makes the dangerous value the one an operator has to type on purpose.

Consequence worth stating: all three fields default false, false is the kernel's own behavior for each, and `NewDefault` therefore names no `fuse` section at all. The zero value *is* the default, and a second place for a default to live is how the last set drifted. `TestFUSEZeroValueIsTheDefault` pins the property that omission depends on.

## Two of the four are not plumbable

Recorded at the field that would have carried each, rather than dropped in silence:

- **Splice.** go-fuse's `trySplice` type-asserts the `ReadResult` to a seekable or stateful result and bails otherwise. `FileHandle.Read` returns `fuse.ReadResultData` at all four of its return sites, because the bytes come from S3 or from an in-memory cache and there is no fd. `DisableSplice` would disable a path this filesystem never takes — a config key whose effect is provably nothing.
- **The writeback cache.** It maps to `fuse.MountOptions.ExplicitDataCacheControl`, which per go-fuse's own documentation makes the filesystem "fully responsible for invalidating data cache." Grepping `NotifyContent|NotifyEntry|NotifyInval` across the repository returns zero hits. Enabling it would convert bounded staleness into permanent staleness. (There is no `WritebackCache` field on `fuse.MountOptions` at all; `CAP_WRITEBACK_CACHE` appears only in go-fuse's own types and printer.)

## The kernel's half

Whether a second `read(2)` at the same offset reaches the filesystem, and whether cached pages survive `open(2)`, cannot be observed without `/dev/fuse` — absent on `ubuntu-latest` and on a macOS host without macFUSE. Those tests live in `kernel_options_live_test.go` behind a `fuse_mount` build tag, with a `make test-fuse-mount` target. They **fail rather than skip** when the device is missing: a test that skips itself reports success.

CI compiles the tag it cannot run (`go vet -tags=fuse_mount ./internal/fuse/`), because a build tag nothing compiles is exactly how four others in this repo came to carry code that does not build (#240). This is a down-payment on that issue, not a substitute for it.

## Coverage floor

`internal/fuse` goes 59 → 67. Seven of those points are a correction rather than a raise: the package measured **66.2%** on the previous commit while the floor said 59, so the gate had drifted into eight points of slack that would have permitted a real regression silently. The remaining 1.3 points are this change's four seam tests.

## Gates

- `go build ./...`, `go vet ./...`, `go vet -tags=fuse_mount ./internal/fuse/` — clean
- `go test -race -timeout 20m ./...` — 0 failures
- `golangci-lint run --new-from-merge-base=origin/main` — 0 issues
- `./scripts/coverage-gate.sh` — 30 packages at or above floor
- `markdownlint` on `CHANGELOG.md` — no findings in the added range