### PR TITLE
fix: the gossip default carries a cluster, and truncation says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A three-node cluster could not form at the default gossip packet size, and said the cluster secret
+  was wrong** ([#277]). `MaxGossipPacket` defaulted to 1024 bytes. A sealed sync message costs about 200
+  bytes of envelope plus about 415 bytes per member — measured, not estimated, because `seal` wraps the
+  payload in JSON with a hex MAC and base64-encodes the byte field, so the payload-to-datagram ratio is
+  not a constant one can reason to. 1024 bytes therefore held **two** members. A third node's sync was
+  truncated by the receive buffer, the truncated JSON failed the authentication envelope parse, and the
+  failure was counted and logged as `MessagesUnauthenticated` — whose documented meaning is a peer
+  configured with a different cluster secret. So the symptom of a size limit was a message sending the
+  operator to verify a secret that was correct, and membership stalled at two nodes.
+
+  Three separable defects, each fixed on its own terms rather than by raising one number:
+
+  The default is now 8192 bytes, which carries about nineteen members in a single datagram. Not 65507,
+  the maximum UDP payload: a datagram over the path MTU is fragmented by IP and one lost fragment loses
+  the whole datagram, so the effective loss rate rises with size. 8 KiB does exceed a 1500-byte MTU and
+  will fragment — a deliberate trade, since six fragments for a sync that runs once per join is worth
+  more than chunking every small cluster's membership across several round trips. Per-round alive
+  messages are about 483 bytes sealed and never fragment.
+
+  Truncation is now detected and reported as truncation. The receive buffer is sized `MaxGossipPacket+1`,
+  because a buffer sized exactly to the limit cannot distinguish "at the limit" from "truncated" —
+  `ReadFromUDP` discards an oversize datagram's tail and reports only what it copied, so with one spare
+  byte `n > MaxGossipPacket` is unambiguous evidence. Such a datagram is dropped before it reaches the
+  authenticator, counted as `MessagesTruncated`, and logged with the limit and the instruction to set
+  the same value on every node. An oversize *send* is likewise refused after sealing, counted as
+  `MessagesOversize`, and returns an error naming the size and the limit — the two directions are
+  counted separately because the operator action differs: an oversize send is this node's memberlist
+  outgrowing its own limit, while a truncated receive is a peer whose limit is larger than ours.
+
+  Sync messages are now chunked rather than unbounded, so a memberlist larger than one datagram is sent
+  as several. Each chunk is a complete `SyncMessage`; this is sound because `handleSyncMessage` merges
+  per node rather than replacing wholesale, so a receiver applying two chunks reaches the same state as
+  one applying their union. Chunk boundaries are computed over a sorted key order so they are a function
+  of the membership rather than of Go's map iteration order, and each candidate chunk is sealed to
+  measure it, so the budget includes the envelope, the MAC, and the message ID. A single member too
+  large for any datagram is emitted alone and logged, so `sendMessage` refuses it loudly rather than a
+  member being silently dropped.
+
+  A fourth defect was found along the way: `NewClusterManager`'s nil-config literal restated sixteen
+  fields that `applyConfigDefaults` sets to the same values two lines later, including a second
+  `MaxGossipPacket: 1024`. That literal is now one field — `CacheReplication`, the only one it was ever
+  load-bearing for, because it is a bool defaulting to true and a bool's zero value cannot be
+  distinguished from unset. A duplicated default is how a stale copy survives a fix to the default.
+
+  The `-tags=distributed` suite no longer overrides `MaxGossipPacket` anywhere, which is what makes it
+  cover this: a test that sets the value cannot notice the default regressing. That suite now passes
+  unaided, and the unit test for the default asserts that a three-member sync fits in one datagram —
+  the property the issue was about — rather than asserting that a constant equals itself.
+
 - `MountManager.Wait` and the FUSE serving goroutine read `m.server` without holding the mutex that
   `Unmount` writes it under. Both reads are also nil dereferences: if the unmount lands first,
   `m.server.Wait()` panics on a background goroutine, which is unrecoverable and takes the process
@@ -270,9 +319,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mechanism — it learns of a peer from an inbound message, and the only unsolicited send is
   `joinCluster`, which runs only when seeds are configured. So its three managers were three clusters of
   one that had never heard of each other, which is what "Node *i* sees 1 nodes in cluster" three times
-  was saying. It now seeds all three from node 0, gives each a backend because strong consistency fans
-  the write out, and raises `MaxGossipPacket` past the default that would otherwise truncate the sync
-  ([#277]). `TestLoadBalancer_NodeSelection` registered four peers at addresses nothing listens on and
+  was saying. It now seeds all three from node 0 and gives each a backend, because strong consistency
+  fans the write out. It also raised `MaxGossipPacket` past the default that would otherwise truncate
+  the sync — a workaround, since removed once the default itself was fixed ([#277]).
+  `TestLoadBalancer_NodeSelection` registered four peers at addresses nothing listens on and
   then asserted a strong-consistency PUT across two of them succeeded; it timed out for 30 seconds and
   reported that as a defect. It now asserts what its name promises — that selection chooses from the
   whole membership, and that the operation executes and the bytes reach storage — and says in a comment

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -161,6 +161,25 @@ type ClusterStats struct {
 	NetworkErrors    int64 `json:"network_errors"`
 }
 
+// defaultMaxGossipPacket is the largest gossip datagram this node will send or accept, in bytes.
+//
+// 8 KiB, chosen against measurement rather than round numbers. A sealed sync message costs ~200 bytes
+// of envelope plus ~415 bytes per member, so this carries about 19 members in a single datagram and
+// larger memberlists in chunks — see [GossipProtocol.marshalSyncChunksLocked].
+//
+// The old default was 1024, which holds *two* members. A three-node cluster's sync did not fit, the
+// datagram was truncated by the receive buffer, and the truncated JSON then failed the authentication
+// envelope parse — so cluster formation stalled and reported it as a wrong cluster secret. No CI job
+// builds -tags=distributed, so the one test that would have caught it had been failing unobserved
+// (#277, #240).
+//
+// Why not 65507, the maximum UDP payload: a datagram over the path MTU is fragmented by IP, and a
+// single lost fragment loses the whole datagram, so the effective loss rate rises with size. 8 KiB
+// exceeds a 1500-byte MTU and will fragment, which is a deliberate trade — six fragments for a sync
+// that runs once per join is worth more than chunking every small cluster's membership across several
+// round trips. Per-round alive messages are ~483 bytes sealed and never fragment.
+const defaultMaxGossipPacket = 8192
+
 // applyConfigDefaults applies default values for zero-valued configuration fields
 func applyConfigDefaults(config *ClusterConfig) {
 	if config.ListenAddr == "" {
@@ -188,7 +207,7 @@ func applyConfigDefaults(config *ClusterConfig) {
 		config.GossipFanout = 3
 	}
 	if config.MaxGossipPacket == 0 {
-		config.MaxGossipPacket = 1024
+		config.MaxGossipPacket = defaultMaxGossipPacket
 	}
 	if config.ReplicationFactor == 0 {
 		config.ReplicationFactor = 3
@@ -213,24 +232,17 @@ func applyConfigDefaults(config *ClusterConfig) {
 // NewClusterManager creates a new cluster manager
 func NewClusterManager(config *ClusterConfig) (*ClusterManager, error) {
 	if config == nil {
-		config = &ClusterConfig{
-			ListenAddr:        "0.0.0.0:8080",
-			AdvertiseAddr:     "127.0.0.1:8080",
-			JoinTimeout:       30 * time.Second,
-			ElectionTimeout:   5 * time.Second,
-			HeartbeatInterval: 1 * time.Second,
-			LeadershipTTL:     10 * time.Second,
-			GossipInterval:    500 * time.Millisecond,
-			GossipFanout:      3,
-			MaxGossipPacket:   1024,
-			CacheReplication:  true,
-			ReplicationFactor: 3,
-			ConsistencyLevel:  "eventual",
-			MaxConcurrentOps:  100,
-			OperationTimeout:  30 * time.Second,
-			RetryAttempts:     3,
-			RetryBackoff:      time.Second,
-		}
+		// CacheReplication only, and then applyConfigDefaults below fills the rest.
+		//
+		// This used to restate all sixteen fields, every one of which applyConfigDefaults sets to the
+		// same value two lines later — so the literal was dead except for this one field, and the
+		// duplication was live: MaxGossipPacket appeared here as 1024 and had to be changed in two
+		// places, which is how a stale copy of a default survives a fix to the default (#277).
+		//
+		// CacheReplication is the exception because it is a bool whose default is true, and a bool's
+		// zero value is indistinguishable from "not set" — so applyConfigDefaults cannot express it and
+		// a caller passing nil is the only case where the intent is known.
+		config = &ClusterConfig{CacheReplication: true}
 	}
 
 	// Apply defaults for zero-valued fields

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -134,6 +134,52 @@ func TestNewClusterManager_ConfigDefaults(t *testing.T) {
 	}
 }
 
+// TestNewClusterManager_DefaultMaxGossipPacketHoldsAThreeNodeSync asserts the default against the
+// thing it has to be big enough for, rather than against its own value.
+//
+// A test comparing MaxGossipPacket to 8192 would pass on the 1024 that could not form a three-node
+// cluster, if someone had written it when 1024 was the constant — it would only ever say that the
+// constant equals itself. So this builds the sync message a three-node cluster actually sends and
+// asserts it fits, which is the property #277 was about. It is also the property that would break
+// silently if NodeInfo grew a field.
+func TestNewClusterManager_DefaultMaxGossipPacketHoldsAThreeNodeSync(t *testing.T) {
+	t.Parallel()
+	cm, err := NewClusterManager(&ClusterConfig{NodeID: "fit-host", SecretFile: writeTestSecret(t)})
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	gp := cm.gossip
+
+	gp.mu.Lock()
+	for i := range 2 {
+		// Realistic identifiers, not "a" and "b": a hostname is the length that decides whether this
+		// fits, and a test using two-character IDs would pass at almost any limit.
+		id := fmt.Sprintf("objectfs-node-%02d.cluster.example.edu", i)
+		gp.memberlist[id] = &GossipNode{
+			Info: &NodeInfo{
+				ID: id, Address: fmt.Sprintf("10.20.30.%d:8080", i+1),
+				Status: NodeStatusAlive, LastSeen: time.Now(), Version: "0.11.0",
+				Metadata: map[string]string{},
+			},
+			Incarnation: 1, State: StateAlive, StateChange: time.Now(),
+		}
+	}
+	members := len(gp.memberlist)
+	chunks, err := gp.marshalSyncChunksLocked()
+	gp.mu.Unlock()
+
+	if err != nil {
+		t.Fatalf("marshalSyncChunksLocked: %v", err)
+	}
+	if members != 3 {
+		t.Fatalf("memberlist has %d members, want 3 (self plus two peers)", members)
+	}
+	if len(chunks) != 1 {
+		t.Errorf("a three-member sync took %d datagrams at the %d-byte default, want 1: the default "+
+			"cannot carry the smallest cluster that needs a quorum", len(chunks), defaultMaxGossipPacket)
+	}
+}
+
 // TestClusterManager_InitialState verifies the state of a newly created manager
 // before Start is called.
 func TestClusterManager_InitialState(t *testing.T) {

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -185,6 +185,18 @@ type GossipStats struct {
 	// node that refutes repeatedly is alive and being falsely accused, which points at packet loss
 	// or a heartbeat interval set below the network's actual latency — not at the node.
 	SuspicionRefutations int64 `json:"suspicion_refutations"`
+
+	// Datagrams that did not fit MaxGossipPacket, counted separately in each direction because the
+	// operator action differs: an oversize send is this node's memberlist outgrowing the limit and is
+	// refused before it reaches the socket, while a truncated receive is a *peer* whose limit is
+	// larger than ours, which is a configuration mismatch across the cluster.
+	//
+	// These exist because a truncated datagram used to present as an authentication failure. The JSON
+	// was cut mid-object, the envelope parse failed, and MessagesUnauthenticated went up — whose
+	// documented reading, two fields above, is "a peer with a different cluster secret." An operator
+	// chasing a size problem was sent to check a secret that was correct (#277).
+	MessagesTruncated int64 `json:"messages_truncated"`
+	MessagesOversize  int64 `json:"messages_oversize"`
 }
 
 // NewGossipProtocol creates a new gossip protocol instance.
@@ -330,7 +342,12 @@ func (gp *GossipProtocol) LeaveCluster(ctx context.Context) error {
 // Background goroutines
 
 func (gp *GossipProtocol) receiveMessages(ctx context.Context) {
-	buffer := make([]byte, gp.config.MaxGossipPacket)
+	// One byte larger than the limit, so a datagram of exactly MaxGossipPacket is distinguishable from
+	// one that exceeded it. ReadFromUDP discards the remainder of an oversize datagram and reports only
+	// what it copied, so n == len(buffer) is the only evidence available that anything was lost — and
+	// with a buffer sized exactly to the limit, a legitimate maximum-size message is indistinguishable
+	// from a truncated larger one. The extra byte makes n > MaxGossipPacket mean truncated, full stop.
+	buffer := make([]byte, gp.config.MaxGossipPacket+1)
 
 	for {
 		// Check stop conditions without blocking before each receive.
@@ -362,6 +379,25 @@ func (gp *GossipProtocol) receiveMessages(ctx context.Context) {
 			gp.stats.mu.Lock()
 			gp.stats.NetworkErrors++
 			gp.stats.mu.Unlock()
+			continue
+		}
+
+		// Truncation is reported as truncation, not handed to the authenticator. A datagram larger than
+		// the buffer arrives with its tail discarded by the kernel, so the JSON is cut mid-object and
+		// the envelope parse fails — which used to be counted and logged as an authentication failure,
+		// sending the operator to check a cluster secret that was correct. The size is what is wrong and
+		// the size is what the message says (#277).
+		if n > gp.config.MaxGossipPacket {
+			gp.stats.mu.Lock()
+			gp.stats.MessagesTruncated++
+			gp.stats.mu.Unlock()
+
+			slog.Warn("dropped a truncated gossip datagram",
+				"peer", addr,
+				"max_gossip_packet", gp.config.MaxGossipPacket,
+				"hint", "the sending node's max_gossip_packet is larger than this node's; raise it here "+
+					"or lower it there, and set the same value on every node")
+
 			continue
 		}
 
@@ -1077,6 +1113,23 @@ func (gp *GossipProtocol) sendMessage(addr string, msg *GossipMessage) error {
 		return fmt.Errorf("failed to marshal message: %w", err)
 	}
 
+	// Refused here rather than sent and silently truncated at the far end. The sealed length is what
+	// goes on the wire, so this is the last point at which the size is knowable and the first at which
+	// it is final — checking before sealing would miss the envelope and the MAC.
+	//
+	// An error rather than a best-effort send, because the receiver cannot do anything useful with a
+	// prefix: the JSON is cut mid-object and the datagram is dropped. Returning the error gives the
+	// caller the chance to send something smaller, and gives an operator a message naming the limit
+	// instead of a peer that has mysteriously stopped converging (#277).
+	if len(data) > gp.config.MaxGossipPacket {
+		gp.stats.mu.Lock()
+		gp.stats.MessagesOversize++
+		gp.stats.mu.Unlock()
+
+		return fmt.Errorf("a %s message is %d bytes sealed, over the %d-byte max_gossip_packet: "+
+			"raise it on every node in the cluster", msg.Type, len(data), gp.config.MaxGossipPacket)
+	}
+
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return fmt.Errorf("failed to resolve address: %w", err)
@@ -1131,13 +1184,17 @@ func (gp *GossipProtocol) broadcastMessage(msg *GossipMessage) error {
 	return nil
 }
 
+// sendSyncMessage sends this node's full membership view to addr, split across as many datagrams as
+// it takes to stay under MaxGossipPacket.
+//
+// Chunking is sound because [GossipProtocol.handleSyncMessage] merges per node rather than replacing
+// the memberlist: each chunk is a complete SyncMessage that means "these members, as I last saw
+// them," and a receiver applying two of them reaches the same state as one applying their union. So a
+// lost or reordered chunk costs the freshness of the members it carried until the next sync, and
+// nothing more. That is already true of gossip generally — this is why the protocol is eventually
+// consistent rather than atomic — and it is what makes chunking preferable to failing the whole sync,
+// which is what a single oversize datagram used to do silently (#277).
 func (gp *GossipProtocol) sendSyncMessage(addr string) error {
-	msg := &GossipMessage{
-		Type:      MessageTypeSync,
-		Timestamp: time.Now(),
-		MessageID: gp.generateMessageID(),
-	}
-
 	// Marshaled under the lock, as performGossip does for its own message and for the same reason.
 	//
 	// This used to take the read lock only to maps.Copy the memberlist and then marshal outside it —
@@ -1150,19 +1207,130 @@ func (gp *GossipProtocol) sendSyncMessage(addr string) error {
 	//
 	// Marshaling under the lock rather than deep-copying, because the alternative is a copy that has
 	// to stay deep as GossipNode grows — it holds two pointers today — and a shallow one is exactly the
-	// bug being fixed. If the memberlist ever gets large enough that holding gp.mu across a marshal
-	// matters, the answer is to bound the sync (#277), not to reintroduce a copy that can be wrong.
+	// bug being fixed.
 	gp.mu.RLock()
-	msg.From = gp.localNode.ID
-	data, marshalErr := json.Marshal(&SyncMessage{Nodes: gp.memberlist})
+	from := gp.localNode.ID
+	chunks, marshalErr := gp.marshalSyncChunksLocked()
 	gp.mu.RUnlock()
 
 	if marshalErr != nil {
 		return fmt.Errorf("marshaling the sync message: %w", marshalErr)
 	}
-	msg.Data = data
 
-	return gp.sendMessage(addr, msg)
+	// Every chunk attempted even if one fails, and the first error returned: a partial sync is worth
+	// more than none, and stopping at the first failure would make the members in later chunks depend
+	// on the ones before them.
+	var firstErr error
+	for _, data := range chunks {
+		err := gp.sendMessage(addr, &GossipMessage{
+			Type:      MessageTypeSync,
+			From:      from,
+			Timestamp: time.Now(),
+			MessageID: gp.generateMessageID(),
+			Data:      data,
+		})
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+// marshalSyncChunksLocked marshals gp.memberlist into one or more SyncMessage payloads, each small
+// enough that the datagram carrying it fits MaxGossipPacket. gp.mu must be held.
+//
+// The budget is derived by measuring rather than by estimating the envelope: seal wraps the payload in
+// JSON with a hex MAC, and base64-encodes it as a []byte field, so the ratio between payload and
+// datagram is not a constant anyone should hardcode. Each candidate chunk is therefore grown one
+// member at a time and the whole message sealed to check, which costs an extra marshal per member on a
+// path that runs once per join — not per gossip round.
+func (gp *GossipProtocol) marshalSyncChunksLocked() ([][]byte, error) {
+	ids := slices.Sorted(maps.Keys(gp.memberlist))
+
+	// Sorted so that a chunk boundary is a function of the membership rather than of Go's map
+	// iteration order. Two syncs of an unchanged memberlist then produce identical chunks, which is
+	// what makes a truncation bug reproducible instead of intermittent.
+
+	var (
+		chunks  [][]byte
+		current = map[string]*GossipNode{}
+	)
+
+	flush := func() error {
+		if len(current) == 0 {
+			return nil
+		}
+		data, err := json.Marshal(&SyncMessage{Nodes: current})
+		if err != nil {
+			return err
+		}
+		chunks = append(chunks, data)
+		current = map[string]*GossipNode{}
+		return nil
+	}
+
+	for _, id := range ids {
+		current[id] = gp.memberlist[id]
+
+		fits, err := gp.syncChunkFits(current)
+		if err != nil {
+			return nil, err
+		}
+		if fits {
+			continue
+		}
+
+		// Over budget with this member added. Send what fit without it, then start a chunk with it.
+		if len(current) == 1 {
+			// A single member does not fit, so no chunking can help. Emit it anyway and let
+			// sendMessage refuse it with a message naming the limit — silently dropping a member from
+			// the sync would make it disappear from the cluster's view with nothing logged, which is
+			// strictly worse than a loud failure.
+			slog.Warn("a single member does not fit max_gossip_packet; the sync for it will be refused",
+				"node_id", id, "max_gossip_packet", gp.config.MaxGossipPacket)
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		delete(current, id)
+		if err := flush(); err != nil {
+			return nil, err
+		}
+		current[id] = gp.memberlist[id]
+	}
+
+	if err := flush(); err != nil {
+		return nil, err
+	}
+
+	return chunks, nil
+}
+
+// syncChunkFits reports whether a sync message carrying nodes would fit MaxGossipPacket once sealed.
+func (gp *GossipProtocol) syncChunkFits(nodes map[string]*GossipNode) (bool, error) {
+	payload, err := json.Marshal(&SyncMessage{Nodes: nodes})
+	if err != nil {
+		return false, err
+	}
+
+	// The same message sendMessage would build, so the measurement includes the envelope, the MAC, and
+	// the message ID rather than a guess at their combined size. MessageID is generated here and
+	// discarded: it varies in content but not in length.
+	sealed, err := gp.auth.seal(&GossipMessage{
+		Type:      MessageTypeSync,
+		From:      gp.localNode.ID,
+		Timestamp: time.Now(),
+		MessageID: gp.generateMessageID(),
+		Data:      payload,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return len(sealed) <= gp.config.MaxGossipPacket, nil
 }
 
 func (gp *GossipProtocol) getCurrentIncarnation() uint32 {
@@ -1227,6 +1395,8 @@ func (gp *GossipProtocol) GetStats() *GossipStats {
 		MessagesReplayed:        gp.stats.MessagesReplayed,
 		MessagesWrongVersion:    gp.stats.MessagesWrongVersion,
 		SuspicionRefutations:    gp.stats.SuspicionRefutations,
+		MessagesTruncated:       gp.stats.MessagesTruncated,
+		MessagesOversize:        gp.stats.MessagesOversize,
 	}
 	maps.Copy(stats.MessagesByType, gp.stats.MessagesByType)
 	gp.stats.mu.RUnlock()

--- a/internal/distributed/gossip_test.go
+++ b/internal/distributed/gossip_test.go
@@ -2,6 +2,9 @@ package distributed
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -892,6 +895,201 @@ func TestGossipProtocol_PerformGossipResolvesAddressesUnderTheLock(t *testing.T)
 	}
 	if peer.State != StateAlive {
 		t.Errorf("addr-race-peer state = %v, want %v", peer.State, StateAlive)
+	}
+}
+
+// ── Datagram size limits (#277) ───────────────────────────────────────────────
+//
+// The defect these pin was not that the limit existed but that exceeding it was silent and then
+// misattributed: an oversize sync was sent, truncated by the receive buffer, failed the envelope
+// parse, and was counted as an authentication failure — whose documented meaning is a wrong cluster
+// secret. So each of these asserts on what an operator is told, not only on whether the datagram
+// arrived.
+
+// fillMemberlist adds n peers with realistic identifiers and returns the resulting member count.
+//
+// Realistic lengths matter: a hostname is most of a member's serialized size, so a helper using "a"
+// and "b" would make a chunking test pass at almost any limit.
+func fillMemberlist(gp *GossipProtocol, n int) int {
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
+	for i := range n {
+		id := fmt.Sprintf("objectfs-node-%03d.cluster.example.edu", i)
+		gp.memberlist[id] = &GossipNode{
+			Info: &NodeInfo{
+				ID: id, Address: fmt.Sprintf("10.20.30.%d:8080", i%250+1),
+				Status: NodeStatusAlive, LastSeen: time.Now(), Version: "0.11.0",
+				Metadata: map[string]string{},
+			},
+			Incarnation: 1, State: StateAlive, StateChange: time.Now(),
+		}
+	}
+
+	return len(gp.memberlist)
+}
+
+// TestSendSyncMessage_ChunksAMemberlistThatDoesNotFit verifies that a membership too large for one
+// datagram is split rather than sent oversize, and that every chunk actually fits once sealed.
+//
+// Asserting on the sealed size of each chunk rather than on the chunk count is deliberate: the count
+// depends on the limit and on how large a NodeInfo happens to be, and pinning it would make this test
+// fail on an unrelated field addition. What must hold is that nothing this function emits can be
+// truncated at the far end.
+func TestSendSyncMessage_ChunksAMemberlistThatDoesNotFit(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "chunk-host")
+	cfg.MaxGossipPacket = 2048 // holds ~4 members, so 20 needs several datagrams
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	gp := cm.gossip
+
+	members := fillMemberlist(gp, 20)
+
+	gp.mu.RLock()
+	chunks, err := gp.marshalSyncChunksLocked()
+	gp.mu.RUnlock()
+	if err != nil {
+		t.Fatalf("marshalSyncChunksLocked: %v", err)
+	}
+
+	if len(chunks) < 2 {
+		t.Fatalf("a %d-member sync produced %d chunk(s) at a %d-byte limit, want several: it would be "+
+			"truncated on receipt", members, len(chunks), cfg.MaxGossipPacket)
+	}
+
+	// Every chunk fits, measured the way sendMessage measures it.
+	seen := 0
+	for i, data := range chunks {
+		sealed, err := gp.auth.seal(&GossipMessage{
+			Type: MessageTypeSync, From: "chunk-host", Timestamp: time.Now(),
+			MessageID: gp.generateMessageID(), Data: data,
+		})
+		if err != nil {
+			t.Fatalf("seal chunk %d: %v", i, err)
+		}
+		if len(sealed) > cfg.MaxGossipPacket {
+			t.Errorf("chunk %d is %d bytes sealed, over the %d-byte limit", i, len(sealed), cfg.MaxGossipPacket)
+		}
+
+		var sm SyncMessage
+		if err := json.Unmarshal(data, &sm); err != nil {
+			t.Errorf("chunk %d is not a complete SyncMessage: %v", i, err)
+			continue
+		}
+		seen += len(sm.Nodes)
+	}
+
+	// And no member is dropped or duplicated: handleSyncMessage merges per node, so the union of the
+	// chunks has to be the whole memberlist for a receiver to converge.
+	if seen != members {
+		t.Errorf("chunks carry %d members in total, want %d: chunking must not lose or repeat one", seen, members)
+	}
+}
+
+// TestSendMessage_RefusesAnOversizeDatagram verifies that a message too large for the configured limit
+// is refused with an error naming the limit, rather than sent to be truncated in silence.
+func TestSendMessage_RefusesAnOversizeDatagram(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "oversize-host")
+	cfg.MaxGossipPacket = 512
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	gp := cm.gossip
+
+	err = gp.sendMessage("127.0.0.1:1", &GossipMessage{
+		Type:      MessageTypeSync,
+		From:      "oversize-host",
+		Timestamp: time.Now(),
+		MessageID: gp.generateMessageID(),
+		Data:      []byte(`"` + strings.Repeat("x", 1024) + `"`),
+	})
+
+	if err == nil {
+		t.Fatal("sendMessage accepted a datagram over max_gossip_packet; it would be truncated on receipt")
+	}
+	// The limit's configuration key, so the error says which knob to turn.
+	if !strings.Contains(err.Error(), "max_gossip_packet") {
+		t.Errorf("error does not name the setting to change: %v", err)
+	}
+
+	stats := gp.GetStats()
+	if stats.MessagesOversize != 1 {
+		t.Errorf("MessagesOversize = %d, want 1", stats.MessagesOversize)
+	}
+	if stats.MessagesSent != 0 {
+		t.Errorf("MessagesSent = %d, want 0: the datagram must not reach the socket", stats.MessagesSent)
+	}
+}
+
+// TestReceiveMessages_CountsATruncatedDatagramAsTruncated is the operator-facing half of #277: a
+// datagram larger than the receive buffer must not be reported as an authentication failure.
+//
+// It sends a real oversize UDP datagram to a running gossip listener and asserts on which counter
+// moves. MessagesUnauthenticated is documented as meaning "a peer with a different cluster secret",
+// so counting a size problem there sent the operator to verify a secret that was correct — which is
+// the specific cost this pins.
+func TestReceiveMessages_CountsATruncatedDatagramAsTruncated(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t, "trunc-host")
+	cfg.ListenAddr = "127.0.0.1:0"
+	cfg.MaxGossipPacket = 1024
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	gp := cm.gossip
+
+	if err := gp.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = gp.Stop() }()
+
+	// The kernel-assigned port, since ListenAddr asked for an ephemeral one.
+	local, ok := gp.conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("LocalAddr is %T, want *net.UDPAddr", gp.conn.LocalAddr())
+	}
+
+	conn, err := net.DialUDP("udp", nil, local)
+	if err != nil {
+		t.Fatalf("dialing the listener: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Valid JSON, and oversize. Valid so that a failure to detect truncation would be a *parse* failure
+	// on the prefix rather than on the payload — i.e. so the test distinguishes the two causes.
+	oversize := []byte(`{"v":1,"mac":"00","payload":"` + strings.Repeat("y", 2048) + `"}`)
+	if _, err := conn.Write(oversize); err != nil {
+		t.Fatalf("sending the oversize datagram: %v", err)
+	}
+
+	// Poll rather than sleep a fixed interval: the receive loop has a 100ms read deadline, so the
+	// datagram is picked up within one cycle and there is no reason to wait longer than it takes.
+	deadline := time.Now().Add(3 * time.Second)
+	var stats *GossipStats
+	for time.Now().Before(deadline) {
+		stats = gp.GetStats()
+		if stats.MessagesTruncated > 0 || stats.MessagesRejected > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if stats.MessagesTruncated != 1 {
+		t.Errorf("MessagesTruncated = %d, want 1", stats.MessagesTruncated)
+	}
+	if stats.MessagesUnauthenticated != 0 {
+		t.Errorf("MessagesUnauthenticated = %d, want 0: a datagram over max_gossip_packet is a size "+
+			"problem, and counting it here tells the operator to check a cluster secret that is correct",
+			stats.MessagesUnauthenticated)
+	}
+	if stats.MessagesRejected != 0 {
+		t.Errorf("MessagesRejected = %d, want 0", stats.MessagesRejected)
 	}
 }
 

--- a/tests/distributed_test.go
+++ b/tests/distributed_test.go
@@ -74,7 +74,6 @@ func TestClusterManager_BasicOperations(t *testing.T) {
 		HeartbeatInterval: 500 * time.Millisecond,
 		GossipInterval:    100 * time.Millisecond,
 		GossipFanout:      2,
-		MaxGossipPacket:   1024,
 		CacheReplication:  true,
 		ReplicationFactor: 1,
 		ConsistencyLevel:  "eventual",
@@ -302,13 +301,12 @@ func TestConsensusEngine_LeaderElection(t *testing.T) {
 func TestGossipProtocol_BasicFunctionality(t *testing.T) {
 	// Test basic gossip protocol functionality
 	config := &distributed.ClusterConfig{
-		NodeID:          "gossip-test-1",
-		SecretFile:      writeClusterSecret(t),
-		ListenAddr:      "127.0.0.1:18082",
-		AdvertiseAddr:   "127.0.0.1:18082",
-		GossipInterval:  100 * time.Millisecond,
-		GossipFanout:    2,
-		MaxGossipPacket: 1024,
+		NodeID:         "gossip-test-1",
+		SecretFile:     writeClusterSecret(t),
+		ListenAddr:     "127.0.0.1:18082",
+		AdvertiseAddr:  "127.0.0.1:18082",
+		GossipInterval: 100 * time.Millisecond,
+		GossipFanout:   2,
 	}
 
 	cm, err := distributed.NewClusterManager(config)
@@ -525,13 +523,13 @@ func TestMultiNodeCluster(t *testing.T) {
 			ConsistencyLevel:  "strong",
 			ReplicationFactor: 2,
 
-			// The default is 1024 bytes, and a sync message carries the entire memberlist in one
-			// datagram — three members exceeds it. The receive buffer is sized from this value, so the
-			// datagram is truncated mid-JSON and then fails the authentication envelope parse, which is
-			// what "gossip message failed authentication: unexpected end of JSON input" in this test's
-			// output was. Membership stalled at two nodes as a result. Raised here so this test measures
-			// leader election rather than that; the default itself is [#277].
-			MaxGossipPacket: 65507,
+			// MaxGossipPacket is deliberately left at its default. It used to be set to 65507 here, to
+			// work around a 1024-byte default that could not carry a three-member sync: the datagram was
+			// truncated by the receive buffer and the truncated JSON then failed the authentication
+			// envelope parse, so membership stalled at two nodes and reported it as a wrong cluster
+			// secret. Both halves are fixed (#277) — the default holds ~19 members and larger memberlists
+			// are chunked — and leaving it unset is what makes this test cover that, since a test that
+			// overrides the default cannot notice the default regressing.
 		}
 
 		cm, err := distributed.NewClusterManager(config)


### PR DESCRIPTION
Closes #277.

`MaxGossipPacket` defaulted to 1024 bytes. A sealed sync message costs ~200 bytes of envelope plus ~415 bytes per member — measured, not estimated, because `seal` wraps the payload in JSON with a hex MAC and base64-encodes the byte field, so the payload:datagram ratio is not a constant one can reason to. **1024 bytes held two members.** A third node's sync was truncated by the receive buffer, the truncated JSON failed the authentication envelope parse, and the failure was counted and logged as `MessagesUnauthenticated` — whose documented meaning is a peer configured with a different cluster secret. So the symptom of a size limit was a message sending the operator to verify a secret that was correct, and membership stalled at two nodes.

Measured sealed sizes (throwaway probe, since deleted): 1 member = 622 B, 3 = 1448, 5 = 2262, 10 = 4333, 25 = 10520, 50 = 20841, 100 = 41476. Alive message = 483 B.

## Three separable defects

**The default is now 8192**, carrying ~19 members in one datagram. Not 65507, the maximum UDP payload: a datagram over the path MTU is fragmented by IP and a single lost fragment loses the whole datagram, so effective loss rate rises with size. 8 KiB does exceed a 1500-byte MTU and will fragment — a deliberate trade, since six fragments for a sync that runs once per join is worth more than chunking every small cluster's membership across several round trips. Per-round alive messages never fragment.

**Truncation is detected and reported as truncation.** The receive buffer is `MaxGossipPacket+1`, because a buffer sized exactly to the limit cannot distinguish "at the limit" from "truncated" — `ReadFromUDP` discards an oversize datagram's tail and reports only what it copied, so one spare byte makes `n > MaxGossipPacket` unambiguous evidence. Such a datagram is dropped *before* it reaches the authenticator, counted as `MessagesTruncated`, and logged with the limit and the instruction to set the same value on every node. An oversize *send* is refused after sealing (the last point the size is knowable, the first it is final) and counted as `MessagesOversize`. The two directions are counted separately because the operator action differs: an oversize send is this node's memberlist outgrowing its own limit; a truncated receive is a peer whose limit is larger than ours.

**Sync messages are chunked** rather than unbounded. Each chunk is a complete `SyncMessage` — sound because `handleSyncMessage` merges per node rather than replacing wholesale, so a receiver applying two chunks reaches the same state as one applying their union. Boundaries are computed over a sorted key order so they are a function of the membership rather than of Go's map iteration order, and each candidate chunk is sealed to measure it, so the budget includes envelope, MAC, and message ID. A single member too large for any datagram is emitted alone and logged, so `sendMessage` refuses it loudly rather than a member being silently dropped.

## A fourth defect found along the way

`NewClusterManager`'s nil-config literal restated sixteen fields that `applyConfigDefaults` sets to the same values two lines later — including a second `MaxGossipPacket: 1024`. It is now one field, `CacheReplication`, the only one it was ever load-bearing for, because it is a bool defaulting to true and a bool's zero value cannot be distinguished from unset. A duplicated default is how a stale copy survives a fix to the default.

## Why the tagged suite is the load-bearing verification

The `-tags=distributed` suite no longer overrides `MaxGossipPacket` anywhere — including the `65507` workaround `TestMultiNodeCluster` carried. A test that sets the value cannot notice the default regressing, so removing the override is what makes the suite cover this. It passes unaided: `go test -count=1 -race -tags=distributed ./tests/` → **ok in 18.186s, 0 races**.

Likewise the unit test asserts that a three-member sync fits in **one** datagram — the property the issue is about — rather than asserting the constant equals 8192, which would only prove a constant equals itself. It uses realistic hostnames, because a hostname's length is part of what decides whether this fits.

## Mutation verification

| mutation | caught by |
|---|---|
| `defaultMaxGossipPacket` back to 1024 | `TestNewClusterManager_DefaultMaxGossipPacketHoldsAThreeNodeSync` — *"a three-member sync took 2 datagrams at the 1024-byte default, want 1"* |
| truncation check → `if false` | `TestReceiveMessages_CountsATruncatedDatagramAsTruncated` — `MessagesTruncated = 0, want 1` **and** `MessagesUnauthenticated = 1, want 0`, reproducing #277's exact misdiagnosis |
| oversize refusal → `if false` | `TestSendMessage_RefusesAnOversizeDatagram` |
| chunking disabled | `TestSendSyncMessage_ChunksAMemberlistThatDoesNotFit` — *"a 21-member sync produced 1 chunk(s) at a 2048-byte limit, want several"* |

The chunking test asserts every chunk seals under the limit, each unmarshals as a complete `SyncMessage`, and the union carries exactly the whole memberlist with nothing lost or duplicated — deliberately without pinning the chunk count. The truncation test writes *valid* oversize JSON so it distinguishes the two causes rather than passing for the wrong reason.

One omission caught during review and worth noting: the two new counters were initially added to `GossipStats` but not to the field-by-field copy in `GetStats`, so the new tests would have silently read zeros. That is the exact trap a hand-maintained struct copy invites.

## Gates

`go build ./...` · `go vet ./...` · `gofmt -l .` — clean
`go test -count=1 -race -covermode=atomic ./...` — exit 0
`./scripts/coverage-gate.sh` — 35 packages at or above floor
`golangci-lint --new-from-merge-base=origin/main` — 0 issues
`gosec ./internal/distributed/` — 2 findings, both the pre-existing `G404`s at `consensus.go:930,933`
`go test -count=1 -race -tags=distributed ./tests/` — ok 18.186s, 0 races
`go test ./internal/config/` (doc/changelog gates) — ok