### PR TITLE
feat: authenticate gossip messages, and refuse to start without a secret (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Gossip messages are authenticated, and a cluster will not start without a shared secret**
+  ([#206]). The gossip protocol runs over UDP and verified nothing about who sent a datagram, so any
+  host that could reach the port could add itself to the cluster, announce that a node was dead, or
+  announce that it held the current copy of a cached object — which is a path to a reading process
+  being served bytes chosen by whoever sent the last announcement. Every message now carries an
+  HMAC-SHA256 over its exact bytes, checked before the payload is parsed, so an unauthenticated
+  datagram never reaches the decoding of any message type, let alone a handler.
+
+  The secret comes from `OBJECTFS_CLUSTER_SECRET` or from a file named by `SecretFile`, and never
+  from a YAML field: packaging installs the shipped configuration world-readable, so a secret there
+  would be published to every user on the node. A secret file readable by anyone but its owner is
+  refused, as is one shorter than 32 bytes, and both errors say how to generate a good one. If no
+  secret is configured at all, `NewClusterManager` returns an error naming both sources rather than
+  starting unauthenticated — running without authentication is the failure nobody notices, so it is
+  refused at construction. That fail-closed behavior broke five existing tests when it landed, which
+  is the evidence that it cannot be bypassed.
+
+  A MAC authenticates the sender but not the moment, so messages also carry a timestamp and ID
+  checked against a 30-second window with a nonce cache: a captured "node N owns key K" cannot be
+  replayed later to undo the state that replaced it. Freshness is checked *after* the MAC, because a
+  nonce cache writable by an unauthenticated sender could be flooded with random IDs to evict the
+  real entries and re-open the window. Rejections are counted separately for a bad MAC, a replay,
+  and an unknown envelope version, and each logs a different operator hint — a cluster of one with a
+  rising unauthenticated count is a wrong secret, while the same cluster with a rising wrong-version
+  count is a half-finished upgrade. What this does not do is stated in the package documentation:
+  payloads are not encrypted, and because every member holds the same key, a compromised node can
+  impersonate any other.
+
+[#206]: https://github.com/scttfrdmn/objectfs/issues/206
+
 ### Fixed
 
 - `MountManager.Wait` and the FUSE serving goroutine read `m.server` without holding the mutex that

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -325,6 +325,15 @@ features:
 # whole mount; everything else under cluster: is read only by the experimental coordinator.
 # A Redis that cannot be reached at startup fails the mount rather than falling back, so two
 # nodes cannot both come up believing they share a cache when they do not.
+#
+# There is no secret_file key here, and its absence is deliberate rather than an omission. Gossip
+# messages are authenticated with a shared cluster secret and a cluster refuses to start without one
+# (#206), but the secret is configured on internal/distributed.ClusterConfig — a type disjoint from
+# this one (#139) — or through OBJECTFS_CLUSTER_SECRET. It is never a key in this file: packaging
+# installs this configuration world-readable, so a secret written here would be readable by every
+# user on the node. Generate one with `openssl rand -hex 32 > /etc/objectfs/cluster.secret` and
+# `chmod 600` it. Adding the key here before anything reads it would be a setting that silently
+# does nothing, which is the class of defect this file has been cleaned of.
 cluster:
   enabled: false
   node_id: ""                         # empty = derived at startup

--- a/internal/distributed/auth.go
+++ b/internal/distributed/auth.go
@@ -143,7 +143,11 @@ func LoadClusterSecret(secretFile string) ([]byte, error) {
 			ErrSecretPermissions, secretFile, perm, secretFile)
 	}
 
-	raw, err := os.ReadFile(secretFile) //nolint:gosec // the path is operator-supplied configuration
+	// Both directives, deliberately: golangci-lint's gosec honors only //nolint, and the standalone
+	// gosec whose SARIF feeds GitHub code scanning honors only #nosec. One without the other passes
+	// the lint job and fails the security check.
+	//nolint:gosec // the path is operator-supplied configuration, which is the point
+	raw, err := os.ReadFile(secretFile) // #nosec G304 -- operator-supplied path; reading the file it names is the function
 	if err != nil {
 		return nil, fmt.Errorf("reading cluster secret file %s: %w", secretFile, err)
 	}

--- a/internal/distributed/auth.go
+++ b/internal/distributed/auth.go
@@ -1,0 +1,309 @@
+package distributed
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Message authentication for the gossip protocol (#206).
+//
+// Every gossip datagram is wrapped in an authEnvelope carrying an HMAC-SHA256 over the exact bytes
+// of the inner message. A receiver that cannot verify the MAC drops the datagram before it is
+// parsed, so an unauthenticated peer cannot join the cluster, cannot announce cache ownership, and
+// cannot be the source of bytes that a reading process sees as file content.
+//
+// Why HMAC with a shared cluster secret rather than TLS or mTLS: the deployment model is a single
+// tenant on a trusted HPC network, and the cost of distributing and rotating per-node certificates
+// across compute nodes is what would make the feature never get switched on. A secret distributed
+// the same way the rest of the node configuration is distributed is proportionate to the threat —
+// a host on the cluster network that is not supposed to be in the cluster — and it is one that an
+// operator can actually deploy.
+//
+// What this does not do: it does not provide confidentiality (gossip payloads are membership
+// metadata and cache keys, sent in the clear), and it does not distinguish one cluster member from
+// another, because every member holds the same key. A compromised node can impersonate any other
+// node. Defending against that needs per-node keys and is a different threat model; it is not
+// pretended here.
+
+const (
+	// authVersion is the envelope version. It exists so that a future change to the MAC
+	// construction can be rejected explicitly rather than as a verification failure, which would
+	// otherwise be indistinguishable from a wrong secret.
+	authVersion = 1
+
+	// minSecretLen is the shortest cluster secret accepted, in bytes.
+	//
+	// HMAC-SHA256's security does not improve past a block-length key, but a short secret is
+	// almost always a human-chosen one, and the gossip port is reachable by anything on the
+	// network. 32 bytes is what `openssl rand -hex 32` produces and what the documentation
+	// tells operators to run.
+	minSecretLen = 32
+
+	// replayWindow bounds how far a message's timestamp may be from the receiver's clock.
+	//
+	// It does two jobs: it rejects a captured datagram replayed later, and it bounds the size of
+	// the nonce cache, which only has to remember one window's worth of message IDs. 30s is wide
+	// enough for the NTP skew of a normal cluster and narrow enough that the cache stays small at
+	// the default gossip interval.
+	replayWindow = 30 * time.Second
+)
+
+// Errors from secret loading and message verification. These are distinguished because they send an
+// operator to different places: a missing secret is a deployment step that was not done, a bad MAC
+// is a wrong secret or an intruder, and a replay is neither.
+var (
+	// ErrNoClusterSecret means clustering is enabled and no secret was found. Fail closed: a
+	// cluster that silently runs unauthenticated is the defect this exists to prevent.
+	ErrNoClusterSecret = errors.New("no cluster secret configured")
+
+	// ErrSecretTooShort means a secret was found but is too short to be a generated one.
+	ErrSecretTooShort = errors.New("cluster secret too short")
+
+	// ErrSecretPermissions means the secret file is readable by users other than its owner.
+	ErrSecretPermissions = errors.New("cluster secret file is readable by other users")
+
+	// ErrUnauthenticated means the MAC did not verify. The message is dropped unparsed.
+	ErrUnauthenticated = errors.New("gossip message failed authentication")
+
+	// ErrReplayed means the MAC verified but the message is a duplicate or outside the freshness
+	// window. Distinct from ErrUnauthenticated because it is not evidence of a wrong secret.
+	ErrReplayed = errors.New("gossip message replayed or outside the freshness window")
+
+	// ErrUnknownAuthVersion means the envelope version is not one this build understands, which is
+	// a version skew during a rolling upgrade rather than an authentication failure.
+	ErrUnknownAuthVersion = errors.New("unknown gossip envelope version")
+)
+
+// ClusterSecretEnv is the environment variable read for the cluster secret.
+//
+// Environment and file are the only two sources. A YAML field is deliberately not one: the shipped
+// example configuration is installed to /etc/objectfs/config.yaml by the packaging scripts and is
+// world-readable, so a secret field there would be a secret published to every user on the node.
+const ClusterSecretEnv = "OBJECTFS_CLUSTER_SECRET"
+
+// authEnvelope wraps a gossip message with its MAC.
+//
+// Payload is json.RawMessage rather than a decoded GossipMessage so that the MAC is computed and
+// verified over the exact bytes that crossed the network. Re-marshaling to verify would make the
+// check depend on Go's map ordering and number formatting agreeing byte-for-byte with the sender's
+// — true today between identical builds, and a silent cluster-wide authentication failure the first
+// time it is not.
+type authEnvelope struct {
+	Version int             `json:"v"`
+	MAC     string          `json:"mac"`
+	Payload json.RawMessage `json:"msg"`
+}
+
+// LoadClusterSecret reads the cluster secret from the environment or from a file.
+//
+// The environment takes precedence, because that is what a container orchestrator injects and it
+// avoids a file that has to be mounted. secretFile may be empty, in which case only the environment
+// is consulted.
+//
+// Returned errors name which source was tried and what was wrong with it. "no cluster secret
+// configured" naming both candidates is the difference between an operator finding the missing step
+// and an operator reading "failed to start cluster".
+func LoadClusterSecret(secretFile string) ([]byte, error) {
+	if env := os.Getenv(ClusterSecretEnv); env != "" {
+		secret := []byte(strings.TrimSpace(env))
+		if len(secret) < minSecretLen {
+			return nil, fmt.Errorf("%w: %s holds %d bytes, need at least %d "+
+				"(generate one with: openssl rand -hex 32)",
+				ErrSecretTooShort, ClusterSecretEnv, len(secret), minSecretLen)
+		}
+
+		return secret, nil
+	}
+
+	if secretFile == "" {
+		return nil, fmt.Errorf("%w: set %s or cluster.secret_file. Clustering will not start "+
+			"without one, because an unauthenticated gossip port lets any host on the network "+
+			"join the cluster and announce ownership of cached objects",
+			ErrNoClusterSecret, ClusterSecretEnv)
+	}
+
+	info, err := os.Stat(secretFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading cluster secret file %s: %w", secretFile, err)
+	}
+
+	// A secret readable by every user on the node is not a secret. This is checked rather than
+	// fixed, because silently chmod-ing a file the operator placed is worse than refusing it.
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		return nil, fmt.Errorf("%w: %s is mode %#o, want 0600 (chmod 600 %s)",
+			ErrSecretPermissions, secretFile, perm, secretFile)
+	}
+
+	raw, err := os.ReadFile(secretFile) //nolint:gosec // the path is operator-supplied configuration
+	if err != nil {
+		return nil, fmt.Errorf("reading cluster secret file %s: %w", secretFile, err)
+	}
+
+	// Trailing newlines are what every editor and `openssl rand -hex 32 > file` leave behind. A
+	// secret that depends on whether the file ends in \n is a support case, not a security
+	// property.
+	secret := []byte(strings.TrimSpace(string(raw)))
+	if len(secret) < minSecretLen {
+		return nil, fmt.Errorf("%w: %s holds %d bytes, need at least %d "+
+			"(generate one with: openssl rand -hex 32 > %s && chmod 600 %s)",
+			ErrSecretTooShort, secretFile, len(secret), minSecretLen, secretFile, secretFile)
+	}
+
+	return secret, nil
+}
+
+// messageAuthenticator signs and verifies gossip datagrams.
+//
+// It holds the nonce cache, so it is per-node state rather than a pure function of the secret.
+type messageAuthenticator struct {
+	secret []byte
+
+	mu   sync.Mutex
+	seen map[string]time.Time // message ID -> when it was accepted
+
+	// now is the clock, injectable so that freshness and eviction are testable without sleeping.
+	now func() time.Time
+}
+
+// newMessageAuthenticator returns an authenticator for secret.
+func newMessageAuthenticator(secret []byte) *messageAuthenticator {
+	return &messageAuthenticator{
+		secret: secret,
+		seen:   make(map[string]time.Time),
+		now:    time.Now,
+	}
+}
+
+// mac computes the HMAC-SHA256 of payload, hex-encoded.
+func (a *messageAuthenticator) mac(payload []byte) string {
+	h := hmac.New(sha256.New, a.secret)
+	h.Write(payload)
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// seal marshals msg and wraps it in an authenticated envelope ready to send.
+func (a *messageAuthenticator) seal(msg *GossipMessage) ([]byte, error) {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling gossip message: %w", err)
+	}
+
+	return json.Marshal(authEnvelope{
+		Version: authVersion,
+		MAC:     a.mac(payload),
+		Payload: payload,
+	})
+}
+
+// open verifies a received datagram and returns the message it carries.
+//
+// Order matters and is deliberate: the MAC is checked before the payload is parsed, so a datagram
+// from an unauthenticated source never reaches the JSON decoding of any message type, let alone a
+// handler. Replay is checked after the MAC, because the nonce cache must not be writable by an
+// unauthenticated sender — otherwise flooding it with random message IDs would evict the real
+// entries and re-open the replay window.
+func (a *messageAuthenticator) open(data []byte) (*GossipMessage, error) {
+	var env authEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("%w: not an authenticated envelope: %w", ErrUnauthenticated, err)
+	}
+
+	if env.Version != authVersion {
+		return nil, fmt.Errorf("%w: got %d, want %d", ErrUnknownAuthVersion, env.Version, authVersion)
+	}
+
+	want, err := hex.DecodeString(env.MAC)
+	if err != nil {
+		return nil, fmt.Errorf("%w: malformed MAC: %w", ErrUnauthenticated, err)
+	}
+
+	got, err := hex.DecodeString(a.mac(env.Payload))
+	if err != nil {
+		// Unreachable: mac returns hex it encoded itself.
+		return nil, fmt.Errorf("%w: %w", ErrUnauthenticated, err)
+	}
+
+	if !hmac.Equal(got, want) {
+		return nil, ErrUnauthenticated
+	}
+
+	var msg GossipMessage
+	if err := json.Unmarshal(env.Payload, &msg); err != nil {
+		return nil, fmt.Errorf("%w: authenticated payload is not a gossip message: %w",
+			ErrUnauthenticated, err)
+	}
+
+	if err := a.checkFresh(&msg); err != nil {
+		return nil, err
+	}
+
+	return &msg, nil
+}
+
+// checkFresh enforces the freshness window and rejects duplicate message IDs.
+//
+// A MAC authenticates the sender, not the moment. Without this, a captured "node N owns key K" —
+// or a captured "node N is dead" — stays valid forever and can be replayed to undo the state that
+// replaced it. That is the case the issue singles out, because an ownership announcement is what a
+// cache-warming read would follow.
+//
+// Why a timestamp window plus a nonce cache rather than a per-node monotonic sequence: a sequence
+// has to survive restarts to be monotonic, so a restarted node either starts from persisted state
+// — which is the fsync-before-ack obligation that per-key conditional writes exist to avoid — or
+// starts from zero and is rejected by every peer until they age it out. A window bounds the cache
+// without any persistent state, and a restart is indistinguishable from a normal message.
+func (a *messageAuthenticator) checkFresh(msg *GossipMessage) error {
+	now := a.now()
+
+	skew := now.Sub(msg.Timestamp)
+	if skew < 0 {
+		skew = -skew
+	}
+
+	if skew > replayWindow {
+		return fmt.Errorf("%w: timestamp is %s from local time (window %s)",
+			ErrReplayed, skew.Round(time.Millisecond), replayWindow)
+	}
+
+	// An empty message ID cannot be deduplicated, so it cannot be accepted — otherwise omitting
+	// the field is a way to opt out of replay protection while still passing the MAC check.
+	if msg.MessageID == "" {
+		return fmt.Errorf("%w: message carries no ID, so a replay of it could not be detected",
+			ErrReplayed)
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Evict anything older than the window. Entries outside it are already rejected on timestamp,
+	// so remembering them adds nothing but memory.
+	for id, at := range a.seen {
+		if now.Sub(at) > replayWindow {
+			delete(a.seen, id)
+		}
+	}
+
+	if _, dup := a.seen[msg.MessageID]; dup {
+		return fmt.Errorf("%w: message %s was already accepted", ErrReplayed, msg.MessageID)
+	}
+
+	a.seen[msg.MessageID] = now
+
+	return nil
+}
+
+// secretFilePermissionsOK reports whether mode is safe for a secret file. Split out so the rule is
+// stated once and can be asserted directly by a test.
+func secretFilePermissionsOK(mode fs.FileMode) bool {
+	return mode.Perm()&0o077 == 0
+}

--- a/internal/distributed/auth_test.go
+++ b/internal/distributed/auth_test.go
@@ -1,0 +1,528 @@
+package distributed
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The bar these tests hold the implementation to is #206's own: a host that does not hold the
+// cluster secret must not be able to join the cluster or announce ownership of cached objects, and a
+// captured message must not stay valid forever. So the assertions are on observable cluster state —
+// "node-b is not in the nodes map" — and not only on the error returned by the verifier. An
+// authenticator that rejects correctly while a handler runs anyway would pass the second kind of
+// test and fail the first, and the handler is what changes what a reading process sees.
+
+// testSecret is a secret of exactly the minimum accepted length. Fixed rather than random so a
+// failure reproduces.
+func testSecret() []byte { return []byte(strings.Repeat("k", minSecretLen)) }
+
+// gossipForAuth returns a gossip protocol wired to a cluster manager, with no socket open.
+//
+// handleIncomingMessage is called directly rather than over UDP: the datagram's path from the socket
+// to the handler is one function call, and driving it directly makes the test deterministic and
+// independent of the loopback network, port availability, and delivery timing.
+func gossipForAuth(t *testing.T, nodeID string) *GossipProtocol {
+	t.Helper()
+
+	cm, err := NewClusterManager(testConfig(t, nodeID))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	return cm.gossip
+}
+
+// joinDatagram builds a join message announcing nodeID, sealed with secret.
+func joinDatagram(t *testing.T, secret []byte, nodeID string) []byte {
+	t.Helper()
+
+	payload, err := json.Marshal(JoinMessage{
+		Node: &NodeInfo{
+			ID:       nodeID,
+			Address:  "10.0.0.99:8080",
+			Status:   NodeStatusAlive,
+			LastSeen: time.Now(),
+			Metadata: map[string]string{},
+		},
+		Incarnation: 1,
+	})
+	if err != nil {
+		t.Fatalf("marshaling the join payload: %v", err)
+	}
+
+	msg := &GossipMessage{
+		Type:      MessageTypeJoin,
+		From:      nodeID,
+		Data:      payload,
+		Timestamp: time.Now(),
+		MessageID: "join-" + nodeID,
+	}
+
+	data, err := newMessageAuthenticator(secret).seal(msg)
+	if err != nil {
+		t.Fatalf("sealing the join message: %v", err)
+	}
+
+	return data
+}
+
+// TestUnauthenticatedJoinIsRejected is the defect in #206 stated as a test: before authentication,
+// any host that could reach the gossip port could add itself to the cluster.
+func TestUnauthenticatedJoinIsRejected(t *testing.T) {
+	t.Parallel()
+
+	gp := gossipForAuth(t, "node-a")
+	addr := &net.UDPAddr{IP: net.IPv4(10, 0, 0, 99), Port: 8080}
+
+	// Sealed with a different secret — an attacker who knows the wire format but not the key.
+	gp.handleIncomingMessage(joinDatagram(t, []byte(strings.Repeat("x", minSecretLen)), "intruder"), addr)
+
+	if _, joined := gp.cluster.GetNodes()["intruder"]; joined {
+		t.Error("a node holding the wrong cluster secret joined the cluster")
+	}
+
+	// An unsealed message must fare no better: the envelope itself is mandatory, so a peer speaking
+	// the pre-authentication wire format is not accepted either. It is counted as a version
+	// mismatch rather than an authentication failure, and deliberately so — a bare GossipMessage
+	// carries no "v" field, so it decodes as version 0, and a peer sending one is running a build
+	// from before authentication existed. During a rolling upgrade that is what an operator needs
+	// to be told; "wrong secret" would send them to check a secret that is fine.
+	bare, err := json.Marshal(&GossipMessage{
+		Type:      MessageTypeJoin,
+		From:      "plaintext",
+		Timestamp: time.Now(),
+		MessageID: "plaintext-join",
+	})
+	if err != nil {
+		t.Fatalf("marshaling the bare message: %v", err)
+	}
+
+	gp.handleIncomingMessage(bare, addr)
+
+	if _, joined := gp.cluster.GetNodes()["plaintext"]; joined {
+		t.Error("a node sending an unauthenticated message joined the cluster")
+	}
+
+	stats := gp.GetStats()
+	if stats.MessagesRejected != 2 {
+		t.Errorf("MessagesRejected = %d, want 2", stats.MessagesRejected)
+	}
+	if stats.MessagesUnauthenticated != 1 {
+		t.Errorf("MessagesUnauthenticated = %d, want 1 (the wrong-secret join)", stats.MessagesUnauthenticated)
+	}
+	if stats.MessagesWrongVersion != 1 {
+		t.Errorf("MessagesWrongVersion = %d, want 1 (the unenveloped message)", stats.MessagesWrongVersion)
+	}
+}
+
+// TestAuthenticatedJoinIsAccepted is the other half: authentication that rejects everything is not a
+// working feature. Without this, every assertion above would pass on a handler that dropped all
+// traffic.
+func TestAuthenticatedJoinIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "node-a"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	// The peer holds the same secret this manager loaded, which is the shared-secret model.
+	gp := cm.gossip
+	data := joinDatagram(t, gp.auth.secret, "node-b")
+
+	gp.handleIncomingMessage(data, &net.UDPAddr{IP: net.IPv4(10, 0, 0, 99), Port: 8080})
+
+	if _, joined := cm.GetNodes()["node-b"]; !joined {
+		t.Fatal("a node holding the correct cluster secret failed to join")
+	}
+
+	if got := gp.GetStats().MessagesRejected; got != 0 {
+		t.Errorf("MessagesRejected = %d, want 0 for an authenticated message", got)
+	}
+}
+
+// TestReplayedAnnouncementIsRejected covers the case the issue singles out: a captured ownership or
+// liveness announcement, replayed later, must not take effect a second time. A MAC alone does not
+// stop this, because the replayed bytes carry a MAC that verifies.
+func TestReplayedAnnouncementIsRejected(t *testing.T) {
+	t.Parallel()
+
+	gp := gossipForAuth(t, "node-a")
+	addr := &net.UDPAddr{IP: net.IPv4(10, 0, 0, 99), Port: 8080}
+	data := joinDatagram(t, gp.auth.secret, "node-b")
+
+	gp.handleIncomingMessage(data, addr)
+	gp.handleIncomingMessage(data, addr) // the same datagram, captured and sent again
+
+	stats := gp.GetStats()
+	if stats.MessagesReplayed != 1 {
+		t.Errorf("MessagesReplayed = %d, want 1", stats.MessagesReplayed)
+	}
+	if stats.MessagesRejected != 1 {
+		t.Errorf("MessagesRejected = %d, want 1", stats.MessagesRejected)
+	}
+}
+
+// TestStaleMessageIsRejected pins the freshness window. A message older than the window is refused
+// even though its MAC verifies and its ID has never been seen — which is what bounds the nonce
+// cache to one window's worth of entries.
+func TestStaleMessageIsRejected(t *testing.T) {
+	t.Parallel()
+
+	a := newMessageAuthenticator(testSecret())
+
+	data, err := a.seal(&GossipMessage{
+		Type:      MessageTypeAlive,
+		From:      "node-b",
+		Timestamp: time.Now().Add(-2 * replayWindow),
+		MessageID: "stale",
+	})
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	if _, err := a.open(data); !errors.Is(err, ErrReplayed) {
+		t.Errorf("open(stale) error = %v, want ErrReplayed", err)
+	}
+}
+
+// TestMessageWithoutIDIsRejected pins the rule that a message with no ID cannot be accepted: it
+// cannot be deduplicated, so accepting it would be a way to opt out of replay protection while
+// still passing the MAC check.
+func TestMessageWithoutIDIsRejected(t *testing.T) {
+	t.Parallel()
+
+	a := newMessageAuthenticator(testSecret())
+
+	data, err := a.seal(&GossipMessage{
+		Type:      MessageTypeAlive,
+		From:      "node-b",
+		Timestamp: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	if _, err := a.open(data); !errors.Is(err, ErrReplayed) {
+		t.Errorf("open(no ID) error = %v, want ErrReplayed", err)
+	}
+}
+
+// TestTamperedPayloadIsRejected checks that the MAC covers the payload and not merely its presence.
+// The mutation is a single byte inside the sealed message, leaving the envelope well-formed.
+func TestTamperedPayloadIsRejected(t *testing.T) {
+	t.Parallel()
+
+	a := newMessageAuthenticator(testSecret())
+
+	data, err := a.seal(&GossipMessage{
+		Type:      MessageTypeAlive,
+		From:      "node-b",
+		Timestamp: time.Now(),
+		MessageID: "tamper",
+	})
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	var env authEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatalf("unmarshaling the envelope: %v", err)
+	}
+
+	// Rewrite the sender inside the authenticated payload, keeping the original MAC.
+	env.Payload = json.RawMessage(strings.Replace(string(env.Payload), `"node-b"`, `"node-x"`, 1))
+
+	tampered, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("re-marshaling the envelope: %v", err)
+	}
+
+	if _, err := a.open(tampered); !errors.Is(err, ErrUnauthenticated) {
+		t.Errorf("open(tampered) error = %v, want ErrUnauthenticated", err)
+	}
+}
+
+// TestUnknownEnvelopeVersionIsDistinguished pins that a version this build does not understand is
+// reported as version skew rather than as an authentication failure. The distinction is what an
+// operator needs during a rolling upgrade: "wrong secret" sends them to the wrong place.
+func TestUnknownEnvelopeVersionIsDistinguished(t *testing.T) {
+	t.Parallel()
+
+	a := newMessageAuthenticator(testSecret())
+
+	data, err := json.Marshal(authEnvelope{Version: authVersion + 1, MAC: "00", Payload: json.RawMessage(`{}`)})
+	if err != nil {
+		t.Fatalf("marshaling the envelope: %v", err)
+	}
+
+	_, err = a.open(data)
+	if !errors.Is(err, ErrUnknownAuthVersion) {
+		t.Errorf("open(future version) error = %v, want ErrUnknownAuthVersion", err)
+	}
+	if errors.Is(err, ErrUnauthenticated) {
+		t.Error("a version mismatch must not be reported as an authentication failure")
+	}
+}
+
+// TestRoundTripAcrossAuthenticators verifies that a message sealed by one node opens on another
+// holding the same secret. Sealing and opening with the same instance would pass even if the MAC
+// were computed over something node-local.
+func TestRoundTripAcrossAuthenticators(t *testing.T) {
+	t.Parallel()
+
+	sender := newMessageAuthenticator(testSecret())
+	receiver := newMessageAuthenticator(testSecret())
+
+	want := &GossipMessage{
+		Type:      MessageTypeCacheInvalidate,
+		From:      "node-b",
+		Data:      json.RawMessage(`{"key":"objects/data.bin","from":"node-b"}`),
+		Timestamp: time.Now(),
+		MessageID: "round-trip",
+	}
+
+	data, err := sender.seal(want)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	got, err := receiver.open(data)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	if got.From != want.From || got.Type != want.Type || string(got.Data) != string(want.Data) {
+		t.Errorf("round trip changed the message: got %+v, want %+v", got, want)
+	}
+}
+
+// TestNonceCacheIsEvicted pins that the cache does not grow without bound. Without eviction the
+// freshness window would bound what is accepted but not what is remembered, and a long-running node
+// would accumulate an entry per message forever.
+func TestNonceCacheIsEvicted(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	clock := base
+	a := newMessageAuthenticator(testSecret())
+	a.now = func() time.Time { return clock }
+
+	first := &GossipMessage{Type: MessageTypeAlive, From: "node-b", Timestamp: base, MessageID: "first"}
+	data, err := a.seal(first)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := a.open(data); err != nil {
+		t.Fatalf("open(first): %v", err)
+	}
+
+	// Move past the window and accept an in-window message, which is what runs eviction.
+	clock = base.Add(2 * replayWindow)
+
+	second := &GossipMessage{Type: MessageTypeAlive, From: "node-b", Timestamp: clock, MessageID: "second"}
+	data, err = a.seal(second)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := a.open(data); err != nil {
+		t.Fatalf("open(second): %v", err)
+	}
+
+	a.mu.Lock()
+	_, stillThere := a.seen["first"]
+	size := len(a.seen)
+	a.mu.Unlock()
+
+	if stillThere {
+		t.Error("an entry older than the replay window was not evicted")
+	}
+	if size != 1 {
+		t.Errorf("nonce cache holds %d entries, want 1", size)
+	}
+}
+
+// TestClusterRefusesToStartWithoutASecret is the fail-closed rule. Running unauthenticated is the
+// failure nobody notices, so the absence of a secret has to be an error at construction — and the
+// error has to name what is missing, because "failed to create gossip protocol" does not tell an
+// operator which step they skipped.
+func TestClusterRefusesToStartWithoutASecret(t *testing.T) {
+	// t.Setenv forbids t.Parallel, and this test needs the variable empty.
+	t.Setenv(ClusterSecretEnv, "")
+
+	_, err := NewClusterManager(&ClusterConfig{
+		NodeID:        "no-secret",
+		ListenAddr:    "127.0.0.1:0",
+		AdvertiseAddr: "127.0.0.1:0",
+	})
+	if !errors.Is(err, ErrNoClusterSecret) {
+		t.Fatalf("NewClusterManager without a secret: error = %v, want ErrNoClusterSecret", err)
+	}
+
+	// The message must be actionable: it should name both places a secret can come from.
+	if msg := err.Error(); !strings.Contains(msg, ClusterSecretEnv) || !strings.Contains(msg, "secret_file") {
+		t.Errorf("error message does not name both secret sources: %q", msg)
+	}
+}
+
+// TestLoadClusterSecret covers the sources and the rules that reject a secret.
+func TestLoadClusterSecret(t *testing.T) {
+	t.Run("environment wins over file", func(t *testing.T) {
+		t.Setenv(ClusterSecretEnv, strings.Repeat("e", minSecretLen))
+
+		path := filepath.Join(t.TempDir(), "secret")
+		if err := os.WriteFile(path, []byte(strings.Repeat("f", minSecretLen)), 0o600); err != nil {
+			t.Fatalf("writing the secret file: %v", err)
+		}
+
+		got, err := LoadClusterSecret(path)
+		if err != nil {
+			t.Fatalf("LoadClusterSecret: %v", err)
+		}
+		if string(got) != strings.Repeat("e", minSecretLen) {
+			t.Errorf("got the file's secret, want the environment's")
+		}
+	})
+
+	t.Run("trailing newline is trimmed", func(t *testing.T) {
+		t.Setenv(ClusterSecretEnv, "")
+
+		path := filepath.Join(t.TempDir(), "secret")
+		// What `openssl rand -hex 32 > file` actually leaves behind.
+		if err := os.WriteFile(path, []byte(strings.Repeat("g", minSecretLen)+"\n"), 0o600); err != nil {
+			t.Fatalf("writing the secret file: %v", err)
+		}
+
+		got, err := LoadClusterSecret(path)
+		if err != nil {
+			t.Fatalf("LoadClusterSecret: %v", err)
+		}
+		if string(got) != strings.Repeat("g", minSecretLen) {
+			t.Errorf("secret = %q, want the newline trimmed", got)
+		}
+	})
+
+	t.Run("short secret is refused", func(t *testing.T) {
+		t.Setenv(ClusterSecretEnv, "")
+
+		path := filepath.Join(t.TempDir(), "secret")
+		if err := os.WriteFile(path, []byte("hunter2"), 0o600); err != nil {
+			t.Fatalf("writing the secret file: %v", err)
+		}
+
+		_, err := LoadClusterSecret(path)
+		if !errors.Is(err, ErrSecretTooShort) {
+			t.Errorf("error = %v, want ErrSecretTooShort", err)
+		}
+		// The message should tell the operator how to make a good one.
+		if !strings.Contains(err.Error(), "openssl rand -hex 32") {
+			t.Errorf("error does not say how to generate a secret: %q", err)
+		}
+	})
+
+	t.Run("world-readable file is refused", func(t *testing.T) {
+		t.Setenv(ClusterSecretEnv, "")
+
+		path := filepath.Join(t.TempDir(), "secret")
+		// 0644 is the whole point: this is the insecure file the loader must refuse. gosec's G306 is
+		// suppressed rather than satisfied, because satisfying it would delete the test.
+		if err := os.WriteFile(path, []byte(strings.Repeat("h", minSecretLen)), 0o644); err != nil { //nolint:gosec // deliberately world-readable
+			t.Fatalf("writing the secret file: %v", err)
+		}
+
+		_, err := LoadClusterSecret(path)
+		if !errors.Is(err, ErrSecretPermissions) {
+			t.Errorf("error = %v, want ErrSecretPermissions", err)
+		}
+	})
+
+	t.Run("missing file names the path", func(t *testing.T) {
+		t.Setenv(ClusterSecretEnv, "")
+
+		path := filepath.Join(t.TempDir(), "absent")
+		_, err := LoadClusterSecret(path)
+		if err == nil {
+			t.Fatal("expected an error for a missing secret file")
+		}
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("error does not name the path it tried: %q", err)
+		}
+	})
+}
+
+// TestSecretFilePermissions states the permission rule as a table, so the boundary is visible rather
+// than implied by a bitmask.
+func TestSecretFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mode os.FileMode
+		ok   bool
+		why  string
+	}{
+		{0o600, true, "owner read/write is the intended mode"},
+		{0o400, true, "owner read-only is stricter and fine"},
+		{0o000, true, "unreadable is not a disclosure"},
+		{0o640, false, "the group can read it"},
+		{0o604, false, "everyone can read it"},
+		{0o666, false, "everyone can read and write it"},
+		{0o601, false, "execute for others still exposes the file to others"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.why, func(t *testing.T) {
+			t.Parallel()
+			if got := secretFilePermissionsOK(tc.mode); got != tc.ok {
+				t.Errorf("secretFilePermissionsOK(%#o) = %v, want %v (%s)", tc.mode, got, tc.ok, tc.why)
+			}
+		})
+	}
+}
+
+// TestConcurrentOpenIsSafe drives the nonce cache from several goroutines, because it is reached
+// from the receive path and a map without a lock there would be a race that only appears under load.
+// Exactly one of the concurrent attempts at the same message ID may be accepted.
+func TestConcurrentOpenIsSafe(t *testing.T) {
+	t.Parallel()
+
+	a := newMessageAuthenticator(testSecret())
+
+	data, err := a.seal(&GossipMessage{
+		Type:      MessageTypeAlive,
+		From:      "node-b",
+		Timestamp: time.Now(),
+		MessageID: "contended",
+	})
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	const goroutines = 16
+	results := make(chan error, goroutines)
+
+	for range goroutines {
+		go func() {
+			_, err := a.open(data)
+			results <- err
+		}()
+	}
+
+	accepted := 0
+	for range goroutines {
+		if err := <-results; err == nil {
+			accepted++
+		} else if !errors.Is(err, ErrReplayed) {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	if accepted != 1 {
+		t.Errorf("%d goroutines accepted the same message, want exactly 1", accepted)
+	}
+}

--- a/internal/distributed/auth_test.go
+++ b/internal/distributed/auth_test.go
@@ -430,9 +430,11 @@ func TestLoadClusterSecret(t *testing.T) {
 		t.Setenv(ClusterSecretEnv, "")
 
 		path := filepath.Join(t.TempDir(), "secret")
-		// 0644 is the whole point: this is the insecure file the loader must refuse. gosec's G306 is
-		// suppressed rather than satisfied, because satisfying it would delete the test.
-		if err := os.WriteFile(path, []byte(strings.Repeat("h", minSecretLen)), 0o644); err != nil { //nolint:gosec // deliberately world-readable
+		// 0644 is the whole point: this is the insecure file the loader must refuse. G306 is
+		// suppressed rather than satisfied, because satisfying it would delete the test. Both
+		// directives, since golangci-lint honors only //nolint and standalone gosec only #nosec.
+		//nolint:gosec // deliberately world-readable: this is the file the loader must reject
+		if err := os.WriteFile(path, []byte(strings.Repeat("h", minSecretLen)), 0o644); err != nil { // #nosec G306 -- deliberately world-readable
 			t.Fatalf("writing the secret file: %v", err)
 		}
 

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -53,6 +53,16 @@ type ClusterConfig struct {
 	GossipFanout    int           `yaml:"gossip_fanout"`
 	MaxGossipPacket int           `yaml:"max_gossip_packet"`
 
+	// SecretFile is the path to the shared cluster secret used to authenticate gossip messages
+	// (#206). The secret itself is deliberately not a field here: this configuration is serialized
+	// into a file that packaging installs world-readable, so a secret in it would be published to
+	// every user on the node. The file must be mode 0600 or startup refuses it.
+	//
+	// OBJECTFS_CLUSTER_SECRET takes precedence, so this may be empty when the secret is injected
+	// through the environment. If neither is set, clustering does not start — see
+	// [NewGossipProtocol].
+	SecretFile string `yaml:"secret_file"`
+
 	// Cache coordination
 	CacheReplication  bool   `yaml:"cache_replication"`
 	ReplicationFactor int    `yaml:"replication_factor"`

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -2,6 +2,8 @@ package distributed
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,20 +12,50 @@ import (
 // testConfig returns a minimal ClusterConfig suitable for unit tests.
 // ListenAddr ":0" lets the OS assign an ephemeral UDP port.
 // ElectionTimeout is set long to prevent spurious elections during tests.
-func testConfig(nodeID string) *ClusterConfig {
+//
+// It needs a *testing.T because gossip authentication (#206) fails closed: a cluster cannot be
+// constructed without a cluster secret, so every test that builds one needs a secret file, and that
+// file's lifetime is the test's.
+func testConfig(t *testing.T, nodeID string) *ClusterConfig {
+	t.Helper()
+
 	return &ClusterConfig{
 		NodeID:            nodeID,
 		ListenAddr:        "127.0.0.1:0",
 		AdvertiseAddr:     "127.0.0.1:0",
 		ElectionTimeout:   30 * time.Second,
 		HeartbeatInterval: 100 * time.Millisecond,
+		SecretFile:        writeTestSecret(t),
 	}
+}
+
+// writeTestSecret writes a cluster secret to a file in the test's own temporary directory and
+// returns its path.
+//
+// A file rather than OBJECTFS_CLUSTER_SECRET: the environment is process-wide, and these tests run
+// with t.Parallel(), so a test that set and unset the variable would race every other test's cluster
+// construction. t.TempDir is already mode 0700 and is removed when the test finishes.
+func writeTestSecret(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "cluster.secret")
+
+	// Long enough to pass minSecretLen. Fixed rather than random because a test that fails should
+	// fail the same way twice.
+	if err := os.WriteFile(path, []byte(strings.Repeat("a", minSecretLen)), 0o600); err != nil {
+		t.Fatalf("writing the test cluster secret: %v", err)
+	}
+
+	return path
 }
 
 // TestNewClusterManager_NilConfig verifies that a nil config is accepted and
 // defaults are applied.
 func TestNewClusterManager_NilConfig(t *testing.T) {
-	t.Parallel()
+	// A nil config still needs a secret, and the only source that does not require a config field
+	// is the environment. t.Setenv forbids t.Parallel, which is why this test does not call it.
+	t.Setenv(ClusterSecretEnv, strings.Repeat("b", minSecretLen))
+
 	cm, err := NewClusterManager(nil)
 	if err != nil {
 		t.Fatalf("NewClusterManager(nil): %v", err)
@@ -40,6 +72,7 @@ func TestNewClusterManager_GeneratesNodeID(t *testing.T) {
 	cm, err := NewClusterManager(&ClusterConfig{
 		ListenAddr:    "127.0.0.1:0",
 		AdvertiseAddr: "127.0.0.1:0",
+		SecretFile:    writeTestSecret(t),
 	})
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
@@ -58,7 +91,7 @@ func TestNewClusterManager_GeneratesNodeID(t *testing.T) {
 func TestNewClusterManager_PreservesExplicitNodeID(t *testing.T) {
 	t.Parallel()
 	const want = "explicit-node-id"
-	cm, err := NewClusterManager(testConfig(want))
+	cm, err := NewClusterManager(testConfig(t, want))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -71,7 +104,9 @@ func TestNewClusterManager_PreservesExplicitNodeID(t *testing.T) {
 // are filled with sensible defaults.
 func TestNewClusterManager_ConfigDefaults(t *testing.T) {
 	t.Parallel()
-	cfg := &ClusterConfig{NodeID: "n1"} // all other fields zero
+	// All fields zero except the two that have no default: the node ID under test, and the cluster
+	// secret, which fails closed rather than defaulting (#206).
+	cfg := &ClusterConfig{NodeID: "n1", SecretFile: writeTestSecret(t)}
 	_, err := NewClusterManager(cfg)
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
@@ -99,7 +134,7 @@ func TestNewClusterManager_ConfigDefaults(t *testing.T) {
 // before Start is called.
 func TestClusterManager_InitialState(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("init-node"))
+	cm, err := NewClusterManager(testConfig(t, "init-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -119,7 +154,7 @@ func TestClusterManager_InitialState(t *testing.T) {
 // the nodes map.
 func TestClusterManager_UpdateNodeInfo_Add(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("node-a"))
+	cm, err := NewClusterManager(testConfig(t, "node-a"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -149,7 +184,7 @@ func TestClusterManager_UpdateNodeInfo_Add(t *testing.T) {
 // fields are updated without creating a duplicate entry.
 func TestClusterManager_UpdateNodeInfo_Update(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("node-a"))
+	cm, err := NewClusterManager(testConfig(t, "node-a"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -176,7 +211,7 @@ func TestClusterManager_UpdateNodeInfo_Update(t *testing.T) {
 // does not affect the internal state.
 func TestClusterManager_GetNodes_DeepCopy(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("node-a"))
+	cm, err := NewClusterManager(testConfig(t, "node-a"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -204,7 +239,7 @@ func TestClusterManager_GetNodes_DeepCopy(t *testing.T) {
 // node's ID marks that node as leader but does not set isLeader.
 func TestClusterManager_SetLeader_OtherNode(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("self"))
+	cm, err := NewClusterManager(testConfig(t, "self"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -223,7 +258,7 @@ func TestClusterManager_SetLeader_OtherNode(t *testing.T) {
 // node ID sets isLeader = true.
 func TestClusterManager_SetLeader_SelfNode(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("self"))
+	cm, err := NewClusterManager(testConfig(t, "self"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -242,7 +277,7 @@ func TestClusterManager_SetLeader_SelfNode(t *testing.T) {
 // the election counter and records the leader in stats.
 func TestClusterManager_SetLeader_UpdatesStats(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("self"))
+	cm, err := NewClusterManager(testConfig(t, "self"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -265,7 +300,7 @@ func TestClusterManager_SetLeader_UpdatesStats(t *testing.T) {
 // TestClusterManager_RemoveNode verifies that a node is removed from the map.
 func TestClusterManager_RemoveNode(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("self"))
+	cm, err := NewClusterManager(testConfig(t, "self"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -282,7 +317,7 @@ func TestClusterManager_RemoveNode(t *testing.T) {
 // leader clears the leadership state.
 func TestClusterManager_RemoveNode_WasLeader(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("self"))
+	cm, err := NewClusterManager(testConfig(t, "self"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -303,7 +338,7 @@ func TestClusterManager_RemoveNode_WasLeader(t *testing.T) {
 // a freshly created manager.
 func TestClusterManager_GetStats_Initial(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("stats-node"))
+	cm, err := NewClusterManager(testConfig(t, "stats-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -323,7 +358,7 @@ func TestClusterManager_GetStats_Initial(t *testing.T) {
 // a non-nil coordinator satisfying the DistributedCoordinator interface.
 func TestClusterManager_GetCoordinator_NotNil(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("coord-node"))
+	cm, err := NewClusterManager(testConfig(t, "coord-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -336,7 +371,7 @@ func TestClusterManager_GetCoordinator_NotNil(t *testing.T) {
 // returns an error when no alive nodes are present.
 func TestClusterManager_DistributeOperation_NoNodes(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("dist-node"))
+	cm, err := NewClusterManager(testConfig(t, "dist-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -355,7 +390,7 @@ func TestClusterManager_DistributeOperation_NoNodes(t *testing.T) {
 // TestClusterManager_StartStop verifies the full lifecycle without panics.
 func TestClusterManager_StartStop(t *testing.T) {
 	t.Parallel()
-	cfg := testConfig("lifecycle-node")
+	cfg := testConfig(t, "lifecycle-node")
 	cm, err := NewClusterManager(cfg)
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)

--- a/internal/distributed/consensus_test.go
+++ b/internal/distributed/consensus_test.go
@@ -11,7 +11,7 @@ import (
 // initialized correctly.
 func TestNewConsensusEngine(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("ce-node"))
+	cm, err := NewClusterManager(testConfig(t, "ce-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestNewConsensusEngine(t *testing.T) {
 // engine starts as a follower.
 func TestConsensusEngine_InitialState_IsFollower(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("follower-node"))
+	cm, _ := NewClusterManager(testConfig(t, "follower-node"))
 	ce := cm.consensus
 
 	if got := ce.GetCurrentState(); got != StateFollower {
@@ -36,7 +36,7 @@ func TestConsensusEngine_InitialState_IsFollower(t *testing.T) {
 // TestConsensusEngine_InitialTerm_IsZero verifies that the initial term is 0.
 func TestConsensusEngine_InitialTerm_IsZero(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("term-node"))
+	cm, _ := NewClusterManager(testConfig(t, "term-node"))
 	ce := cm.consensus
 
 	if got := ce.GetCurrentTerm(); got != 0 {
@@ -48,7 +48,7 @@ func TestConsensusEngine_InitialTerm_IsZero(t *testing.T) {
 // pre-seeded with exactly one no-op entry.
 func TestConsensusEngine_InitialLog_HasNoopEntry(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("log-node"))
+	cm, _ := NewClusterManager(testConfig(t, "log-node"))
 	ce := cm.consensus
 
 	ce.mu.RLock()
@@ -68,7 +68,7 @@ func TestConsensusEngine_InitialLog_HasNoopEntry(t *testing.T) {
 // any election.
 func TestConsensusEngine_IsLeader_InitiallyFalse(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("not-leader"))
+	cm, _ := NewClusterManager(testConfig(t, "not-leader"))
 	if cm.consensus.IsLeader() {
 		t.Error("IsLeader() should be false before any election")
 	}
@@ -97,7 +97,7 @@ func TestConsensusState_String(t *testing.T) {
 // values returned by GetStats.
 func TestConsensusEngine_GetStats_InitialValues(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("stats-ce"))
+	cm, _ := NewClusterManager(testConfig(t, "stats-ce"))
 	stats := cm.consensus.GetStats()
 
 	if stats == nil {
@@ -123,7 +123,7 @@ func TestConsensusEngine_GetStats_InitialValues(t *testing.T) {
 // peer votes are available to complete the election.
 func TestConsensusEngine_TriggerElection_BecomesCandidate(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("cand-node"))
+	cm, _ := NewClusterManager(testConfig(t, "cand-node"))
 	ce := cm.consensus
 
 	if err := ce.TriggerElection(context.Background()); err != nil {
@@ -152,8 +152,8 @@ func TestConsensusEngine_TriggerElection_WithPeer_BecomesLeader(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	cfg1 := testConfig("node-a")
-	cfg2 := testConfig("node-b")
+	cfg1 := testConfig(t, "node-a")
+	cfg2 := testConfig(t, "node-b")
 
 	cm1, err := NewClusterManager(cfg1)
 	if err != nil {
@@ -217,8 +217,8 @@ func TestConsensusEngine_TriggerElection_WhenLeader_IsNoOp(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	cfg1 := testConfig("leader-noop-a")
-	cfg2 := testConfig("leader-noop-b")
+	cfg1 := testConfig(t, "leader-noop-a")
+	cfg2 := testConfig(t, "leader-noop-b")
 
 	cm1, err := NewClusterManager(cfg1)
 	if err != nil {
@@ -279,7 +279,7 @@ func TestConsensusEngine_TriggerElection_WhenLeader_IsNoOp(t *testing.T) {
 // the leader can propose changes.
 func TestConsensusEngine_ProposeChange_NotLeader_ReturnsError(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("not-leader-prop"))
+	cm, _ := NewClusterManager(testConfig(t, "not-leader-prop"))
 	ce := cm.consensus
 
 	err := ce.ProposeChange(context.Background(), &ConsensusProposal{
@@ -294,7 +294,7 @@ func TestConsensusEngine_ProposeChange_NotLeader_ReturnsError(t *testing.T) {
 // TestConsensusEngine_StartStop verifies the lifecycle without panics.
 func TestConsensusEngine_StartStop(t *testing.T) {
 	t.Parallel()
-	cfg := testConfig("lifecycle-ce")
+	cfg := testConfig(t, "lifecycle-ce")
 	cfg.ElectionTimeout = 30 * time.Second // prevent elections during the test
 	cm, err := NewClusterManager(cfg)
 	if err != nil {
@@ -326,7 +326,7 @@ func TestConsensusEngine_StartStop(t *testing.T) {
 func TestConsensusEngine_StopRacesAnInboundHeartbeat(t *testing.T) {
 	t.Parallel()
 
-	cfg := testConfig("stop-race")
+	cfg := testConfig(t, "stop-race")
 	cfg.ElectionTimeout = time.Hour // no election fires on its own during this test
 	cm, err := NewClusterManager(cfg)
 	if err != nil {

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -15,7 +15,7 @@ import (
 // (the manager's own ID) pre-registered, without calling Start().
 func makeClusterWithNode(t *testing.T, nodeID string) *ClusterManager {
 	t.Helper()
-	cm, err := NewClusterManager(testConfig(nodeID))
+	cm, err := NewClusterManager(testConfig(t, nodeID))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -102,7 +102,7 @@ func (e *errBackend) HealthCheck(_ context.Context) error { return e.err }
 // non-nil coordinator with its load balancer and replicator initialized.
 func TestNewCoordinator(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("c-node"))
+	cm, err := NewClusterManager(testConfig(t, "c-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestNewCoordinator(t *testing.T) {
 // returns an error when no alive nodes are available.
 func TestCoordinator_ExecuteOperation_NoAliveNodes(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("c-node"))
+	cm, err := NewClusterManager(testConfig(t, "c-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestCoordinator_ExecuteOperation_StrongConsistency(t *testing.T) {
 func TestCoordinator_ExecuteOperation_ExplicitTargetNodes(t *testing.T) {
 	t.Parallel()
 	// No alive nodes in the cluster, but explicit targets are provided.
-	cm, err := NewClusterManager(testConfig("explicit-node"))
+	cm, err := NewClusterManager(testConfig(t, "explicit-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -362,7 +362,7 @@ func TestCoordinator_ExecuteOperation_ListUsesLeader(t *testing.T) {
 // the expected top-level keys.
 func TestCoordinator_GetStats_Structure(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("stats-coord"))
+	cm, err := NewClusterManager(testConfig(t, "stats-coord"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -384,8 +384,8 @@ func TestCoordinator_ExecuteOperation_TwoNodes_RealUDP(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	cfg1 := testConfig("coord-node-a")
-	cfg2 := testConfig("coord-node-b")
+	cfg1 := testConfig(t, "coord-node-a")
+	cfg2 := testConfig(t, "coord-node-b")
 
 	cm1, err := NewClusterManager(cfg1)
 	if err != nil {
@@ -457,7 +457,7 @@ func TestCoordinator_ExecuteOperation_TwoNodes_RealUDP(t *testing.T) {
 // TestCoordinator_StartStop verifies the coordinator lifecycle.
 func TestCoordinator_StartStop(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("coord-lifecycle"))
+	cm, err := NewClusterManager(testConfig(t, "coord-lifecycle"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -476,7 +476,7 @@ func TestCoordinator_StartStop(t *testing.T) {
 // node list returns an empty result without error.
 func TestLoadBalancer_SelectNodes_Empty(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("lb-empty"))
+	cm, err := NewClusterManager(testConfig(t, "lb-empty"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -495,7 +495,7 @@ func TestLoadBalancer_SelectNodes_Empty(t *testing.T) {
 // through all provided nodes.
 func TestLoadBalancer_RoundRobin(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("lb-rr"))
+	cm, err := NewClusterManager(testConfig(t, "lb-rr"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestLoadBalancer_RoundRobin(t *testing.T) {
 // than available returns only as many as are available.
 func TestLoadBalancer_CountCappedToAvailable(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("lb-cap"))
+	cm, err := NewClusterManager(testConfig(t, "lb-cap"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -536,7 +536,7 @@ func TestLoadBalancer_CountCappedToAvailable(t *testing.T) {
 // TestLoadBalancer_LeastLoad selects nodes by ascending load order.
 func TestLoadBalancer_LeastLoad(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("lb-ll"))
+	cm, err := NewClusterManager(testConfig(t, "lb-ll"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -563,7 +563,7 @@ func TestLoadBalancer_LeastLoad(t *testing.T) {
 // returns the requested number of nodes from the front of the list.
 func TestLoadBalancer_ConsistentHash(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("lb-ch"))
+	cm, err := NewClusterManager(testConfig(t, "lb-ch"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -700,8 +700,8 @@ func TestClusterManager_CacheInvalidation_TwoNodes(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
-	cfg1 := testConfig("inval-node-a")
-	cfg2 := testConfig("inval-node-b")
+	cfg1 := testConfig(t, "inval-node-a")
+	cfg2 := testConfig(t, "inval-node-b")
 
 	cm1, err := NewClusterManager(cfg1)
 	if err != nil {

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -71,24 +71,57 @@ Strong Consistency:
 		Consistency: distributed.ConsistencyStrong,
 	}
 
+# Gossip Authentication
+
+Every node in a cluster must hold the same cluster secret, and a cluster will not start without one.
+This is deliberate: the gossip protocol runs over UDP, and before authentication existed any host
+that could reach the port could add itself to the cluster and announce that it held the current copy
+of a cached object. Running unauthenticated is the failure nobody notices, so it is refused at
+construction rather than warned about.
+
+Generate a secret once per cluster and distribute it the way the rest of the node configuration is
+distributed:
+
+	openssl rand -hex 32 > /etc/objectfs/cluster.secret
+	chmod 600 /etc/objectfs/cluster.secret
+
+Then name it in the cluster configuration, or set OBJECTFS_CLUSTER_SECRET, which takes precedence
+and is what a container orchestrator injects. The secret is never a field in the YAML configuration:
+packaging installs that file world-readable, so a secret in it would be published to every user on
+the node. A secret file readable by anyone but its owner is refused for the same reason.
+
+Each message carries an HMAC-SHA256 over its exact bytes, plus a timestamp and message ID checked
+against a 30-second freshness window, so a captured datagram cannot be replayed later to reassert
+state that has since been replaced. Rejections are counted in [GossipStats] — separately for a bad
+MAC, a replay, and an envelope version this build does not understand, because those three send an
+operator to three different places. A cluster of one with a rising MessagesUnauthenticated count is
+a wrong secret; the same cluster with a rising MessagesWrongVersion is a half-finished upgrade.
+
+What this does not do: gossip payloads are not encrypted (they are membership metadata and cache
+keys), and because every member holds the same key, a compromised node can impersonate any other.
+Defending against that needs per-node keys and is a different threat model.
+
 # Setting Up a Cluster
 
 Basic cluster configuration:
 
 	config := &distributed.ClusterConfig{
-		Enabled:           true,
-		NodeID:            "node-1",
-		ListenAddr:        "0.0.0.0:8080",
-		AdvertiseAddr:     "192.168.1.10:8080",
-		SeedNodes:         []string{
+		NodeID:        "node-1",
+		ListenAddr:    "0.0.0.0:8080",
+		AdvertiseAddr: "192.168.1.10:8080",
+		SeedNodes: []string{
 			"192.168.1.11:8080",
 			"192.168.1.12:8080",
 		},
 		ReplicationFactor: 3,
 		ConsistencyLevel:  "eventual",
+
+		// Required. The same file, with the same contents, on every node.
+		SecretFile: "/etc/objectfs/cluster.secret",
 	}
 
-	// Create cluster manager
+	// Create cluster manager. This returns an error rather than a cluster if no secret
+	// is configured, so a missing deployment step is caught at startup.
 	cluster, err := distributed.NewClusterManager(config)
 	if err != nil {
 		log.Fatal(err)
@@ -100,8 +133,10 @@ Basic cluster configuration:
 	}
 	defer cluster.Stop()
 
-	// Create coordinator
-	coordinator, err := distributed.NewCoordinator(cluster, config)
+	// Create coordinator. The third argument is the types.Backend it executes
+	// operations against; nil leaves it unset, and operations then fail rather
+	// than silently succeeding.
+	coordinator, err := distributed.NewCoordinator(cluster, config, backend)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -313,7 +348,6 @@ Example: Complete Cluster Setup
 
 	func main() {
 		config := &distributed.ClusterConfig{
-			Enabled:           true,
 			NodeID:            "node-primary",
 			ListenAddr:        "0.0.0.0:8080",
 			AdvertiseAddr:     "192.168.1.10:8080",
@@ -321,7 +355,8 @@ Example: Complete Cluster Setup
 			ReplicationFactor: 3,
 			ConsistencyLevel:  "eventual",
 			GossipInterval:    time.Second,
-			FailureTimeout:    30 * time.Second,
+			HeartbeatInterval: time.Second,
+			SecretFile:        "/etc/objectfs/cluster.secret",
 		}
 
 		// Initialize cluster
@@ -337,7 +372,7 @@ Example: Complete Cluster Setup
 		defer cluster.Stop()
 
 		// Initialize coordinator
-		coordinator, err := distributed.NewCoordinator(cluster, config)
+		coordinator, err := distributed.NewCoordinator(cluster, config, backend)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -5,6 +5,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -24,6 +25,12 @@ type GossipProtocol struct {
 	conn       *net.UDPConn
 	stats      *GossipStats
 	stopCh     chan struct{}
+
+	// auth signs outgoing datagrams and verifies incoming ones (#206). Never nil: a gossip
+	// protocol cannot be constructed without a cluster secret, because an unauthenticated gossip
+	// port lets any host on the network join the cluster and announce ownership of cached
+	// objects. See auth.go.
+	auth *messageAuthenticator
 }
 
 // GossipNode represents a node in the gossip protocol
@@ -144,10 +151,34 @@ type GossipStats struct {
 	NetworkErrors       int64            `json:"network_errors"`
 	AvgMessageLatency   time.Duration    `json:"avg_message_latency"`
 	LastMessageReceived time.Time        `json:"last_message_received"`
+
+	// Authentication rejections (#206). These are counted separately because they answer
+	// different operator questions, and a single "rejected" number cannot: a nonzero
+	// MessagesUnauthenticated means a peer has the wrong secret or a host that is not a member is
+	// talking to the port, MessagesReplayed means someone is re-sending captured datagrams or a
+	// node's clock is off by more than the freshness window, and MessagesWrongVersion means
+	// version skew during a rolling upgrade. MessagesRejected is their sum, so a monitor can alert
+	// on one series.
+	MessagesRejected        int64 `json:"messages_rejected"`
+	MessagesUnauthenticated int64 `json:"messages_unauthenticated"`
+	MessagesReplayed        int64 `json:"messages_replayed"`
+	MessagesWrongVersion    int64 `json:"messages_wrong_version"`
 }
 
-// NewGossipProtocol creates a new gossip protocol instance
+// NewGossipProtocol creates a new gossip protocol instance.
+//
+// It fails if no cluster secret is available. That is deliberate and is the whole point of #206:
+// starting without authentication would mean any host that can reach the gossip port can join the
+// cluster and announce cache ownership for arbitrary keys, which — once cache-warming reads fetch
+// from peers — makes a peer's response into file content a reading process sees. Refusing to start
+// with an error naming the missing secret is the failure an operator can fix; running unauthenticated
+// is the one nobody notices.
 func NewGossipProtocol(cluster *ClusterManager, config *ClusterConfig) (*GossipProtocol, error) {
+	secret, err := LoadClusterSecret(config.SecretFile)
+	if err != nil {
+		return nil, fmt.Errorf("gossip authentication: %w", err)
+	}
+
 	gp := &GossipProtocol{
 		cluster:    cluster,
 		config:     config,
@@ -156,6 +187,7 @@ func NewGossipProtocol(cluster *ClusterManager, config *ClusterConfig) (*GossipP
 			MessagesByType: make(map[string]int64),
 		},
 		stopCh: make(chan struct{}),
+		auth:   newMessageAuthenticator(secret),
 	}
 
 	// Initialize local node
@@ -309,9 +341,39 @@ func (gp *GossipProtocol) receiveMessages(ctx context.Context) {
 }
 
 func (gp *GossipProtocol) handleIncomingMessage(data []byte, addr *net.UDPAddr) {
-	var msg GossipMessage
-	if err := json.Unmarshal(data, &msg); err != nil {
-		slog.Warn("failed to unmarshal gossip message", "error", err)
+	// Authenticate before parsing (#206). A datagram that does not verify never reaches the JSON
+	// decoding of any message type, let alone a handler, so an unauthenticated host cannot join the
+	// cluster or announce cache ownership.
+	msg, err := gp.auth.open(data)
+	if err != nil {
+		// Rejections are counted and logged at warn, not dropped silently: a misconfigured secret
+		// and a network problem produce the same symptom — a cluster of one — and without this the
+		// operator has no way to tell them apart. The peer address is included because that is what
+		// identifies which node has the wrong secret, or which host should not be talking to this
+		// port at all.
+		// The hint differs by reason because the three send an operator to different places, and a
+		// single catch-all string would send two of them to the wrong one. A version mismatch during
+		// a rolling upgrade is not a secret problem, and telling someone to check a secret that is
+		// correct costs them the time it takes to rule it out.
+		var hint string
+
+		gp.stats.mu.Lock()
+		gp.stats.MessagesRejected++
+		switch {
+		case errors.Is(err, ErrReplayed):
+			gp.stats.MessagesReplayed++
+			hint = "a duplicate datagram, or clock skew beyond the freshness window — check NTP on both hosts"
+		case errors.Is(err, ErrUnknownAuthVersion):
+			gp.stats.MessagesWrongVersion++
+			hint = "a peer running a build that predates gossip authentication, or a newer envelope format"
+		default:
+			gp.stats.MessagesUnauthenticated++
+			hint = "a peer with a different cluster secret, or a host that is not a cluster member"
+		}
+		gp.stats.mu.Unlock()
+
+		slog.Warn("rejected gossip message", "error", err, "peer", addr, "hint", hint)
+
 		return
 	}
 
@@ -326,46 +388,46 @@ func (gp *GossipProtocol) handleIncomingMessage(data []byte, addr *net.UDPAddr) 
 	// Process message based on type
 	switch msg.Type {
 	case MessageTypeJoin:
-		gp.handleJoinMessage(&msg)
+		gp.handleJoinMessage(msg)
 	case MessageTypeLeave:
-		gp.handleLeaveMessage(&msg)
+		gp.handleLeaveMessage(msg)
 	case MessageTypeAlive:
-		gp.handleAliveMessage(&msg)
+		gp.handleAliveMessage(msg)
 	case MessageTypeSuspect:
-		gp.handleSuspectMessage(&msg)
+		gp.handleSuspectMessage(msg)
 	case MessageTypeDead:
-		gp.handleDeadMessage(&msg)
+		gp.handleDeadMessage(msg)
 	case MessageTypeSync:
-		gp.handleSyncMessage(&msg)
+		gp.handleSyncMessage(msg)
 	case MessageTypeGossipHeartbeat:
-		gp.handleHeartbeatMessage(&msg)
+		gp.handleHeartbeatMessage(msg)
 
 	// Consensus messages
 	case MessageTypeRequestVote:
 		if gp.cluster.consensus != nil {
-			gp.cluster.consensus.handleNetworkRequestVote(&msg)
+			gp.cluster.consensus.handleNetworkRequestVote(msg)
 		}
 	case MessageTypeRequestVoteResp:
 		if gp.cluster.consensus != nil {
-			gp.cluster.consensus.handleNetworkRequestVoteResp(&msg)
+			gp.cluster.consensus.handleNetworkRequestVoteResp(msg)
 		}
 	case MessageTypeAppendEntries:
 		if gp.cluster.consensus != nil {
-			gp.cluster.consensus.handleNetworkAppendEntries(&msg)
+			gp.cluster.consensus.handleNetworkAppendEntries(msg)
 		}
 	case MessageTypeAppendEntriesResp:
 		if gp.cluster.consensus != nil {
-			gp.cluster.consensus.handleNetworkAppendEntriesResp(&msg)
+			gp.cluster.consensus.handleNetworkAppendEntriesResp(msg)
 		}
 
 	// Coordinator messages
 	case MessageTypeNodeOperation:
 		if gp.cluster.coordinator != nil {
-			gp.cluster.coordinator.handleNetworkOperation(&msg)
+			gp.cluster.coordinator.handleNetworkOperation(msg)
 		}
 	case MessageTypeNodeOperationResp:
 		if gp.cluster.coordinator != nil {
-			gp.cluster.coordinator.handleNetworkOperationResp(&msg)
+			gp.cluster.coordinator.handleNetworkOperationResp(msg)
 		}
 
 	// Cache invalidation
@@ -823,7 +885,10 @@ func (gp *GossipProtocol) calculateStats() {
 // Helper methods
 
 func (gp *GossipProtocol) sendMessage(addr string, msg *GossipMessage) error {
-	data, err := json.Marshal(msg)
+	// Every outgoing datagram is authenticated here rather than at each call site, because this is
+	// the only place that writes to the socket — so a new message type cannot be introduced
+	// unauthenticated by forgetting a step.
+	data, err := gp.auth.seal(msg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal message: %w", err)
 	}
@@ -955,6 +1020,11 @@ func (gp *GossipProtocol) GetStats() *GossipStats {
 		AvgMessageLatency:   gp.stats.AvgMessageLatency,
 		LastMessageReceived: gp.stats.LastMessageReceived,
 		MessagesByType:      make(map[string]int64),
+
+		MessagesRejected:        gp.stats.MessagesRejected,
+		MessagesUnauthenticated: gp.stats.MessagesUnauthenticated,
+		MessagesReplayed:        gp.stats.MessagesReplayed,
+		MessagesWrongVersion:    gp.stats.MessagesWrongVersion,
 	}
 	maps.Copy(stats.MessagesByType, gp.stats.MessagesByType)
 	gp.stats.mu.RUnlock()

--- a/internal/distributed/gossip_test.go
+++ b/internal/distributed/gossip_test.go
@@ -26,7 +26,7 @@ func makeGossipMsg(t *testing.T, msgType MessageType, payload any) *GossipMessag
 // non-nil GossipProtocol with the expected initial state.
 func TestNewGossipProtocol(t *testing.T) {
 	t.Parallel()
-	cm, err := NewClusterManager(testConfig("gp-node"))
+	cm, err := NewClusterManager(testConfig(t, "gp-node"))
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestNewGossipProtocol(t *testing.T) {
 // pre-seeded in the memberlist upon construction.
 func TestGossipProtocol_InitialMemberlist_HasSelf(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("self-node"))
+	cm, _ := NewClusterManager(testConfig(t, "self-node"))
 	gp := cm.gossip
 
 	ml := gp.GetMemberlist()
@@ -68,7 +68,7 @@ func TestGossipProtocol_InitialMemberlist_HasSelf(t *testing.T) {
 // GetStats are zero on a fresh GossipProtocol.
 func TestGossipProtocol_InitialStats_Zeroed(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("stats-gp"))
+	cm, _ := NewClusterManager(testConfig(t, "stats-gp"))
 	stats := cm.gossip.GetStats()
 
 	if stats == nil {
@@ -95,7 +95,7 @@ func TestGossipProtocol_InitialStats_Zeroed(t *testing.T) {
 // MessagesByType map is non-nil (not a nil map panic waiting to happen).
 func TestGossipProtocol_GetStats_MessagesByType_Initialized(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("mbt-node"))
+	cm, _ := NewClusterManager(testConfig(t, "mbt-node"))
 	stats := cm.gossip.GetStats()
 
 	if stats.MessagesByType == nil {
@@ -107,7 +107,7 @@ func TestGossipProtocol_GetStats_MessagesByType_Initialized(t *testing.T) {
 // returned by GetMemberlist does not affect internal state.
 func TestGossipProtocol_GetMemberlist_DeepCopy(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("copy-node"))
+	cm, _ := NewClusterManager(testConfig(t, "copy-node"))
 	gp := cm.gossip
 
 	copy1 := gp.GetMemberlist()
@@ -128,7 +128,7 @@ func TestGossipProtocol_GetMemberlist_DeepCopy(t *testing.T) {
 // adds the new node to the memberlist and updates the cluster manager.
 func TestGossipProtocol_HandleJoinMessage_AddsNode(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("host-node"))
+	cm, _ := NewClusterManager(testConfig(t, "host-node"))
 	gp := cm.gossip
 
 	joiner := &NodeInfo{
@@ -163,7 +163,7 @@ func TestGossipProtocol_HandleJoinMessage_AddsNode(t *testing.T) {
 // NodesDiscovered increments when a join message arrives.
 func TestGossipProtocol_HandleJoinMessage_IncrementsStat(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("stat-host"))
+	cm, _ := NewClusterManager(testConfig(t, "stat-host"))
 	gp := cm.gossip
 
 	before := gp.GetStats().NodesDiscovered
@@ -187,7 +187,7 @@ func TestGossipProtocol_HandleJoinMessage_IncrementsStat(t *testing.T) {
 // message for an unknown node adds it to the memberlist.
 func TestGossipProtocol_HandleAliveMessage_NewNode(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("alive-host"))
+	cm, _ := NewClusterManager(testConfig(t, "alive-host"))
 	gp := cm.gossip
 
 	before := gp.GetStats().NodesDiscovered
@@ -214,7 +214,7 @@ func TestGossipProtocol_HandleAliveMessage_NewNode(t *testing.T) {
 // alive message with a higher incarnation updates an existing node.
 func TestGossipProtocol_HandleAliveMessage_UpdatesExisting(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("update-host"))
+	cm, _ := NewClusterManager(testConfig(t, "update-host"))
 	gp := cm.gossip
 
 	// Manually insert an existing node at incarnation 1.
@@ -253,7 +253,7 @@ func TestGossipProtocol_HandleAliveMessage_UpdatesExisting(t *testing.T) {
 // suspect message transitions an alive node to StateSuspect.
 func TestGossipProtocol_HandleSuspectMessage_MarksSuspect(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("suspect-host"))
+	cm, _ := NewClusterManager(testConfig(t, "suspect-host"))
 	gp := cm.gossip
 
 	// Insert a live node at incarnation 1.
@@ -288,7 +288,7 @@ func TestGossipProtocol_HandleSuspectMessage_MarksSuspect(t *testing.T) {
 // suspect message with a non-matching incarnation is ignored.
 func TestGossipProtocol_HandleSuspectMessage_WrongIncarnation(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("wrong-inc"))
+	cm, _ := NewClusterManager(testConfig(t, "wrong-inc"))
 	gp := cm.gossip
 
 	gp.mu.Lock()
@@ -316,7 +316,7 @@ func TestGossipProtocol_HandleSuspectMessage_WrongIncarnation(t *testing.T) {
 // second suspect message from a different node is appended to Suspicion.From.
 func TestGossipProtocol_HandleSuspectMessage_MultipleReporters(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("multi-reporter"))
+	cm, _ := NewClusterManager(testConfig(t, "multi-reporter"))
 	gp := cm.gossip
 
 	gp.mu.Lock()
@@ -348,7 +348,7 @@ func TestGossipProtocol_HandleSuspectMessage_MultipleReporters(t *testing.T) {
 // transitions a node to StateDead.
 func TestGossipProtocol_HandleDeadMessage_MarksDead(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("dead-host"))
+	cm, _ := NewClusterManager(testConfig(t, "dead-host"))
 	gp := cm.gossip
 
 	gp.mu.Lock()
@@ -386,7 +386,7 @@ func TestGossipProtocol_HandleDeadMessage_MarksDead(t *testing.T) {
 // message with a lower incarnation is ignored.
 func TestGossipProtocol_HandleDeadMessage_StaleIncarnation(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("stale-dead"))
+	cm, _ := NewClusterManager(testConfig(t, "stale-dead"))
 	gp := cm.gossip
 
 	gp.mu.Lock()
@@ -414,7 +414,7 @@ func TestGossipProtocol_HandleDeadMessage_StaleIncarnation(t *testing.T) {
 // message adds unknown nodes to the memberlist.
 func TestGossipProtocol_HandleSyncMessage_MergesNodes(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("sync-host"))
+	cm, _ := NewClusterManager(testConfig(t, "sync-host"))
 	gp := cm.gossip
 
 	remoteNodes := map[string]*GossipNode{
@@ -446,7 +446,7 @@ func TestGossipProtocol_HandleSyncMessage_MergesNodes(t *testing.T) {
 // does not overwrite the local node's own entry.
 func TestGossipProtocol_HandleSyncMessage_SkipsSelf(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("sync-self"))
+	cm, _ := NewClusterManager(testConfig(t, "sync-self"))
 	gp := cm.gossip
 
 	// Record the original self incarnation.
@@ -476,7 +476,7 @@ func TestGossipProtocol_HandleSyncMessage_SkipsSelf(t *testing.T) {
 // heartbeat message updates the LastSeen time of the target node.
 func TestGossipProtocol_HandleHeartbeatMessage_UpdatesLastSeen(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("hb-host"))
+	cm, _ := NewClusterManager(testConfig(t, "hb-host"))
 	gp := cm.gossip
 
 	oldTime := time.Now().Add(-1 * time.Hour)
@@ -506,7 +506,7 @@ func TestGossipProtocol_HandleHeartbeatMessage_UpdatesLastSeen(t *testing.T) {
 // heartbeat from a suspected node clears suspicion and restores StateAlive.
 func TestGossipProtocol_HandleHeartbeatMessage_ClearsSuspicion(t *testing.T) {
 	t.Parallel()
-	cm, _ := NewClusterManager(testConfig("hb-suspect"))
+	cm, _ := NewClusterManager(testConfig(t, "hb-suspect"))
 	gp := cm.gossip
 
 	gp.mu.Lock()
@@ -541,7 +541,7 @@ func TestGossipProtocol_HandleHeartbeatMessage_ClearsSuspicion(t *testing.T) {
 // error or panic.
 func TestGossipProtocol_StartStop(t *testing.T) {
 	t.Parallel()
-	cfg := testConfig("lifecycle-gp")
+	cfg := testConfig(t, "lifecycle-gp")
 	cm, err := NewClusterManager(cfg)
 	if err != nil {
 		t.Fatalf("NewClusterManager: %v", err)

--- a/tests/distributed_test.go
+++ b/tests/distributed_test.go
@@ -6,12 +6,34 @@ package tests
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/scttfrdmn/objectfs/internal/distributed"
 )
+
+// writeClusterSecret writes a shared cluster secret to a file and returns its path.
+//
+// Gossip authentication (#206) fails closed: a cluster cannot be constructed without a secret,
+// because an unauthenticated gossip port lets any host on the network join and announce ownership of
+// cached objects. Every cluster built in this file therefore needs one.
+//
+// A file rather than OBJECTFS_CLUSTER_SECRET because the environment is process-wide, and mode 0600
+// because LoadClusterSecret refuses anything more permissive.
+func writeClusterSecret(tb testing.TB) string {
+	tb.Helper()
+
+	path := filepath.Join(tb.TempDir(), "cluster.secret")
+	if err := os.WriteFile(path, []byte(strings.Repeat("s", 32)), 0o600); err != nil {
+		tb.Fatalf("writing the cluster secret: %v", err)
+	}
+
+	return path
+}
 
 func TestClusterManager_BasicOperations(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -20,6 +42,7 @@ func TestClusterManager_BasicOperations(t *testing.T) {
 	// Create cluster configuration
 	config := &distributed.ClusterConfig{
 		NodeID:            "test-node-1",
+		SecretFile:        writeClusterSecret(t),
 		ListenAddr:        "127.0.0.1:18080",
 		AdvertiseAddr:     "127.0.0.1:18080",
 		ElectionTimeout:   2 * time.Second,
@@ -94,6 +117,7 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 
 	config := &distributed.ClusterConfig{
 		NodeID:           "test-node-2",
+		SecretFile:       writeClusterSecret(t),
 		ListenAddr:       "127.0.0.1:18081",
 		AdvertiseAddr:    "127.0.0.1:18081",
 		ElectionTimeout:  time.Second,
@@ -155,6 +179,7 @@ func TestConsensusEngine_LeaderElection(t *testing.T) {
 
 	config := &distributed.ClusterConfig{
 		NodeID:            "consensus-test-1",
+		SecretFile:        writeClusterSecret(t),
 		ElectionTimeout:   time.Second,
 		HeartbeatInterval: 200 * time.Millisecond,
 		LeadershipTTL:     5 * time.Second,
@@ -200,6 +225,7 @@ func TestGossipProtocol_BasicFunctionality(t *testing.T) {
 	// Test basic gossip protocol functionality
 	config := &distributed.ClusterConfig{
 		NodeID:          "gossip-test-1",
+		SecretFile:      writeClusterSecret(t),
 		ListenAddr:      "127.0.0.1:18082",
 		AdvertiseAddr:   "127.0.0.1:18082",
 		GossipInterval:  100 * time.Millisecond,
@@ -238,6 +264,7 @@ func TestGossipProtocol_BasicFunctionality(t *testing.T) {
 func TestLoadBalancer_NodeSelection(t *testing.T) {
 	config := &distributed.ClusterConfig{
 		NodeID:            "lb-test-1",
+		SecretFile:        writeClusterSecret(t),
 		MaxConcurrentOps:  5,
 		ConsistencyLevel:  "eventual",
 		ReplicationFactor: 2,
@@ -321,10 +348,16 @@ func TestMultiNodeCluster(t *testing.T) {
 	nodeCount := 3
 	clusters := make([]*distributed.ClusterManager, nodeCount)
 
+	// One secret for the whole cluster, not one per node. Gossip authentication (#206) uses a
+	// shared cluster secret, so three different secrets would produce three clusters of one —
+	// which is the failure this test exists to distinguish from a working cluster.
+	secretFile := writeClusterSecret(t)
+
 	// Create and start multiple cluster nodes
 	for i := 0; i < nodeCount; i++ {
 		config := &distributed.ClusterConfig{
 			NodeID:            fmt.Sprintf("multi-node-%d", i),
+			SecretFile:        secretFile,
 			ListenAddr:        fmt.Sprintf("127.0.0.1:1808%d", i),
 			AdvertiseAddr:     fmt.Sprintf("127.0.0.1:1808%d", i),
 			ElectionTimeout:   time.Second + time.Duration(i)*100*time.Millisecond,
@@ -416,6 +449,7 @@ func TestConcurrentOperations(t *testing.T) {
 
 	config := &distributed.ClusterConfig{
 		NodeID:           "concurrent-test",
+		SecretFile:       writeClusterSecret(t),
 		ListenAddr:       "127.0.0.1:18090",
 		AdvertiseAddr:    "127.0.0.1:18090",
 		ElectionTimeout:  time.Second,
@@ -496,6 +530,7 @@ func BenchmarkDistributedOperations(b *testing.B) {
 
 	config := &distributed.ClusterConfig{
 		NodeID:           "bench-node",
+		SecretFile:       writeClusterSecret(b),
 		ElectionTimeout:  500 * time.Millisecond,
 		MaxConcurrentOps: 100,
 		ConsistencyLevel: "eventual",


### PR DESCRIPTION
Closes #206.

The gossip protocol runs over UDP and verified nothing about who sent a datagram. Any host that could
reach the port could add itself to the cluster, announce that a node was dead, or announce that it
held the current copy of a cached object — which is a path to a reading process being served bytes
chosen by whoever sent the last announcement.

Every message is now wrapped in an envelope carrying an HMAC-SHA256 over the exact bytes of the inner
message.

## The design, in the parts that are load-bearing

**Authentication happens at two chokepoints.** `sendMessage` and `handleIncomingMessage` are the only
places that write to and read from the socket, so authentication is wired there rather than per
message type. A new message type cannot be introduced unauthenticated by forgetting a step, because
there is no step to forget.

**The MAC is verified before the payload is parsed.** A datagram from an unauthenticated source never
reaches the JSON decoding of any message type, let alone a handler.

**Freshness is checked after the MAC.** The nonce cache must not be writable by an unauthenticated
sender — otherwise flooding it with random message IDs would evict the real entries and re-open the
replay window.

**The MAC covers a `json.RawMessage` of what arrived, never a re-marshal.** Re-marshaling to verify
would make the check depend on Go's map ordering and number formatting agreeing byte-for-byte with
the sender's. That is true today between identical builds, and a silent cluster-wide authentication
failure the first time it is not.

**Replay protection is a window plus a nonce cache, not a sequence number.** A MAC authenticates the
sender but not the moment, so a captured "node N owns key K" would otherwise stay valid forever and
could be replayed to undo the state that replaced it. A per-node monotonic sequence would have to
survive restarts to be monotonic, which reintroduces the fsync-before-ack obligation that per-key
conditional writes exist to avoid; a 30-second window bounds the cache with no persistent state, and
a restart is indistinguishable from a normal message.

**It fails closed.** With no secret configured, `NewClusterManager` returns an error naming both
`OBJECTFS_CLUSTER_SECRET` and `cluster.secret_file` rather than starting unauthenticated. Running
without authentication is the failure nobody notices. This broke five existing tests when it landed,
which is the evidence that it cannot be bypassed — and the multi-node test now supplies one secret
for the whole cluster rather than one per node, since three different secrets would produce three
clusters of one, the exact failure that test exists to distinguish from a working cluster.

**The secret is never a YAML field.** Packaging installs the shipped configuration world-readable, so
a secret there would be published to every user on the node. Environment or file only; a file
readable by anyone but its owner is refused, as is one shorter than 32 bytes, and both errors say how
to generate a good one. `examples/config.yaml` explains why there is no `secret_file` key in it
rather than adding one that nothing reads.

**Rejections are counted three ways, not one.** A bad MAC, a replay, and an unknown envelope version
each get their own counter and their own operator hint, because they send someone to three different
places: a cluster of one with a rising unauthenticated count is a wrong secret; the same cluster with
a rising wrong-version count is a half-finished upgrade. An unenveloped message decodes as version 0
and is therefore reported as version skew rather than a bad secret — correct, since a peer sending
one is running a build from before this change.

## What it does not do

Stated in the package documentation rather than left to be assumed: payloads are not encrypted (they
are membership metadata and cache keys), and because every member holds the same key, a compromised
node can impersonate any other. Per-node keys are a different threat model.

## Verification

Mutation-verified, per the rule that a predicted failure signature is not a verified one. Five
mutations, each caught by the tests:

| mutation | caught by |
|---|---|
| MAC comparison always succeeds | `TestUnauthenticatedJoinIsRejected`, `TestTamperedPayloadIsRejected` |
| freshness check skipped | five replay/window tests |
| missing secret falls back to a default | `TestClusterRefusesToStartWithoutASecret` |
| permissions check removed | `TestLoadClusterSecret`, `TestSecretFilePermissions` |
| **auth bypassed at the chokepoint** (falls through to the bare message) | `TestUnauthenticatedJoinIsRejected` |

The last one is the one that matters most: an authenticator that verifies correctly while a handler
runs anyway would pass every test that only checks the verifier's return value. So the join tests
assert on observable cluster state — "the intruder is not in the nodes map" — and not only on errors.

Gates: `go build`, `go vet`, `gofmt -l` clean, full suite green under `-race`, coverage gate 34
packages at or above floor (`internal/distributed` 70.0%), `golangci-lint --new-from-merge-base`
0 issues.

## One thing found along the way, not fixed here

`tests/distributed_test.go` is behind `-tags=distributed` and has a pre-existing failure that this
branch did not introduce (confirmed by stashing): `TestConcurrentOperations` prints
`Failed 10 out of 10 concurrent operations` and then `Successful: 10, Failed: 0` in the same run,
because a failed operation is counted as a success. Filed as #269. That no CI job compiles this tag
is #240, and this is what it would have caught.