### PR TITLE
fix: stop counting a failed distributed operation as a success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,10 +201,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discarded every stats update after the first, so a live feed and a permanently stale one were
   indistinguishable from the outside.
 
+- **A distributed operation that failed on every node was counted as a success** ([#269]). The three
+  consistency executors each reported failure in `OperationResult.Success` and returned a nil error,
+  and `ClusterManager.DistributeOperation` classified on the error — the ordinary thing to do in Go —
+  so `SuccessfulOps` climbed for operations that did nothing. The counters are what an operator reads
+  to decide whether coordination is working, and a cluster where every operation fails while the
+  success count rises is worse than one with no metrics: it actively argues against investigating.
+
+  `ExecuteOperation` now returns an error whenever the result is unsuccessful, carrying the failure
+  text so the two representations cannot drift. Reconciled at that one choke point rather than in each
+  executor, because it is the single point every consistency level passes through: a fourth level added
+  later cannot reintroduce the disagreement, and no executor has to remember to report the same fact
+  twice.
+
+  The `-tags=distributed` suite that surfaced this was itself asserting against a misconfiguration —
+  it never injected a backend, so every operation failed with `no backend configured` and
+  `TestConcurrentOperations` printed "Failed 10 out of 10" and "Successful: 10, Failed: 0" in the same
+  run. Those tests now run against a real S3 backend on an in-process substrate endpoint, seed the keys
+  they read, and check the returned bytes rather than only the success flag, so the assertion covers a
+  real operation. No CI job builds that tag, which is why the contradiction sat there unobserved — see
+  [#240].
+
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
+[#240]: https://github.com/scttfrdmn/objectfs/issues/240
 [#267]: https://github.com/scttfrdmn/objectfs/issues/267
+[#269]: https://github.com/scttfrdmn/objectfs/issues/269
 [#272]: https://github.com/scttfrdmn/objectfs/issues/272
 [scttfrdmn/substrate#540]: https://github.com/scttfrdmn/substrate/issues/540
 

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -2,6 +2,8 @@ package distributed
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -581,5 +583,125 @@ func TestCalculateClusterStats_SumsCacheSizeAcrossAliveNodes(t *testing.T) {
 	}
 	if stats.CacheHitRate <= 0 {
 		t.Errorf("CacheHitRate = %v, want > 0", stats.CacheHitRate)
+	}
+}
+
+// ── Operation success accounting (#269) ───────────────────────────────────────
+//
+// These assert on the pair (err, result.Success) rather than on either alone. The defect they pin
+// was not that either value was wrong — each executor set result.Success correctly and every
+// executor returned a nil error — it was that the two disagreed, and DistributeOperation classified
+// on the one that carried no information. A test checking only result.Success passes on the defect,
+// and so does a test checking only that FailedOps is reachable.
+
+// TestDistributeOperation_FailedOperationCountsAsFailed is the counter the issue was filed about: an
+// operation that failed on every node must not be recorded as a success.
+func TestDistributeOperation_FailedOperationCountsAsFailed(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "acct-fail-node")
+	cm.SetBackend(&errBackend{err: errors.New("s3: AccessDenied")})
+
+	result, err := cm.DistributeOperation(context.Background(), &DistributedOperation{
+		Type:        OpTypeGet,
+		Key:         "k",
+		Consistency: ConsistencyEventual,
+	})
+
+	if err == nil {
+		t.Error("DistributeOperation returned a nil error for an operation that failed on every node")
+	}
+	if result == nil {
+		t.Fatal("result is nil; the failure detail is the only thing that says which node failed and why")
+	}
+	if result.Success {
+		t.Error("result.Success = true for a failed operation")
+	}
+
+	// The error must carry the cause. "operation failed" with the AccessDenied dropped sends an
+	// operator to the wrong place, which is the same defect one layer along.
+	if err != nil && !strings.Contains(err.Error(), "AccessDenied") {
+		t.Errorf("error %q should name the backend failure", err)
+	}
+
+	stats := cm.GetStats()
+	if stats.TotalOperations != 1 {
+		t.Errorf("TotalOperations = %d, want 1", stats.TotalOperations)
+	}
+	if stats.FailedOps != 1 {
+		t.Errorf("FailedOps = %d, want 1", stats.FailedOps)
+	}
+	if stats.SuccessfulOps != 0 {
+		t.Errorf("SuccessfulOps = %d, want 0: the operation failed on every node", stats.SuccessfulOps)
+	}
+}
+
+// TestDistributeOperation_SucceededOperationCountsAsSuccessful is the other half. Without it, a fix
+// that returned an error unconditionally would pass the test above.
+func TestDistributeOperation_SucceededOperationCountsAsSuccessful(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithBackend(t, "acct-ok-node")
+
+	result, err := cm.DistributeOperation(context.Background(), &DistributedOperation{
+		Type:        OpTypeGet,
+		Key:         "k",
+		Consistency: ConsistencyEventual,
+	})
+	if err != nil {
+		t.Fatalf("DistributeOperation: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("result.Success = false: %s", result.Error)
+	}
+
+	stats := cm.GetStats()
+	if stats.SuccessfulOps != 1 {
+		t.Errorf("SuccessfulOps = %d, want 1", stats.SuccessfulOps)
+	}
+	if stats.FailedOps != 0 {
+		t.Errorf("FailedOps = %d, want 0", stats.FailedOps)
+	}
+}
+
+// TestDistributeOperation_ErrorAndSuccessNeverDisagree checks the invariant itself across every
+// consistency level and both outcomes, rather than the two counters that happen to read it today.
+//
+// This is the assertion that would have caught the defect at any of the three executors: the fix is
+// at one choke point precisely so a fourth level cannot reintroduce the disagreement, and this is
+// what would notice if one did.
+func TestDistributeOperation_ErrorAndSuccessNeverDisagree(t *testing.T) {
+	t.Parallel()
+
+	levels := []ConsistencyLevel{ConsistencyEventual, ConsistencySession, ConsistencyStrong}
+
+	for _, level := range levels {
+		for _, failing := range []bool{false, true} {
+			name := fmt.Sprintf("%s/failing=%v", level, failing)
+
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				cm := makeClusterWithNode(t, fmt.Sprintf("agree-%s-%v", level, failing))
+				if failing {
+					cm.SetBackend(&errBackend{err: errors.New("s3: ServiceUnavailable")})
+				} else {
+					cm.SetBackend(&mockBackend{})
+				}
+
+				result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
+					Type:        OpTypeGet,
+					Key:         "k",
+					Consistency: level,
+				})
+				if result == nil {
+					t.Fatal("result is nil")
+				}
+				if result.Success == (err != nil) {
+					t.Errorf("result.Success = %v with err = %v: the two must agree", result.Success, err)
+				}
+				if result.Success == failing {
+					t.Errorf("result.Success = %v, want %v", result.Success, !failing)
+				}
+			})
+		}
 	}
 }

--- a/internal/distributed/coordinator.go
+++ b/internal/distributed/coordinator.go
@@ -290,6 +290,19 @@ func (c *Coordinator) ExecuteOperation(ctx context.Context, op *DistributedOpera
 	result.CompletedAt = time.Now()
 	result.Latency = time.Since(start)
 
+	// A result that failed is returned with an error, always. The three executors above each
+	// reported failure only in result.Success and returned a nil error, so a caller that checked
+	// err — the ordinary thing to do in Go, and what ClusterManager.DistributeOperation did —
+	// recorded an operation that failed on every node as a success (#269).
+	//
+	// Reconciling here rather than in each executor is deliberate: this is the single point every
+	// consistency level passes through, so a fourth level added later cannot reintroduce the
+	// disagreement, and none of them has to remember to return two representations of the same
+	// fact. The error text is result.Error so the two cannot drift either.
+	if err == nil && !result.Success {
+		err = fmt.Errorf("operation %s on %q failed: %s", op.Type, op.Key, result.Error)
+	}
+
 	// Update load balancer stats
 	c.loadBalancer.stats.mu.Lock()
 	c.loadBalancer.stats.RequestsRouted++

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -42,6 +42,13 @@ Architecture
 Three levels are accepted, and this section says what each one does rather than what it is named
 after, because the names promise guarantees the code does not provide.
 
+Whichever level is used, a failed operation is reported both ways: [Coordinator.ExecuteOperation]
+returns a non-nil error and an [OperationResult] with Success false, and the error carries the same
+text as OperationResult.Error. Checking either is sufficient. Until v0.11.0 it was not — the
+executors reported failure only in the result and returned a nil error, so a caller checking err
+alone saw a success, which is what [ClusterManager.DistributeOperation] did when incrementing its
+own counters (#269).
+
 The reason they cannot provide them is structural, not a missing feature: every node in a cluster
 writes the same key in the same bucket. S3 is the single copy. So "replicate to the other nodes"
 means issuing the same PUT again from another node, and a majority of nodes reporting success means

--- a/tests/distributed_test.go
+++ b/tests/distributed_test.go
@@ -14,7 +14,30 @@ import (
 	"time"
 
 	"github.com/scttfrdmn/objectfs/internal/distributed"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
 )
+
+// withBackend gives a cluster a real S3 backend, against an in-process substrate endpoint.
+//
+// Every test here that executed an operation used to run with no backend at all, so executeLocally
+// took its `c.backend == nil` arm and every operation failed with "no backend configured". The
+// assertions then said either nothing or the opposite of the truth — TestConcurrentOperations
+// reported ten failures and ten successes in the same run (#269). A test that asserts an operation
+// succeeded has to be able to perform one.
+//
+// A real backend rather than a mock, per the harness note in CLAUDE.md: a mock on the far side of
+// this seam would agree with the coordinator by construction, which is how the seam defects this
+// suite exists to catch were missed in the first place.
+// It returns the endpoint so a caller can seed the keys its operations read, and check afterwards
+// what actually reached storage.
+func withBackend(t *testing.T, cm *distributed.ClusterManager) *testaws.TestServer {
+	t.Helper()
+
+	srv := testaws.Start(t)
+	cm.SetBackend(srv.Backend())
+
+	return srv
+}
 
 // writeClusterSecret writes a shared cluster secret to a file and returns its path.
 //
@@ -131,6 +154,18 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 		t.Fatalf("Failed to create cluster manager: %v", err)
 	}
 
+	srv := withBackend(t, cm)
+
+	// The operation below is a GET, so the key has to exist. Seeded through the raw SDK rather than
+	// through the coordinator: a test that both writes and reads through the layer under test cannot
+	// tell a symmetric encoding bug from correct behaviour.
+	const (
+		key  = "test-key"
+		body = "distributed-operation-payload"
+	)
+
+	srv.PutObject(key, []byte(body))
+
 	err = cm.Start(ctx)
 	if err != nil {
 		t.Fatalf("Failed to start cluster manager: %v", err)
@@ -143,7 +178,7 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 	// Create a distributed operation
 	op := &distributed.DistributedOperation{
 		Type:        distributed.OpTypeGet,
-		Key:         "test-key",
+		Key:         key,
 		Consistency: distributed.ConsistencyEventual,
 		Timeout:     3 * time.Second,
 	}
@@ -162,6 +197,12 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 		t.Errorf("Expected successful operation, got error: %s", result.Error)
 	}
 
+	// The bytes, not just the success flag. A GET reported successful that returned something else is
+	// the failure this assertion exists for.
+	if string(result.Data) != body {
+		t.Errorf("result.Data = %q, want %q", result.Data, body)
+	}
+
 	// Verify stats were updated
 	stats := cm.GetStats()
 	if stats.TotalOperations == 0 {
@@ -170,6 +211,41 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 
 	if stats.SuccessfulOps == 0 {
 		t.Error("Expected successful operation count to be incremented")
+	}
+
+	// And the counters must not contradict the result they describe (#269).
+	if stats.FailedOps != 0 {
+		t.Errorf("FailedOps = %d, want 0 for an operation that succeeded", stats.FailedOps)
+	}
+
+	// The same operation against a key that does not exist. Both halves are needed: with only the
+	// success case above, a fix that returned an error unconditionally would pass, and with only the
+	// failure case one that always errored would too. This is also the half that fails if the
+	// reconciliation in ExecuteOperation is removed — the assertion the counters could not make while
+	// every operation in this file failed for the same reason (#269).
+	failed, err := cm.DistributeOperation(ctx, &distributed.DistributedOperation{
+		Type:        distributed.OpTypeGet,
+		Key:         "a-key-that-was-never-written",
+		Consistency: distributed.ConsistencyEventual,
+		Timeout:     3 * time.Second,
+	})
+	if err == nil {
+		t.Error("DistributeOperation returned a nil error for a GET of a key that does not exist")
+	}
+	if failed == nil {
+		t.Fatal("Expected a non-nil result even on failure: it carries which node failed and why")
+	}
+	if failed.Success {
+		t.Error("result.Success = true for a GET of a key that does not exist")
+	}
+
+	stats = cm.GetStats()
+	if stats.FailedOps != 1 {
+		t.Errorf("FailedOps = %d, want 1 after one failed operation", stats.FailedOps)
+	}
+	if stats.SuccessfulOps != 1 {
+		t.Errorf("SuccessfulOps = %d, want 1: the failed operation must not be counted here",
+			stats.SuccessfulOps)
 	}
 }
 
@@ -463,6 +539,14 @@ func TestConcurrentOperations(t *testing.T) {
 		t.Fatalf("Failed to create cluster manager: %v", err)
 	}
 
+	// Execute concurrent operations
+	numOps := 10
+
+	srv := withBackend(t, cm)
+	for i := range numOps {
+		srv.PutObject(fmt.Sprintf("concurrent-key-%d", i), []byte(fmt.Sprintf("payload-%d", i)))
+	}
+
 	err = cm.Start(ctx)
 	if err != nil {
 		t.Fatalf("Failed to start cluster manager: %v", err)
@@ -472,8 +556,6 @@ func TestConcurrentOperations(t *testing.T) {
 	// Wait for leadership
 	time.Sleep(2 * time.Second)
 
-	// Execute concurrent operations
-	numOps := 10
 	var wg sync.WaitGroup
 	errors := make(chan error, numOps)
 
@@ -497,6 +579,11 @@ func TestConcurrentOperations(t *testing.T) {
 
 			if result == nil || !result.Success {
 				errors <- fmt.Errorf("operation %d failed: %v", opID, result)
+				return
+			}
+
+			if want := fmt.Sprintf("payload-%d", opID); string(result.Data) != want {
+				errors <- fmt.Errorf("operation %d returned %q, want %q", opID, result.Data, want)
 			}
 		}(i)
 	}
@@ -519,6 +606,17 @@ func TestConcurrentOperations(t *testing.T) {
 	stats := cm.GetStats()
 	if int(stats.TotalOperations) < numOps {
 		t.Errorf("Expected at least %d operations, got %d", numOps, stats.TotalOperations)
+	}
+
+	// The counters have to agree with what the operations above actually did. This test used to print
+	// "Failed 10 out of 10" and "Successful: 10, Failed: 0" in the same run: every operation failed
+	// with "no backend configured", and DistributeOperation classified on an error the executors never
+	// returned, so the statistics an operator reads argued against investigating (#269).
+	if int(stats.SuccessfulOps) < numOps {
+		t.Errorf("SuccessfulOps = %d, want at least %d", stats.SuccessfulOps, numOps)
+	}
+	if stats.FailedOps != 0 {
+		t.Errorf("FailedOps = %d, want 0: every operation above succeeded", stats.FailedOps)
 	}
 
 	t.Logf("Concurrent test completed - Total ops: %d, Successful: %d, Failed: %d",


### PR DESCRIPTION
The three consistency executors each reported failure in `OperationResult.Success` and returned a
nil error. `ClusterManager.DistributeOperation` classified on the error — the ordinary thing to do
in Go — so an operation that failed on every node incremented `SuccessfulOps`.

The counters are what an operator reads to decide whether coordination is working. A cluster where
every operation fails while the success count climbs is worse than one with no metrics: it actively
argues against investigating.

## The fix

`ExecuteOperation` now returns an error whenever the result is unsuccessful, carrying the result's
own failure text so the two representations cannot drift.

Reconciled at that one choke point rather than in each executor, because it is the single point
every consistency level passes through: a fourth level added later cannot reintroduce the
disagreement, and no executor has to remember to report one fact in two places. The contract is now
stated in `doc.go` — a failed operation is reported both ways, and checking either is sufficient.

## The test gap in the same change

The `-tags=distributed` suite that surfaced this was asserting against a misconfiguration. It never
injected a backend, so `executeLocally` took its `c.backend == nil` arm and every operation failed
with `no backend configured` — which is how `TestConcurrentOperations` came to print both of these
in the same run:

```
Failed 10 out of 10 concurrent operations
Concurrent test completed - Total ops: 10, Successful: 10, Failed: 0
```

Those tests now use a real S3 backend against an in-process substrate endpoint, seed the keys they
read, and check the returned bytes rather than only the success flag. A real backend rather than a
mock, per the harness note in `CLAUDE.md`: a mock on the far side of this seam would agree with the
coordinator by construction, which is how the defect was missed.

`TestClusterManager_DistributedOperation` also executes a GET of an absent key, so the tagged suite
can now fail if the reconciliation is removed — the assertion its counters could not make while
every operation failed for the same reason.

## Verification

Three mutations, each caught:

| mutation | caught by |
|---|---|
| reconciliation removed (the original defect) | `TestDistributeOperation_FailedOperationCountsAsFailed`, `TestDistributeOperation_ErrorAndSuccessNeverDisagree` (3 failing subtests), and `TestClusterManager_DistributedOperation` under `-tags=distributed` |
| error returned unconditionally | `TestDistributeOperation_SucceededOperationCountsAsSuccessful`, `…NeverDisagree` (3 passing subtests) |
| cause dropped from the error text | `TestDistributeOperation_FailedOperationCountsAsFailed` |

`…ErrorAndSuccessNeverDisagree` asserts the invariant itself — `result.Success == (err != nil)` must
be false — across all three consistency levels and both outcomes, rather than the two counters that
happen to read it today.

Gates: build, vet, gofmt clean; full `-race` suite green; coverage gate 35 packages at or above
floor with `internal/distributed` 73.4% → 73.9%; `golangci-lint --new-from-merge-base=origin/main`
0 issues; gosec unchanged (the two pre-existing `G404` at `consensus.go:856,859`).

## Two further defects found while fixing this

Filed as #275, not fixed here. Confirmed by probe rather than by reading:

- **A single-node cluster never elects a leader.** `startElection` sets `voteCount = 1` and the
  majority check lives only in `handleVoteResponse`, which is reached only when a peer replies.
  With one node there is no peer, so a node that has already satisfied the majority never evaluates
  it, and the term increments forever.
- **`GetStats` reports zero nodes for the first five seconds after `Start`**, because nothing
  computes the statistics before `updateStats`' hardcoded ticker first fires — while `GetNodes`
  correctly reports one.

Both are why three tests in the `-tags=distributed` suite have been failing unobserved. No CI job
builds that tag (#240).

Closes #269