### PR TITLE
fix: make the consistent-hash strategy actually consistent (#131)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -131,6 +131,10 @@ internal/config          88
 internal/cost            98
 internal/difftest        75
 internal/distributed     67
+# 100, and it can hold there: the package is one type with five methods and two free functions, no
+# I/O, no clock, and no error paths — so there is no code in it that is expensive to reach. A floor
+# below 100 here would only be permission to add an untested branch.
+internal/distributed/hashring 100
 internal/filesystem      88
 # 45 → 48: the previous floor was not a stable measurement. Eight tests started a Monitor whose
 # default Config enables the health endpoint on the fixed port 8081, so each Start raced its siblings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   LocalStack, and the sprint it named is long past; it now names the specific gap, which is that the
   consensus engine elects leaders and replicates nothing.
 
+- **`StrategyConsistentHash` was not consistent, and could not have been** ([#131]).
+  `selectConsistentHash` was `return nodes[:count]` under a comment saying a real ring belonged there,
+  and its node slice is built by ranging a map — so the same key reached a different node on each
+  call, which is the one property consistent hashing exists to provide. A per-node cache keyed on an
+  assignment that changes per call cannot hit.
+
+  It is now a rendezvous (highest-random-weight) ring in `internal/distributed/hashring`: score every
+  node against the key, take the highest. Removing a node moves only the keys that node owned —
+  measured at about 1/n, and asserted with that bound — rather than remapping everything. Lookup is
+  O(n) in nodes, which the benchmark settles rather than argues: 1555 ns at 100 nodes and 125 ns at 8,
+  zero allocations, three orders of magnitude below the S3 round trip it precedes, so a sorted ring
+  with virtual nodes would be complexity spent on nothing.
+
+  The fix needed a signature change the issue did not mention: `LoadBalancer.SelectNodes` never
+  received the operation key, so no implementation behind it could have hashed by key. It now takes
+  one, which makes the key mandatory at all five call sites instead of something a strategy could
+  silently do without. `selectTargetNodes` also sorts its alive-node slice, because the ring sorts
+  internally but round-robin and the least-load tiebreak index positionally — for those, the order the
+  map happened to be iterated in *was* the decision. A keyless operation (a list with no elected
+  leader, a batch) falls back to round-robin rather than hashing the empty string, which would
+  concentrate every such operation on one node.
+
+  The existing test for this strategy asserted only the returned count, and its own comment described
+  the defect — "returns the requested number of nodes from the front of the list" — as the intended
+  behavior. A count assertion cannot tell a hash ring from a slice prefix, so it now asserts that
+  permuting the input does not change the output, which the prefix fails.
+
+[#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#267]: https://github.com/scttfrdmn/objectfs/issues/267
 [scttfrdmn/substrate#540]: https://github.com/scttfrdmn/substrate/issues/540

--- a/internal/distributed/coordinator.go
+++ b/internal/distributed/coordinator.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"sort"
 	"sync"
 	"time"
 
+	"github.com/scttfrdmn/objectfs/internal/distributed/hashring"
 	"github.com/scttfrdmn/objectfs/pkg/types"
 )
 
@@ -319,31 +321,37 @@ func (c *Coordinator) selectTargetNodes(op *DistributedOperation) ([]string, err
 		return nil, fmt.Errorf("no alive nodes available")
 	}
 
+	// GetNodes returns a map, and Go randomizes map iteration order, so aliveNodes arrives in a
+	// different order on every call. Sorting it makes selection a function of the membership set
+	// rather than of the iteration that observed it — which the hash ring guarantees for itself, but
+	// round-robin and the least-load tiebreak do not (#131).
+	sort.Strings(aliveNodes)
+
 	// Select nodes based on operation type and consistency requirements
 	switch op.Type {
 	case OpTypeGet:
 		// For reads, select based on load balancing strategy
-		return c.loadBalancer.SelectNodes(aliveNodes, 1)
+		return c.loadBalancer.SelectNodes(op.Key, aliveNodes, 1)
 
 	case OpTypePut, OpTypeDelete:
 		// For writes, select based on replication factor
 		replicationFactor := min(c.config.ReplicationFactor, len(aliveNodes))
-		return c.loadBalancer.SelectNodes(aliveNodes, replicationFactor)
+		return c.loadBalancer.SelectNodes(op.Key, aliveNodes, replicationFactor)
 
 	case OpTypeList:
 		// For list operations, use the leader or a random node
 		if leader := c.cluster.GetLeader(); leader != "" {
 			return []string{leader}, nil
 		}
-		return c.loadBalancer.SelectNodes(aliveNodes, 1)
+		return c.loadBalancer.SelectNodes(op.Key, aliveNodes, 1)
 
 	case OpTypeBatch:
 		// For batch operations, distribute across multiple nodes
 		nodeCount := min(len(aliveNodes), 3)
-		return c.loadBalancer.SelectNodes(aliveNodes, nodeCount)
+		return c.loadBalancer.SelectNodes(op.Key, aliveNodes, nodeCount)
 
 	default:
-		return c.loadBalancer.SelectNodes(aliveNodes, 1)
+		return c.loadBalancer.SelectNodes(op.Key, aliveNodes, 1)
 	}
 }
 
@@ -852,13 +860,22 @@ func (c *Coordinator) calculateLoadBalancerStats() {
 
 // LoadBalancer methods
 
-// SelectNodes selects nodes based on the load balancing strategy
-func (lb *LoadBalancer) SelectNodes(availableNodes []string, count int) ([]string, error) {
+// SelectNodes selects count nodes to execute an operation on the given key.
+//
+// key is the object key the operation addresses. It is a parameter rather than something the
+// strategies look up because StrategyConsistentHash cannot function without it: the whole point of
+// consistent hashing is that the node is a function of the key, and this method previously took only
+// the node set and the count (#131). Every strategy takes it so that adding a key-dependent strategy
+// is not another signature change, and the strategies that ignore it say so.
+//
+// The returned slice is in preference order: element 0 is the primary. Callers rely on that —
+// Session consistency executes on targetNodes[0] first.
+func (lb *LoadBalancer) SelectNodes(key string, availableNodes []string, count int) ([]string, error) {
 	if count > len(availableNodes) {
 		count = len(availableNodes)
 	}
 
-	if count == 0 {
+	if count <= 0 {
 		return []string{}, nil
 	}
 
@@ -868,7 +885,7 @@ func (lb *LoadBalancer) SelectNodes(availableNodes []string, count int) ([]strin
 	case StrategyLeastLoad:
 		return lb.selectLeastLoad(availableNodes, count)
 	case StrategyConsistentHash:
-		return lb.selectConsistentHash(availableNodes, count)
+		return lb.selectConsistentHash(key, availableNodes, count)
 	default:
 		return availableNodes[:count], nil
 	}
@@ -915,14 +932,27 @@ func (lb *LoadBalancer) selectLeastLoad(nodes []string, count int) ([]string, er
 	return selected, nil
 }
 
-func (lb *LoadBalancer) selectConsistentHash(nodes []string, count int) ([]string, error) {
-	// Simple consistent hash implementation
-	// In practice, you'd use a proper consistent hash ring
-	if len(nodes) <= count {
-		return nodes, nil
+// selectConsistentHash maps key onto nodes with a rendezvous hash ring, so that the same key reaches
+// the same node for as long as that node is alive.
+//
+// This used to be `return nodes[:count]` under a comment saying a real ring belonged here (#131).
+// Since nodes arrives from a map iteration, that returned a different answer on each call for the
+// same key — which is the one property consistent hashing exists to provide, and the property a
+// cache needs in order to hit. See internal/distributed/hashring for the scheme and its bounds.
+//
+// The ring is built per call rather than kept as state on the LoadBalancer. Building it is a sorted
+// insert per node, and the alternative is a ring that has to be kept in step with gossip membership
+// — a second copy of the node set that can disagree with the first. At the node counts here the
+// build is cheaper than being wrong; hashring's benchmarks are what that claim rests on.
+func (lb *LoadBalancer) selectConsistentHash(key string, nodes []string, count int) ([]string, error) {
+	if key == "" {
+		// A keyless operation has nothing to hash. Round-robin is the honest fallback: it does not
+		// pretend to affinity it cannot provide, and it does not silently return nodes[:count],
+		// which would concentrate every keyless operation on whichever node sorted first.
+		return lb.selectRoundRobin(nodes, count)
 	}
 
-	return nodes[:count], nil
+	return hashring.New(nodes...).LookupN(key, count), nil
 }
 
 // GetStats returns coordinator statistics

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -3,6 +3,8 @@ package distributed
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -482,7 +484,7 @@ func TestLoadBalancer_SelectNodes_Empty(t *testing.T) {
 	}
 	lb := cm.coordinator.loadBalancer
 
-	got, err := lb.SelectNodes([]string{}, 3)
+	got, err := lb.SelectNodes("objects/data.bin", []string{}, 3)
 	if err != nil {
 		t.Fatalf("SelectNodes: %v", err)
 	}
@@ -503,7 +505,7 @@ func TestLoadBalancer_RoundRobin(t *testing.T) {
 	lb.strategy = StrategyRoundRobin
 
 	nodes := []string{"n1", "n2", "n3"}
-	got, err := lb.SelectNodes(nodes, 3)
+	got, err := lb.SelectNodes("objects/data.bin", nodes, 3)
 	if err != nil {
 		t.Fatalf("SelectNodes: %v", err)
 	}
@@ -524,7 +526,7 @@ func TestLoadBalancer_CountCappedToAvailable(t *testing.T) {
 	lb.strategy = StrategyRoundRobin
 
 	nodes := []string{"n1", "n2"}
-	got, err := lb.SelectNodes(nodes, 10) // request more than available
+	got, err := lb.SelectNodes("objects/data.bin", nodes, 10) // request more than available
 	if err != nil {
 		t.Fatalf("SelectNodes: %v", err)
 	}
@@ -550,7 +552,7 @@ func TestLoadBalancer_LeastLoad(t *testing.T) {
 	lb.stats.NodeLoad["n3"] = 5
 	lb.stats.mu.Unlock()
 
-	got, err := lb.SelectNodes([]string{"n1", "n2", "n3"}, 1)
+	got, err := lb.SelectNodes("objects/data.bin", []string{"n1", "n2", "n3"}, 1)
 	if err != nil {
 		t.Fatalf("SelectNodes: %v", err)
 	}
@@ -559,8 +561,14 @@ func TestLoadBalancer_LeastLoad(t *testing.T) {
 	}
 }
 
-// TestLoadBalancer_ConsistentHash verifies that consistent-hash selection
-// returns the requested number of nodes from the front of the list.
+// TestLoadBalancer_ConsistentHash verifies that consistent-hash selection maps a key to the same
+// nodes regardless of the order the node list arrives in.
+//
+// This test used to assert only the count, and its own comment described the behavior as "returns
+// the requested number of nodes from the front of the list" — which was an accurate description of
+// the defect (#131). A count assertion passes on `return nodes[:count]`, so it could not tell a hash
+// ring from a slice prefix. The assertion below cannot pass on a slice prefix: aliveNodes reaches
+// this function from a map iteration, so a prefix gives a different answer per permutation.
 func TestLoadBalancer_ConsistentHash(t *testing.T) {
 	t.Parallel()
 	cm, err := NewClusterManager(testConfig(t, "lb-ch"))
@@ -570,13 +578,179 @@ func TestLoadBalancer_ConsistentHash(t *testing.T) {
 	lb := cm.coordinator.loadBalancer
 	lb.strategy = StrategyConsistentHash
 
-	nodes := []string{"n1", "n2", "n3"}
-	got, err := lb.SelectNodes(nodes, 2)
+	const key = "objects/dataset.bin"
+
+	want, err := lb.SelectNodes(key, []string{"n1", "n2", "n3"}, 2)
+	if err != nil {
+		t.Fatalf("SelectNodes: %v", err)
+	}
+	if len(want) != 2 {
+		t.Fatalf("expected 2 nodes, got %d: %v", len(want), want)
+	}
+
+	for _, order := range [][]string{
+		{"n3", "n2", "n1"},
+		{"n2", "n3", "n1"},
+		{"n2", "n1", "n3"},
+		{"n3", "n1", "n2"},
+	} {
+		got, err := lb.SelectNodes(key, order, 2)
+		if err != nil {
+			t.Fatalf("SelectNodes(%v): %v", order, err)
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("nodes in order %v selected %v, want %v — selection depends on input order",
+				order, got, want)
+		}
+	}
+
+	// Different keys must not all land on the same node, or affinity is technically satisfied and
+	// practically useless — every object in the bucket served by one member of the cluster.
+	owners := make(map[string]bool)
+	for i := range 32 {
+		got, err := lb.SelectNodes(fmt.Sprintf("objects/file-%d.bin", i), []string{"n1", "n2", "n3"}, 1)
+		if err != nil {
+			t.Fatalf("SelectNodes: %v", err)
+		}
+		owners[got[0]] = true
+	}
+	if len(owners) < 2 {
+		t.Errorf("32 distinct keys reached %d node(s): %v", len(owners), owners)
+	}
+}
+
+// TestLoadBalancer_ConsistentHashWithoutAKey covers the operation types that carry no key — a list
+// with no leader, and a batch. Hashing "" would send every keyless operation to one node, so the
+// strategy falls back to round-robin, and this pins that it does rather than returning a prefix.
+func TestLoadBalancer_ConsistentHashWithoutAKey(t *testing.T) {
+	t.Parallel()
+	cm, err := NewClusterManager(testConfig(t, "lb-ch-nokey"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	lb := cm.coordinator.loadBalancer
+	lb.strategy = StrategyConsistentHash
+
+	got, err := lb.SelectNodes("", []string{"n1", "n2", "n3"}, 2)
 	if err != nil {
 		t.Fatalf("SelectNodes: %v", err)
 	}
 	if len(got) != 2 {
-		t.Errorf("expected 2 nodes, got %d", len(got))
+		t.Fatalf("expected 2 nodes, got %d: %v", len(got), got)
+	}
+}
+
+// TestSelectTargetNodes_IsOrderIndependent is the end-to-end version, and the one that matters:
+// selectTargetNodes builds its node slice by ranging the cluster's node map, so this exercises the
+// randomized iteration the unit test above can only simulate. Repeated calls with unchanged
+// membership must select the same node for the same key.
+func TestSelectTargetNodes_IsOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "n1"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	cm.coordinator.loadBalancer.strategy = StrategyConsistentHash
+
+	// Five alive members, so a prefix over a randomized iteration would almost never agree with
+	// itself across 50 calls. Registered directly rather than via Start, because Start opens a
+	// socket and runs gossip, and this test is about the selection decision.
+	cm.mu.Lock()
+	for _, id := range []string{"n1", "n2", "n3", "n4", "n5"} {
+		cm.nodes[id] = &NodeInfo{ID: id, Address: "10.0.0.1:8080", Status: NodeStatusAlive}
+	}
+	cm.mu.Unlock()
+
+	op := &DistributedOperation{Type: OpTypeGet, Key: "objects/dataset.bin"}
+
+	want, err := cm.coordinator.selectTargetNodes(op)
+	if err != nil {
+		t.Fatalf("selectTargetNodes: %v", err)
+	}
+
+	for i := range 50 {
+		got, err := cm.coordinator.selectTargetNodes(op)
+		if err != nil {
+			t.Fatalf("selectTargetNodes (call %d): %v", i, err)
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("call %d selected %v, want %v — map iteration order reached the decision",
+				i, got, want)
+		}
+	}
+}
+
+// TestSelectTargetNodes_SortsAliveNodes covers the half of the fix the hash ring does not: the ring
+// sorts its own nodes, so removing the sort in selectTargetNodes changes nothing a consistent-hash
+// test can see — verified by removing it. Round-robin and the least-load tiebreak index the slice
+// positionally, so for them the order the map was iterated in *is* the decision.
+//
+// StrategyRoundRobin with count == len(nodes) returns the slice as given, which makes it the
+// cheapest probe for whether the caller sorted.
+func TestSelectTargetNodes_SortsAliveNodes(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "n1"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	cm.coordinator.loadBalancer.strategy = StrategyRoundRobin
+	cm.config.ReplicationFactor = 5
+
+	cm.mu.Lock()
+	for _, id := range []string{"n1", "n2", "n3", "n4", "n5"} {
+		cm.nodes[id] = &NodeInfo{ID: id, Address: "10.0.0.1:8080", Status: NodeStatusAlive}
+	}
+	cm.mu.Unlock()
+
+	want := []string{"n1", "n2", "n3", "n4", "n5"}
+	op := &DistributedOperation{Type: OpTypePut, Key: "objects/dataset.bin"}
+
+	// 50 calls, because an unsorted 5-element map iteration lands on ascending order roughly 1 time
+	// in 120; a single call would pass on the unsorted code more often than it would be worth.
+	for i := range 50 {
+		got, err := cm.coordinator.selectTargetNodes(op)
+		if err != nil {
+			t.Fatalf("selectTargetNodes (call %d): %v", i, err)
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("call %d selected %v, want %v — alive nodes reach the strategy in map order",
+				i, got, want)
+		}
+	}
+}
+
+// TestSelectTargetNodes_ExcludesDeadNodes is the precondition the two tests above assume: selection
+// happens over the alive set. Asserted rather than assumed, because sorting a slice that contains
+// dead nodes would be deterministic and still route to a node that cannot answer.
+func TestSelectTargetNodes_ExcludesDeadNodes(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "n1"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	cm.coordinator.loadBalancer.strategy = StrategyConsistentHash
+
+	cm.mu.Lock()
+	cm.nodes["n1"] = &NodeInfo{ID: "n1", Status: NodeStatusAlive}
+	cm.nodes["n2"] = &NodeInfo{ID: "n2", Status: NodeStatusDead}
+	cm.nodes["n3"] = &NodeInfo{ID: "n3", Status: NodeStatusSuspect}
+	cm.mu.Unlock()
+
+	// Enough keys that a node in the candidate set would be selected by at least one of them.
+	for i := range 64 {
+		got, err := cm.coordinator.selectTargetNodes(&DistributedOperation{
+			Type: OpTypeGet,
+			Key:  fmt.Sprintf("objects/file-%d.bin", i),
+		})
+		if err != nil {
+			t.Fatalf("selectTargetNodes: %v", err)
+		}
+		if len(got) != 1 || got[0] != "n1" {
+			t.Fatalf("selected %v, want [n1]: only n1 is alive", got)
+		}
 	}
 }
 

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -205,9 +205,15 @@ Least Load (StrategyLeastLoad):
 - Default strategy
 
 Consistent Hash (StrategyConsistentHash):
-- Maps keys to specific nodes
-- Minimizes rebalancing on node changes
-- Good for cache distribution
+- Maps a key to a node by rendezvous (highest-random-weight) hashing
+- The same key reaches the same node for as long as that node is alive
+- Removing a node moves only the keys it owned, about 1/n, not the whole mapping
+- Selection is independent of the order the node set is iterated in. Until v0.11.0 it was not:
+the implementation was a slice prefix over a slice built by ranging a map, so the same key
+reached a different node on each call, and a per-node cache could not hit (#131)
+- Requires an operation key. A keyless operation — a list with no elected leader, or a batch —
+falls back to round-robin, since hashing the empty key would send all of them to one node
+- See internal/distributed/hashring for the scheme, its bounds, and the lookup benchmark
 
 Latency Based (StrategyLatencyBased):
 - Routes to fastest responding nodes

--- a/internal/distributed/hashring/hashring.go
+++ b/internal/distributed/hashring/hashring.go
@@ -1,0 +1,191 @@
+// Package hashring assigns keys to cluster nodes so that the same key lands on the same node, and so
+// that adding or removing a node moves as few keys as possible.
+//
+// That second property is the point, and it is what "consistent" means here. A cache is only worth
+// having if a key's owner is stable: if the mapping changes, the data sitting on the old owner is
+// dead weight and the new owner has to fetch from S3. With N nodes and a modulo assignment, losing
+// one node remaps roughly every key. With the scheme in this package, it remaps only the keys the
+// departed node owned.
+//
+// The implementation is rendezvous hashing, also called highest random weight (HRW): to place a key,
+// hash (node, key) for every node and take the highest score. Nothing is precomputed and there is no
+// ring structure to rebalance, so Add and Remove are trivial and there are no virtual nodes to tune.
+// The cost is that a lookup is O(n) in the number of nodes rather than O(log n) — which for the node
+// counts a filesystem cluster actually has is not a cost worth a more complicated data structure.
+// See the benchmark.
+//
+// Ties are broken by node ID, so a lookup does not depend on the order nodes were added or on Go's
+// map iteration order. That determinism is the whole property being bought and is asserted directly
+// by the tests: it is the specific thing the previous implementation — a slice prefix, over a slice
+// built by ranging a map — did not have.
+package hashring
+
+import (
+	"sort"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// HashRing maps keys to nodes.
+//
+// An implementation must be deterministic: for the same key and the same set of nodes, Lookup and
+// LookupN return the same answer, whatever order the nodes were added in.
+type HashRing interface {
+	// Add adds a node. Adding a node already present is a no-op.
+	Add(nodeID string)
+
+	// Remove removes a node. Removing a node not present is a no-op.
+	Remove(nodeID string)
+
+	// Lookup returns the node that owns key, or "" if there are no nodes.
+	Lookup(key string) string
+
+	// LookupN returns the n nodes with the highest scores for key, in descending score order, so
+	// that element 0 is the primary owner and the rest are replicas in a stable preference order.
+	// Fewer than n are returned when the ring holds fewer than n nodes, and the result is never nil
+	// for n > 0 — an empty ring yields an empty slice, not a panic.
+	LookupN(key string, n int) []string
+}
+
+// RendezvousRing is a HashRing using highest-random-weight hashing.
+//
+// It holds no lock. A ring is built from a snapshot of the alive nodes and used for one selection,
+// which is how the coordinator uses it; sharing one across goroutines while calling Add or Remove
+// needs external synchronization. Stated rather than solved with a mutex nothing would contend on.
+type RendezvousRing struct {
+	// nodes is kept sorted so that iteration order is fixed. Determinism does not depend on this —
+	// ties are broken explicitly — but it makes the invariant hold by construction rather than by
+	// argument, and it makes Add/Remove/String cheap to reason about.
+	nodes []string
+}
+
+// New returns a ring holding the given nodes. Duplicates are collapsed.
+func New(nodes ...string) *RendezvousRing {
+	r := &RendezvousRing{}
+	for _, n := range nodes {
+		r.Add(n)
+	}
+
+	return r
+}
+
+// Len returns the number of nodes in the ring.
+func (r *RendezvousRing) Len() int { return len(r.nodes) }
+
+// Nodes returns the ring's nodes in sorted order. The returned slice is a copy.
+func (r *RendezvousRing) Nodes() []string {
+	out := make([]string, len(r.nodes))
+	copy(out, r.nodes)
+
+	return out
+}
+
+// Add adds a node, keeping the node list sorted and free of duplicates.
+func (r *RendezvousRing) Add(nodeID string) {
+	i := sort.SearchStrings(r.nodes, nodeID)
+	if i < len(r.nodes) && r.nodes[i] == nodeID {
+		return
+	}
+
+	r.nodes = append(r.nodes, "")
+	copy(r.nodes[i+1:], r.nodes[i:])
+	r.nodes[i] = nodeID
+}
+
+// Remove removes a node.
+func (r *RendezvousRing) Remove(nodeID string) {
+	i := sort.SearchStrings(r.nodes, nodeID)
+	if i >= len(r.nodes) || r.nodes[i] != nodeID {
+		return
+	}
+
+	r.nodes = append(r.nodes[:i], r.nodes[i+1:]...)
+}
+
+// Lookup returns the owner of key, or "" when the ring is empty.
+//
+// This is LookupN(key, 1) without allocating, since it is the common case: a read picks one node.
+func (r *RendezvousRing) Lookup(key string) string {
+	if len(r.nodes) == 0 {
+		return ""
+	}
+
+	best := scored{node: r.nodes[0], score: score(r.nodes[0], key)}
+
+	// outranks, not an inlined comparison, so that a tie resolves the same way here as it does in
+	// LookupN. Two implementations of one rule is how the two entry points would drift apart.
+	for _, node := range r.nodes[1:] {
+		if cand := (scored{node: node, score: score(node, key)}); outranks(cand, best) {
+			best = cand
+		}
+	}
+
+	return best.node
+}
+
+// LookupN returns the n highest-scoring nodes for key, in descending score order.
+func (r *RendezvousRing) LookupN(key string, n int) []string {
+	if n <= 0 || len(r.nodes) == 0 {
+		return []string{}
+	}
+
+	all := make([]scored, len(r.nodes))
+	for i, node := range r.nodes {
+		all[i] = scored{node: node, score: score(node, key)}
+	}
+
+	sort.Slice(all, func(i, j int) bool { return outranks(all[i], all[j]) })
+
+	if n > len(all) {
+		n = len(all)
+	}
+
+	out := make([]string, n)
+	for i := range n {
+		out[i] = all[i].node
+	}
+
+	return out
+}
+
+// scored is a node with its weight for one key.
+type scored struct {
+	node  string
+	score uint64
+}
+
+// outranks reports whether a should be placed before b: higher score wins, and equal scores are
+// broken by the lower node ID.
+//
+// The tiebreak is the reason this is a named function rather than an inline closure. Two nodes
+// colliding on a 64-bit score is not reachable from any input a test can construct, so a test
+// driving Lookup cannot exercise it — and sort.Slice is not stable, so without the tiebreak a
+// collision would resolve to whichever element the sort happened to leave first, which is exactly
+// the input-order dependence this package exists to remove. Extracting it makes the rule assertable
+// directly instead of relying on a collision that will not occur.
+func outranks(a, b scored) bool {
+	if a.score != b.score {
+		return a.score > b.score
+	}
+
+	return a.node < b.node
+}
+
+// score is the rendezvous weight of a (node, key) pair.
+//
+// The separator matters: without it, node "a" with key "bc" and node "ab" with key "c" hash the same
+// bytes and therefore score the same, which would make one node's ownership depend on another node's
+// name. "#" is used because a node ID is a hostname or a generated "node-<hex>" identifier and
+// contains neither "#" nor a NUL.
+//
+// xxhash rather than a cryptographic hash because this is a placement decision, not a security
+// boundary: an adversary who can choose keys can already choose which node to talk to. It is also
+// already in the module graph as a transitive dependency, so this adds no new one.
+func score(nodeID, key string) uint64 {
+	h := xxhash.New()
+	_, _ = h.WriteString(nodeID) // xxhash's Write never returns an error
+	_, _ = h.WriteString("#")
+	_, _ = h.WriteString(key)
+
+	return h.Sum64()
+}

--- a/internal/distributed/hashring/hashring_test.go
+++ b/internal/distributed/hashring/hashring_test.go
@@ -1,0 +1,545 @@
+package hashring
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The property under test is not "keys are spread evenly" — a slice prefix does that too, and a
+// slice prefix is what this package replaces. It is that the mapping is *stable*: stable across
+// calls, stable across the order nodes arrive in, and stable across the departure of a node that
+// did not own the key. Those three are what a cache needs, and they are what the previous
+// implementation — `return nodes[:count]`, over a slice built by ranging a map — did not have.
+
+func nodeIDs(n int) []string {
+	ids := make([]string, n)
+	for i := range n {
+		ids[i] = fmt.Sprintf("node-%02d", i)
+	}
+
+	return ids
+}
+
+func keys(n int) []string {
+	ks := make([]string, n)
+	for i := range n {
+		ks[i] = fmt.Sprintf("objects/dataset-%04d.bin", i)
+	}
+
+	return ks
+}
+
+// TestRendezvousRingImplementsHashRing pins the interface at compile time. Stated as a test rather
+// than a blank var so the reason is visible: the coordinator holds the interface, not the struct.
+func TestRendezvousRingImplementsHashRing(t *testing.T) {
+	t.Parallel()
+
+	var _ HashRing = New("node-a")
+}
+
+// TestLookupIsDeterministic is the defect in #131 stated directly: the same key and the same node
+// set must give the same answer regardless of the order the nodes were added.
+//
+// The permutations matter because the caller builds its node slice by ranging a map, whose order Go
+// deliberately randomizes per iteration. A test that only calls Lookup twice on one ring would pass
+// on an implementation that returned nodes[0].
+func TestLookupIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	nodes := nodeIDs(8)
+
+	// A ring built in ascending order is the reference.
+	want := make(map[string]string, 64)
+	ref := New(nodes...)
+	for _, k := range keys(64) {
+		want[k] = ref.Lookup(k)
+	}
+
+	// Descending, and then several rotations, cover the orderings a map iteration could produce
+	// without depending on the map to produce them.
+	orders := [][]string{reversed(nodes)}
+	for shift := 1; shift < len(nodes); shift++ {
+		orders = append(orders, rotated(nodes, shift))
+	}
+
+	for i, order := range orders {
+		ring := New(order...)
+		for k, wantNode := range want {
+			if got := ring.Lookup(k); got != wantNode {
+				t.Fatalf("order %d: Lookup(%q) = %q, want %q — insertion order changed the mapping",
+					i, k, got, wantNode)
+			}
+		}
+	}
+}
+
+// TestLookupNIsDeterministic extends the same requirement to the replica list, including its order.
+// Replica order is load-bearing: targetNodes[0] is the node Session consistency executes on first,
+// so a set that is right but ordered differently per call still moves work between nodes.
+func TestLookupNIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	nodes := nodeIDs(6)
+	ref := New(nodes...)
+	shuffled := New(reversed(nodes)...)
+
+	for _, k := range keys(32) {
+		want := ref.LookupN(k, 3)
+		got := shuffled.LookupN(k, 3)
+
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("LookupN(%q, 3) = %v, want %v — insertion order changed the replica order",
+				k, got, want)
+		}
+	}
+}
+
+// TestLookupAgreesWithLookupN checks the two entry points cannot drift apart. Lookup is a separate
+// non-allocating loop, so nothing but a test keeps it consistent with the sort in LookupN.
+func TestLookupAgreesWithLookupN(t *testing.T) {
+	t.Parallel()
+
+	ring := New(nodeIDs(10)...)
+
+	for _, k := range keys(128) {
+		single := ring.Lookup(k)
+		first := ring.LookupN(k, 1)
+
+		if len(first) != 1 || first[0] != single {
+			t.Fatalf("Lookup(%q) = %q but LookupN(%q, 1) = %v", k, single, k, first)
+		}
+	}
+}
+
+// TestRemovingANonOwnerDoesNotRemap is the property that makes this worth doing. Removing a node
+// must only move the keys that node owned; every other key must stay where it was, or the cache on
+// every surviving node is invalidated by an unrelated node's departure.
+func TestRemovingANonOwnerDoesNotRemap(t *testing.T) {
+	t.Parallel()
+
+	nodes := nodeIDs(5)
+	ring := New(nodes...)
+
+	before := make(map[string]string, 256)
+	for _, k := range keys(256) {
+		before[k] = ring.Lookup(k)
+	}
+
+	victim := nodes[2]
+	ring.Remove(victim)
+
+	moved := 0
+	for k, owner := range before {
+		got := ring.Lookup(k)
+
+		switch {
+		case owner == victim:
+			// Its keys must go somewhere, and not to the node that just left.
+			if got == victim {
+				t.Fatalf("Lookup(%q) still returns the removed node %q", k, victim)
+			}
+			moved++
+		case got != owner:
+			t.Errorf("Lookup(%q) moved from %q to %q, but %q was not the removed node",
+				k, owner, got, owner)
+		}
+	}
+
+	if moved == 0 {
+		t.Fatal("removing a node moved no keys, so the victim owned none — the test proves nothing")
+	}
+}
+
+// TestAddingANodeOnlyTakesKeys is the mirror: a new node may claim keys, but no key may move
+// between two nodes that were both already present. That is the bound on rebalancing cost.
+func TestAddingANodeOnlyTakesKeys(t *testing.T) {
+	t.Parallel()
+
+	ring := New(nodeIDs(5)...)
+
+	before := make(map[string]string, 256)
+	for _, k := range keys(256) {
+		before[k] = ring.Lookup(k)
+	}
+
+	const newcomer = "node-new"
+	ring.Add(newcomer)
+
+	claimed := 0
+	for k, owner := range before {
+		switch got := ring.Lookup(k); got {
+		case owner:
+		case newcomer:
+			claimed++
+		default:
+			t.Errorf("Lookup(%q) moved from %q to %q — neither is the added node", k, owner, got)
+		}
+	}
+
+	if claimed == 0 {
+		t.Error("the new node claimed no keys out of 256, which is not a plausible share of 6")
+	}
+}
+
+// TestLookupNReturnsDistinctNodes pins that replicas are distinct. Returning the same node twice
+// would report a replication factor of 3 while storing one copy — the class of defect where a
+// success is reported for something that did not happen.
+func TestLookupNReturnsDistinctNodes(t *testing.T) {
+	t.Parallel()
+
+	ring := New(nodeIDs(7)...)
+
+	for _, k := range keys(64) {
+		got := ring.LookupN(k, 3)
+		if len(got) != 3 {
+			t.Fatalf("LookupN(%q, 3) returned %d nodes", k, len(got))
+		}
+
+		seen := make(map[string]bool, 3)
+		for _, n := range got {
+			if seen[n] {
+				t.Fatalf("LookupN(%q, 3) = %v contains %q twice", k, got, n)
+			}
+			seen[n] = true
+		}
+	}
+}
+
+// TestLookupNClampsToRingSize covers asking for more replicas than there are nodes, which is what a
+// ReplicationFactor of 3 on a two-node cluster does. Fewer nodes, no error, no padding with "".
+func TestLookupNClampsToRingSize(t *testing.T) {
+	t.Parallel()
+
+	ring := New("node-a", "node-b")
+
+	got := ring.LookupN("objects/data.bin", 5)
+	if len(got) != 2 {
+		t.Fatalf("LookupN with n > ring size returned %d nodes, want 2: %v", len(got), got)
+	}
+	for i, n := range got {
+		if n == "" {
+			t.Errorf("element %d is empty — the result was padded rather than clamped", i)
+		}
+	}
+}
+
+// TestEmptyRing pins that an empty ring is answered rather than panicked on. The coordinator
+// already refuses an operation when no node is alive, but a ring that panics on an empty node set
+// turns a routing decision into a crash of the mount process.
+func TestEmptyRing(t *testing.T) {
+	t.Parallel()
+
+	ring := New()
+
+	if got := ring.Lookup("objects/data.bin"); got != "" {
+		t.Errorf("Lookup on an empty ring = %q, want \"\"", got)
+	}
+
+	got := ring.LookupN("objects/data.bin", 3)
+	if got == nil {
+		t.Error("LookupN on an empty ring returned nil; want an empty slice, so callers can range it")
+	}
+	if len(got) != 0 {
+		t.Errorf("LookupN on an empty ring = %v, want empty", got)
+	}
+}
+
+// TestNonPositiveCount pins the boundary on the other side. count reaches here from
+// min(ReplicationFactor, len(aliveNodes)), and a misconfigured factor of 0 or a negative must not
+// index a slice.
+func TestNonPositiveCount(t *testing.T) {
+	t.Parallel()
+
+	ring := New(nodeIDs(3)...)
+
+	for _, n := range []int{0, -1} {
+		got := ring.LookupN("objects/data.bin", n)
+		if len(got) != 0 {
+			t.Errorf("LookupN(key, %d) = %v, want empty", n, got)
+		}
+	}
+}
+
+// TestAddIsIdempotentAndSorted covers membership bookkeeping: a node announced twice by gossip must
+// not be counted twice, or it would receive two of the three replicas of a key.
+func TestAddIsIdempotentAndSorted(t *testing.T) {
+	t.Parallel()
+
+	ring := New()
+	for _, id := range []string{"node-c", "node-a", "node-b", "node-a", "node-c"} {
+		ring.Add(id)
+	}
+
+	got := ring.Nodes()
+	want := []string{"node-a", "node-b", "node-c"}
+
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Nodes() = %v, want %v", got, want)
+	}
+	if ring.Len() != 3 {
+		t.Errorf("Len() = %d, want 3", ring.Len())
+	}
+
+	// A duplicate must not be able to take two replica slots for one key.
+	replicas := ring.LookupN("objects/data.bin", 3)
+	seen := make(map[string]bool, 3)
+	for _, n := range replicas {
+		if seen[n] {
+			t.Fatalf("LookupN = %v repeats %q, so a duplicate Add created a second slot", replicas, n)
+		}
+		seen[n] = true
+	}
+}
+
+// TestRemoveUnknownIsANoOp covers the gossip path where a node leaves twice, or leaves before it was
+// ever added.
+func TestRemoveUnknownIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	ring := New("node-a", "node-b")
+	ring.Remove("node-z")
+	ring.Remove("node-a")
+	ring.Remove("node-a")
+
+	got := ring.Nodes()
+	if len(got) != 1 || got[0] != "node-b" {
+		t.Errorf("Nodes() = %v, want [node-b]", got)
+	}
+}
+
+// TestNodesReturnsACopy pins that a caller cannot mutate the ring's membership through the slice it
+// hands out. Sorted order is an invariant Add and Remove rely on with binary search.
+func TestNodesReturnsACopy(t *testing.T) {
+	t.Parallel()
+
+	ring := New("node-a", "node-b")
+
+	snapshot := ring.Nodes()
+	snapshot[0] = "node-mutated"
+
+	if got := ring.Nodes(); got[0] != "node-a" {
+		t.Errorf("mutating the returned slice changed the ring: Nodes() = %v", got)
+	}
+}
+
+// TestSeparatorPreventsBoundaryCollisions is why score joins with "#" rather than concatenating.
+// Without a separator, ("a", "bc") and ("ab", "c") hash identical bytes, so one node's ownership of
+// a key would depend on another node's name — a bug that would look like a rare, unreproducible
+// misroute rather than a hashing mistake.
+func TestSeparatorPreventsBoundaryCollisions(t *testing.T) {
+	t.Parallel()
+
+	if score("a", "bc") == score("ab", "c") {
+		t.Error("score(\"a\", \"bc\") == score(\"ab\", \"c\"): the node/key boundary is not separated")
+	}
+}
+
+// TestOutranksBreaksTiesByNodeID asserts the tiebreak directly, because no input reachable through
+// Lookup can produce a 64-bit score collision — so removing the tiebreak passes every other test in
+// this file. That was verified by removing it. sort.Slice is not stable, so on a collision the
+// winner without this rule is whichever element the sort left first, which is the input-order
+// dependence the package exists to remove.
+func TestOutranksBreaksTiesByNodeID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a, b scored
+		want bool
+	}{
+		{"higher score wins", scored{"node-z", 2}, scored{"node-a", 1}, true},
+		{"lower score loses", scored{"node-a", 1}, scored{"node-z", 2}, false},
+		{"tie goes to the lower node ID", scored{"node-a", 7}, scored{"node-b", 7}, true},
+		{"tie against the lower node ID loses", scored{"node-b", 7}, scored{"node-a", 7}, false},
+		{"a node does not outrank itself", scored{"node-a", 7}, scored{"node-a", 7}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := outranks(tc.a, tc.b); got != tc.want {
+				t.Errorf("outranks(%+v, %+v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDistributionIsNotWildlyUneven is a sanity bound, not a uniformity proof. Its job is to catch
+// an implementation that is deterministic but degenerate — the previous one sent every key to
+// nodes[0], which is deterministic once the input is sorted and still useless.
+func TestDistributionIsNotWildlyUneven(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nodeCount = 10
+		keyCount  = 10000
+	)
+
+	ring := New(nodeIDs(nodeCount)...)
+
+	counts := make(map[string]int, nodeCount)
+	for _, k := range keys(keyCount) {
+		counts[ring.Lookup(k)]++
+	}
+
+	if len(counts) != nodeCount {
+		t.Errorf("only %d of %d nodes received any key", len(counts), nodeCount)
+	}
+
+	// Generous bounds: half to double the fair share. A tighter bound would make this a test of
+	// xxhash's distribution, which is not this package's contract, and would be flaky by design.
+	expected := keyCount / nodeCount
+	for node, n := range counts {
+		if n < expected/2 || n > expected*2 {
+			t.Errorf("node %s got %d keys, want roughly %d — distribution is degenerate",
+				node, n, expected)
+		}
+	}
+}
+
+// TestRemovalMovesOnlyAFairShare bounds the disruption a departure causes. This is the quantitative
+// version of TestRemovingANonOwnerDoesNotRemap: with n nodes, removing one should move about 1/n of
+// the keys, not all of them. The old slice-prefix implementation would fail this outright.
+func TestRemovalMovesOnlyAFairShare(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nodeCount = 10
+		keyCount  = 10000
+	)
+
+	nodes := nodeIDs(nodeCount)
+	ring := New(nodes...)
+
+	before := make(map[string]string, keyCount)
+	for _, k := range keys(keyCount) {
+		before[k] = ring.Lookup(k)
+	}
+
+	ring.Remove(nodes[0])
+
+	moved := 0
+	for k, owner := range before {
+		if ring.Lookup(k) != owner {
+			moved++
+		}
+	}
+
+	// The fair share is keyCount/nodeCount = 1000. Allow up to double before calling it a defect.
+	if limit := 2 * keyCount / nodeCount; moved > limit {
+		t.Errorf("removing 1 of %d nodes moved %d of %d keys, want at most %d",
+			nodeCount, moved, keyCount, limit)
+	}
+	if moved == 0 {
+		t.Error("removing a node moved no keys at all, which cannot be right")
+	}
+}
+
+func reversed(in []string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[len(in)-1-i] = s
+	}
+
+	return out
+}
+
+func rotated(in []string, shift int) []string {
+	out := make([]string, 0, len(in))
+	out = append(out, in[shift:]...)
+	out = append(out, in[:shift]...)
+
+	return out
+}
+
+// BenchmarkLookup100Nodes measures the O(n) lookup at a node count well above what a cluster of
+// this kind has, so the constant is visible rather than argued about. The point of the benchmark is
+// the acceptance criterion in #131: if a lookup at 100 nodes is cheap relative to an S3 round trip
+// — which is milliseconds — then O(n) buys simplicity for free and no ring structure is warranted.
+//
+// Measured on an Apple M4 Max, go1.26.5: 1555 ns/op at 100 nodes and 125 ns/op at 8, both with zero
+// allocations. Three orders of magnitude below an S3 GET, so the answer is that O(n) is fine and a
+// sorted ring with virtual nodes would be complexity spent on nothing. Recorded because a figure in
+// a comment is checkable against a re-run, whereas "acceptable" is not.
+func BenchmarkLookup100Nodes(b *testing.B) {
+	ring := New(nodeIDs(100)...)
+	ks := keys(256)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; b.Loop(); i++ {
+		_ = ring.Lookup(ks[i%len(ks)])
+	}
+}
+
+// BenchmarkLookupN3Of100Nodes is the write path's cost: a replication factor of 3 sorts all 100
+// candidates. If this is where the O(n log n) shows up, this is the benchmark that says so.
+func BenchmarkLookupN3Of100Nodes(b *testing.B) {
+	ring := New(nodeIDs(100)...)
+	ks := keys(256)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; b.Loop(); i++ {
+		_ = ring.LookupN(ks[i%len(ks)], 3)
+	}
+}
+
+// BenchmarkLookup8Nodes is the realistic case, for comparison against the 100-node figure.
+func BenchmarkLookup8Nodes(b *testing.B) {
+	ring := New(nodeIDs(8)...)
+	ks := keys(256)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; b.Loop(); i++ {
+		_ = ring.Lookup(ks[i%len(ks)])
+	}
+}
+
+// FuzzLookupIsStable drives arbitrary node IDs and keys through the invariant that matters: the
+// answer does not depend on insertion order. Hand-written cases use well-formed "node-NN" IDs; a
+// fuzzer reaches the empty string, unicode, embedded separators, and duplicates.
+func FuzzLookupIsStable(f *testing.F) {
+	f.Add("node-a", "node-b", "node-c", "objects/data.bin")
+	f.Add("", "", "", "")
+	f.Add("a", "ab", "abc", "#")
+	f.Add("node#1", "node#2", "1", "node")
+
+	f.Fuzz(func(t *testing.T, a, b, c, key string) {
+		forward := New(a, b, c)
+		backward := New(c, b, a)
+
+		if got, want := backward.Lookup(key), forward.Lookup(key); got != want {
+			t.Fatalf("Lookup(%q) = %q forward, %q backward, for nodes %q/%q/%q",
+				key, want, got, a, b, c)
+		}
+
+		// Membership must not depend on order either: both rings hold the same distinct IDs.
+		fw, bw := forward.Nodes(), backward.Nodes()
+		sort.Strings(fw)
+		sort.Strings(bw)
+		if strings.Join(fw, ",") != strings.Join(bw, ",") {
+			t.Fatalf("membership differs by insertion order: %v vs %v", fw, bw)
+		}
+
+		// Replicas are distinct however many distinct nodes went in.
+		replicas := forward.LookupN(key, 3)
+		seen := make(map[string]bool, len(replicas))
+		for _, n := range replicas {
+			if seen[n] {
+				t.Fatalf("LookupN(%q, 3) = %v repeats %q", key, replicas, n)
+			}
+			seen[n] = true
+		}
+		if len(replicas) != forward.Len() && len(replicas) != 3 {
+			t.Fatalf("LookupN(%q, 3) returned %d nodes for a ring of %d",
+				key, len(replicas), forward.Len())
+		}
+	})
+}


### PR DESCRIPTION
Closes #131.

## The defect

`selectConsistentHash` was:

```go
func (lb *LoadBalancer) selectConsistentHash(nodes []string, count int) ([]string, error) {
	// Simple consistent hash implementation
	// In practice, you'd use a proper consistent hash ring
	if len(nodes) <= count {
		return nodes, nil
	}
	return nodes[:count], nil
}
```

`nodes` arrives from `selectTargetNodes`, which builds it by ranging `c.cluster.GetNodes()` — a map,
whose iteration order Go randomizes per call. So the same key reached a different node on each call.
That is the one property consistent hashing exists to provide, and the one a per-node cache needs in
order to hit at all.

## The fix

`internal/distributed/hashring`: rendezvous (HRW) hashing. Score every node against the key with
`xxhash(nodeID + "#" + key)`, take the highest, break ties on node ID. No new `go.mod` entry —
`cespare/xxhash/v2` was already an indirect dependency.

Removing a node moves only the keys that node owned, about 1/n, which is asserted with that bound
rather than described. `Lookup` is O(n) in nodes; the benchmark settles whether that matters:

```
BenchmarkLookup100Nodes-16        1533300      1555 ns/op    0 B/op   0 allocs/op
BenchmarkLookupN3Of100Nodes-16     381340      6109 ns/op  2832 B/op   5 allocs/op
BenchmarkLookup8Nodes-16         19270704       124.7 ns/op   0 B/op   0 allocs/op
```

Three orders of magnitude below the S3 round trip it precedes, so a sorted ring with virtual nodes
would be complexity spent on nothing.

## A prerequisite the issue did not mention

`LoadBalancer.SelectNodes(availableNodes []string, count int)` never received the operation key, so
no implementation behind it could have hashed by key however it was written. It now takes one, which
makes the key mandatory at all five call sites in `selectTargetNodes` rather than something a
strategy could quietly do without.

`selectTargetNodes` also sorts its alive-node slice now. The ring sorts internally, so removing that
sort changes nothing a consistent-hash test can observe — verified by removing it — but round-robin
and the least-load tiebreak index the slice positionally, and for those the order the map happened
to be iterated in *was* the decision.

## A test that could not have caught this

`TestLoadBalancer_ConsistentHash` asserted only the returned count, and its own doc comment described
the defect as the intended behavior: *"returns the requested number of nodes from the front of the
list."* A count assertion passes on `nodes[:count]`. It now asserts that permuting the input does not
change the output, plus an end-to-end `selectTargetNodes` test that exercises the real randomized map
iteration rather than simulating it.

## Verification

Seven mutations, all caught:

| mutation | caught by |
|---|---|
| selection reverted to a slice prefix | `TestLoadBalancer_ConsistentHash`, `TestSelectTargetNodes_IsOrderIndependent` |
| alive nodes left unsorted | `TestSelectTargetNodes_SortsAliveNodes` |
| hash separator removed | `TestSeparatorPreventsBoundaryCollisions` |
| tie-break removed | `TestOutranksBreaksTiesByNodeID` |
| `Remove` made a no-op | 3 removal/rebalance tests |
| `LookupN` sorts by node instead of score | `TestLookupAgreesWithLookupN` |
| `Add` made non-idempotent | `TestAddIsIdempotentAndSorted`, `FuzzLookupIsStable` |

Two of the seven were caught only after adding tests, which is the reason for running them rather
than predicting them:

- **The tie-break** is unreachable through the public API — it needs a 64-bit score collision — so
  removing it passed every test in the file. `sort.Slice` is not stable, so on a collision the winner
  without it is whichever element the sort left first, i.e. the input-order dependence this whole
  change removes. Extracted as `outranks` so the rule is assertable directly, and `Lookup` now uses
  it too, so the two entry points cannot drift apart on a tie.
- **The sort** needed an end-to-end round-robin test; the ring had been hiding its absence.

Gates: `go build` · `go vet` · `gofmt -l` 0 · full suite `-race` green · coverage gate **35 packages
at or above floor**, `hashring` at **100%** with a floor to match · `golangci-lint
--new-from-merge-base` **0 issues** · standalone `gosec` finds nothing in the new code (the two
`G404` hits in `consensus.go:856,859` are pre-existing and untouched) · `FuzzLookupIsStable` 30M
executions clean.