### PR TITLE
fix: let a node contradict a false report of its own death (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,9 +124,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior. A count assertion cannot tell a hash ring from a slice prefix, so it now asserts that
   permuting the input does not change the output, which the prefix fails.
 
+- **A node marked dead by one lost heartbeat could never rejoin, and every node's gossiped statistics
+  were frozen at the first value ever received** ([#272]). Both follow from one omission: incarnation
+  numbers were set to 1 at construction and nothing ever incremented them. An incarnation is how a
+  SWIM-style protocol lets an accused node contradict a false report of its own failure, and every
+  comparison that depends on one is strictly-greater — so with the number fixed at 1, all of them were
+  false for every message after the one that discovered a node.
+
+  What that cost is not a degraded metric, it is a lost node. `checkSuspicions` promotes suspect to
+  dead and nothing demoted it; the only path back to alive was `handleJoinMessage`, reachable solely
+  by a process restart. So a transient network problem — a few dropped datagrams, which is the normal
+  condition of UDP — removed a healthy node from routing permanently. Proven by execution before
+  fixing: a node discovered at state 0 was still at state 2 after an alive message from it arrived.
+
+  A node now refutes an accusation about itself rather than recording it, publishing an incarnation
+  above the accused one, which supersedes that accusation everywhere it has spread. Refusing to record
+  it matters as much as the refutation: `performGossip` and `broadcastMessage` both skip nodes that are
+  not alive, so a node that accepted a suspicion about itself would stop gossiping and make the report
+  true. The new number is one past the *higher* of ours and theirs, not ours plus one, or a peer
+  holding a stale higher incarnation would keep rejecting the refutation and the disagreement would
+  never resolve; an accusation naming an incarnation already superseded is ignored, which is what makes
+  the exchange converge instead of ring. Sync messages are answered too, since a full sync is often
+  where a node learns it was written off during a partition. `GossipStats.SuspicionRefutations` counts
+  these, because a cluster refuting steadily is healthy and misconfigured — a heartbeat interval below
+  the network's real latency — not failing.
+
+  The frozen statistics were the same guard seen from the other side. An incarnation orders claims
+  about whether a node is alive; it says nothing about the freshness of the load and cache figures
+  riding along with the claim, and a healthy node never raises its incarnation because it has nothing
+  to refute. So gating the payload on a strict increase pinned every peer's stats to the moment it was
+  discovered. An alive message at an equal incarnation now refreshes the payload without touching the
+  state machine — only for a node already believed alive, so the refresh cannot become a second,
+  unguarded path back from dead. `performGossip` also stamps its own `LastSeen` before announcing
+  itself; it had been broadcasting the timestamp set at construction, and since `UpdateNodeInfo` copies
+  that field and `performHealthChecks` compares it against three heartbeat intervals, every alive
+  message a node sent was evidence it had not been heard from. Inert only while the guard discarded the
+  payload, and a flap the moment it stopped.
+
+  The acceptance test [#132] proposes for the stats half — wait two heartbeats, assert `MemoryUsage >
+  0` — **passes on this bug**, because the first message is applied and the value stays non-zero
+  forever after. The tests here assert that a *changed* value arrives on a second message, and that
+  dead becomes alive; a single-transition assertion cannot distinguish a live feed from a permanently
+  stale one, and a green test over a stale metric is worse than no test because it certifies what it
+  cannot see. Nine mutations were checked, each reverting one part of the fix, and each fails a test
+  that names the consequence.
+
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
+[#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#267]: https://github.com/scttfrdmn/objectfs/issues/267
+[#272]: https://github.com/scttfrdmn/objectfs/issues/272
 [scttfrdmn/substrate#540]: https://github.com/scttfrdmn/substrate/issues/540
 
 ### Changed

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -265,6 +265,24 @@ The gossip protocol implements:
 
 Failure Detection:
 
+A node that has not been heard from for three heartbeat intervals is marked suspect, and one that
+stays suspect is marked dead. Detection is a guess — a lost datagram and a lost node look identical
+from the outside — so the guess has to be reversible.
+
+That is what the incarnation number is for. Every accusation names the incarnation it was made
+about, and the accused answers by publishing a higher one, which supersedes the accusation
+everywhere it has spread. A node never accepts a suspect or dead report about itself; it refutes it.
+Recovery therefore needs no operator action and no restart: a node that was unreachable for a while
+rejoins on its next gossip round, and [GossipStats.SuspicionRefutations] counts how often that has
+happened — a number that climbs steadily means a healthy cluster whose heartbeat interval is set
+below the network's real latency.
+
+Until v0.11.0 none of that worked, because nothing ever incremented an incarnation. Every
+strictly-greater comparison in the protocol was permanently false after the message that discovered
+a node, with two consequences: a node marked dead by one lost heartbeat was gone from routing until
+its process restarted, and the node statistics riding along with each alive message were frozen at
+the first value ever received, so anything reading them was reading a snapshot of startup (#272).
+
 	// Nodes automatically detect failures via gossip protocol
 	// Failed nodes are marked as NodeStatusSuspect or NodeStatusDead
 

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -52,6 +52,22 @@ const (
 	StateLeft
 )
 
+// String returns the state's name, so that a log line reports "dead" rather than the integer 2.
+func (s GossipState) String() string {
+	switch s {
+	case StateAlive:
+		return "alive"
+	case StateSuspect:
+		return "suspect"
+	case StateDead:
+		return "dead"
+	case StateLeft:
+		return "left"
+	default:
+		return fmt.Sprintf("GossipState(%d)", int(s))
+	}
+}
+
 // Suspicion tracks suspicion about a node's liveness
 type Suspicion struct {
 	Incarnation uint32    `json:"incarnation"`
@@ -163,6 +179,12 @@ type GossipStats struct {
 	MessagesUnauthenticated int64 `json:"messages_unauthenticated"`
 	MessagesReplayed        int64 `json:"messages_replayed"`
 	MessagesWrongVersion    int64 `json:"messages_wrong_version"`
+
+	// SuspicionRefutations counts the times this node was reported suspect or dead and raised its
+	// own incarnation to say otherwise (#272). It is an operator signal, not a health signal: a
+	// node that refutes repeatedly is alive and being falsely accused, which points at packet loss
+	// or a heartbeat interval set below the network's actual latency — not at the node.
+	SuspicionRefutations int64 `json:"suspicion_refutations"`
 }
 
 // NewGossipProtocol creates a new gossip protocol instance.
@@ -200,7 +222,14 @@ func NewGossipProtocol(cluster *ClusterManager, config *ClusterConfig) (*GossipP
 		Metadata: make(map[string]string),
 	}
 
-	// Add self to member list
+	// Add self to member list.
+	//
+	// Incarnation 1 is the starting point, not a constant: refuteSuspicion raises it whenever a peer
+	// accuses this node of being suspect or dead. Until v0.11.0 nothing ever raised it, which made
+	// the strictly-greater guards in handleAliveMessage and handleSyncMessage permanently false for
+	// every message after the one that discovered a node — so gossiped node stats froze at their
+	// first observed value and a node marked dead by a transient network blip could never rejoin
+	// routing without a process restart (#272).
 	gp.memberlist[gp.localNode.ID] = &GossipNode{
 		Info:        gp.localNode,
 		Incarnation: 1,
@@ -518,15 +547,41 @@ func (gp *GossipProtocol) handleAliveMessage(msg *GossipMessage) {
 	nodeID := aliveMsg.Node.ID
 
 	if gossipNode, exists := gp.memberlist[nodeID]; exists {
-		// Update incarnation and state if newer
-		if aliveMsg.Incarnation > gossipNode.Incarnation {
+		switch {
+		case aliveMsg.Incarnation > gossipNode.Incarnation:
+			// A higher incarnation supersedes whatever we believed, including a death. This is the
+			// only path by which a node we wrote off can rejoin routing without restarting, and it
+			// is reachable because refuteSuspicion is what produces the higher number: a node we
+			// accused answers with an incarnation that postdates the accusation. Before v0.11.0 no
+			// incarnation ever advanced, so this arm was dead code after discovery and a node
+			// removed by one lost heartbeat stayed removed (#272).
+			if gossipNode.State == StateDead || gossipNode.State == StateSuspect {
+				slog.Info("node refuted its own suspicion; restoring to alive",
+					"node_id", nodeID, "incarnation", aliveMsg.Incarnation)
+			}
+
 			gossipNode.Incarnation = aliveMsg.Incarnation
 			gossipNode.State = StateAlive
 			gossipNode.StateChange = time.Now()
 			gossipNode.Info = aliveMsg.Node
 			gossipNode.Suspicion = nil // Clear any suspicion
 
-			// Update cluster manager
+			aliveMsg.Node.Status = NodeStatusAlive
+			gp.cluster.UpdateNodeInfo(nodeID, aliveMsg.Node)
+
+		case aliveMsg.Incarnation == gossipNode.Incarnation && gossipNode.State == StateAlive:
+			// Refresh the payload without touching the state machine. An incarnation orders claims
+			// about whether a node is alive; it says nothing about how fresh the load and cache
+			// figures riding along with the claim are. A healthy node never raises its incarnation —
+			// it has nothing to refute — so gating the payload on a strict increase froze every
+			// node's stats at the first value ever received from it, which is how a load balancer
+			// reading them came to route on numbers that were hours stale (#272, #132).
+			//
+			// Only for a node we already believe is alive: accepting a same-incarnation payload for
+			// a suspect or dead node would silently undo the accusation without the refutation that
+			// is supposed to be required to overturn it.
+			gossipNode.Info = aliveMsg.Node
+
 			aliveMsg.Node.Status = NodeStatusAlive
 			gp.cluster.UpdateNodeInfo(nodeID, aliveMsg.Node)
 		}
@@ -549,6 +604,64 @@ func (gp *GossipProtocol) handleAliveMessage(msg *GossipMessage) {
 	}
 }
 
+// refuteSuspicion raises this node's own incarnation and re-announces it as alive, superseding a
+// peer's claim that it is suspect or dead.
+//
+// This is what the incarnation number is for, and it is what makes the strictly-greater comparisons
+// elsewhere in this file mean anything. An accusation names the incarnation it was made about, so a
+// higher one is not a competing opinion — it is proof that the accusation is stale, published by the
+// only node in a position to know. Until v0.11.0 nothing incremented an incarnation anywhere, so
+// those comparisons were permanently false after the message that discovered a node, and a node
+// accused once stayed accused for the life of the process (#272).
+//
+// accusedIncarnation is the incarnation the accusation was made about. The new incarnation is one
+// past whichever is larger, ours or theirs — not simply ours plus one. A peer should never hold an
+// incarnation for us higher than the one we published, but if it does (a peer resurrected from an old
+// snapshot, or a node restarted with a lower number), refuting with self+1 would produce a number the
+// accuser's guards still reject, and the two would disagree forever with each message reinforcing
+// the other's position.
+//
+// Callers must hold gp.mu.
+func (gp *GossipProtocol) refuteSuspicion(accusation string, reporter string, accusedIncarnation uint32) {
+	self, exists := gp.memberlist[gp.localNode.ID]
+	if !exists {
+		return
+	}
+
+	self.Incarnation = max(self.Incarnation, accusedIncarnation) + 1
+	self.State = StateAlive
+	self.StateChange = time.Now()
+	self.Suspicion = nil
+
+	slog.Info("refuting accusation about this node",
+		"accusation", accusation, "reported_by", reporter, "new_incarnation", self.Incarnation)
+
+	gp.stats.mu.Lock()
+	gp.stats.SuspicionRefutations++
+	gp.stats.mu.Unlock()
+
+	// The refutation is only useful if it reaches the cluster, and the incarnation is read here
+	// under the lock we already hold rather than via getCurrentIncarnation, which would deadlock on
+	// re-entry. Sending happens in a goroutine for the same reason: broadcastMessage takes gp.mu for
+	// reading.
+	aliveMsg := &AliveMessage{Node: gp.localNode, Incarnation: self.Incarnation}
+	data, err := json.Marshal(aliveMsg)
+	if err != nil {
+		slog.Warn("failed to marshal refutation", "error", err)
+		return
+	}
+
+	msg := &GossipMessage{
+		Type:      MessageTypeAlive,
+		From:      gp.localNode.ID,
+		Timestamp: time.Now(),
+		MessageID: gp.generateMessageID(),
+		Data:      data,
+	}
+
+	go func() { _ = gp.broadcastMessage(msg) }()
+}
+
 func (gp *GossipProtocol) handleSuspectMessage(msg *GossipMessage) {
 	var suspectMsg SuspectMessage
 	if err := json.Unmarshal(msg.Data, &suspectMsg); err != nil {
@@ -560,6 +673,16 @@ func (gp *GossipProtocol) handleSuspectMessage(msg *GossipMessage) {
 	defer gp.mu.Unlock()
 
 	nodeID := suspectMsg.Node
+
+	// An accusation about ourselves is answered, not recorded. Recording it would mark this node
+	// suspect in its own memberlist, and since performGossip and broadcastMessage both skip nodes
+	// that are not alive, a node could talk itself out of the cluster on one lost heartbeat (#272).
+	if nodeID == gp.localNode.ID {
+		if self, exists := gp.memberlist[nodeID]; exists && suspectMsg.Incarnation >= self.Incarnation {
+			gp.refuteSuspicion("suspect", suspectMsg.From, suspectMsg.Incarnation)
+		}
+		return
+	}
 
 	if gossipNode, exists := gp.memberlist[nodeID]; exists {
 		// Only process if incarnation matches and node has not already been
@@ -610,6 +733,16 @@ func (gp *GossipProtocol) handleDeadMessage(msg *GossipMessage) {
 
 	nodeID := deadMsg.Node
 
+	// Same reasoning as handleSuspectMessage: a node that accepted a death notice about itself would
+	// stop gossiping and would then genuinely be gone, having agreed with a report that was wrong
+	// when it was sent (#272).
+	if nodeID == gp.localNode.ID {
+		if self, exists := gp.memberlist[nodeID]; exists && deadMsg.Incarnation >= self.Incarnation {
+			gp.refuteSuspicion("dead", deadMsg.From, deadMsg.Incarnation)
+		}
+		return
+	}
+
 	if gossipNode, exists := gp.memberlist[nodeID]; exists {
 		// Only process if incarnation matches or is newer
 		if deadMsg.Incarnation >= gossipNode.Incarnation {
@@ -645,7 +778,20 @@ func (gp *GossipProtocol) handleSyncMessage(msg *GossipMessage) {
 	// Merge membership information
 	for nodeID, remoteNode := range syncMsg.Nodes {
 		if nodeID == gp.localNode.ID {
-			continue // Skip ourselves
+			// Never take a peer's word for our own state — but do answer it. A full sync is often
+			// the first thing a node receives after a partition heals, so it is often where a node
+			// learns it was written off while it was unreachable. Refuting here is what stops that
+			// entry from propagating back out through the next round of syncs (#272). The guard in
+			// refuteSuspicion's callers means a stale entry that predates an earlier refutation is
+			// ignored rather than refuted again, so this converges instead of ringing.
+			if remoteNode.State == StateSuspect || remoteNode.State == StateDead {
+				if self, ok := gp.memberlist[nodeID]; ok && remoteNode.Incarnation >= self.Incarnation {
+					gp.refuteSuspicion("stale "+remoteNode.State.String()+" entry in a membership sync",
+						msg.From, remoteNode.Incarnation)
+				}
+			}
+
+			continue
 		}
 
 		localNode, exists := gp.memberlist[nodeID]
@@ -731,7 +877,23 @@ func (gp *GossipProtocol) gossipLoop(ctx context.Context) {
 }
 
 func (gp *GossipProtocol) performGossip() {
-	gp.mu.RLock()
+	// Stamp our own LastSeen before announcing ourselves. UpdateNodeInfo copies this field onto the
+	// receiver's record, and performHealthChecks compares it against HeartbeatInterval*3 to decide
+	// suspicion — so broadcasting the value set at construction, as this did until v0.11.0, means
+	// every alive message we send is evidence that we have not been heard from. It was inert only
+	// because the incarnation guard discarded our payload entirely; with that guard fixed it would
+	// make a healthy node suspect itself into a flap (#272).
+	// One critical section, because the incarnation must be the one that goes out with this payload:
+	// taking the write lock to stamp, dropping it, and then calling getCurrentIncarnation would let a
+	// refutation land in between and publish the old number with the new stats.
+	gp.mu.Lock()
+	gp.localNode.LastSeen = time.Now()
+
+	incarnation := uint32(1)
+	if self, exists := gp.memberlist[gp.localNode.ID]; exists {
+		incarnation = self.Incarnation
+	}
+
 	nodes := make([]*GossipNode, 0, len(gp.memberlist))
 	for _, node := range gp.memberlist {
 		// Guard against nodes whose Info was never populated (e.g. added via a
@@ -743,7 +905,16 @@ func (gp *GossipProtocol) performGossip() {
 			nodes = append(nodes, node)
 		}
 	}
-	gp.mu.RUnlock()
+
+	// Marshal under the lock: gp.localNode is read here and written above, and refuteSuspicion
+	// marshals the same struct from a receive goroutine.
+	data, marshalErr := json.Marshal(&AliveMessage{Node: gp.localNode, Incarnation: incarnation})
+	gp.mu.Unlock()
+
+	if marshalErr != nil {
+		slog.Warn("failed to marshal alive message", "error", marshalErr)
+		return
+	}
 
 	if len(nodes) == 0 {
 		return
@@ -752,21 +923,13 @@ func (gp *GossipProtocol) performGossip() {
 	// Select random nodes to gossip with
 	fanout := min(gp.config.GossipFanout, len(nodes))
 
-	// Send alive message about ourselves
-	aliveMsg := &AliveMessage{
-		Node:        gp.localNode,
-		Incarnation: gp.getCurrentIncarnation(),
-	}
-
 	msg := &GossipMessage{
 		Type:      MessageTypeAlive,
 		From:      gp.localNode.ID,
 		Timestamp: time.Now(),
 		MessageID: gp.generateMessageID(),
+		Data:      data,
 	}
-
-	data, _ := json.Marshal(aliveMsg)
-	msg.Data = data
 
 	// Gossip to random subset of nodes
 	for i := range fanout {
@@ -776,11 +939,13 @@ func (gp *GossipProtocol) performGossip() {
 		}
 	}
 
-	// Send heartbeat
+	// Send heartbeat. Same incarnation as the alive message above, deliberately: the two describe one
+	// moment, and handleHeartbeatMessage clears suspicion on `>=`, so a heartbeat carrying a stale
+	// number would fail to clear a suspicion the accompanying alive message just refuted.
 	heartbeatMsg := &HeartbeatMessage{
 		Node:        gp.localNode.ID,
 		Timestamp:   time.Now(),
-		Incarnation: gp.getCurrentIncarnation(),
+		Incarnation: incarnation,
 	}
 
 	heartbeatGossipMsg := &GossipMessage{
@@ -1025,6 +1190,7 @@ func (gp *GossipProtocol) GetStats() *GossipStats {
 		MessagesUnauthenticated: gp.stats.MessagesUnauthenticated,
 		MessagesReplayed:        gp.stats.MessagesReplayed,
 		MessagesWrongVersion:    gp.stats.MessagesWrongVersion,
+		SuspicionRefutations:    gp.stats.SuspicionRefutations,
 	}
 	maps.Copy(stats.MessagesByType, gp.stats.MessagesByType)
 	gp.stats.mu.RUnlock()

--- a/internal/distributed/gossip_test.go
+++ b/internal/distributed/gossip_test.go
@@ -442,17 +442,19 @@ func TestGossipProtocol_HandleSyncMessage_MergesNodes(t *testing.T) {
 	}
 }
 
-// TestGossipProtocol_HandleSyncMessage_SkipsSelf verifies that a sync message
-// does not overwrite the local node's own entry.
+// TestGossipProtocol_HandleSyncMessage_SkipsSelf verifies that a sync message does not overwrite
+// the local node's own state with a peer's opinion of it.
+//
+// A peer's entry for us is hearsay: it is what that peer last heard, routed through however many
+// other peers, and it can be arbitrarily stale. Adopting it would let one node with an old view
+// mark a healthy node dead in its own memberlist — after which it stops gossiping, since
+// performGossip and broadcastMessage both skip non-alive nodes, and the stale claim becomes true.
 func TestGossipProtocol_HandleSyncMessage_SkipsSelf(t *testing.T) {
 	t.Parallel()
 	cm, _ := NewClusterManager(testConfig(t, "sync-self"))
 	gp := cm.gossip
 
-	// Record the original self incarnation.
-	selfBefore := gp.GetMemberlist()["sync-self"].Incarnation
-
-	// Remote claims our node is at incarnation 999.
+	// Remote claims our node is dead at incarnation 999.
 	remoteNodes := map[string]*GossipNode{
 		"sync-self": {
 			Info:        &NodeInfo{ID: "sync-self", Metadata: map[string]string{}},
@@ -464,11 +466,17 @@ func TestGossipProtocol_HandleSyncMessage_SkipsSelf(t *testing.T) {
 	msg := makeGossipMsg(t, MessageTypeSync, &SyncMessage{Nodes: remoteNodes})
 	gp.handleSyncMessage(msg)
 
-	// Self entry should be unchanged.
-	selfAfter := gp.GetMemberlist()["sync-self"].Incarnation
-	if selfAfter != selfBefore {
-		t.Errorf("self incarnation changed from %d to %d; handleSyncMessage must skip self",
-			selfBefore, selfAfter)
+	self := gp.GetMemberlist()["sync-self"]
+	if self.State != StateAlive {
+		t.Errorf("self state = %v after a sync claiming we are dead, want StateAlive", self.State)
+	}
+
+	// The incarnation is asserted to be above the accusation, not merely unchanged. Refuting is the
+	// only way to stop that entry propagating back out, and a refutation the accuser's own
+	// strictly-greater guard would reject is not a refutation (#272).
+	if self.Incarnation <= 999 {
+		t.Errorf("self incarnation = %d after refuting an accusation at 999; want > 999, "+
+			"or the accuser will keep discarding our alive messages", self.Incarnation)
 	}
 }
 
@@ -534,6 +542,295 @@ func TestGossipProtocol_HandleHeartbeatMessage_ClearsSuspicion(t *testing.T) {
 	}
 	if ml["susp-hb-peer"].Suspicion != nil {
 		t.Error("Suspicion should be cleared after heartbeat")
+	}
+}
+
+// The tests below cover incarnation liveness (#272): the mechanism that lets a node contradict a
+// false report of its own failure, and the consequences of it never having advanced.
+//
+// Each of these fails on the pre-fix code, and the two most important ones — frozen stats and
+// resurrection — are exactly what a single-transition assertion cannot see. "Send an alive message,
+// assert the value arrived" passes on the bug, because the *first* message is applied; only a second
+// message carrying a *different* value distinguishes a live feed from a permanently stale one.
+
+// TestGossipProtocol_RefutesSuspicionAboutItself verifies that a suspect message naming this node
+// raises its incarnation rather than marking it suspect in its own memberlist.
+func TestGossipProtocol_RefutesSuspicionAboutItself(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "refuter"))
+	gp := cm.gossip
+
+	before := gp.GetMemberlist()["refuter"].Incarnation
+
+	msg := makeGossipMsg(t, MessageTypeSuspect, &SuspectMessage{
+		Node:        "refuter",
+		Incarnation: before,
+		From:        "confused-peer",
+	})
+	gp.handleSuspectMessage(msg)
+
+	self := gp.GetMemberlist()["refuter"]
+	if self.State != StateAlive {
+		t.Errorf("self state = %v after a suspect message about ourselves, want StateAlive", self.State)
+	}
+	if self.Incarnation <= before {
+		t.Errorf("self incarnation = %d, want > %d: a refutation that does not raise the "+
+			"incarnation is indistinguishable from silence", self.Incarnation, before)
+	}
+	if got := gp.GetStats().SuspicionRefutations; got != 1 {
+		t.Errorf("SuspicionRefutations = %d, want 1", got)
+	}
+}
+
+// TestGossipProtocol_RefutesDeathReportAboutItself verifies the same for a death report, which is
+// the more consequential of the two: nothing else in the protocol demotes a dead node.
+func TestGossipProtocol_RefutesDeathReportAboutItself(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "not-dead"))
+	gp := cm.gossip
+
+	before := gp.GetMemberlist()["not-dead"].Incarnation
+
+	msg := makeGossipMsg(t, MessageTypeDead, &DeadMessage{
+		Node:        "not-dead",
+		Incarnation: before,
+		From:        "mistaken-witness",
+	})
+	gp.handleDeadMessage(msg)
+
+	self := gp.GetMemberlist()["not-dead"]
+	if self.State != StateAlive {
+		t.Errorf("self state = %v after a death report about ourselves, want StateAlive: a node "+
+			"that agrees it is dead stops gossiping and the report becomes true", self.State)
+	}
+	if self.Incarnation <= before {
+		t.Errorf("self incarnation = %d, want > %d", self.Incarnation, before)
+	}
+	if got := gp.GetStats().DeathEvents; got != 0 {
+		t.Errorf("DeathEvents = %d, want 0: our own refuted death is not a death event", got)
+	}
+}
+
+// TestGossipProtocol_RefutationOutranksTheAccusation verifies that the new incarnation exceeds the
+// accused one even when the accusation names a number higher than ours.
+//
+// A peer should not hold a higher incarnation for us than we published, but a peer restored from an
+// old snapshot can. Refuting with self+1 would then produce a number that peer's own
+// strictly-greater guard rejects, and the disagreement would never resolve.
+func TestGossipProtocol_RefutationOutranksTheAccusation(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "outranked"))
+	gp := cm.gossip
+
+	const accused = 400
+
+	msg := makeGossipMsg(t, MessageTypeSuspect, &SuspectMessage{
+		Node:        "outranked",
+		Incarnation: accused,
+		From:        "peer-from-the-future",
+	})
+	gp.handleSuspectMessage(msg)
+
+	if got := gp.GetMemberlist()["outranked"].Incarnation; got <= accused {
+		t.Errorf("self incarnation = %d after an accusation at %d, want > %d", got, accused, accused)
+	}
+}
+
+// TestGossipProtocol_StaleAccusationAboutItselfIsIgnored verifies that an accusation naming an
+// incarnation we have already superseded does not raise ours again.
+//
+// This is what makes refutation converge. Without the guard, two nodes exchanging stale views would
+// each refute the other's refutation and the incarnation would climb without bound.
+func TestGossipProtocol_StaleAccusationAboutItselfIsIgnored(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "already-answered"))
+	gp := cm.gossip
+
+	gp.mu.Lock()
+	gp.memberlist["already-answered"].Incarnation = 9
+	gp.mu.Unlock()
+
+	msg := makeGossipMsg(t, MessageTypeSuspect, &SuspectMessage{
+		Node:        "already-answered",
+		Incarnation: 8, // predates the refutation that produced 9
+		From:        "lagging-peer",
+	})
+	gp.handleSuspectMessage(msg)
+
+	if got := gp.GetMemberlist()["already-answered"].Incarnation; got != 9 {
+		t.Errorf("self incarnation = %d, want 9: an accusation we have already answered must not "+
+			"be answered again, or refutation never converges", got)
+	}
+	if got := gp.GetStats().SuspicionRefutations; got != 0 {
+		t.Errorf("SuspicionRefutations = %d, want 0", got)
+	}
+}
+
+// TestGossipProtocol_AliveMessageResurrectsADeadNode verifies that a node written off as dead
+// returns to the memberlist and to the cluster manager on an alive message at a higher incarnation.
+//
+// Before #272 this was unreachable: no incarnation ever advanced, so the only alive message that
+// could clear a death was one that never arrived, and a node removed by a transient network problem
+// stayed removed for the life of the process — permanently absent from routing.
+func TestGossipProtocol_AliveMessageResurrectsADeadNode(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "resurrect-host"))
+	gp := cm.gossip
+
+	gp.mu.Lock()
+	gp.memberlist["revenant"] = &GossipNode{
+		Info:        &NodeInfo{ID: "revenant", Address: "10.0.0.9:9000", Status: NodeStatusDead, Metadata: map[string]string{}},
+		Incarnation: 3,
+		State:       StateDead,
+		StateChange: time.Now(),
+	}
+	gp.mu.Unlock()
+	cm.UpdateNodeInfo("revenant", &NodeInfo{
+		ID: "revenant", Address: "10.0.0.9:9000", Status: NodeStatusDead, Metadata: map[string]string{},
+	})
+
+	// The revenant refuted the death report and re-announced at a higher incarnation.
+	msg := makeGossipMsg(t, MessageTypeAlive, &AliveMessage{
+		Node:        &NodeInfo{ID: "revenant", Address: "10.0.0.9:9000", Metadata: map[string]string{}},
+		Incarnation: 4,
+	})
+	gp.handleAliveMessage(msg)
+
+	if got := gp.GetMemberlist()["revenant"].State; got != StateAlive {
+		t.Errorf("state = %v after an alive message at a higher incarnation, want StateAlive", got)
+	}
+
+	// Asserted through the cluster manager as well, because that — not the memberlist — is what
+	// SelectNodes reads. A node restored in gossip but still dead in the cluster manager is still
+	// absent from routing, which is the consequence that matters.
+	if got := cm.GetNodes()["revenant"].Status; got != NodeStatusAlive {
+		t.Errorf("cluster manager status = %v, want %v: a node restored only in the memberlist is "+
+			"still excluded from node selection", got, NodeStatusAlive)
+	}
+}
+
+// TestGossipProtocol_AliveMessageDoesNotResurrectAtTheSameIncarnation verifies that the
+// same-incarnation payload refresh does not quietly undo a death.
+//
+// The refresh exists so live stats are not frozen; it must not become a second, unguarded path back
+// to alive, or the incarnation would stop being the thing that decides liveness.
+func TestGossipProtocol_AliveMessageDoesNotResurrectAtTheSameIncarnation(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "no-quiet-revival"))
+	gp := cm.gossip
+
+	gp.mu.Lock()
+	gp.memberlist["corpse"] = &GossipNode{
+		Info:        &NodeInfo{ID: "corpse", Status: NodeStatusDead, MemoryUsage: 0.1, Metadata: map[string]string{}},
+		Incarnation: 7,
+		State:       StateDead,
+		StateChange: time.Now(),
+	}
+	gp.mu.Unlock()
+
+	msg := makeGossipMsg(t, MessageTypeAlive, &AliveMessage{
+		Node:        &NodeInfo{ID: "corpse", MemoryUsage: 0.9, Metadata: map[string]string{}},
+		Incarnation: 7,
+	})
+	gp.handleAliveMessage(msg)
+
+	ml := gp.GetMemberlist()
+	if got := ml["corpse"].State; got != StateDead {
+		t.Errorf("state = %v after a same-incarnation alive message, want StateDead: overturning a "+
+			"death requires a refutation, not a repeat", got)
+	}
+	if got := ml["corpse"].Info.MemoryUsage; got != 0.1 {
+		t.Errorf("MemoryUsage = %v, want 0.1: a dead node's payload must not be refreshed either", got)
+	}
+}
+
+// TestGossipProtocol_GossipedStatsAreNotFrozenAtTheFirstValue verifies that a *changed* stats value
+// on a subsequent alive message reaches the memberlist and the cluster manager.
+//
+// This is the test #132's stated acceptance criterion could not be. "Wait two heartbeats, assert
+// MemoryUsage > 0" passes on the frozen-stats bug, because the first message is applied and the
+// value is non-zero forever after. A green test over a permanently stale metric is worse than no
+// test: it certifies the thing it cannot see.
+func TestGossipProtocol_GossipedStatsAreNotFrozenAtTheFirstValue(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "stats-host"))
+	gp := cm.gossip
+
+	// First alive message: discovery. Applied even on the buggy code.
+	first := makeGossipMsg(t, MessageTypeAlive, &AliveMessage{
+		Node: &NodeInfo{
+			ID: "busy-peer", Address: "10.0.0.5:9000",
+			MemoryUsage: 0.1, CacheSize: 1024, CacheHitRate: 0.5, Operations: 10,
+			Metadata: map[string]string{},
+		},
+		Incarnation: 1,
+	})
+	gp.handleAliveMessage(first)
+
+	// Second alive message, same incarnation — which is what a healthy node sends, since it has
+	// nothing to refute and so never raises its incarnation — carrying new figures.
+	second := makeGossipMsg(t, MessageTypeAlive, &AliveMessage{
+		Node: &NodeInfo{
+			ID: "busy-peer", Address: "10.0.0.5:9000",
+			MemoryUsage: 0.9, CacheSize: 4096, CacheHitRate: 0.8, Operations: 99,
+			Metadata: map[string]string{},
+		},
+		Incarnation: 1,
+	})
+	gp.handleAliveMessage(second)
+
+	got := gp.GetMemberlist()["busy-peer"].Info
+	if got.MemoryUsage != 0.9 {
+		t.Errorf("MemoryUsage = %v, want 0.9: stats froze at the first value ever received", got.MemoryUsage)
+	}
+	if got.CacheSize != 4096 {
+		t.Errorf("CacheSize = %d, want 4096", got.CacheSize)
+	}
+	if got.CacheHitRate != 0.8 {
+		t.Errorf("CacheHitRate = %v, want 0.8", got.CacheHitRate)
+	}
+	if got.Operations != 99 {
+		t.Errorf("Operations = %d, want 99", got.Operations)
+	}
+
+	// And through the cluster manager, since that is what a load-aware strategy would read.
+	if cmGot := cm.GetNodes()["busy-peer"].MemoryUsage; cmGot != 0.9 {
+		t.Errorf("cluster manager MemoryUsage = %v, want 0.9", cmGot)
+	}
+}
+
+// TestGossipProtocol_PerformGossipStampsItsOwnLastSeen verifies that the LastSeen this node
+// broadcasts is current.
+//
+// UpdateNodeInfo copies LastSeen onto the receiver's record and performHealthChecks compares it
+// against HeartbeatInterval*3, so a node that announced the timestamp it was constructed with would
+// be evidence of its own absence. That was inert only while the incarnation guard discarded the
+// payload; once stats flow, it would make a healthy node flap.
+func TestGossipProtocol_PerformGossipStampsItsOwnLastSeen(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "stamp-host"))
+	gp := cm.gossip
+
+	stale := time.Now().Add(-time.Hour)
+	gp.mu.Lock()
+	gp.localNode.LastSeen = stale
+	// A peer is required, or performGossip returns before doing anything.
+	gp.memberlist["stamp-peer"] = &GossipNode{
+		Info:        &NodeInfo{ID: "stamp-peer", Address: "127.0.0.1:1", Metadata: map[string]string{}},
+		Incarnation: 1,
+		State:       StateAlive,
+	}
+	gp.mu.Unlock()
+
+	gp.performGossip()
+
+	gp.mu.RLock()
+	got := gp.localNode.LastSeen
+	gp.mu.RUnlock()
+
+	if !got.After(stale) {
+		t.Errorf("localNode.LastSeen = %v, unchanged from the stale value: every alive message this "+
+			"node sends would be evidence it has not been heard from", got)
 	}
 }
 


### PR DESCRIPTION
Closes #272.

## The defect

`GossipNode.Incarnation` was set to `1` in the constructor and **nothing ever incremented it** — the only two other writes copy a value received from a peer. Every comparison that depends on an incarnation is strictly-greater, so all of them were false for every message after the one that discovered a node.

Two consequences, both proven by execution before fixing:

1. **A node marked dead could never rejoin.** `checkSuspicions` promotes suspect → dead and nothing demoted it. The only path back to alive was `handleJoinMessage`, reachable solely by a process restart. A few dropped datagrams — the normal condition of UDP — removed a healthy node from routing permanently. Probe: `discovered: state=0` / `after alive from a recovered node: state=2`.
2. **Every peer's gossiped statistics froze at the first value ever received.** Probe: `after first alive: CPUUsage=0.1` / `after second alive: CPUUsage=0.1 (sender said 0.9)`.

## The fix

**Refutation.** A node answers a suspect or dead report about itself by publishing a higher incarnation, which supersedes the accusation everywhere it has spread. Refusing to *record* it matters as much: `performGossip` and `broadcastMessage` both skip non-alive nodes, so a node that accepted a suspicion about itself would stop gossiping and make the report true. Sync messages are answered too — a full sync is often where a node learns it was written off during a partition.

Two details that are load-bearing rather than incidental:

- The new number is one past the **higher** of ours and theirs, not ours plus one. A peer restored from an old snapshot can hold a higher incarnation for us than we published; refuting with `self+1` produces a number that peer's own guard rejects, and the disagreement never resolves.
- An accusation naming an incarnation we have **already superseded** is ignored. Without that, two nodes with stale views each refute the other's refutation and the incarnation climbs without bound.

**Resurrection.** An alive message at a higher incarnation restores a dead or suspect node, in the cluster manager as well as the memberlist — the cluster manager is what `SelectNodes` reads, so a node restored only in gossip is still absent from routing.

**Stats refresh.** An incarnation orders claims about *liveness*; it says nothing about the freshness of the figures riding along with the claim, and a healthy node never raises its incarnation because it has nothing to refute. An equal incarnation now refreshes the payload without touching the state machine — only for a node already believed alive, so the refresh cannot become a second, unguarded path back from dead.

**One adjacent defect this activated.** `performGossip` broadcast the `LastSeen` set at construction and never refreshed it. `UpdateNodeInfo` copies that field and `performHealthChecks` compares it against three heartbeat intervals, so every alive message a node sent was evidence it had not been heard from. Inert only while the incarnation guard discarded the payload — a flap the moment it stopped. Now stamped, in the same critical section that reads the incarnation so a refutation cannot land between the two and publish the old number with the new stats.

## Why the tests are shaped this way

**#132's stated acceptance criterion for the stats half — "wait 2× heartbeat, assert \`MemoryUsage > 0\`" — passes on this bug.** The first message is applied, so the value is non-zero forever after. A green test over a permanently stale metric is worse than no test: it certifies the thing it cannot see.

So the assertions are that a *changed* value arrives on a *second* message, and that dead becomes alive. Nine mutations checked, each reverting one part of the fix:

| mutation | caught by |
|---|---|
| incarnation never advances (the original defect) | `RefutesSuspicionAboutItself`, `RefutesDeathReportAboutItself`, `RefutationOutranksTheAccusation`, `HandleSyncMessage_SkipsSelf` |
| no same-incarnation stats refresh | `GossipedStatsAreNotFrozenAtTheFirstValue` |
| same-incarnation refresh ignores state | `AliveMessageDoesNotResurrectAtTheSameIncarnation` |
| dead nodes not resurrected | `AliveMessageResurrectsADeadNode`, `HandleAliveMessage_UpdatesExisting` |
| self-suspect recorded instead of refuted | `RefutesSuspicionAboutItself`, `RefutationOutranksTheAccusation` |
| self-death accepted instead of refuted | `RefutesDeathReportAboutItself` |
| sync refutation removed | `HandleSyncMessage_SkipsSelf` |
| stale-accusation guard dropped | `StaleAccusationAboutItselfIsIgnored` |
| `LastSeen` not stamped | `PerformGossipStampsItsOwnLastSeen` |

One existing test was retargeted rather than deleted: `HandleSyncMessage_SkipsSelf` asserted the self incarnation was *unchanged* after a sync claiming we are dead at 999, which the fix deliberately changes. Its intent — don't take a peer's word for our own state — still holds, and it now asserts the incarnation ends up **above** the accusation, since a refutation the accuser's own guard would reject is not a refutation.

## Gates

- \`go build ./...\` · \`go vet ./...\` · \`gofmt -l .\` → clean
- Full \`-race\` suite: **exit 0**
- Coverage gate: **35 packages at or above floor**; \`internal/distributed\` 69.5% → **71.3%**
- \`golangci-lint --new-from-merge-base=origin/main\`: **0 issues**
- gosec: only the two pre-existing \`G404\` findings at \`consensus.go:856,859\`

This is the prerequisite for #132 — without it nothing in that issue has an observable effect after startup.