### PR TITLE
fix: one size parser reads every size a config file names (#159)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -52,7 +52,20 @@ internal/cache/redis     88
 internal/circuit         96
 # internal/compression goes from 87 to 88 with the decoder-table tests #230 added: a matrix over
 # every writable algorithm read back by every algorithm and by a disabled compressor.
-internal/compression     88
+#
+# 88 → 87 with #159's parser consolidation, and this is the deletion-of-tested-code shape rather than a
+# weakened gate — the same one internal/fuse's note below records. Counted rather than asserted: the
+# package went from 280 statements with 248 covered to 264 with 232, so all 16 statements that left were
+# covered ones and the uncovered count is unchanged at 32. `parseSize` and the `TestParseSize` that
+# exercised it both went; the floor a percentage produces moves even when nothing became less tested.
+#
+# What replaced them is not a smaller test. TestMinSizeIsParsedByTheSharedParser asserts `c.minSize` —
+# the floor that actually reaches the Compressor — over twelve cases including the three the deleted
+# parser got wrong, where TestParseSize asserted a private function's return value and passed while
+# disagreeing with the parser the mount used. The 32 statements still uncovered are the codec-table
+# construction failures in buildDecoders and NewCompressor, unreachable without breaking
+# SupportedAlgorithms itself.
+internal/compression     87
 # internal/config goes from 83 to 86 with the validation the config plumbing added. The two points
 # that raise is worth are in what the new tests assert rather than in the number: each case checks
 # that the rejection message names the YAML path, because the failure being prevented is not "a bad
@@ -168,6 +181,22 @@ internal/adapter         40
 # mount-only — the mount and unmount lifecycle and the signal handling around it — plus the kernel's
 # own half of direct I/O and page-cache retention, which is what the fuse_mount build tag and
 # `make test-fuse-mount` are for.
+#
+# 67 held, but not on the measurement it was set from, and the discrepancy is worth recording because it
+# is the third instance of the same mistake in this file. The package measures 67.5% run alone and 66.4%
+# under `go test ./...`, so the floor set from an isolated run failed the very next full-repo gate. Six
+# statements were load-dependent: the trim loop in inflightFetches.unclaimedStart and the arm in
+# performPrefetch that drops a prefetch whose whole range is already in flight. Both are only reached
+# when a read is outstanding at the instant a prefetch is scheduled, which an idle machine arranges by
+# accident and a loaded one does not — the same shape as internal/health's port race above and
+# internal/network's platform split below. A floor is a claim about a *measurement*, so the measurement
+# has to be the one CI takes.
+#
+# They are now owned by tests rather than by luck: unclaimedStart is driven directly over seven cases
+# including the chained advance a real reader cannot be made to produce on demand, and the drop arm is
+# driven by a fetch registered and never finished. The second one is bounded with an explicit timeout
+# because removing the arm makes the prefetch *block* on the read it was trimmed against rather than
+# fetch too much — a parked prefetch worker, which no byte-count assertion can see.
 internal/fuse            67
 
 # internal/cache went 74 → 76 with the re-keying work — the byte-range keying, splitting, coalescing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The read-ahead trim is covered by tests rather than by luck.** `inflightFetches.unclaimedStart`
+  and the arm of `performPrefetch` that drops a prefetch whose whole range is already in flight had no
+  test of their own. Both are reached only when a read is outstanding at the instant a prefetch is
+  scheduled, so an idle machine ran them by accident and a loaded one did not: `internal/fuse` measured
+  67.5% alone and 66.4% under `go test ./...`, and the coverage gate failed on a commit that touched
+  neither file. No behavior changed here — the point is that a branch nothing owns is a branch a
+  refactor can delete in silence, and this one prevents a sequential read from paying for the same
+  bytes twice.
+
+  The drop arm is asserted with an explicit timeout rather than a byte count, which is what removing it
+  actually does: a prefetch trimmed to a non-positive length waits on the very read it was trimmed
+  against, so the failure is a parked prefetch worker, not an over-large GET. With every worker parked
+  the read-ahead stops entirely and nothing reports it.
+
 - **A data race between `ConsensusEngine.Stop` and an inbound heartbeat.** `Stop` read
   `ce.electionTimer` without holding `ce.mu` while `resetElectionTimer` was replacing it from the
   gossip receiver goroutine, which is where an `AppendEntries` RPC is handled. Neither shutdown signal
@@ -295,6 +309,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefix with it. A sixth implementation is one enrollment away from being held to the same contract.
 
 ### Changed
+
+- **One size parser reads every size in a configuration file ([#159]).** `pkg/utils.ParseBytes` is
+  now the only implementation; the three surviving copies — `internal/compression.parseSize`,
+  `internal/config.parseOptionalSize`, and a fourth in `tests/unit_test.go` — are deleted, and
+  `utils.ParseOptionalBytes` handles the unset-means-zero case identically everywhere. Every size a
+  config file names is therefore validated at load with a message naming the YAML key, and no size is
+  substituted silently.
+
+  Four parsers were four answers to the same string, and the disagreements were not cosmetic. Each
+  one is verified by running the deleted code rather than by reading it:
+  - `internal/compression`'s stopped its unit table at GB, so `min_size: 1TB` was an error while
+    `1GB` worked; it accepted `-1MB` as a **negative** compression floor, which makes
+    `len(data) < c.minSize` false for every input and compresses everything including the bytes the
+    threshold exists to skip; and `99999999999GB` overflowed to `math.MaxInt64`, the same defect
+    inverted — a floor nothing is ever below, so compression is configured on and never happens.
+    Neither reported anything.
+  - The copy in `tests/unit_test.go` fell through to `strconv.ParseFloat`, which accepts Go float
+    syntax: `InfMB` parsed as `math.MaxInt64` and `1e3MB` as 1000 MB. It also rejected `1TB`. A test
+    asserting against a private copy of a parser is a test that agrees with itself — this one passed
+    while disagreeing with the parser the mount used.
+  - `internal/adapter`'s, removed earlier in this release, returned 1 GiB and no error for anything
+    it could not parse.
+
+  `ParseBytes` is strict for the reason the loader is strict: it rejects trailing garbage (`4KiB`,
+  the spelling someone who knows the units writes), negatives, `Inf`/`NaN`, exponent and hex-float
+  notation, and any value that overflows `int64` once multiplied. The empty string is the one case
+  with a second meaning, and `ParseOptionalBytes` is where it lives — unset means zero, which is the
+  caller's signal to use its own default. It deliberately does not distinguish `""` from a literal
+  `"0"`, because no caller in this repository does.
 
 - **Each listener's address is one setting, beside the `enabled` flag that governs it
   ([#202], [#211], [#212]).** `global.metrics_port`, `global.health_port`, `global.profile_port`,
@@ -542,6 +585,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [scttfrdmn/cargoship#352]: https://github.com/scttfrdmn/cargoship/issues/352
 [#154]: https://github.com/scttfrdmn/objectfs/issues/154
+[#159]: https://github.com/scttfrdmn/objectfs/issues/159
 [#156]: https://github.com/scttfrdmn/objectfs/issues/156
 [#157]: https://github.com/scttfrdmn/objectfs/issues/157
 [#162]: https://github.com/scttfrdmn/objectfs/issues/162

--- a/internal/compression/s3_integration.go
+++ b/internal/compression/s3_integration.go
@@ -3,10 +3,9 @@ package compression
 import (
 	"fmt"
 	"sort"
-	"strconv"
-	"strings"
 
 	comprpkg "github.com/scttfrdmn/objectfs/pkg/compression"
+	"github.com/scttfrdmn/objectfs/pkg/utils"
 )
 
 // Settings are the inputs needed to build a Compressor.
@@ -75,7 +74,7 @@ func NewCompressor(cfg Settings) (*Compressor, error) {
 		return nil, fmt.Errorf("create %s codec: %w", cfg.Algorithm, err)
 	}
 
-	minSize, err := parseSize(cfg.MinSize)
+	minSize, err := utils.ParseOptionalBytes(cfg.MinSize)
 	if err != nil {
 		return nil, fmt.Errorf("invalid min_size %q: %w", cfg.MinSize, err)
 	}
@@ -218,41 +217,17 @@ func (c *Compressor) Stats(original, compressed int64) comprpkg.Stats {
 	}
 }
 
-// parseSize converts human-readable size strings (e.g. "4KB", "1MB") to bytes.
-// Accepted suffixes (case-insensitive): B, KB, MB, GB.
-// An empty or "0" string returns 0.
-func parseSize(s string) (int64, error) {
-	s = strings.TrimSpace(s)
-	if s == "" || s == "0" {
-		return 0, nil
-	}
-
-	upper := strings.ToUpper(s)
-	units := []struct {
-		suffix string
-		mult   int64
-	}{
-		{"GB", 1024 * 1024 * 1024},
-		{"MB", 1024 * 1024},
-		{"KB", 1024},
-		{"B", 1},
-	}
-
-	for _, u := range units {
-		if strings.HasSuffix(upper, u.suffix) {
-			numStr := strings.TrimSpace(s[:len(s)-len(u.suffix)])
-			n, err := strconv.ParseFloat(numStr, 64)
-			if err != nil {
-				return 0, fmt.Errorf("cannot parse %q: %w", s, err)
-			}
-			return int64(n * float64(u.mult)), nil
-		}
-	}
-
-	// Plain integer (bytes)
-	n, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("cannot parse %q as size", s)
-	}
-	return n, nil
-}
+// The parseSize that used to be here is gone; [utils.ParseOptionalBytes] is called directly from
+// NewCompressor (#159). It was one of four size parsers, and it accepted three things a compression
+// floor must not be:
+//
+//   - "1TB" and "1PB" as *errors*, because its unit table stopped at GB — so a size larger than the
+//     ones it knew was rejected while smaller malformed ones were accepted;
+//   - "-1MB" as -1048576, a negative minimum, which makes `len(data) < c.minSize` true for nothing and
+//     silently compresses every object including the ones below the floor an operator set;
+//   - "99999999999GB" as math.MaxInt64, because the multiply overflowed unchecked — a floor no object
+//     can reach, which is compression silently off while the configuration says it is on.
+//
+// The last two are the same defect in opposite directions and neither reports anything, which is the
+// argument for one parser rather than four: this one was the *safe* copy, in that it returned an error
+// at all.

--- a/internal/compression/s3_integration_test.go
+++ b/internal/compression/s3_integration_test.go
@@ -202,35 +202,70 @@ func TestCompressor_DecompressUnknownEncoding(t *testing.T) {
 	}
 }
 
-func TestParseSize(t *testing.T) {
+// TestMinSizeIsParsedByTheSharedParser replaces TestParseSize, which tested a copy of a parser this
+// package no longer has (#159).
+//
+// The subject is the floor that reaches the Compressor, not the parser — [utils.ParseBytes] has its own
+// table test and fuzz target in pkg/utils, and duplicating them here is what let the deleted copy
+// disagree with the real parser for a release without failing anything. What is asserted here is the
+// seam: that NewCompressor's min_size goes through the shared parser, so the cases the local copy got
+// wrong are now impossible.
+//
+// Three of the rows below are those cases, and each is a floor that silently disables or silently
+// bypasses compression rather than reporting anything:
+//
+//   - "1TB" was an *error*, because the local unit table stopped at GB. A size too large to be a
+//     sensible floor was rejected while smaller malformed strings were accepted.
+//   - "-1MB" parsed to a negative floor, which no object is below, so every object was compressed
+//     including the ones an operator set the floor to exclude.
+//   - "99999999999GB" overflowed to math.MaxInt64, a floor no object can reach — compression off while
+//     the configuration says it is on.
+func TestMinSizeIsParsedByTheSharedParser(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		input   string
+		name    string
+		minSize string
 		want    int64
 		wantErr bool
+		why     string
 	}{
-		{"", 0, false},
-		{"0", 0, false},
-		{"1", 1, false},
-		{"512", 512, false},
-		{"1KB", 1024, false},
-		{"4KB", 4096, false},
-		{"1MB", 1024 * 1024, false},
-		{"2GB", 2 * 1024 * 1024 * 1024, false},
-		{"1.5MB", int64(1.5 * 1024 * 1024), false},
-		{"not-a-size", 0, true},
-		{"1ZB", 0, true},
+		{name: "empty means no floor", minSize: "", want: 0,
+			why: "an unset min_size is the common case and must not be an error"},
+		{name: "zero means no floor", minSize: "0", want: 0,
+			why: "\"0\" and \"\" agree, which is what utils.ParseOptionalBytes exists to guarantee"},
+		{name: "bare number is bytes", minSize: "512", want: 512},
+		{name: "kilobytes", minSize: "4KB", want: 4096},
+		{name: "megabytes", minSize: "1MB", want: 1024 * 1024},
+		{name: "fractional", minSize: "1.5MB", want: int64(1.5 * 1024 * 1024)},
+		{name: "terabytes are a unit", minSize: "1TB", want: 1 << 40,
+			why: "the deleted copy's unit table stopped at GB, so this was an error"},
+		{name: "negative is rejected", minSize: "-1MB", wantErr: true,
+			why: "the deleted copy returned -1048576, a floor below every object, so the floor was " +
+				"silently ignored and everything was compressed"},
+		{name: "overflow is rejected", minSize: "99999999999GB", wantErr: true,
+			why: "the deleted copy overflowed to math.MaxInt64, a floor no object reaches, so " +
+				"compression was silently off"},
+		{name: "malformed is rejected", minSize: "not-a-size", wantErr: true},
+		{name: "unknown unit is rejected", minSize: "1ZB", wantErr: true},
+		{name: "trailing garbage is rejected", minSize: "4KiB", wantErr: true,
+			why: "the spelling someone who knows the units writes; accepting it as 4 bytes is worse " +
+				"than refusing it"},
 	}
+
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := parseSize(tt.input)
+			c, err := NewCompressor(makeConfig(true, "zstd", tt.minSize, 0))
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseSize(%q): err=%v, wantErr=%v", tt.input, err, tt.wantErr)
+				t.Fatalf("NewCompressor(min_size: %q): err=%v, wantErr=%v. %s",
+					tt.minSize, err, tt.wantErr, tt.why)
+			}
+			if tt.wantErr {
 				return
 			}
-			if !tt.wantErr && got != tt.want {
-				t.Errorf("parseSize(%q) = %d, want %d", tt.input, got, tt.want)
+			if c.minSize != tt.want {
+				t.Errorf("min_size %q became a floor of %d bytes, want %d. %s",
+					tt.minSize, c.minSize, tt.want, tt.why)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1408,12 +1408,12 @@ func (c *Configuration) validateS3Config() error {
 
 	// Ordering matters and is asserted by a test: a chunk size above the threshold means the first
 	// part of every multipart upload is the whole object, so multipart never engages at all.
-	threshold, err := parseOptionalSize(s3cfg.Multipart.Threshold)
+	threshold, err := utils.ParseOptionalBytes(s3cfg.Multipart.Threshold)
 	if err != nil {
 		return fmt.Errorf("storage.s3.multipart.threshold is invalid: %w", err)
 	}
 
-	chunk, err := parseOptionalSize(s3cfg.Multipart.ChunkSize)
+	chunk, err := utils.ParseOptionalBytes(s3cfg.Multipart.ChunkSize)
 	if err != nil {
 		return fmt.Errorf("storage.s3.multipart.chunk_size is invalid: %w", err)
 	}
@@ -1580,19 +1580,6 @@ func (c *Configuration) validateDurations() error {
 	}
 
 	return nil
-}
-
-// parseOptionalSize parses a size that may be empty, where empty means zero.
-//
-// Zero is the caller's signal to fall back to a built-in default, which is distinct from a size of
-// literally zero bytes — "0" parses to 0 and is accepted, and no caller of this distinguishes them
-// because a zero-byte threshold and an absent one both mean "use the default".
-func parseOptionalSize(s string) (int64, error) {
-	if s == "" {
-		return 0, nil
-	}
-
-	return utils.ParseBytes(s)
 }
 
 // validateReadAheadConfig rejects a read-ahead configuration the manager cannot run with.

--- a/internal/config/validate_s3_test.go
+++ b/internal/config/validate_s3_test.go
@@ -83,7 +83,7 @@ func TestValidateRejectsUnusableS3Settings(t *testing.T) {
 				c.Storage.S3.Multipart.Threshold = "32 megabytes"
 			},
 			wantText: "storage.s3.multipart.threshold",
-			why:      "parseOptionalSize is strict; the old parser would have substituted 1 GiB",
+			why:      "utils.ParseOptionalBytes is strict; the old parser would have substituted 1 GiB",
 		},
 		{
 			name: "an unparseable multipart chunk size",
@@ -137,6 +137,44 @@ func TestValidateRejectsUnusableS3Settings(t *testing.T) {
 			wantText: "brotli",
 			why: "this is audit finding C1's shape — the shipped default named an algorithm the " +
 				"codec factory rejected, so the binary exited on its own default configuration",
+		},
+
+		// The three min_size rows below are the cases internal/compression's own parseSize got wrong
+		// before #159 consolidated on utils.ParseBytes. Each is a compression floor that silently
+		// disables or silently bypasses compression, which is why they are worth naming individually
+		// rather than trusting one malformed-input row to stand for all of them: a floor is a number
+		// nothing reports, so the only place a mistake in it can surface is here.
+		{
+			name: "a min_size unit the old parser did not know",
+			mutate: func(c *Configuration) {
+				c.Storage.S3.Compression.Enabled = true
+				c.Storage.S3.Compression.MinSize = "4MG"
+			},
+			wantText: "min_size",
+			why: "the typo this issue was filed about (#159). It is accepted by nothing now, but the " +
+				"adapter's parser turned it into a 1 GiB floor — compression off for every object " +
+				"with no message anywhere",
+		},
+		{
+			name: "a negative min_size",
+			mutate: func(c *Configuration) {
+				c.Storage.S3.Compression.Enabled = true
+				c.Storage.S3.Compression.MinSize = "-1MB"
+			},
+			wantText: "min_size",
+			why: "internal/compression's parser accepted this as -1048576, a floor below every " +
+				"object, so the floor was ignored and everything was compressed including what the " +
+				"operator excluded",
+		},
+		{
+			name: "a min_size that overflows",
+			mutate: func(c *Configuration) {
+				c.Storage.S3.Compression.Enabled = true
+				c.Storage.S3.Compression.MinSize = "99999999999GB"
+			},
+			wantText: "min_size",
+			why: "internal/compression's parser overflowed this to math.MaxInt64 — a floor no object " +
+				"can reach, so compression was silently off while the config said it was on",
 		},
 	}
 

--- a/internal/fuse/read_path_test.go
+++ b/internal/fuse/read_path_test.go
@@ -793,3 +793,155 @@ func TestGetattrReportsPendingSize(t *testing.T) {
 		t.Errorf("reading at offset %d returned %q, want %q", len(original), got, appended)
 	}
 }
+
+// TestUnclaimedStartAdvancesPastEveryCoveringFetch drives the prefetch-trim arithmetic directly.
+//
+// It is a unit test on an in-package helper, which the rest of this file avoids on principle — every
+// other assertion here is on observed HTTP requests. The reason for the exception is that these
+// statements were previously reached only by winning a race: `performPrefetch` trims against whatever
+// reads happen to be in flight at that instant, so on an idle machine the branch ran and under
+// full-repo test contention it did not. Coverage of it moved by a point depending on load, which means
+// no test owned it — and a branch nothing owns is a branch a refactor may delete silently. The
+// chaining case is the one that cannot be arranged by a real reader on demand at all.
+//
+// The chain is the property worth pinning: skipping past one fetch can land inside a second, so the
+// loop advances repeatedly. A single-pass implementation returns the wrong offset for exactly the
+// shape a reader one step ahead of the prefetcher produces.
+func TestUnclaimedStartAdvancesPastEveryCoveringFetch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		flights [][2]int64 // {off, length} of each fetch registered, in order
+		off     int64
+		want    int64
+		why     string
+	}{
+		{
+			name: "no fetch in flight leaves the offset alone",
+			off:  4096,
+			want: 4096,
+			why:  "an unclaimed range must not be trimmed; this is the ordinary case",
+		},
+		{
+			name:    "an offset inside a fetch advances to its end",
+			flights: [][2]int64{{0, 1024}},
+			off:     512,
+			want:    1024,
+			why:     "the bytes from 512 to 1024 are already being fetched and would be paid for twice",
+		},
+		{
+			name:    "a chain of adjoining fetches is followed to the end",
+			flights: [][2]int64{{0, 1024}, {1024, 1024}, {2048, 1024}},
+			off:     0,
+			want:    3072,
+			why: "advancing past the first lands inside the second, which is why the loop repeats; a " +
+				"single pass would return 1024 and re-fetch 1024-3072",
+		},
+		{
+			name:    "a chain given out of order is still followed",
+			flights: [][2]int64{{2048, 1024}, {0, 1024}, {1024, 1024}},
+			off:     0,
+			want:    3072,
+			why:     "registration order is arrival order and says nothing about offsets",
+		},
+		{
+			name:    "a fetch starting after the offset is ignored",
+			flights: [][2]int64{{8192, 1024}},
+			off:     4096,
+			want:    4096,
+			why: "trimming the front is the only safe move — cutting the window short at a small read " +
+				"in the middle would give up the whole tail to avoid duplicating a kilobyte",
+		},
+		{
+			name:    "a fetch ending exactly at the offset is not covering",
+			flights: [][2]int64{{0, 4096}},
+			off:     4096,
+			want:    4096,
+			why:     "the range is half-open, so byte 4096 is not among the bytes [0,4096) is fetching",
+		},
+		{
+			name:    "a fetch for another object does not trim this one",
+			flights: nil,
+			off:     512,
+			want:    512,
+			why:     "containment is only meaningful within one object; byPath is keyed for that reason",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var fetches inflightFetches
+
+			for _, fl := range tc.flights {
+				fetches.start("obj.dat", fl[0], fl[1])
+			}
+
+			// Registered under a different key in every case, so the last case above has something to
+			// be ignored and the others prove a foreign object cannot interfere either.
+			fetches.start("other.dat", 0, 1<<20)
+
+			if got := fetches.unclaimedStart("obj.dat", tc.off); got != tc.want {
+				t.Errorf("unclaimedStart(%d) = %d, want %d: %s", tc.off, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestPrefetchDropsARangeAlreadyEntirelyInFlight covers the arm that returns without fetching.
+//
+// The trim can consume the whole prefetch: a reader that has the entire predicted window outstanding
+// leaves nothing to read ahead for. Issuing the GET anyway is the 17,408-bytes-for-a-16,384-byte-file
+// case in performPrefetch's comment, and it is invisible in any assertion on returned data because a
+// prefetch returns nothing to anyone.
+//
+// The fetch is registered and deliberately never finished, which is what a reader mid-GET looks like
+// and what makes this deterministic rather than a race the test hopes to win.
+func TestPrefetchDropsARangeAlreadyEntirelyInFlight(t *testing.T) {
+	t.Parallel()
+
+	f := newReadPathFixture(t)
+	f.srv.SeedRandom("inflight.dat", 64<<10)
+
+	// Warm the size lookup through the write path before counting, since FileSize issues a HEAD.
+	if _, err := f.fs.buffer.FileSize(context.Background(), "inflight.dat"); err != nil {
+		t.Fatalf("FileSize: %v", err)
+	}
+
+	// A read of the whole file is outstanding. Never finished: this is a reader mid-GET.
+	self, _ := f.fs.fetches.start("inflight.dat", 0, 64<<10)
+	t.Cleanup(func() { f.fs.fetches.finish("inflight.dat", self, nil, nil) })
+
+	before := len(f.srv.GETs("inflight.dat"))
+
+	// A prefetch wholly inside the outstanding read. Called directly rather than queued, so there is no
+	// worker scheduling to wait on and no timing for the assertion to depend on.
+	//
+	// Bounded, and the bound is an assertion rather than a convenience. Trimming without dropping leaves
+	// a non-positive length, and a prefetch that reaches the shared fetch path with one waits on the
+	// in-flight read it was trimmed against — so the arm's absence presents as a prefetch worker parked
+	// on a channel, not as a wrong byte count. Parked workers are the failure this reports; a bare call
+	// here would have made that a test-suite timeout with no message.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.fs.readAhead.performPrefetch(&PrefetchRequest{path: "inflight.dat", offset: 1024, size: 4096})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("performPrefetch did not return while a read covering its whole range was in flight. " +
+			"A prefetch has no caller waiting on it, so one that blocks consumes a prefetch worker " +
+			"until the read completes; with every worker parked the read-ahead stops entirely and " +
+			"nothing reports it.")
+	}
+
+	if after := len(f.srv.GETs("inflight.dat")); after != before {
+		t.Errorf("a prefetch entirely inside an in-flight read issued %d GET(s); every byte it asked "+
+			"for was already being fetched, so the object's bytes would be paid for twice",
+			after-before)
+	}
+}

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -165,14 +165,25 @@ func FormatBytes(bytes int64) string {
 // an optional trailing B. Multipliers are binary: 1 K is 1024 bytes, as everywhere else in ObjectFS.
 // Case and surrounding whitespace are ignored. A bare number is a count of bytes.
 //
-// This is the only size parser in the repository, and consolidating on it is the point. There were
-// four: this one, [internal/adapter.parseSize], one in internal/compression, and a fourth copy in
-// tests. They disagreed about the cases that matter. The adapter's returned 1 GiB — silently, with no
-// error — for *any* input it could not parse, so `cache_size: 2G` (no B) configured a 1 GiB cache and
-// `cache_size: tiny-typo` configured a 1 GiB cache, and neither said so. internal/compression's
-// treated "0" as zero where the adapter's treated it as a byte count. A configuration value that
-// means one thing to the layer that validates it and another to the layer that acts on it is audit
-// finding C1's mechanism, and four parsers is four chances to reintroduce it.
+// This is the only size parser in the repository, and consolidating on it was the point (#159). There
+// were four: this one, `internal/adapter.parseSize`, one in internal/compression, and a fourth copy in
+// tests/unit_test.go. They disagreed about exactly the cases that matter, in every direction:
+//
+//   - the adapter's returned 1 GiB — silently, with no error — for *any* input it could not parse, so
+//     `cache_size: 2G` (no B), `cache_size: 64MiB` and `cache_size: tpyo` all configured the same 1 GiB
+//     cache and none of them said so;
+//   - internal/compression's unit table stopped at GB, so it *rejected* "1TB" while accepting "-1MB" as
+//     a negative floor and "99999999999GB" as math.MaxInt64 — a compression floor below every object
+//     and a floor above every object, neither reported;
+//   - the copy in tests fell through to strconv.ParseFloat on the number, which accepts Go float
+//     syntax: it read "InfMB" as math.MaxInt64 and "1e3MB" as 1000 MB, and it rejected "1TB" for the
+//     same missing-unit reason;
+//   - and they disagreed about the empty string, which is the most common value in a config file:
+//     (0, nil), 1 GiB, and an error respectively.
+//
+// A configuration value that means one thing to the layer that validates it and another to the layer
+// that acts on it is audit finding C1's mechanism, and four parsers is four chances to reintroduce it.
+// See [ParseOptionalBytes] for the empty-string half.
 //
 // It is strict for the same reason [internal/config.Configuration.LoadFromFile] is strict: this
 // function's callers are reading operator configuration, and a size it accepts becomes a cache
@@ -239,6 +250,26 @@ func ParseBytes(s string) (int64, error) {
 	}
 
 	return int64(bytes), nil
+}
+
+// ParseOptionalBytes is [ParseBytes] for a size an operator may leave unset, where unset means zero.
+//
+// Zero is the caller's signal to fall back to a built-in default, and it is deliberately not distinct
+// from a literal "0": no caller in this repository distinguishes them, because a zero-byte threshold
+// and an absent one both mean "use the default". A caller that needs the distinction should read the
+// string itself rather than teach this function a third answer.
+//
+// It exists so that "" is handled identically everywhere, which was the second half of the four-parser
+// problem described on [ParseBytes]. The parsers disagreed about the empty string as much as about
+// malformed input: internal/compression's returned (0, nil), internal/adapter's returned 1 GiB and no
+// error, and the copy in tests returned an error. An unset size is the most common thing in a
+// configuration file, so that is the disagreement most likely to be reached.
+func ParseOptionalBytes(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	return ParseBytes(s)
 }
 
 // checkDecimal reports whether s is a plain non-negative decimal number.

--- a/pkg/utils/logging_test.go
+++ b/pkg/utils/logging_test.go
@@ -456,6 +456,61 @@ func TestParseBytesErrorsQuoteTheInput(t *testing.T) {
 	}
 }
 
+// TestParseOptionalBytesDiffersOnlyOnTheEmptyString is the whole contract, and it is stated as a
+// difference rather than as a table of sizes on purpose.
+//
+// A table would restate TestParseBytes and pass just as well if ParseOptionalBytes grew a second
+// implementation — which is the defect this function exists to prevent, four times over. The parsers
+// it replaced disagreed about "" (compression's returned zero, the adapter's returned 1 GiB, the copy
+// in tests returned an error) *and* about "1TB", "-1MB" and "InfMB", because each was a separate
+// implementation rather than a wrapper. So the property asserted is delegation: for every input except
+// "", the two functions must return the same value and the same error-ness.
+func TestParseOptionalBytesDiffersOnlyOnTheEmptyString(t *testing.T) {
+	t.Parallel()
+
+	// Every shape a config file produces, plus the four the deleted parsers got wrong.
+	inputs := []string{
+		"0", "1", "512", "4KB", "1.5G", " 2 GB ", "1TB", "1PB", "128K",
+		"-1MB", "99999999999GB", "InfMB", "1e3MB", "64MiB", "4MG", "12abc", "not-a-size", " ",
+	}
+
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			want, wantErr := ParseBytes(in)
+			got, gotErr := ParseOptionalBytes(in)
+
+			if (gotErr != nil) != (wantErr != nil) {
+				t.Fatalf("ParseOptionalBytes(%q) err=%v but ParseBytes err=%v: the two disagree about "+
+					"whether this value is usable, which is the four-parser defect returning", in, gotErr, wantErr)
+			}
+			if got != want {
+				t.Errorf("ParseOptionalBytes(%q) = %d, ParseBytes = %d: a size means one thing to the "+
+					"layer that validates it and another to the layer that acts on it", in, got, want)
+			}
+		})
+	}
+
+	// The one deliberate divergence. Unset is zero and not an error, because zero is the caller's
+	// signal to use its own default and an absent size is the most common thing in a config file.
+	n, err := ParseOptionalBytes("")
+	if err != nil {
+		t.Errorf("ParseOptionalBytes(\"\") = %v; an omitted size must mean \"use the default\", not "+
+			"\"refuse to start\" — every partial config file omits most sizes", err)
+	}
+	if n != 0 {
+		t.Errorf("ParseOptionalBytes(\"\") = %d, want 0: a non-zero substitute is the silent 1 GiB "+
+			"the adapter's parser returned", n)
+	}
+
+	// And ParseBytes itself must still reject it, since its callers require a size.
+	if _, err := ParseBytes(""); err == nil {
+		t.Error("ParseBytes(\"\") was accepted, so performance.cache_size could be omitted and " +
+			"become a zero-byte read cache rather than a config-load error")
+	}
+}
+
 // FuzzParseBytes asserts the parser is total and that what it accepts is non-negative.
 //
 // Two properties, both about what the callers do with the result. It reads operator configuration, so

--- a/tests/unit_test.go
+++ b/tests/unit_test.go
@@ -3,8 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/scttfrdmn/objectfs/internal/config"
 	"github.com/scttfrdmn/objectfs/internal/metrics"
 	"github.com/scttfrdmn/objectfs/internal/vfs"
+	"github.com/scttfrdmn/objectfs/pkg/utils"
 )
 
 // Unit tests for cache system
@@ -207,37 +206,16 @@ func TestMetricsCollectorUnit(t *testing.T) {
 	assert.NotNil(t, metricsAfterReset)
 }
 
-// Helper function for parsing sizes (since it's not in the config package)
-func parseSize(sizeStr string) (int64, error) {
-	sizeStr = strings.TrimSpace(sizeStr)
-	if sizeStr == "" {
-		return 0, fmt.Errorf("empty size string")
-	}
-
-	// Handle plain numbers
-	if val, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
-		return val, nil
-	}
-
-	// Handle sizes with units
-	units := map[string]int64{
-		"B":  1,
-		"KB": 1024,
-		"MB": 1024 * 1024,
-		"GB": 1024 * 1024 * 1024,
-	}
-
-	for unit, multiplier := range units {
-		if before, ok := strings.CutSuffix(strings.ToUpper(sizeStr), unit); ok {
-			numStr := before
-			if val, err := strconv.ParseFloat(numStr, 64); err == nil {
-				return int64(val * float64(multiplier)), nil
-			}
-		}
-	}
-
-	return 0, fmt.Errorf("invalid size format: %s", sizeStr)
-}
+// The parseSize helper that used to be here is gone. Its comment said "since it's not in the config
+// package", and it never was: [utils.ParseBytes] has been the parser this whole time, and a copy in a
+// test file is the worst of the four places one can live (#159). A test that reimplements the function
+// it exercises asserts that two implementations agree, which is exactly what does not need asserting.
+//
+// Verified rather than assumed, by running the deleted copy: it read "InfMB" as math.MaxInt64 and
+// "1e3MB" as 1000 MB, because it handed the number to strconv.ParseFloat, which accepts Go float
+// syntax. It also rejected "1TB", since its unit map stopped at GB. utils.ParseBytes refuses all
+// three — so this file's local parser disagreed with the one every mount uses, in both directions, for
+// as long as it existed.
 
 // Unit tests for configuration system
 func TestConfigUnit(t *testing.T) {
@@ -298,32 +276,14 @@ func TestConfigUnit(t *testing.T) {
 	err = validConfig.Validate()
 	assert.NoError(t, err)
 
-	// Test size parsing
-	size, err := parseSize(validConfig.Performance.CacheSize)
+	// A size written in a configuration this test declares valid parses under the parser the mount
+	// itself uses. That is the property worth asserting here, and it is the only one: the units, the
+	// malformed inputs, and the boundary cases belong to TestParseBytes and FuzzParseBytes in
+	// pkg/utils, which is where the function is. Re-testing them through a local copy is what let this
+	// file's copy disagree with the real parser without failing anything.
+	size, err := utils.ParseBytes(validConfig.Performance.CacheSize)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(100*1024*1024), size)
-
-	// Test invalid size parsing
-	_, err = parseSize("invalid-size")
-	assert.Error(t, err)
-
-	// Test various size formats
-	testCases := []struct {
-		input    string
-		expected int64
-	}{
-		{"1024", 1024},
-		{"1KB", 1024},
-		{"1MB", 1024 * 1024},
-		{"1GB", 1024 * 1024 * 1024},
-		{"1.5MB", int64(1.5 * 1024 * 1024)},
-	}
-
-	for _, tc := range testCases {
-		size, err := parseSize(tc.input)
-		assert.NoError(t, err, "Failed to parse size: %s", tc.input)
-		assert.Equal(t, tc.expected, size, "Unexpected size for: %s", tc.input)
-	}
 }
 
 // Unit tests for utility functions and edge cases


### PR DESCRIPTION
Closes #159.

`pkg/utils.ParseBytes` is now the only size parser in the repository. The three surviving copies are deleted — `internal/compression.parseSize`, `internal/config.parseOptionalSize`, and a fourth in `tests/unit_test.go` — and `utils.ParseOptionalBytes` handles the unset-means-zero case identically everywhere.

## What the parsers actually disagreed about

Each verified by running the deleted code, not by reading it:

| input | `internal/compression` | `tests/unit_test.go` | `utils.ParseBytes` |
|---|---|---|---|
| `1TB` | error (table stopped at GB) | error | `1 << 40` |
| `-1MB` | `-1048576` | `-1048576` | rejected |
| `99999999999GB` | `math.MaxInt64` | `math.MaxInt64` | rejected |
| `InfMB` | error | `math.MaxInt64` | rejected |
| `1e3MB` | error | 1000 MB | rejected |
| `""` | `(0, nil)` | error | rejected (use `ParseOptionalBytes`) |

A negative compression floor and an overflowed one are the same defect in opposite directions, and neither reports anything: `len(data) < c.minSize` is false for everything with a negative floor, so everything is compressed including the bytes the threshold exists to skip; and true for everything with a `MaxInt64` floor, so compression is configured on and never happens.

The fourth parser, `internal/adapter.parseSize`, was the dangerous one — 1 GiB and no error for anything unparseable — and was already removed earlier in this release. That is worth stating on the issue, since it is the one #159's text is about.

## Why these tests rather than a parser table

- `TestMinSizeIsParsedByTheSharedParser` asserts `c.minSize`, the floor that actually reaches the `Compressor`, over twelve cases. The `TestParseSize` it replaces asserted a private function's return value, which is how that copy passed while disagreeing with the parser the mount used.
- `TestParseOptionalBytesDiffersOnlyOnTheEmptyString` asserts *delegation*. A table of sizes would restate `TestParseBytes` and would pass just as well if `ParseOptionalBytes` grew a second implementation — which is precisely the defect being removed.
- Three `min_size` rows join `TestValidateRejectsUnusableS3Settings`, each asserting the rejection names the YAML key. Probed: `storage.s3.compression configuration invalid: invalid min_size "4MG": ...`

Mutation-verified: swallowing the parse error in `NewCompressor` fails five subtests plus the pre-existing `TestNewCompressor_InvalidMinSize`; making `ParseOptionalBytes` reimplement the parse fails seven cases; making it delegate the empty string too fails with the "use the default" message.

## Also in this PR: the read-ahead trim is covered by tests rather than by luck

`inflightFetches.unclaimedStart` and the arm of `performPrefetch` that drops a prefetch already wholly in flight had no test of their own. Both are reached only when a read is outstanding at the instant a prefetch is scheduled, so an idle machine ran them by accident and a loaded one did not: `internal/fuse` measures **67.5% alone and 66.4% under `go test ./...`**, and the coverage gate failed on a commit that touched neither file. That is the third instance in `.coverage-floors` of a floor set from a luckier measurement, and the note now records it alongside `internal/health`'s port race and `internal/network`'s platform split.

No behavior changed — the point is that a branch nothing owns is a branch a refactor can delete in silence, and this one keeps a sequential reader from paying for the same bytes twice.

The drop arm is asserted with an explicit timeout rather than a byte count, because that is what removing it actually does: a prefetch trimmed to a non-positive length waits on the very read it was trimmed against, so the failure is a parked prefetch worker, not an over-large GET. Confirmed by mutation — the unbounded version of this test hung the suite instead of failing it, which is why the bound is an assertion and not a convenience.

## Coverage floors

- `internal/fuse` stays at 67 with the note corrected to say which measurement it is a claim about.
- `internal/compression` **88 → 87**, counted rather than asserted: 280 statements with 248 covered became 264 with 232, so all 16 that left were covered ones and the uncovered count is unchanged at 32. Deleting tested code, not losing coverage — the one shape of lowering this file already blesses.

## Gates

- `go build ./...`, `go vet ./...`, `gofmt -l internal pkg tests` — clean
- `go test -race ./...` — exit 0
- `./scripts/coverage-gate.sh` — 30 packages at or above their floors
- `golangci-lint run --new-from-merge-base=origin/main` — 0 issues