### PR TITLE
feat: measure the node statistics gossip has always carried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot see. Nine mutations were checked, each reverting one part of the fix, and each fails a test
   that names the consequence.
 
+- **Every node advertised itself as idle with an empty cache, for the life of the process** ([#132]).
+  The six resource and cache fields on the local `NodeInfo` were set at construction and never written
+  again, so the figures a peer received described a node that had just started and never done anything.
+  Four of them now carry a measurement, taken once per gossip round and travelling with the alive
+  message that immediately follows: heap in use as a fraction of heap obtained, and cache size, hit
+  rate, and operation count from sources this package already had. Once per round rather than on a
+  ticker of its own, because the only consumer is that message — and because `ReadMemStats` stops the
+  world, so its frequency should be bounded by something.
+
+  Three premises in the issue turned out not to hold, and the resulting scope is smaller than it asked
+  for. There is no new message type, because the alive message already carries the full `NodeInfo` —
+  the transport was never missing. `StrategyLeastLoad` was not reading these fields at all; it reads
+  `LoadBalancerStats.NodeLoad`, which is populated, so the strategy was not broken in the way the
+  issue described. And `CPUUsage` cannot be `HeapInuse/HeapSys` as proposed, because that is the same
+  expression assigned to `MemoryUsage` — two fields holding one quantity under different names.
+
+  So `CPUUsage`, `DiskUsage`, and `NetworkBandwidth` are left at zero, with the reason recorded on the
+  fields and pinned by a test. Each needs a platform-specific source that is not in this repository:
+  `/proc/stat` or `host_statistics`, `statfs` against a cache directory this package does not know
+  about, interface counters sampled over an interval. A field filled with a proxy from an unrelated
+  quantity is worse than an empty one — an obviously-zero `CPUUsage` prompts someone to implement it,
+  while one carrying heap fragmentation looks like a measurement and gets used as one.
+
+  Also fixed: `calculateClusterStats` summed a `totalCacheSize` and discarded it with `_ =`. The value
+  was correct and simply never assigned anywhere, so `ClusterStats` reported an average hit rate with no
+  way to say how much was cached. It is now a field, summed across alive nodes only — a dead node's
+  cache is not reachable, so counting it would overstate what the cluster can serve without going to S3.
+
+  This work was only observable because [#272] landed first: with incarnations frozen, a receiving node
+  discarded every stats update after the first, so a live feed and a permanently stale one were
+  indistinguishable from the outside.
+
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"runtime"
 	"sync"
 	"time"
 
@@ -84,13 +85,27 @@ type NodeInfo struct {
 	Version  string            `json:"version"`
 	Metadata map[string]string `json:"metadata"`
 
-	// Resource information
+	// Resource information.
+	//
+	// MemoryUsage is the Go heap in use as a fraction of the heap obtained from the OS, from
+	// runtime.ReadMemStats. It is the process's own memory, not the host's — a node under memory
+	// pressure from something else on the box reports a low number here, which is the honest answer to
+	// the question this field can actually answer.
+	//
+	// CPUUsage, DiskUsage, and NetworkBandwidth are not populated and are left at zero. Every one of
+	// them needs a platform-specific source that is not in this repository: /proc/stat or host_statistics
+	// for CPU, statfs against a cache directory this package does not know about for disk, and interface
+	// counters sampled over an interval for bandwidth. Filling a field with a proxy from an unrelated
+	// quantity would be worse than leaving it zero — an obviously-zero CPUUsage prompts someone to
+	// implement it, while one carrying heap fragmentation looks like a measurement and gets used as one
+	// (#132).
 	CPUUsage         float64 `json:"cpu_usage"`
 	MemoryUsage      float64 `json:"memory_usage"`
 	DiskUsage        float64 `json:"disk_usage"`
 	NetworkBandwidth int64   `json:"network_bandwidth"`
 
-	// Cache statistics
+	// Cache statistics. Populated from the injected cache's own Stats, so they are absent rather than
+	// zero when no cache is set — see refreshLocalStats.
 	CacheSize    int64   `json:"cache_size"`
 	CacheHitRate float64 `json:"cache_hit_rate"`
 	Operations   int64   `json:"operations"`
@@ -128,8 +143,15 @@ type ClusterStats struct {
 	FailedOps       int64         `json:"failed_ops"`
 	AvgOpLatency    time.Duration `json:"avg_op_latency"`
 
-	// Cache coordination
+	// Cache coordination.
+	//
+	// CacheHitRate is the mean across alive nodes and TotalCacheSize their sum, which is why the two are
+	// combined differently: a rate averaged over nodes answers "how well is the cluster caching",
+	// while a size summed answers "how much is cached", and summing rates or averaging sizes answers
+	// nothing. TotalCacheSize was accumulated and then discarded with `_ =` until v0.11.0 — the value
+	// was correct and simply never assigned anywhere (#132).
 	CacheHitRate          float64 `json:"cache_hit_rate"`
+	TotalCacheSize        int64   `json:"total_cache_size"`
 	ReplicationEvents     int64   `json:"replication_events"`
 	ConsistencyViolations int64   `json:"consistency_violations"`
 
@@ -366,6 +388,7 @@ func (cm *ClusterManager) GetStats() *ClusterStats {
 		FailedOps:             cm.stats.FailedOps,
 		AvgOpLatency:          cm.stats.AvgOpLatency,
 		CacheHitRate:          cm.stats.CacheHitRate,
+		TotalCacheSize:        cm.stats.TotalCacheSize,
 		ReplicationEvents:     cm.stats.ReplicationEvents,
 		ConsistencyViolations: cm.stats.ConsistencyViolations,
 		MessagesSent:          cm.stats.MessagesSent,
@@ -556,11 +579,50 @@ func (cm *ClusterManager) calculateClusterStats() {
 		}
 	}
 
+	cm.stats.TotalCacheSize = totalCacheSize
+
 	// Calculate average cache hit rate
 	if aliveNodesCount > 0 {
 		cm.stats.CacheHitRate = totalCacheHitRate / float64(aliveNodesCount)
 	}
-	_ = totalCacheSize
+}
+
+// refreshLocalStats reads this node's current resource and cache figures into dst.
+//
+// It is called once per gossip round rather than on a ticker of its own, because the only consumer is
+// the alive message that immediately follows: sampling on an independent schedule would publish
+// figures from an arbitrary point before the send with no benefit. ReadMemStats stops the world
+// briefly, which is why this is bounded by the gossip interval and not called per request (#132).
+//
+// The fields it does not touch are as deliberate as the ones it sets; see the NodeInfo comments.
+func (cm *ClusterManager) refreshLocalStats(dst *NodeInfo) {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	// HeapSys is what the process obtained from the OS and HeapInuse what it is actually using, so the
+	// ratio is how much of its own footprint is live rather than fragmentation. HeapSys is zero only
+	// before the first allocation, which cannot happen here, but the guard costs nothing and a division
+	// by zero would put a NaN into a field a load balancer compares.
+	if mem.HeapSys > 0 {
+		dst.MemoryUsage = float64(mem.HeapInuse) / float64(mem.HeapSys)
+	}
+
+	cm.mu.RLock()
+	cache := cm.cache
+	cm.mu.RUnlock()
+
+	// Left untouched when no cache is injected, rather than zeroed. Zero is a meaningful cache size —
+	// an empty cache — and reporting it for "there is no cache" would make a node with no cache look
+	// like the emptiest and therefore most attractive one to a size-aware strategy.
+	if cache != nil {
+		cacheStats := cache.Stats()
+		dst.CacheSize = cacheStats.Size
+		dst.CacheHitRate = cacheStats.HitRate
+	}
+
+	cm.stats.mu.RLock()
+	dst.Operations = cm.stats.TotalOperations
+	cm.stats.mu.RUnlock()
 }
 
 // Helper method to update node information

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
 )
 
 // testConfig returns a minimal ClusterConfig suitable for unit tests.
@@ -410,5 +412,174 @@ func TestClusterManager_StartStop(t *testing.T) {
 
 	if err := cm.Stop(); err != nil {
 		t.Fatalf("Stop: %v", err)
+	}
+}
+
+// ── Local node statistics (#132) ──────────────────────────────────────────────
+
+// TestRefreshLocalStats_PopulatesMemoryAndOperations verifies that this node measures its own memory
+// and operation count rather than advertising the zeros it was constructed with.
+//
+// Until v0.11.0 the six resource fields on the local NodeInfo were set at construction and never
+// written again, so every node advertised itself as idle with an empty cache for the life of the
+// process — and a load-aware strategy comparing those numbers was comparing identical zeros.
+func TestRefreshLocalStats_PopulatesMemoryAndOperations(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "stats-refresh")
+
+	cm.stats.mu.Lock()
+	cm.stats.TotalOperations = 42
+	cm.stats.mu.Unlock()
+
+	var got NodeInfo
+	cm.refreshLocalStats(&got)
+
+	// A ratio of live heap to obtained heap, so strictly between 0 and 1 in a running process. Bounds
+	// rather than a value: the exact figure depends on what the test binary has allocated, and an
+	// assertion on it would be a test of the Go allocator.
+	if got.MemoryUsage <= 0 || got.MemoryUsage > 1 {
+		t.Errorf("MemoryUsage = %v, want a fraction in (0, 1]", got.MemoryUsage)
+	}
+	if got.Operations != 42 {
+		t.Errorf("Operations = %d, want 42", got.Operations)
+	}
+}
+
+// TestRefreshLocalStats_ReadsTheInjectedCache verifies that the cache figures come from the cache
+// rather than being left at zero.
+func TestRefreshLocalStats_ReadsTheInjectedCache(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "stats-cache")
+	cm.SetCache(&mockCache{stats: types.CacheStats{Size: 8192, HitRate: 0.75}})
+
+	var got NodeInfo
+	cm.refreshLocalStats(&got)
+
+	if got.CacheSize != 8192 {
+		t.Errorf("CacheSize = %d, want 8192", got.CacheSize)
+	}
+	if got.CacheHitRate != 0.75 {
+		t.Errorf("CacheHitRate = %v, want 0.75", got.CacheHitRate)
+	}
+}
+
+// TestRefreshLocalStats_LeavesCacheFieldsAloneWithNoCache verifies that an absent cache is
+// distinguishable from an empty one.
+//
+// Zero is a meaningful cache size, so writing it for "there is no cache" would make a node with no
+// cache look like the emptiest and therefore most attractive one to a size-aware strategy.
+func TestRefreshLocalStats_LeavesCacheFieldsAloneWithNoCache(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "stats-nocache")
+
+	got := NodeInfo{CacheSize: -1, CacheHitRate: -1}
+	cm.refreshLocalStats(&got)
+
+	if got.CacheSize != -1 || got.CacheHitRate != -1 {
+		t.Errorf("cache fields = (%d, %v), want them untouched at (-1, -1) when no cache is injected",
+			got.CacheSize, got.CacheHitRate)
+	}
+}
+
+// TestRefreshLocalStats_LeavesUnmeasurableFieldsAtZero verifies that CPU, disk, and bandwidth are not
+// filled with a proxy from an unrelated quantity.
+//
+// Each needs a platform-specific source this repository does not have. An obviously-zero CPUUsage
+// prompts someone to implement it; one carrying heap fragmentation looks like a measurement and gets
+// used as one. #132 proposed HeapInuse/HeapSys for CPUUsage, which is the same expression already
+// assigned to MemoryUsage — so this test also pins the two fields apart.
+func TestRefreshLocalStats_LeavesUnmeasurableFieldsAtZero(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "stats-honest")
+
+	var got NodeInfo
+	cm.refreshLocalStats(&got)
+
+	if got.CPUUsage != 0 {
+		t.Errorf("CPUUsage = %v, want 0: no CPU source exists in this repository, and a stand-in "+
+			"reads as a measurement", got.CPUUsage)
+	}
+	if got.DiskUsage != 0 {
+		t.Errorf("DiskUsage = %v, want 0", got.DiskUsage)
+	}
+	if got.NetworkBandwidth != 0 {
+		t.Errorf("NetworkBandwidth = %d, want 0", got.NetworkBandwidth)
+	}
+}
+
+// TestPerformGossipRefreshesTheAdvertisedStats verifies that the figures a peer receives are the
+// current ones, end to end through the gossip round.
+//
+// refreshLocalStats being correct is not enough: it has to be called, and its output has to reach the
+// struct that performGossip marshals. Asserting through gp.localNode covers the assignment the unit
+// tests above cannot see.
+func TestPerformGossipRefreshesTheAdvertisedStats(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "advertise-host")
+	cm.SetCache(&mockCache{stats: types.CacheStats{Size: 4096, HitRate: 0.5}})
+
+	cm.stats.mu.Lock()
+	cm.stats.TotalOperations = 7
+	cm.stats.mu.Unlock()
+
+	gp := cm.gossip
+
+	// A peer is required, or performGossip returns before sending anything.
+	gp.mu.Lock()
+	gp.memberlist["advertise-peer"] = &GossipNode{
+		Info:        &NodeInfo{ID: "advertise-peer", Address: "127.0.0.1:1", Metadata: map[string]string{}},
+		Incarnation: 1,
+		State:       StateAlive,
+	}
+	gp.mu.Unlock()
+
+	gp.performGossip()
+
+	gp.mu.RLock()
+	got := *gp.localNode
+	gp.mu.RUnlock()
+
+	if got.CacheSize != 4096 {
+		t.Errorf("advertised CacheSize = %d, want 4096", got.CacheSize)
+	}
+	if got.CacheHitRate != 0.5 {
+		t.Errorf("advertised CacheHitRate = %v, want 0.5", got.CacheHitRate)
+	}
+	if got.Operations != 7 {
+		t.Errorf("advertised Operations = %d, want 7", got.Operations)
+	}
+	if got.MemoryUsage <= 0 {
+		t.Errorf("advertised MemoryUsage = %v, want > 0", got.MemoryUsage)
+	}
+}
+
+// TestCalculateClusterStats_SumsCacheSizeAcrossAliveNodes verifies that the accumulator discarded
+// with `_ =` until v0.11.0 now reaches a field.
+//
+// Summed, not averaged: the question a total cache size answers is "how much is cached", and an
+// average answers nothing that the per-node figures do not already. The hit rate beside it is averaged
+// for the mirror-image reason, which is why the two are combined differently.
+func TestCalculateClusterStats_SumsCacheSizeAcrossAliveNodes(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "sum-host")
+
+	cm.mu.Lock()
+	cm.nodes["sum-a"] = &NodeInfo{ID: "sum-a", Status: NodeStatusAlive, CacheSize: 1000, CacheHitRate: 0.4, Metadata: map[string]string{}}
+	cm.nodes["sum-b"] = &NodeInfo{ID: "sum-b", Status: NodeStatusAlive, CacheSize: 3000, CacheHitRate: 0.6, Metadata: map[string]string{}}
+	// Dead nodes contribute nothing: their cache is not reachable, so counting it would overstate what
+	// the cluster can serve without going to S3.
+	cm.nodes["sum-dead"] = &NodeInfo{ID: "sum-dead", Status: NodeStatusDead, CacheSize: 9_000_000, Metadata: map[string]string{}}
+	cm.mu.Unlock()
+
+	cm.calculateClusterStats()
+
+	stats := cm.GetStats()
+
+	// 1000 + 3000, plus whatever the self node reports — zero here, since nothing refreshed it.
+	if stats.TotalCacheSize != 4000 {
+		t.Errorf("TotalCacheSize = %d, want 4000 (dead node's 9000000 excluded)", stats.TotalCacheSize)
+	}
+	if stats.CacheHitRate <= 0 {
+		t.Errorf("CacheHitRate = %v, want > 0", stats.CacheHitRate)
 	}
 }

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -839,10 +839,12 @@ func TestCoordinator_ExecuteLocally_BackendError(t *testing.T) {
 
 // ── Cache invalidation tests ──────────────────────────────────────────────────
 
-// mockCache is a minimal types.Cache for testing cache invalidation.
+// mockCache is a minimal types.Cache for testing cache invalidation, and for the local-stats refresh
+// in cluster_test.go, which needs Stats to return something distinguishable from a zero value.
 type mockCache struct {
 	mu      sync.Mutex
 	deleted []string
+	stats   types.CacheStats
 }
 
 func (mc *mockCache) Get(_ string, _, _ int64) []byte { return nil }
@@ -852,9 +854,14 @@ func (mc *mockCache) Delete(key string) {
 	mc.deleted = append(mc.deleted, key)
 	mc.mu.Unlock()
 }
-func (mc *mockCache) Evict(_ int64) bool      { return false }
-func (mc *mockCache) Size() int64             { return 0 }
-func (mc *mockCache) Stats() types.CacheStats { return types.CacheStats{} }
+func (mc *mockCache) Evict(_ int64) bool { return false }
+func (mc *mockCache) Size() int64        { return 0 }
+func (mc *mockCache) Stats() types.CacheStats {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	return mc.stats
+}
 
 // TestClusterManager_InvalidateCacheKey_NoGossip verifies that
 // InvalidateCacheKey is a no-op (does not panic) when gossip is not running.

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -241,18 +241,28 @@ Check cluster health and node status:
 	// Get cluster state
 	nodes := cluster.GetNodes()
 	for nodeID, node := range nodes {
-		log.Printf("Node %s: Status=%s, Load=%.2f",
-			nodeID, node.Status, node.Load)
+		log.Printf("Node %s: Status=%s, Memory=%.2f, Cache=%d bytes",
+			nodeID, node.Status, node.MemoryUsage, node.CacheSize)
 	}
 
 	// Get leader
-	:= cluster.GetLeader()
+	leader := cluster.GetLeader()
 	log.Printf("Current leader: %s", leader)
 
 	// Check if this node is leader
 	if cluster.IsLeader() {
 		// Perform leader-only operations
 	}
+
+Which of [NodeInfo]'s figures mean anything is worth knowing before building on them. MemoryUsage,
+CacheSize, CacheHitRate, and Operations are measured once per gossip round and travel with each alive
+message. CPUUsage, DiskUsage, and NetworkBandwidth are always zero: each needs a platform-specific
+source that is not in this repository, and a plausible stand-in would be worse than a zero, because a
+zero prompts someone to implement the field while a number that looks measured gets used as one.
+
+None of the four carried a live value before v0.11.0. They were set at construction and never written
+again, so every node advertised itself as idle with an empty cache — and the receiving side would have
+discarded an update anyway, for the incarnation reason described below (#132, #272).
 
 Failure Detection & Recovery
 

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -886,8 +886,22 @@ func (gp *GossipProtocol) performGossip() {
 	// One critical section, because the incarnation must be the one that goes out with this payload:
 	// taking the write lock to stamp, dropping it, and then calling getCurrentIncarnation would let a
 	// refutation land in between and publish the old number with the new stats.
+	// Sampled before the lock, because ReadMemStats stops the world and cm.cache is read under
+	// cm.mu — holding gp.mu across either invites a stall or a lock-order inversion. The values land in
+	// gp.localNode below, under gp.mu, alongside the timestamp they belong with.
+	var fresh NodeInfo
+	gp.cluster.refreshLocalStats(&fresh)
+
 	gp.mu.Lock()
 	gp.localNode.LastSeen = time.Now()
+
+	// The figures a peer will route on. Until v0.11.0 these six fields were set to zero at
+	// construction and never written again, so every node advertised itself as idle with an empty cache
+	// forever — and the incarnation guard meant a peer would have discarded the update anyway (#132).
+	gp.localNode.MemoryUsage = fresh.MemoryUsage
+	gp.localNode.CacheSize = fresh.CacheSize
+	gp.localNode.CacheHitRate = fresh.CacheHitRate
+	gp.localNode.Operations = fresh.Operations
 
 	incarnation := uint32(1)
 	if self, exists := gp.memberlist[gp.localNode.ID]; exists {


### PR DESCRIPTION
The six resource and cache fields on the local `NodeInfo` were set at construction
and never written again, so the figures a peer received described a node that had
just started and never done anything.

Four now carry a measurement, taken once per gossip round and travelling with the
alive message that immediately follows: heap in use as a fraction of heap obtained,
and cache size, hit rate, and operation count from sources this package already had.
Once per round rather than on a ticker of its own, because the only consumer is that
message — and `ReadMemStats` stops the world, so its frequency should be bounded by
something.

This builds on #273: until an incarnation could advance, the receiving side discarded
every stats payload after the first one, so nothing here would have had an observable
effect after startup.

## Three of #132's premises did not hold

The scope here is smaller than the issue asked for:

- **No new message type is needed.** The alive message already carries the full
  `NodeInfo`, so the transport was never missing.
- **`StrategyLeastLoad` does not read these fields.** It reads
  `LoadBalancerStats.NodeLoad` (`coordinator.go:913`), which is populated.
- **`CPUUsage` cannot be `HeapInuse/HeapSys`** as proposed — that is the expression
  already assigned to `MemoryUsage`.

`CPUUsage`, `DiskUsage`, and `NetworkBandwidth` are therefore left at zero, with the
reason on the fields and pinned by a test. Each needs a platform-specific source that
is not in this repository: `/proc/stat` or `host_statistics` for CPU, `statfs` against
a cache directory this package does not know about for disk, and interface counters
sampled over an interval for bandwidth. A field filled with a proxy from an unrelated
quantity is worse than an empty one: an obviously-zero `CPUUsage` prompts someone to
implement it, while one carrying heap fragmentation looks like a measurement and gets
used as one.

Zero is likewise not written for "no cache injected" — an empty cache is a meaningful
zero, and reporting it for a cache-less node would make that node look like the
emptiest and most attractive one to a size-aware strategy.

## Also

`calculateClusterStats` summed a `totalCacheSize` and discarded it with `_ =`. The
value was correct and simply never assigned. It is now a field, summed across alive
nodes only — a dead node's cache is not reachable, so counting it would overstate what
the cluster can serve without going to S3.

Corrects the health-monitoring example in `doc.go`, which printed a `node.Load` field
that does not exist and contained an invalid `:= cluster.GetLeader()`, and records
which figures mean anything.

## Verification

Five mutations, each caught by a test that names the consequence:

| mutation | caught by |
|---|---|
| refreshed stats never applied to the outgoing payload | `TestPerformGossipRefreshesTheAdvertisedStats` |
| no-cache case zeroes the cache fields | `TestRefreshLocalStats_LeavesCacheFieldsAloneWithNoCache` |
| `CPUUsage` proxied from heap figures | `TestRefreshLocalStats_LeavesUnmeasurableFieldsAtZero` |
| `totalCacheSize` discarded again | `TestCalculateClusterStats_SumsCacheSizeAcrossAliveNodes` |
| dead node's cache counted in the cluster total | `TestCalculateClusterStats_SumsCacheSizeAcrossAliveNodes` |

Gates: build, vet, gofmt clean; full `-race` suite green; coverage gate 35 packages at
or above floor with `internal/distributed` 71.3% → 73.4%; `golangci-lint
--new-from-merge-base=origin/main` 0 issues.

Closes #132