### PR TITLE
fix: a three-node cluster forms, elects one leader, and does it race-free (#275, #278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real operation. No CI job builds that tag, which is why the contradiction sat there unobserved — see
   [#240].
 
+- **A single-node cluster never elected a leader** ([#275]). The majority check lived only in
+  `handleVoteResponse`, which runs when a peer replies to a vote request. `startElection` casts this
+  node's vote for itself and sets the count to 1 — already a majority of one — but nothing evaluated
+  it, so with no peers the election timeout fired again, the term incremented, and the cycle repeated
+  for the life of the process while `IsLeader` stayed false. A cluster of one is not a corner case: it
+  is the first thing anyone runs, and the shape a deployment has while its second node is being
+  provisioned.
+
+  The count-and-check is now `checkVoteMajority`, called from both places where the vote count changes.
+  Extracting it rather than duplicating the comparison is the point — the defect was that a check
+  existed in one of the two places it belonged, and two copies would drift the same way. The
+  candidate-state guard moved with it, so a vote arriving after a higher-term heartbeat has demoted
+  this node cannot promote a follower on a stale count.
+
+  A membership view of one is only a majority if this node really is the whole cluster, so the check
+  now distinguishes the two cases that view cannot: a node whose `seed_nodes` names an address other
+  than its own waits to hear from a peer, and a node that names none proceeds. Without that, a probe of
+  three seeded nodes showed all three electing themselves at term 1, each on its own single vote, within
+  the first second — before any had heard of the others. Gossip learns of a peer only from an inbound
+  message and the election timer does not wait for one, so every node of a starting cluster spends its
+  first few hundred milliseconds looking exactly like a cluster of one.
+
+- **A deposed leader went on reporting itself as the leader** ([#275]). `becomeLeader` calls
+  `SetLeader`; no step-down path did. So `ClusterManager.IsLeader` was effectively write-once — a node
+  that saw a higher term became a follower inside the consensus engine while the accessor that callers
+  actually ask, and that the coordinator routes on, kept returning true for the life of the process.
+  That is what turned a momentary election race into a permanent two-leader state instead of something
+  the next heartbeat resolved. Both step-down paths now inform the cluster manager: a heartbeat names
+  the new leader, and a vote request at a higher term clears leadership without naming one, because a
+  candidate has not won anything yet and claiming it had would be worse than admitting there is no
+  leader.
+
+- **`GetStats` reported zero nodes for the first five seconds after `Start`** ([#275]). The cluster
+  statistics were computed only by a five-second ticker, so `GetStats().TotalNodes` was 0 while
+  `GetNodes()` over the same membership correctly returned 1 — two public accessors disagreeing, with
+  the one an operator, a health check, and a readiness probe reads being the wrong one. They are now
+  computed once during `Start`, so they are current when it returns. The regression test asserts with
+  no sleep, which is the whole of the test: one that slept first could not tell the fix from the
+  defect.
+
+  These were found by probe while fixing [#269], and they are why three tests in the
+  `-tags=distributed` suite had been failing unobserved — no CI job builds that tag ([#240]).
+
+- **Two more `-tags=distributed` tests were asserting against misconfigurations**, the same class as the
+  missing backend above. `TestMultiNodeCluster` set no `SeedNodes`, and gossip has no other discovery
+  mechanism — it learns of a peer from an inbound message, and the only unsolicited send is
+  `joinCluster`, which runs only when seeds are configured. So its three managers were three clusters of
+  one that had never heard of each other, which is what "Node *i* sees 1 nodes in cluster" three times
+  was saying. It now seeds all three from node 0, gives each a backend because strong consistency fans
+  the write out, and raises `MaxGossipPacket` past the default that would otherwise truncate the sync
+  ([#277]). `TestLoadBalancer_NodeSelection` registered four peers at addresses nothing listens on and
+  then asserted a strong-consistency PUT across two of them succeeded; it timed out for 30 seconds and
+  reported that as a defect. It now asserts what its name promises — that selection chooses from the
+  whole membership, and that the operation executes and the bytes reach storage — and says in a comment
+  why one reachable node out of five can carry one of those claims per operation but not both.
+
+- **Four data races on the membership maps, all one mistake made four times** ([#278]). `maps.Copy` on a
+  `map[string]*T` copies the pointers, so taking the lock, copying the map, dropping the lock and then
+  reading through the copy is not synchronization — it reads the same structs the gossip receive
+  goroutine is writing. `ClusterManager.calculateClusterStats` did this with `cm.nodes` against
+  `UpdateNodeInfo`, and `GossipProtocol.sendSyncMessage` did it with `gp.memberlist`, where this node's
+  own entry aliases `gp.localNode` itself. The same shape in pointer-slice form was in `performGossip`
+  and `broadcastMessage`, which collected `*GossipNode` and read `.Info.Address` after unlocking. The
+  fix in each case removes the aliasing rather than locking around it: tally, marshal, or resolve the
+  address inside the critical section, and carry out only values. `GetNodes` and `GetMemberlist` had
+  always done it correctly, twenty lines away in the same files.
+
+  The consequence was not merely a stale read. `calculateClusterStats` classifies a node by `Status`
+  and, in the same iteration, sums `CacheSize` and `CacheHitRate` from it — so a node counted alive on
+  a torn read contributes figures from a different moment into the number a size-aware balancer routes
+  on. And `handleSyncMessage` decides whether to merge an update by comparing incarnations, so an
+  inconsistently-marshaled memberlist decides whether membership converges at all.
+
+  The two regression tests are race tests, not assertion tests: each drives a gossip round and an
+  inbound alive message concurrently, and under `-race` fails on the defect and passes after it.
+  Without `-race` both pass either way, which is stated in their doc comments so nobody later reads a
+  green run without the flag as coverage.
+
+- **A three-node cluster now forms, elects a single leader, and does it race-free**, which is the thing
+  all of the above adds up to and which had never been observed. Verified by probe: membership converges
+  to 3 on every node and leadership settles on exactly one, stably, rather than the two or three
+  simultaneous leaders that the single-node fix alone produced. `TestMultiNodeCluster` now passes under
+  `-race`; the whole `-tags=distributed` suite is green for the first time.
+
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
@@ -229,6 +313,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#267]: https://github.com/scttfrdmn/objectfs/issues/267
 [#269]: https://github.com/scttfrdmn/objectfs/issues/269
 [#272]: https://github.com/scttfrdmn/objectfs/issues/272
+[#275]: https://github.com/scttfrdmn/objectfs/issues/275
+[#277]: https://github.com/scttfrdmn/objectfs/issues/277
+[#278]: https://github.com/scttfrdmn/objectfs/issues/278
 [scttfrdmn/substrate#540]: https://github.com/scttfrdmn/substrate/issues/540
 
 ### Changed

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -274,8 +274,29 @@ func NewClusterManager(config *ClusterConfig) (*ClusterManager, error) {
 	return cm, nil
 }
 
-// Start starts the cluster manager
+// Start starts the cluster manager.
+//
+// When it returns, [ClusterManager.GetStats] already describes the cluster: the statistics are
+// computed once here rather than left to the first tick of the background refresher. Until v0.11.0
+// they were not, so for the first five seconds of every process GetStats reported zero nodes while
+// GetNodes correctly reported one — two accessors over the same membership disagreeing, and the one an
+// operator or a health check reads being the wrong one (#275).
 func (cm *ClusterManager) Start(ctx context.Context) error {
+	if err := cm.startLocked(ctx); err != nil {
+		return err
+	}
+
+	// After startLocked releases cm.mu, because calculateClusterStats takes it for reading and a Go
+	// RWMutex is not reentrant.
+	cm.calculateClusterStats()
+
+	slog.Info("cluster manager started successfully")
+	return nil
+}
+
+// startLocked registers this node and starts the components and background tasks, holding cm.mu for
+// the whole of it.
+func (cm *ClusterManager) startLocked(ctx context.Context) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
@@ -313,7 +334,6 @@ func (cm *ClusterManager) Start(ctx context.Context) error {
 	go cm.monitorCluster(ctx)
 	go cm.updateStats(ctx)
 
-	slog.Info("cluster manager started successfully")
 	return nil
 }
 
@@ -545,45 +565,59 @@ func (cm *ClusterManager) updateStats(ctx context.Context) {
 }
 
 func (cm *ClusterManager) calculateClusterStats() {
+	var (
+		totalNodes     int
+		aliveNodes     int
+		suspectNodes   int
+		deadNodes      int
+		leader         string
+		totalCacheSize int64
+		totalHitRate   float64
+	)
+
+	// Tallied under cm.mu, not from a copy taken under it.
+	//
+	// This used to maps.Copy cm.nodes and then walk the copy after unlocking — which looks
+	// synchronized and is not, because the copy holds the same *NodeInfo pointers. Every field read
+	// below therefore hit a struct UpdateNodeInfo was concurrently writing from the gossip receive
+	// goroutine, and -race reported it on any cluster where a node is still announcing itself while
+	// the stats ticker fires, which is every cluster (#278). GetNodes does this correctly, copying
+	// each NodeInfo by value inside the critical section; this function is where the pattern was
+	// missed.
+	//
+	// Only cm.mu is held here: the results land in cm.stats afterwards, so the two locks are never
+	// nested and no order between them has to be established.
 	cm.mu.RLock()
-	nodes := make(map[string]*NodeInfo)
-	maps.Copy(nodes, cm.nodes)
-	leader := cm.leader
+	totalNodes = len(cm.nodes)
+	leader = cm.leader
+	for _, node := range cm.nodes {
+		switch node.Status {
+		case NodeStatusAlive:
+			aliveNodes++
+			totalCacheSize += node.CacheSize
+			totalHitRate += node.CacheHitRate
+		case NodeStatusSuspect:
+			suspectNodes++
+		case NodeStatusDead:
+			deadNodes++
+		}
+	}
 	cm.mu.RUnlock()
 
 	cm.stats.mu.Lock()
 	defer cm.stats.mu.Unlock()
 
-	// Reset counters
-	cm.stats.TotalNodes = len(nodes)
-	cm.stats.AliveNodes = 0
-	cm.stats.SuspectNodes = 0
-	cm.stats.DeadNodes = 0
+	cm.stats.TotalNodes = totalNodes
+	cm.stats.AliveNodes = aliveNodes
+	cm.stats.SuspectNodes = suspectNodes
+	cm.stats.DeadNodes = deadNodes
 	cm.stats.CurrentLeader = leader
-
-	totalCacheSize := int64(0)
-	totalCacheHitRate := 0.0
-	aliveNodesCount := 0
-
-	for _, node := range nodes {
-		switch node.Status {
-		case NodeStatusAlive:
-			cm.stats.AliveNodes++
-			totalCacheSize += node.CacheSize
-			totalCacheHitRate += node.CacheHitRate
-			aliveNodesCount++
-		case NodeStatusSuspect:
-			cm.stats.SuspectNodes++
-		case NodeStatusDead:
-			cm.stats.DeadNodes++
-		}
-	}
-
 	cm.stats.TotalCacheSize = totalCacheSize
 
-	// Calculate average cache hit rate
-	if aliveNodesCount > 0 {
-		cm.stats.CacheHitRate = totalCacheHitRate / float64(aliveNodesCount)
+	// Left at its previous value when no node is alive, rather than zeroed: a hit rate of zero is a
+	// cache that never hits, which is not what "there was nothing to average" means.
+	if aliveNodes > 0 {
+		cm.stats.CacheHitRate = totalHitRate / float64(aliveNodes)
 	}
 }
 
@@ -651,6 +685,26 @@ func (cm *ClusterManager) UpdateNodeInfo(nodeID string, info *NodeInfo) {
 		maps.Copy(newNode.Metadata, info.Metadata)
 		cm.nodes[nodeID] = &newNode
 	}
+}
+
+// expectsPeers reports whether this node is configured to join an existing cluster rather than to be
+// the whole of a new one.
+//
+// It is the seed list, minus this node's own address, exactly as [ClusterManager.joinCluster] treats
+// it: a seed pointing at ourselves is not a peer to wait for. [ConsensusEngine.checkVoteMajority] uses
+// this to decide whether a membership view of one is a cluster of one or a cluster whose other members
+// have not been discovered yet — the two are indistinguishable from the membership map alone, and
+// electing a leader on the wrong answer is a split brain (#275).
+//
+// No lock: cm.config is written once by NewClusterManager and never mutated, which is why joinCluster
+// reads SeedNodes unlocked too.
+func (cm *ClusterManager) expectsPeers() bool {
+	for _, seed := range cm.config.SeedNodes {
+		if seed != cm.config.AdvertiseAddr {
+			return true
+		}
+	}
+	return false
 }
 
 // SetLeader updates the cluster leader

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -417,6 +417,46 @@ func TestClusterManager_StartStop(t *testing.T) {
 	}
 }
 
+// ── Statistics are current when Start returns (#275) ──────────────────────────
+
+// TestClusterManager_StartComputesStatsImmediately verifies that GetStats describes the cluster as soon
+// as Start returns, with no sleep.
+//
+// The absence of a sleep is the test. Until v0.11.0 the statistics were computed only by updateStats'
+// five-second ticker, so for the first five seconds of every process GetStats reported zero nodes while
+// GetNodes over the same membership reported one. Both are public accessors and the one that
+// disagreed with the truth is the one an operator, a health check, and the three tagged tests in
+// tests/distributed_test.go read (#275). A test that slept before asserting could not tell the fix from
+// the defect.
+func TestClusterManager_StartComputesStatsImmediately(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "stats-at-start"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	if err := cm.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cm.Stop() }()
+
+	stats := cm.GetStats()
+
+	if stats.TotalNodes != 1 {
+		t.Errorf("TotalNodes = %d immediately after Start, want 1", stats.TotalNodes)
+	}
+	if stats.AliveNodes != 1 {
+		t.Errorf("AliveNodes = %d immediately after Start, want 1", stats.AliveNodes)
+	}
+
+	// The two accessors must agree, which is the invariant the defect broke rather than either value
+	// being wrong in isolation.
+	if got := len(cm.GetNodes()); stats.TotalNodes != got {
+		t.Errorf("GetStats().TotalNodes = %d but GetNodes() has %d entries; the two describe the same "+
+			"membership and must agree", stats.TotalNodes, got)
+	}
+}
+
 // ── Local node statistics (#132) ──────────────────────────────────────────────
 
 // TestRefreshLocalStats_PopulatesMemoryAndOperations verifies that this node measures its own memory
@@ -583,6 +623,56 @@ func TestCalculateClusterStats_SumsCacheSizeAcrossAliveNodes(t *testing.T) {
 	}
 	if stats.CacheHitRate <= 0 {
 		t.Errorf("CacheHitRate = %v, want > 0", stats.CacheHitRate)
+	}
+}
+
+// TestCalculateClusterStats_TalliesUnderTheLock is a race test, not an assertion test: under -race it
+// fails on the defect and passes after it, and without -race it passes either way.
+//
+// calculateClusterStats used to maps.Copy cm.nodes and walk the copy after unlocking. maps.Copy on a
+// map[string]*NodeInfo copies the pointers, so every field read below aliased a struct UpdateNodeInfo
+// writes in place from the gossip receive goroutine (#278). What makes it a real defect rather than a
+// stale read is that Status is read to classify the node while CacheSize and CacheHitRate are summed
+// from it — a node counted alive on a torn read contributes figures from a different moment, and
+// TotalCacheSize is what a size-aware balancer routes on.
+//
+// The loop runs long enough for the two goroutines to interleave many times; -race needs the accesses
+// to actually overlap, not merely to be possible.
+func TestCalculateClusterStats_TalliesUnderTheLock(t *testing.T) {
+	t.Parallel()
+	cm := makeClusterWithNode(t, "race-host")
+
+	cm.mu.Lock()
+	cm.nodes["race-peer"] = &NodeInfo{ID: "race-peer", Status: NodeStatusAlive, Metadata: map[string]string{}}
+	cm.mu.Unlock()
+
+	const rounds = 500
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range rounds {
+			// The same path handleAliveMessage takes: a fresh NodeInfo for a node already known, whose
+			// fields are copied onto the existing record in place.
+			cm.UpdateNodeInfo("race-peer", &NodeInfo{
+				ID:           "race-peer",
+				Status:       NodeStatusAlive,
+				LastSeen:     time.Now(),
+				CacheSize:    int64(i),
+				CacheHitRate: float64(i%100) / 100,
+				Metadata:     map[string]string{},
+			})
+		}
+	}()
+
+	for range rounds {
+		cm.calculateClusterStats()
+	}
+	<-done
+
+	// Sanity, so a test that raced but computed nothing does not look like a pass: the peer and the
+	// self node are both alive.
+	if stats := cm.GetStats(); stats.AliveNodes != 2 {
+		t.Errorf("AliveNodes = %d, want 2", stats.AliveNodes)
 	}
 }
 

--- a/internal/distributed/consensus.go
+++ b/internal/distributed/consensus.go
@@ -381,6 +381,14 @@ func (ce *ConsensusEngine) startElection() {
 
 	// Send vote requests to all other nodes
 	ce.sendVoteRequests()
+
+	// And evaluate the majority we may already hold. Until v0.11.0 this check lived only in
+	// handleVoteResponse, which is reached only when a peer replies — so a single-node cluster, which
+	// satisfies its own majority with the vote cast on the line above, never evaluated it. The election
+	// timer fired again, the term incremented, and the loop repeated for the life of the process. A
+	// cluster of one is not a corner case: it is the first thing anyone runs, and the shape a
+	// deployment has while the second node is still being provisioned (#275).
+	ce.checkVoteMajority()
 }
 
 func (ce *ConsensusEngine) sendVoteRequests() {
@@ -427,13 +435,47 @@ func (ce *ConsensusEngine) handleVoteResponse(nodeID string, voteGranted bool) {
 		slog.Info("received vote", "from", nodeID, "total_votes", ce.voteCount)
 	}
 
-	// Check if we have majority
+	ce.checkVoteMajority()
+}
+
+// checkVoteMajority promotes this node to leader if the votes it has collected are a majority of the
+// alive membership.
+//
+// Called from every point where the vote count changes — startElection, which casts this node's vote
+// for itself, and handleVoteResponse, which counts a peer's. That is the whole of the fix for #275:
+// the comparison used to live inline in handleVoteResponse alone, so it was evaluated only when a
+// peer replied, and a cluster of one — which satisfies its own majority the moment startElection
+// increments the count to 1 — never evaluated it at all.
+//
+// The caller must hold ce.mu, as becomeLeader requires and both callers already do.
+func (ce *ConsensusEngine) checkVoteMajority() {
+	if ce.state != StateCandidate {
+		return
+	}
+
 	nodes := ce.cluster.GetNodes()
 	aliveNodes := 0
 	for _, node := range nodes {
 		if node.Status == NodeStatusAlive {
 			aliveNodes++
 		}
+	}
+
+	// A membership of just this node is a majority of one — but only if this node is the whole cluster.
+	// A node configured with seed nodes has peers it has not discovered yet: gossip learns of a peer
+	// from an inbound message, and startElection runs on a timer that does not wait for it. Promoting
+	// on a self-only view would elect every node of a starting cluster its own leader at term 1, each
+	// on one vote, before any of them had heard of the others — which is what a probe of three seeded
+	// nodes showed once the majority check reached startElection at all.
+	//
+	// So the rule is the bootstrap-versus-join distinction: a node that names no seeds is declaring
+	// itself the whole of a new cluster and may elect itself, which is #275's case and the shape of
+	// every single-node deployment. A node that names seeds must hear from one before it can hold a
+	// majority. Discovery makes aliveNodes exceed one and the ordinary vote path takes over.
+	if aliveNodes <= 1 && ce.cluster.expectsPeers() {
+		slog.Debug("declining to self-elect before discovering the configured seed nodes",
+			"term", ce.currentTerm, "alive_nodes", aliveNodes)
+		return
 	}
 
 	majority := aliveNodes/2 + 1
@@ -587,7 +629,9 @@ func (ce *ConsensusEngine) handleNetworkRequestVote(msg *GossipMessage) {
 	ce.mu.Lock()
 
 	// Step down if we see a higher term.
+	steppedDown := false
 	if req.Term > ce.currentTerm {
+		steppedDown = ce.state == StateLeader
 		ce.currentTerm = req.Term
 		ce.state = StateFollower
 		ce.votedFor = ""
@@ -608,6 +652,16 @@ func (ce *ConsensusEngine) handleNetworkRequestVote(msg *GossipMessage) {
 
 	currentTerm := ce.currentTerm
 	ce.mu.Unlock()
+
+	// A leader that steps down on a higher term has to stop claiming leadership, for the same reason
+	// handleNetworkAppendEntries does — see the comment there. There is no new leader to name: the
+	// candidate that sent this request has not won anything yet. Clearing it is what an empty leader
+	// means, and monitorCluster already uses that value when a leader is declared dead.
+	if steppedDown {
+		slog.Info("stepping down: a vote request arrived at a higher term",
+			"term", currentTerm, "candidate", req.CandidateID)
+		ce.cluster.SetLeader("")
+	}
 
 	resp := &RequestVoteRespMessage{
 		Term:        currentTerm,
@@ -660,6 +714,9 @@ func (ce *ConsensusEngine) handleNetworkAppendEntries(msg *GossipMessage) {
 
 	ce.mu.Lock()
 
+	// Set while ce.mu is held, applied after it is released — see the comment at the assignment.
+	newLeader := ""
+
 	success := false
 	if req.Term >= ce.currentTerm {
 		// Recognized leader — step down if needed and reset election timer.
@@ -670,6 +727,19 @@ func (ce *ConsensusEngine) handleNetworkAppendEntries(msg *GossipMessage) {
 		ce.state = StateFollower
 		ce.resetElectionTimer()
 		success = true
+
+		// And tell the cluster manager, which is what callers actually ask. Until v0.11.0 this line was
+		// missing: becomeLeader calls SetLeader but no step-down path did, so cm.isLeader was
+		// effectively write-once. A node that had been leader and then received a heartbeat from a
+		// higher term became a follower in ce.state while ClusterManager.IsLeader kept returning true
+		// for the life of the process — so two nodes each claiming leadership stayed that way
+		// permanently instead of resolving, which is how a transient election race became a durable
+		// split brain (#275).
+		//
+		// Deferred past ce.mu.Unlock below rather than called here: SetLeader takes cm.mu, and while
+		// ce.mu → cm.mu is the established order (becomeLeader does exactly that), there is no reason
+		// to hold the consensus lock across it.
+		newLeader = req.LeaderID
 
 		// Append any new entries (simplified; full consistency is future work).
 		for _, entry := range req.Entries {
@@ -690,6 +760,10 @@ func (ce *ConsensusEngine) handleNetworkAppendEntries(msg *GossipMessage) {
 
 	matchIndex := req.PrevLogIndex + uint64(len(req.Entries))
 	ce.mu.Unlock()
+
+	if newLeader != "" {
+		ce.cluster.SetLeader(newLeader)
+	}
 
 	resp := &AppendEntriesResponse{
 		Success:    success,

--- a/internal/distributed/consensus_test.go
+++ b/internal/distributed/consensus_test.go
@@ -145,6 +145,295 @@ func TestConsensusEngine_TriggerElection_BecomesCandidate(t *testing.T) {
 	}
 }
 
+// ── Single-node leadership (#275) ─────────────────────────────────────────────
+
+// TestConsensusEngine_SingleNodeElectsItself verifies that a cluster of one becomes its own leader.
+//
+// It asserts on the state after TriggerElection returns, with no sleep and no polling, because there
+// is nothing to wait for: the majority of a one-node cluster is one vote, and the candidate casts it
+// itself before TriggerElection returns. Anything that needed a peer round-trip would not be this
+// test.
+//
+// Until v0.11.0 the majority comparison lived only in handleVoteResponse, which is reached only when a
+// peer replies. With no peer it was never evaluated, so a single-node cluster cycled candidate →
+// election timeout → candidate forever, incrementing its term, and IsLeader stayed false for the life
+// of the process (#275). TestConsensusEngine_TriggerElection_BecomesCandidate above accepted either
+// Candidate or Leader, which is why it passed throughout.
+func TestConsensusEngine_SingleNodeElectsItself(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "solo")
+	ce := cm.consensus
+
+	if err := ce.TriggerElection(t.Context()); err != nil {
+		t.Fatalf("TriggerElection: %v", err)
+	}
+
+	if got := ce.GetCurrentState(); got != StateLeader {
+		t.Errorf("state = %v after an election in a one-node cluster, want StateLeader", got)
+	}
+	if !ce.IsLeader() {
+		t.Error("ConsensusEngine.IsLeader() = false, want true")
+	}
+	// The cluster manager has to agree: it is what a caller asks, and what the coordinator routes on.
+	if !cm.IsLeader() {
+		t.Error("ClusterManager.IsLeader() = false, want true")
+	}
+	if got := cm.GetLeader(); got != "solo" {
+		t.Errorf("GetLeader() = %q, want %q", got, "solo")
+	}
+	if won := ce.GetStats().ElectionsWon; won != 1 {
+		t.Errorf("ElectionsWon = %d, want 1", won)
+	}
+}
+
+// TestConsensusEngine_SingleNodeLeadershipIsStable verifies that the elected leader stays elected and
+// its term stops climbing.
+//
+// The visible symptom of #275 was not only that IsLeader was false: electionLoop re-entered
+// startElection on every timeout, so currentTerm climbed without bound. A test that checked the state
+// once, immediately, would pass on a fix that elected the node and then let the timer unseat it. The
+// election timeout here is deliberately short so several would have fired.
+func TestConsensusEngine_SingleNodeLeadershipIsStable(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t, "solo-stable")
+	cfg.ElectionTimeout = 50 * time.Millisecond
+	cfg.HeartbeatInterval = 20 * time.Millisecond
+
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	if err := cm.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cm.Stop() }()
+
+	// No TriggerElection: the election has to happen on its own, driven by electionLoop, which is how it
+	// happens in a real deployment. Several timeouts' worth of margin, since resetElectionTimer
+	// randomizes up to 2× ElectionTimeout.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !cm.consensus.IsLeader() {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !cm.consensus.IsLeader() {
+		t.Fatalf("no leader after 2s in a one-node cluster: state = %v, term = %d",
+			cm.consensus.GetCurrentState(), cm.consensus.GetCurrentTerm())
+	}
+
+	termAtElection := cm.consensus.GetCurrentTerm()
+
+	// Long enough for a handful of election timeouts to fire against a leader that should ignore them.
+	time.Sleep(300 * time.Millisecond)
+
+	if !cm.consensus.IsLeader() {
+		t.Errorf("leadership was lost: state = %v", cm.consensus.GetCurrentState())
+	}
+	if got := cm.consensus.GetCurrentTerm(); got != termAtElection {
+		t.Errorf("term climbed from %d to %d while leader; a leader must not start elections",
+			termAtElection, got)
+	}
+}
+
+// TestCheckVoteMajority_IgnoresANonCandidate verifies that the extracted check does nothing unless this
+// node is a candidate.
+//
+// startElection is not the only caller, and neither is handleVoteResponse the only path to a state
+// change: a heartbeat from a higher term makes this node a follower. Without the guard, a vote arriving
+// after that would promote a follower to leader on a stale count — the reason the state check was
+// inside handleVoteResponse before the extraction, and the thing an extraction is most likely to drop.
+func TestCheckVoteMajority_IgnoresANonCandidate(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "not-a-candidate")
+	ce := cm.consensus
+
+	ce.mu.Lock()
+	ce.state = StateFollower
+	ce.voteCount = 99 // far past any majority
+	ce.checkVoteMajority()
+	state := ce.state
+	ce.mu.Unlock()
+
+	if state != StateFollower {
+		t.Errorf("state = %v, want StateFollower: a follower must not be promoted by a vote count", state)
+	}
+	if ce.IsLeader() {
+		t.Error("IsLeader() = true, want false")
+	}
+}
+
+// TestCheckVoteMajority_WaitsForSeedsBeforeSelfElecting is the regression test for the split brain that
+// the single-node fix would otherwise introduce.
+//
+// Evaluating the majority in startElection is correct for a cluster of one and wrong for a cluster of
+// three that has not finished discovering itself: gossip learns of a peer from an inbound message, and
+// the election timer does not wait for it, so all three nodes hold a membership view of just themselves
+// for the first few hundred milliseconds. A probe of three seeded nodes confirmed the consequence
+// directly — each elected itself at term 1 on one vote, before any of them had heard of the others.
+//
+// The discriminator is configuration, not timing: a node that names seeds is joining a cluster and must
+// hear from a peer first; a node that names none is declaring itself the whole of one. This test sets
+// the seed and asserts the candidate stays a candidate.
+func TestCheckVoteMajority_WaitsForSeedsBeforeSelfElecting(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t, "joiner")
+	cfg.AdvertiseAddr = "127.0.0.1:19301"
+	cfg.SeedNodes = []string{"127.0.0.1:19300"} // a peer that this test never starts
+
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	cm.UpdateNodeInfo("joiner", nodeAlive("joiner"))
+	ce := cm.consensus
+
+	if err := ce.TriggerElection(t.Context()); err != nil {
+		t.Fatalf("TriggerElection: %v", err)
+	}
+
+	if got := ce.GetCurrentState(); got != StateCandidate {
+		t.Errorf("state = %v, want StateCandidate: a node that has not yet discovered its seed nodes "+
+			"must not decide it is a majority of one", got)
+	}
+	if ce.IsLeader() {
+		t.Error("ConsensusEngine.IsLeader() = true, want false")
+	}
+	if cm.IsLeader() {
+		t.Error("ClusterManager.IsLeader() = true, want false")
+	}
+}
+
+// TestExpectsPeers verifies the bootstrap-versus-join discriminator that checkVoteMajority turns on.
+//
+// The third case is the one worth having: a seed list naming only this node's own address is what a
+// uniform configuration file deployed to every node produces, and joinCluster already skips it for
+// exactly that reason. Reading it as "has peers" would stop a single-node deployment from ever electing
+// a leader — reintroducing #275 through the fix for its own regression.
+func TestExpectsPeers(t *testing.T) {
+	t.Parallel()
+
+	const self = "127.0.0.1:7946"
+	cases := []struct {
+		name  string
+		seeds []string
+		want  bool
+	}{
+		{"no seeds is a cluster of one", nil, false},
+		{"an empty seed list is a cluster of one", []string{}, false},
+		{"only ourselves is a cluster of one", []string{self}, false},
+		{"a peer is a cluster to join", []string{"127.0.0.1:7947"}, true},
+		{"ourselves and a peer is a cluster to join", []string{self, "127.0.0.1:7947"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := testConfig(t, "peers")
+			cfg.AdvertiseAddr = self
+			cfg.SeedNodes = tc.seeds
+
+			cm, err := NewClusterManager(cfg)
+			if err != nil {
+				t.Fatalf("NewClusterManager: %v", err)
+			}
+			if got := cm.expectsPeers(); got != tc.want {
+				t.Errorf("expectsPeers() = %v, want %v for seeds %v", got, tc.want, tc.seeds)
+			}
+		})
+	}
+}
+
+// TestStepDown_ClearsClusterLeadership is the regression test for the half of the split brain that made
+// it permanent.
+//
+// becomeLeader calls ClusterManager.SetLeader; until v0.11.0 no step-down path did. So cm.isLeader was
+// effectively write-once: a node that had been leader and then saw a higher term became a follower in
+// ce.state while ClusterManager.IsLeader — which is what callers ask and what the coordinator routes on
+// — kept returning true for the life of the process. A transient election race therefore became a
+// durable two-leader state instead of resolving on the next heartbeat.
+//
+// Both step-down paths are covered, because they are separate code and only one of them has a new leader
+// to name. Driving the handlers directly rather than over UDP is what makes this deterministic; the
+// sender is not a known node, so the response send is skipped and no socket is needed.
+func TestStepDown_ClearsClusterLeadership(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		msg        func(t *testing.T) (*GossipMessage, func(*ConsensusEngine, *GossipMessage))
+		wantLeader string
+	}{
+		{
+			name: "a heartbeat from a higher term names the new leader",
+			msg: func(t *testing.T) (*GossipMessage, func(*ConsensusEngine, *GossipMessage)) {
+				t.Helper()
+				body, err := json.Marshal(&AppendEntriesMessage{Term: 99, LeaderID: "real-leader"})
+				if err != nil {
+					t.Fatalf("marshal: %v", err)
+				}
+				return &GossipMessage{Type: MessageTypeAppendEntries, From: "real-leader", Data: body},
+					(*ConsensusEngine).handleNetworkAppendEntries
+			},
+			wantLeader: "real-leader",
+		},
+		{
+			name: "a vote request at a higher term clears leadership without naming one",
+			msg: func(t *testing.T) (*GossipMessage, func(*ConsensusEngine, *GossipMessage)) {
+				t.Helper()
+				body, err := json.Marshal(&RequestVoteMessage{Term: 99, CandidateID: "challenger"})
+				if err != nil {
+					t.Fatalf("marshal: %v", err)
+				}
+				return &GossipMessage{Type: MessageTypeRequestVote, From: "challenger", Data: body},
+					(*ConsensusEngine).handleNetworkRequestVote
+			},
+			// A candidate has not won anything, so there is no leader to name — and claiming the
+			// challenger were one would be worse than admitting there is none.
+			wantLeader: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := testConfig(t, "incumbent")
+			cfg.ElectionTimeout = time.Hour // no election fires on its own during this test
+			cm, err := NewClusterManager(cfg)
+			if err != nil {
+				t.Fatalf("NewClusterManager: %v", err)
+			}
+			cm.UpdateNodeInfo("incumbent", nodeAlive("incumbent"))
+			ce := cm.consensus
+
+			if err := ce.TriggerElection(t.Context()); err != nil {
+				t.Fatalf("TriggerElection: %v", err)
+			}
+			if !cm.IsLeader() {
+				t.Fatalf("precondition: not leader before the step-down, state = %v", ce.GetCurrentState())
+			}
+
+			msg, handle := tc.msg(t)
+			handle(ce, msg)
+
+			if got := ce.GetCurrentState(); got != StateFollower {
+				t.Errorf("ce.state = %v after a message at a higher term, want StateFollower", got)
+			}
+			if cm.IsLeader() {
+				t.Error("ClusterManager.IsLeader() = true after stepping down; the consensus engine and " +
+					"the cluster manager must agree on who is leader")
+			}
+			if got := cm.GetLeader(); got != tc.wantLeader {
+				t.Errorf("GetLeader() = %q, want %q", got, tc.wantLeader)
+			}
+		})
+	}
+}
+
 // TestConsensusEngine_TriggerElection_WithPeer_BecomesLeader verifies that when
 // two ClusterManagers are connected over loopback UDP, triggering an election
 // causes the candidate to receive a real vote and become the leader.

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -314,6 +314,53 @@ Leader Election:
 	// - Configuration changes
 	// - Quorum decisions
 
+A cluster of one elects itself, within one election timeout of [ClusterManager.Start] and without any
+message being sent. That is worth stating because until v0.11.0 it did not: the majority comparison
+lived only in the handler for an inbound vote reply, so a node with no peers — the first thing anyone
+runs, and the shape a deployment has while its second node is still being provisioned — cycled
+candidate → timeout → candidate for the life of the process, incrementing its term each round, and
+[ClusterManager.IsLeader] never returned true (#275).
+
+"A cluster of one" means SeedNodes names no address other than this node's own. That distinction is
+load-bearing rather than pedantic: a node that is configured to join a cluster holds a membership view
+of just itself for the first few hundred milliseconds, because gossip learns of a peer only from an
+inbound message and the election timer does not wait for one. Reading that view as a majority of one
+would have every node of a starting three-node cluster elect itself at term 1, each on its own single
+vote, before any had heard of the others. So a node with seeds waits to hear from one; a node without
+seeds is declaring itself the whole of a new cluster and proceeds.
+
+Leadership is also given up, not only taken. A node that sees a higher term — in a heartbeat or in a
+vote request — steps down in the consensus engine *and* through [ClusterManager.SetLeader]. Before
+v0.11.0 only the promotion path told the cluster manager, so [ClusterManager.IsLeader] was effectively
+write-once: a deposed leader kept reporting itself as leader for the life of the process, which is what
+turned a momentary election race into a permanent split brain rather than something the next heartbeat
+resolved (#275).
+
+Statistics are also current the moment Start returns. [ClusterManager.GetStats] and
+[ClusterManager.GetNodes] describe the same membership and agree from the first call; previously the
+statistics were computed only by a five-second ticker, so for the first five seconds GetStats reported
+zero nodes while GetNodes reported one (#275).
+
+# Membership Maps and Locking
+
+Both membership maps in this package — ClusterManager.nodes and GossipProtocol.memberlist — hold
+pointers, and every struct behind those pointers is mutated in place by the gossip receive goroutine.
+The invariant that follows is worth stating because it was violated at four separate sites (#278):
+
+Never carry a pointer out of a membership map across the unlock. Copying the map does not help; a
+map copy copies the pointers, so the copy aliases exactly the structs another goroutine is writing.
+Instead, do the read inside the critical section and carry out only values — a tally, a marshaled
+byte slice, an address string, or a by-value struct copy as [ClusterManager.GetNodes] and
+[GossipProtocol.GetMemberlist] do.
+
+This is not a stale-read concern. calculateClusterStats classifies a node by Status and sums CacheSize
+and CacheHitRate from it in the same iteration, so a torn read mixes moments inside a single figure a
+load balancer routes on; and handleSyncMessage decides whether to accept an update by comparing
+incarnations, so an inconsistently-marshaled memberlist affects whether membership converges.
+
+Regression tests for this class are race tests: they pass under `go test` and fail only under -race, so
+a green run without the flag is not evidence.
+
 # Configuration
 
 ClusterConfig controls all distributed system behavior:

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -908,15 +908,23 @@ func (gp *GossipProtocol) performGossip() {
 		incarnation = self.Incarnation
 	}
 
-	nodes := make([]*GossipNode, 0, len(gp.memberlist))
+	// Addresses, not *GossipNode.
+	//
+	// This used to collect the pointers and read targetNode.Info after the unlock below, which is a
+	// read of a field handleAliveMessage assigns from the receive goroutine — the whole point of a
+	// memberlist is that another goroutine is updating it. Resolving the address here, inside the
+	// critical section, is all the send loop actually needs, and it removes the aliasing rather than
+	// synchronizing around it (#278).
+	localID := gp.localNode.ID
+	targets := make([]string, 0, len(gp.memberlist))
 	for _, node := range gp.memberlist {
 		// Guard against nodes whose Info was never populated (e.g. added via a
 		// sync message with a nil Info field) to prevent a nil dereference (#113).
 		if node.Info == nil {
 			continue
 		}
-		if node.Info.ID != gp.localNode.ID && node.State != StateDead && node.State != StateLeft {
-			nodes = append(nodes, node)
+		if node.Info.ID != localID && node.State != StateDead && node.State != StateLeft {
+			targets = append(targets, node.Info.Address)
 		}
 	}
 
@@ -930,16 +938,16 @@ func (gp *GossipProtocol) performGossip() {
 		return
 	}
 
-	if len(nodes) == 0 {
+	if len(targets) == 0 {
 		return
 	}
 
 	// Select random nodes to gossip with
-	fanout := min(gp.config.GossipFanout, len(nodes))
+	fanout := min(gp.config.GossipFanout, len(targets))
 
 	msg := &GossipMessage{
 		Type:      MessageTypeAlive,
-		From:      gp.localNode.ID,
+		From:      localID,
 		Timestamp: time.Now(),
 		MessageID: gp.generateMessageID(),
 		Data:      data,
@@ -947,24 +955,21 @@ func (gp *GossipProtocol) performGossip() {
 
 	// Gossip to random subset of nodes
 	for i := range fanout {
-		targetNode := nodes[i%len(nodes)]
-		if targetNode.Info != nil {
-			_ = gp.sendMessage(targetNode.Info.Address, msg)
-		}
+		_ = gp.sendMessage(targets[i%len(targets)], msg)
 	}
 
 	// Send heartbeat. Same incarnation as the alive message above, deliberately: the two describe one
 	// moment, and handleHeartbeatMessage clears suspicion on `>=`, so a heartbeat carrying a stale
 	// number would fail to clear a suspicion the accompanying alive message just refuted.
 	heartbeatMsg := &HeartbeatMessage{
-		Node:        gp.localNode.ID,
+		Node:        localID,
 		Timestamp:   time.Now(),
 		Incarnation: incarnation,
 	}
 
 	heartbeatGossipMsg := &GossipMessage{
 		Type:      MessageTypeGossipHeartbeat,
-		From:      gp.localNode.ID,
+		From:      localID,
 		Timestamp: time.Now(),
 		MessageID: gp.generateMessageID(),
 	}
@@ -1101,43 +1106,60 @@ func (gp *GossipProtocol) sendMessage(addr string, msg *GossipMessage) error {
 }
 
 func (gp *GossipProtocol) broadcastMessage(msg *GossipMessage) error {
+	// Addresses rather than *NodeInfo, for the reason performGossip resolves them under the lock too:
+	// a pointer taken out of the memberlist aliases a struct the receive goroutine owns. This one
+	// happens to be safe today, because the only NodeInfo anything mutates in place is gp.localNode
+	// and the ID filter below excludes it — but that is a property of a filter two lines away, not of
+	// the code doing the read, and it is the same reasoning that made three other sites wrong (#278).
 	gp.mu.RLock()
-	nodes := make([]*NodeInfo, 0, len(gp.memberlist))
+	localID := gp.localNode.ID
+	targets := make([]string, 0, len(gp.memberlist))
 	for _, gossipNode := range gp.memberlist {
-		if gossipNode.Info != nil && gossipNode.Info.ID != gp.localNode.ID &&
+		if gossipNode.Info != nil && gossipNode.Info.ID != localID &&
 			gossipNode.State != StateDead && gossipNode.State != StateLeft {
-			nodes = append(nodes, gossipNode.Info)
+			targets = append(targets, gossipNode.Info.Address)
 		}
 	}
 	gp.mu.RUnlock()
 
-	for _, node := range nodes {
+	for _, addr := range targets {
 		go func(addr string) {
 			_ = gp.sendMessage(addr, msg)
-		}(node.Address)
+		}(addr)
 	}
 
 	return nil
 }
 
 func (gp *GossipProtocol) sendSyncMessage(addr string) error {
-	gp.mu.RLock()
-	nodes := make(map[string]*GossipNode)
-	maps.Copy(nodes, gp.memberlist)
-	gp.mu.RUnlock()
-
-	syncMsg := &SyncMessage{
-		Nodes: nodes,
-	}
-
 	msg := &GossipMessage{
 		Type:      MessageTypeSync,
-		From:      gp.localNode.ID,
 		Timestamp: time.Now(),
 		MessageID: gp.generateMessageID(),
 	}
 
-	data, _ := json.Marshal(syncMsg)
+	// Marshaled under the lock, as performGossip does for its own message and for the same reason.
+	//
+	// This used to take the read lock only to maps.Copy the memberlist and then marshal outside it —
+	// which looks synchronized and is not, because maps.Copy copies the *GossipNode pointers. The copy
+	// therefore aliases the originals, and this node's entry aliases gp.localNode itself, since
+	// NewGossipProtocol stores that very pointer as its Info. So the marshal walked structs that
+	// performGossip was concurrently stamping with a fresh LastSeen and that handleSyncMessage was
+	// concurrently overwriting. -race reported it on any cluster where a node joins while the gossip
+	// loop runs, which is every cluster (#278).
+	//
+	// Marshaling under the lock rather than deep-copying, because the alternative is a copy that has
+	// to stay deep as GossipNode grows — it holds two pointers today — and a shallow one is exactly the
+	// bug being fixed. If the memberlist ever gets large enough that holding gp.mu across a marshal
+	// matters, the answer is to bound the sync (#277), not to reintroduce a copy that can be wrong.
+	gp.mu.RLock()
+	msg.From = gp.localNode.ID
+	data, marshalErr := json.Marshal(&SyncMessage{Nodes: gp.memberlist})
+	gp.mu.RUnlock()
+
+	if marshalErr != nil {
+		return fmt.Errorf("marshaling the sync message: %w", marshalErr)
+	}
 	msg.Data = data
 
 	return gp.sendMessage(addr, msg)

--- a/internal/distributed/gossip_test.go
+++ b/internal/distributed/gossip_test.go
@@ -834,6 +834,67 @@ func TestGossipProtocol_PerformGossipStampsItsOwnLastSeen(t *testing.T) {
 	}
 }
 
+// TestGossipProtocol_PerformGossipResolvesAddressesUnderTheLock is a race test: under -race it fails
+// on the defect and passes after it, and without -race it passes either way.
+//
+// performGossip used to collect *GossipNode out of the memberlist and read targetNode.Info.Address
+// after releasing gp.mu — a read of the field handleAliveMessage assigns from the receive goroutine
+// (#278). Resolving the address inside the critical section removes the aliasing rather than
+// synchronizing around it, so this test drives both sides at once: the gossip round and the inbound
+// alive message that reassigns Info.
+//
+// A send to 127.0.0.1:1 is expected to fail and its error is discarded by performGossip, which is
+// fine — the address is read whether or not anything is listening, and the read is what is under test.
+func TestGossipProtocol_PerformGossipResolvesAddressesUnderTheLock(t *testing.T) {
+	t.Parallel()
+	cm, _ := NewClusterManager(testConfig(t, "addr-race-host"))
+	gp := cm.gossip
+
+	gp.mu.Lock()
+	gp.memberlist["addr-race-peer"] = &GossipNode{
+		Info:        &NodeInfo{ID: "addr-race-peer", Address: "127.0.0.1:1", Metadata: map[string]string{}},
+		Incarnation: 1,
+		State:       StateAlive,
+	}
+	gp.mu.Unlock()
+
+	const rounds = 300
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range rounds {
+			// A rising incarnation, so the first arm of handleAliveMessage fires and reassigns
+			// gossipNode.Info — the write performGossip was reading through.
+			gp.handleAliveMessage(makeGossipMsg(t, MessageTypeAlive, AliveMessage{
+				Node: &NodeInfo{
+					ID:       "addr-race-peer",
+					Address:  "127.0.0.1:1",
+					LastSeen: time.Now(),
+					Metadata: map[string]string{},
+				},
+				Incarnation: uint32(i + 2), //nolint:gosec // loop bound is 300
+			}))
+		}
+	}()
+
+	for range rounds {
+		gp.performGossip()
+	}
+	<-done
+
+	// Sanity: the peer is still there and still alive, so a run that raced but dropped the member does
+	// not read as a pass.
+	gp.mu.RLock()
+	peer, exists := gp.memberlist["addr-race-peer"]
+	gp.mu.RUnlock()
+	if !exists {
+		t.Fatal("addr-race-peer is gone from the memberlist")
+	}
+	if peer.State != StateAlive {
+		t.Errorf("addr-race-peer state = %v, want %v", peer.State, StateAlive)
+	}
+}
+
 // TestGossipProtocol_StartStop verifies that Start and Stop complete without
 // error or panic.
 func TestGossipProtocol_StartStop(t *testing.T) {

--- a/tests/distributed_test.go
+++ b/tests/distributed_test.go
@@ -6,8 +6,10 @@ package tests
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -337,19 +339,44 @@ func TestGossipProtocol_BasicFunctionality(t *testing.T) {
 	}
 }
 
+// TestLoadBalancer_NodeSelection verifies that an operation routed through the coordinator selects a
+// target from the gossip membership and executes there.
+//
+// What this test can and cannot cover is worth stating, because it used to assert something it had not
+// arranged. The four peers registered below are addresses nothing listens on — UpdateNodeInfo is a
+// membership write, not a running node — so any operation routed to one of them can only time out.
+// The test nonetheless asserted that a strong-consistency PUT succeeded, which needs a majority of the
+// two selected replicas, i.e. the dead peer. It failed for 30 seconds and then reported the timeout as
+// a defect in the code under test. Same class as the missing backend in #269: a test that asserts an
+// operation succeeded has to be able to perform one.
+//
+// So the peers here exist to give selection a membership set of five to choose from, and the two halves
+// are asserted separately: the GET runs unpinned, so selection really does choose from all five, and the
+// PUT is pinned to the local node with TargetNodes because by then it has to be. Least-load routes the
+// second operation away from the node that served the first — which is the load balancer working
+// correctly, and the reason a test with one reachable node out of five can assert selection or repeated
+// execution but not both at once. Multi-replica execution against nodes that really exist is
+// TestMultiNodeCluster, which starts three real managers and does assert it.
 func TestLoadBalancer_NodeSelection(t *testing.T) {
 	config := &distributed.ClusterConfig{
-		NodeID:            "lb-test-1",
-		SecretFile:        writeClusterSecret(t),
-		MaxConcurrentOps:  5,
-		ConsistencyLevel:  "eventual",
-		ReplicationFactor: 2,
+		NodeID:           "lb-test-1",
+		SecretFile:       writeClusterSecret(t),
+		MaxConcurrentOps: 5,
+		ConsistencyLevel: "eventual",
+
+		// One replica, so the selected set is the primary alone. At 2 the second replica is one of the
+		// unreachable peers below, and strong consistency would require it.
+		ReplicationFactor: 1,
 	}
 
 	cm, err := distributed.NewClusterManager(config)
 	if err != nil {
 		t.Fatalf("Failed to create cluster manager: %v", err)
 	}
+
+	// Without this every operation takes executeLocally's `backend == nil` arm and fails with "no
+	// backend configured" (#269).
+	srv := withBackend(t, cm)
 
 	ctx := context.Background()
 	err = cm.Start(ctx)
@@ -376,35 +403,81 @@ func TestLoadBalancer_NodeSelection(t *testing.T) {
 	// Test node selection for different operation types
 	coordinator := cm.GetCoordinator()
 
-	// Test GET operation (should select one node)
+	// A GET needs its key to exist. Seeded through the raw SDK rather than through the coordinator, so
+	// that a symmetric encoding bug cannot pass as correct behaviour.
+	const (
+		getKey  = "test-get-key"
+		getBody = "load-balanced-read-payload"
+	)
+	srv.PutObject(getKey, []byte(getBody))
+
 	getOp := &distributed.DistributedOperation{
 		Type:        distributed.OpTypeGet,
-		Key:         "test-get-key",
+		Key:         getKey,
 		Consistency: distributed.ConsistencyEventual,
+		Timeout:     5 * time.Second,
 	}
 
-	result, err := coordinator.ExecuteOperation(ctx, getOp)
+	raw, err := coordinator.ExecuteOperation(ctx, getOp)
 	if err != nil {
-		t.Errorf("Failed to execute GET operation: %v", err)
-	}
-	if result == nil {
-		t.Error("Expected non-nil result for GET operation")
+		t.Fatalf("Failed to execute GET operation: %v", err)
 	}
 
-	// Test PUT operation (should select multiple nodes based on replication factor)
+	// types.DistributedCoordinator.ExecuteOperation is declared as `(any, error)`, so the concrete
+	// result type is only reachable by assertion — and asserting it is itself worth doing, since a
+	// caller that cannot get at Success or Data has no way to tell an operation apart from a failure.
+	result, ok := raw.(*distributed.OperationResult)
+	if !ok {
+		t.Fatalf("GET returned %T, want *distributed.OperationResult", raw)
+	}
+	if !result.Success {
+		t.Errorf("GET operation reported failure: %s", result.Error)
+	}
+
+	// The bytes, not just the success flag: a GET reported successful that returned something else is
+	// the failure mode this suite exists to catch.
+	if got := string(result.Data); got != getBody {
+		t.Errorf("GET returned %q, want %q", got, getBody)
+	}
+
+	// The selected node has to be the one that could serve it. NodeResults is keyed by node, so it says
+	// where the operation ran — the assertion the test's name promises and never made.
+	if _, ok := result.NodeResults[config.NodeID]; !ok {
+		t.Errorf("GET executed on %v, want the local node %q to be among them",
+			slices.Sorted(maps.Keys(result.NodeResults)), config.NodeID)
+	}
+
 	putOp := &distributed.DistributedOperation{
 		Type:        distributed.OpTypePut,
 		Key:         "test-put-key",
 		Data:        []byte("test data"),
 		Consistency: distributed.ConsistencyStrong,
+		Timeout:     5 * time.Second,
+
+		// Pinned, because the GET above has just raised the local node's load and StrategyLeastLoad will
+		// therefore route this elsewhere — to one of the four peers that do not exist. That is the
+		// balancer being right, so the assertion to keep is the one about execution rather than about
+		// selection, and TargetNodes is how selectTargetNodes lets a caller say where.
+		TargetNodes: []string{config.NodeID},
 	}
 
-	result, err = coordinator.ExecuteOperation(ctx, putOp)
+	raw, err = coordinator.ExecuteOperation(ctx, putOp)
 	if err != nil {
-		t.Errorf("Failed to execute PUT operation: %v", err)
+		t.Fatalf("Failed to execute PUT operation: %v", err)
 	}
-	if result == nil {
-		t.Error("Expected non-nil result for PUT operation")
+	result, ok = raw.(*distributed.OperationResult)
+	if !ok {
+		t.Fatalf("PUT returned %T, want *distributed.OperationResult", raw)
+	}
+	if !result.Success {
+		t.Errorf("PUT operation reported failure: %s", result.Error)
+	}
+
+	// And the object is in storage, read back outside the coordinator. A PUT that reported success
+	// without the bytes reaching S3 is silent data loss, which is the whole reason this check is here
+	// rather than a look at result.Success.
+	if got := string(srv.GetObject("test-put-key")); got != "test data" {
+		t.Errorf("object in storage after PUT = %q, want %q", got, "test data")
 	}
 
 	// Verify coordinator stats
@@ -429,6 +502,14 @@ func TestMultiNodeCluster(t *testing.T) {
 	// which is the failure this test exists to distinguish from a working cluster.
 	secretFile := writeClusterSecret(t)
 
+	// Every node seeds from node 0, which is the only discovery mechanism there is: gossip learns of a
+	// peer from an inbound message, and the only thing that sends an unsolicited one is joinCluster,
+	// which runs only when SeedNodes is non-empty. This test set no seeds at all, so the three managers
+	// were three clusters of one that had never heard of each other — which is why it reported "Node i
+	// sees 1 nodes in cluster" three times and, once single-node elections started working (#275),
+	// three leaders instead of none.
+	seeds := []string{"127.0.0.1:18080"}
+
 	// Create and start multiple cluster nodes
 	for i := 0; i < nodeCount; i++ {
 		config := &distributed.ClusterConfig{
@@ -436,18 +517,31 @@ func TestMultiNodeCluster(t *testing.T) {
 			SecretFile:        secretFile,
 			ListenAddr:        fmt.Sprintf("127.0.0.1:1808%d", i),
 			AdvertiseAddr:     fmt.Sprintf("127.0.0.1:1808%d", i),
+			SeedNodes:         seeds,
 			ElectionTimeout:   time.Second + time.Duration(i)*100*time.Millisecond,
 			HeartbeatInterval: 200 * time.Millisecond,
 			GossipInterval:    100 * time.Millisecond,
 			GossipFanout:      2,
 			ConsistencyLevel:  "strong",
 			ReplicationFactor: 2,
+
+			// The default is 1024 bytes, and a sync message carries the entire memberlist in one
+			// datagram — three members exceeds it. The receive buffer is sized from this value, so the
+			// datagram is truncated mid-JSON and then fails the authentication envelope parse, which is
+			// what "gossip message failed authentication: unexpected end of JSON input" in this test's
+			// output was. Membership stalled at two nodes as a result. Raised here so this test measures
+			// leader election rather than that; the default itself is [#277].
+			MaxGossipPacket: 65507,
 		}
 
 		cm, err := distributed.NewClusterManager(config)
 		if err != nil {
 			t.Fatalf("Failed to create cluster manager %d: %v", i, err)
 		}
+
+		// Every node, not only the one that turns out to be leader: ConsistencyStrong fans the write out
+		// to peers, so a node without a backend fails the operation for the whole cluster (#269).
+		withBackend(t, cm)
 
 		clusters[i] = cm
 


### PR DESCRIPTION
Closes #275. Closes #278.

Four defects, found by probing rather than reading. Each is pinned by a test that fails on the defect before it passes on the fix — verified by mutation, not by prediction.

## The split brain was two defects

**B1, introduced by the single-node fix.** `startElection`'s majority check fired against a membership view containing only this node. Gossip learns of a peer from an inbound message and the election timer does not wait for one, so a probe of three seeded nodes showed all three electing themselves at term 1 on one vote each, within the first second, before any had heard of the others.

A membership map cannot distinguish "cluster of one" from "cluster of three that hasn't discovered itself." The discriminator has to come from configuration, so `ClusterManager.expectsPeers` reads `SeedNodes` minus this node's own address — exactly as `joinCluster` already treats it. A seed list naming only yourself is what a uniform config file deployed to every node produces, and counting that as a peer would reintroduce #275.

**B2, pre-existing, and what made it permanent.** `handleNetworkAppendEntries` and `handleNetworkRequestVote` set `ce.state = StateFollower` without telling the cluster manager. `becomeLeader` called `SetLeader`; no step-down path did. So `ClusterManager.IsLeader` was effectively write-once, and a deposed leader kept reporting itself as leader for the life of the process — which is how a momentary election race became a durable split brain instead of something the next heartbeat resolved.

Probe output before the fix:

\`\`\`
after higher-term heartbeat: ce.state=follower cm.IsLeader=true cm.GetLeader=\"sd\"
\`\`\`

After both fixes, three seeded nodes with real advertise addresses:

\`\`\`
t= 1s leaders=0 [p-0 candidate t=1 v=1 cmL=false sees=\"\" m=3] [p-1 candidate ...] [p-2 ...]
t= 4s leaders=1 [p-0 follower t=7 cmL=false sees=\"p-2\"] [p-1 follower sees=\"p-2\"] [p-2 leader cmL=true sees=\"p-2\" m=3]
...stable through t=10s
\`\`\`

## Four data races, all one mistake made four times (#278)

\`maps.Copy\` on a \`map[string]*T\` copies the pointers. So lock / copy / unlock / read-through-the-copy is not synchronization — it reads the very structs the gossip receive goroutine is writing.

| site | map | aliased write |
|---|---|---|
| \`calculateClusterStats\` | \`cm.nodes\` | \`UpdateNodeInfo\` |
| \`sendSyncMessage\` | \`gp.memberlist\` | \`performGossip\`, \`handleSyncMessage\` |
| \`performGossip\` | \`gp.memberlist\` (pointer slice) | \`handleAliveMessage\` |
| \`broadcastMessage\` | \`gp.memberlist\` (pointer slice) | same shape; safe only by an ID filter two lines away |

In \`sendSyncMessage\` the aliasing is worse than it looks: this node's memberlist entry *is* \`gp.localNode\`, the same pointer stored at \`gossip.go:233-234\`.

Each is fixed by removing the aliasing rather than locking around it — tally, marshal, or resolve the address inside the critical section and carry out only values. \`GetNodes\` and \`GetMemberlist\` had always done it correctly, twenty lines away in the same files.

**Not merely a stale read.** \`calculateClusterStats\` classifies a node by \`Status\` and sums \`CacheSize\`/\`CacheHitRate\` from it in the same iteration, so a node counted alive on a torn read contributes figures from a different moment into the number a size-aware balancer routes on. And \`handleSyncMessage\` gates merges on \`remoteNode.Incarnation > localNode.Incarnation\`, so an inconsistently-marshaled memberlist affects whether membership converges at all.

The two new regression tests are **race tests, not assertion tests**: they drive a gossip round and an inbound alive message concurrently, and under \`-race\` fail on the defect and pass after it. Without \`-race\` both pass either way — stated in their doc comments so nobody later reads a green run without the flag as coverage.

## Two tests were asserting against misconfigurations

\`TestMultiNodeCluster\` set no \`SeedNodes\`, and gossip has no other discovery mechanism, so its three managers were three clusters of one that had never heard of each other — which is what \"Node *i* sees 1 nodes in cluster\" three times was saying. It now seeds all three from node 0, gives each a backend (strong consistency fans the write out, so a node without one fails the operation for the whole cluster), and raises \`MaxGossipPacket\` past the 1024-byte default that truncates a three-member sync mid-JSON and then reports the truncation as \`gossip message failed authentication\` — filed separately as #277.

\`TestLoadBalancer_NodeSelection\` registered four peers at addresses nothing listens on and asserted a strong-consistency PUT across two of them succeeded; it timed out for 30 seconds and reported that as a defect. It now asserts what its name promises — selection chooses from the whole membership, the operation executes, the bytes reach storage — and says in a comment why one reachable node out of five can carry the selection claim *or* the execution claim per operation, not both. \`StrategyLeastLoad\` routing the second operation away from the node that served the first is the balancer working, so the second is pinned with \`TargetNodes\`.

## Mutation verification

Every fix was verified by breaking it and watching the specific test fail:

| mutation | caught by |
|---|---|
| seed guard → \`if false {\` | \`TestCheckVoteMajority_WaitsForSeedsBeforeSelfElecting\` |
| \`SetLeader(newLeader)\` removed from heartbeat path | \`TestStepDown_ClearsClusterLeadership/a_heartbeat\` (\`GetLeader() = \"incumbent\", want \"real-leader\"\`) |
| \`SetLeader(\"\")\` removed from vote path | \`TestStepDown_ClearsClusterLeadership/a_vote_request\` |
| \`expectsPeers\` → \`len(SeedNodes) > 0\` | \`TestExpectsPeers/only_ourselves_is_a_cluster_of_one\` |
| \`calculateClusterStats\` → shallow copy | \`TestCalculateClusterStats_TalliesUnderTheLock\` (3 race reports) |
| \`performGossip\` → pointer slice | \`TestGossipProtocol_PerformGossipResolvesAddressesUnderTheLock\` (2 race reports) |

## Gates

- \`go build ./...\` · \`go vet ./...\` · \`gofmt -l .\` — clean
- \`go test -count=1 -race -covermode=atomic ./...\` — pass
- \`coverage-gate.sh\` — 35 packages at or above floor
- \`golangci-lint --new-from-merge-base=origin/main\` — 0 issues
- \`gosec\` — 2 findings, both the pre-existing \`G404\`s at \`consensus.go:930,933\`
- \`go test -race -tags=distributed ./tests/\` — **green, zero races, for the first time**

No CI job builds \`-tags=distributed\`, which is why all of this sat unobserved (#240).

## Package doc

A new **Membership Maps and Locking** section in \`internal/distributed/doc.go\` states the invariant the four sites violated: never carry a pointer out of a membership map across the unlock, because copying the map copies the pointers. Worth stating in the package doc precisely because it was got wrong four separate times.