### PR TITLE
fix: min_sequential is the threshold, not one of two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`min_sequential` now means what it says: read-ahead had two thresholds over the same counter, and
+  only one was configurable** ([#247]). The prefetch gate required `sequentialHits >= MinSequential`
+  *and* `confidence > 0.5`, where confidence was assigned `sequentialHits / 10.0` a few lines above — so
+  the second condition was `sequentialHits > 5`, the same quantity in different units, and the stricter
+  always won. The effective gate was `max(MinSequential, 6)`: setting 1, 2, 3, 4 or 5 all prefetched
+  first on the sixth sequential read, and the shipped default is 3, so the documented default did not
+  describe the default behavior. Above 6 the floor was redundant, meaning the setting worked as
+  documented in exactly the upper part of its range.
+
+  The confidence floor is gone rather than the defaults being raised to 6, and the measurement is why. A
+  continuing traversal costs the same either way: 3 MiB read sequentially at the kernel's 128 KiB buffer
+  transfers exactly 3,145,728 bytes at every `MinSequential` from 1 to 10, because `FileSystem.fetch`
+  shares one flight between a prefetch and the read it anticipates, so a prefetch that is going to be
+  read adds no bytes at all. What prefetching sooner actually costs is a run that *stops* before
+  consuming what was fetched — and that cost is exactly one prefetch, not a growing tail: a reader that
+  goes sequential and then walks away wastes 131,072 bytes whether it stops after three reads at
+  `min_sequential: 3` or after six at `min_sequential: 6`. The floor never prevented a class of waste,
+  it only moved the point at which the single unredeemed prefetch became possible. So the default
+  configuration now prefetches from the third sequential read instead of the sixth, for one prefetch's
+  worth of exposure on abandoned runs.
+
+  The `confidence` field is deleted rather than left computed-and-unread: it was read at exactly one
+  place, the gate, and a score derived from the threshold it guards is not independent evidence and
+  cannot become any. The paragraph in `examples/config.yaml` explaining why the number did not mean what
+  it said is deleted too, which is the test of whether this was actually fixed rather than documented.
+
+  The gate test now drives both sides of the threshold — nothing on the read before it, a prefetch on
+  the read at it. It previously read six times at `min_sequential: 3` and asserted a prefetch, with a
+  comment explaining that six was required; so it documented the defect instead of catching it, and
+  would have passed identically if `MinSequential` were ignored altogether. A gate test that only drives
+  the satisfying case cannot tell a threshold of 3 from a threshold of 6.
+
 - **A three-node cluster could not form at the default gossip packet size, and said the cluster secret
   was wrong** ([#277]). `MaxGossipPacket` defaulted to 1024 bytes. A sealed sync message costs about 200
   bytes of envelope plus about 415 bytes per member — measured, not estimated, because `seal` wraps the

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -130,14 +130,9 @@ performance:
     # every subsequent read walks past — paid for twice, in egress and in cache capacity.
     window_size: 64KB
 
-    # Consecutive sequential reads required before prefetching starts.
-    #
-    # The effective floor is 6, not this number, and the default is below it: the prefetch also
-    # requires a confidence above 0.5, confidence is sequentialHits/10, so nothing is prefetched
-    # before the sixth consecutive sequential read whatever this says. 3 is kept as the default
-    # because it is what every mount has run since the prefetcher was written — raising it to 6
-    # would document the behavior more honestly but is a change to the shipped value, and the two
-    # thresholds want reconciling in the code rather than papering over here (#247).
+    # Consecutive sequential reads required before prefetching starts. At 3, the third sequential
+    # read triggers the first prefetch. A non-sequential read ends the run and the next one starts
+    # over from zero, so a reader that seeks constantly is never prefetched for.
     min_sequential: 3
 
     # Prefetch workers, each performing one GET at a time. Must be > 0 when enabled — zero starts no

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,17 +284,15 @@ type ReadAheadConfig struct {
 	// 4,325,644 bytes with zero prefetch hits.
 	WindowSize string `yaml:"window_size"`
 
-	// MinSequential is how many consecutive sequential reads must be seen before prefetching starts.
+	// MinSequential is how many consecutive sequential reads must be seen before prefetching starts,
+	// and it is the only threshold: at the default of 3, the third sequential read triggers the first
+	// prefetch.
 	//
-	// The detector requires both this and a confidence above 0.5, and confidence is
-	// sequentialHits/10 — so a value below 6 is governed by the confidence floor rather than by this
-	// number. Set it above 6 to require a longer run than the confidence rule does.
-	//
-	// That the default is 3, and therefore in the inert range, is #247: two thresholds over the same
-	// counter, of which only one is configurable. The default is left where it is because it is what
-	// every mount has run since the prefetcher was written, and reconciling them changes prefetch
-	// behavior at the default configuration — a decision that wants measurement, not a default nudged
-	// in passing while a plumbing gap is closed.
+	// It did not used to be. The detector also required a confidence above 0.5, where confidence was
+	// sequentialHits/10 — the same counter in different units — so the effective gate was
+	// max(MinSequential, 6) and every value from 1 to 5 behaved identically, including the default.
+	// The confidence floor is gone (#247), which makes the default 3 mean what it says and prefetch
+	// from the third read rather than the sixth.
 	MinSequential int `yaml:"min_sequential"`
 
 	// ConcurrentReads is the number of prefetch workers, each of which performs one GET at a time.

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -323,7 +323,7 @@ High Throughput (large sequential reads):
 	  connection_pool_size: 16
 	  read_ahead:
 	    window_size: "1MB"      # read far ahead of a sequential reader
-	    min_sequential: 6       # 6 is the effective floor whatever is set; see ReadAheadConfig
+	    min_sequential: 2       # commit to a prefetch early: these readers do not stop
 	    concurrent_reads: 8
 
 High Latency / Satellite (a round trip is the dominant cost):

--- a/internal/fuse/optimizations.go
+++ b/internal/fuse/optimizations.go
@@ -30,9 +30,8 @@ type ReadAheadManager struct {
 // plumbed. config.ReadAheadConfig owns the YAML names now; this type is the internal shape it maps to.
 //
 // MaxDistance was removed with them. It was a field, a default of 1 MiB, and a yaml tag, and no code
-// in this package ever read it: the detector's decision to prefetch is MinSequential plus a confidence
-// floor, and how far ahead it reads is prefetchLength. A cap on read-ahead distance is a plausible
-// knob, but it was never one.
+// in this package ever read it: the detector's decision to prefetch is MinSequential, and how far ahead
+// it reads is prefetchLength. A cap on read-ahead distance is a plausible knob, but it was never one.
 type ReadAheadConfig struct {
 	Enabled         bool
 	WindowSize      int64         // floor on the prefetch length; see prefetchLength
@@ -41,7 +40,13 @@ type ReadAheadConfig struct {
 	TTL             time.Duration // how long an idle read pattern is remembered
 }
 
-// ReadPattern tracks access patterns for intelligent prefetching
+// ReadPattern tracks access patterns for intelligent prefetching.
+//
+// There was a confidence float64 here, assigned sequentialHits/10 and clamped to 1.0. It was read at
+// exactly one place — the prefetch gate, as `confidence > 0.5` alongside the MinSequential check — so
+// the two conditions were the same counter in different units and the stricter always won. Removed
+// with the gate rather than left as an unread field, because a score derived from the threshold it
+// guards is not independent evidence and cannot become any (#247).
 type ReadPattern struct {
 	path           string
 	lastOffset     int64
@@ -49,7 +54,6 @@ type ReadPattern struct {
 	sequentialHits int
 	lastAccess     time.Time
 	predictedNext  int64
-	confidence     float64
 }
 
 // PrefetchRequest represents a prefetch operation
@@ -124,18 +128,11 @@ func (ram *ReadAheadManager) OnRead(path string, offset, size int64) {
 		ram.activeReads[path] = pattern
 	}
 
-	// Update pattern
 	if offset == pattern.lastOffset+pattern.lastSize {
-		// Sequential read detected
 		pattern.sequentialHits++
-		pattern.confidence = float64(pattern.sequentialHits) / 10.0
-		if pattern.confidence > 1.0 {
-			pattern.confidence = 1.0
-		}
 	} else {
-		// Non-sequential read, reset
+		// Non-sequential read: the run is over, and a new one has to earn MinSequential again.
 		pattern.sequentialHits = 0
-		pattern.confidence = 0.1
 	}
 
 	pattern.lastOffset = offset
@@ -143,8 +140,27 @@ func (ram *ReadAheadManager) OnRead(path string, offset, size int64) {
 	pattern.lastAccess = time.Now()
 	pattern.predictedNext = offset + size
 
-	// Trigger prefetch if pattern is strong enough
-	if pattern.sequentialHits >= ram.config.MinSequential && pattern.confidence > 0.5 {
+	// MinSequential alone, which is what it says it is.
+	//
+	// This was `sequentialHits >= MinSequential && confidence > 0.5`, and confidence was
+	// sequentialHits/10 — so the second condition was `sequentialHits > 5`, the same quantity in
+	// different units, and the stricter of the two always won. The effective gate was
+	// max(MinSequential, 6): setting 1, 2, 3, 4 or 5 all prefetched first on the sixth sequential read,
+	// so the shipped default of 3 did not describe the shipped behavior, and the setting worked as
+	// documented only above 6 (#247).
+	//
+	// Dropping the floor rather than raising the defaults to 6, and the measurement is why. A
+	// continuing traversal costs the same either way — 3 MiB read sequentially at the kernel's 128 KiB
+	// buffer transfers exactly 3,145,728 bytes at every MinSequential from 1 to 10, because
+	// FileSystem.fetch shares one flight between a prefetch and the read it anticipates, so a prefetch
+	// that is going to be read adds no bytes. The cost of prefetching sooner is a run that *stops*
+	// before consuming what was fetched, and that cost is exactly one prefetch: a reader that goes
+	// sequential and then walks away wastes 131,072 bytes whether it stops after 3 reads at
+	// MinSequential=3 or after 6 at MinSequential=6. The floor did not prevent a class of waste, it
+	// only moved when the single unredeemed prefetch became possible. Trading one prefetch's bytes for
+	// prefetching from the third read instead of the sixth is worth it, and now the number a user sets
+	// is the number the detector uses.
+	if pattern.sequentialHits >= ram.config.MinSequential {
 		ram.schedulePrefetch(path, pattern.predictedNext, ram.prefetchLength(size))
 	}
 }

--- a/internal/fuse/optimizations_test.go
+++ b/internal/fuse/optimizations_test.go
@@ -119,9 +119,6 @@ func TestReadAheadManager_NonSequential_ResetsPattern(t *testing.T) {
 	if p.sequentialHits != 0 {
 		t.Errorf("expected sequentialHits=0 after non-sequential read, got %d", p.sequentialHits)
 	}
-	if p.confidence != 0.1 {
-		t.Errorf("expected confidence=0.1 after reset, got %f", p.confidence)
-	}
 }
 
 func TestReadAheadManager_Disabled_NoPatterns(t *testing.T) {
@@ -147,34 +144,61 @@ func TestReadAheadManager_Disabled_NoPatterns(t *testing.T) {
 	}
 }
 
+// TestReadAheadManager_PrefetchScheduled_AfterEnoughHits pins the prefetch gate at MinSequential
+// exactly, in both directions: nothing on the read before it, a prefetch on the read at it.
+//
+// The "nothing before" half is the point. This test used to read six times at MinSequential=3 and
+// assert a prefetch, with a comment explaining that six was needed because of a confidence floor — so
+// it documented #247 rather than catching it, and it would have passed just as well if MinSequential
+// were ignored altogether. A gate test that only drives the satisfying case cannot tell a threshold
+// of 3 from a threshold of 6.
 func TestReadAheadManager_PrefetchScheduled_AfterEnoughHits(t *testing.T) {
 	t.Parallel()
 
-	// Prefetch requires sequentialHits >= MinSequential AND confidence > 0.5.
-	// confidence = sequentialHits / 10.0 → need sequentialHits >= 6 for both
-	// conditions to be met when MinSequential=3.
-	ram := newTestRAM(3, 5*time.Minute)
+	const (
+		blk    = int64(1024)
+		path   = "prefetch.bin"
+		minSeq = 3
+
+		// The threshold lands on read minSeq, not minSeq+1, because the first read of a file counts as
+		// sequential: a fresh ReadPattern has lastOffset and lastSize both zero, so `offset ==
+		// lastOffset+lastSize` holds for a read at offset 0. That makes "min_sequential: 3" mean the
+		// third read of a file, which is what the configuration documentation says. After a
+		// non-sequential read resets the counter to zero it takes three more sequential reads, which is
+		// the same rule counted from a different start.
+		hitRead = minSeq
+	)
+
+	ram := newTestRAM(minSeq, 5*time.Minute)
 	defer ram.Stop()
 
-	const blk = int64(1024)
-	const path = "prefetch.bin"
-	// 6 sequential reads puts sequentialHits=6, confidence=0.6.
-	for i := range 6 {
+	// Reads up to but not including the one that reaches the threshold.
+	for i := range hitRead - 1 {
 		ram.OnRead(path, int64(i)*blk, blk)
 	}
 
-	// The prefetchQueue channel is buffered (cap 100); at least one request
-	// must have been enqueued.
+	if n := len(ram.prefetchQueue); n != 0 {
+		t.Fatalf("%d prefetch(es) scheduled after %d sequential reads at min_sequential=%d, want 0. "+
+			"The gate must not fire before the threshold, or the setting does not bound anything.",
+			n, hitRead-1, minSeq)
+	}
+
+	// The read that reaches it.
+	ram.OnRead(path, int64(hitRead-1)*blk, blk)
+
 	select {
 	case req := <-ram.prefetchQueue:
 		if req.path != path {
 			t.Errorf("expected prefetch for %q, got %q", path, req.path)
 		}
-		if req.offset != 6*blk {
-			t.Errorf("expected prefetch offset=%d, got %d", 6*blk, req.offset)
+		if want := int64(hitRead) * blk; req.offset != want {
+			t.Errorf("prefetch offset=%d, want %d (one read past the last one performed)",
+				req.offset, want)
 		}
 	default:
-		t.Error("expected at least one prefetch request after 6 sequential reads")
+		t.Errorf("no prefetch scheduled on read %d at min_sequential=%d, want one. Before #247 the "+
+			"first prefetch came on the sixth read whatever this was set to, because a confidence "+
+			"floor over the same counter always won.", hitRead, minSeq)
 	}
 }
 

--- a/internal/fuse/read_path_test.go
+++ b/internal/fuse/read_path_test.go
@@ -424,10 +424,11 @@ func TestPrefetchStopsAtEndOfFile(t *testing.T) {
 	t.Parallel()
 
 	// The file has to be long enough for the detector to reach its prefetch threshold and still have
-	// reads left to run off the end. A prefetch needs sequentialHits >= MinSequential (3) *and*
-	// confidence > 0.5, and confidence is sequentialHits/10 — so seven consecutive reads before the
-	// tail prefetch can even be scheduled. A 4 KiB file read in 1 KiB steps never gets there, which is
-	// how the first version of this test came to pass against the unfixed code.
+	// reads left to run off the end: a prefetch needs sequentialHits >= MinSequential, which is 3, so
+	// four consecutive reads. A 4 KiB file read in 1 KiB steps never gets there, which is how the first
+	// version of this test came to pass against the unfixed code. 16 steps leaves ample margin — and it
+	// needed to, because the threshold used to be an effective 6 whatever MinSequential said (#247), so
+	// a file sized against the documented 3 would have gone back to passing vacuously.
 	const (
 		step = 1024
 		size = 16 * step


### PR DESCRIPTION
Closes #247.

The prefetch gate required `sequentialHits >= MinSequential` **and** `confidence > 0.5`, where confidence was assigned `sequentialHits / 10.0` a few lines above. So the second condition was `sequentialHits > 5` — the same quantity in different units — and the stricter always won. The effective gate was `max(MinSequential, 6)`.

Measured directly, driving `OnRead` with a stub queue:

| `min_sequential` | first prefetch on read # |
|---|---|
| 1 | 6 |
| 2 | 6 |
| 3 | 6 |
| 4 | 6 |
| 5 | 6 |
| 6 | 6 |
| 7 | 7 |

The shipped default is 3, so the documented default did not describe the default behavior, and the setting worked as documented in exactly the upper part of its range.

## Why drop the floor rather than raise the defaults to 6

The issue left this open as a behavior decision wanting measurement. Here is the measurement, taken against a real S3 endpoint with the request recorder, asserting bytes transferred.

**A continuing traversal costs the same either way.** 3 MiB read sequentially at the kernel's 128 KiB buffer:

| `min_sequential` | GETs | bytes | ratio |
|---|---|---|---|
| 1, 2, 3, 4, 5, 6, 7, 10 | 24 | 3,145,728 | 1.0000x |

Identical at every value, because `FileSystem.fetch` shares one flight between a prefetch and the read it anticipates — a prefetch that is going to be read adds no bytes at all. So the "prefetches sooner and more often" concern does not cost anything on a reader that keeps going.

**What prefetching sooner costs is a run that stops.** A reader that goes sequential for N reads and then walks away, with the floor removed:

| run length | `min_sequential: 3` | `min_sequential: 6` |
|---|---|---|
| 3 reads | 1.3333x (waste 131,072) | 1.0000x |
| 4 reads | 1.2500x (waste 131,072) | 1.0000x |
| 5 reads | 1.2000x (waste 131,072) | 1.0000x |
| 6 reads | 1.1667x (waste 131,072) | 1.1667x (waste 131,072) |

The waste is **exactly one prefetch**, not a growing tail, and `min_sequential: 6` shows the same single waste once a run reaches 6. The floor never prevented a class of waste — it only moved the point at which the single unredeemed prefetch became possible, from read 6 to read 3. Trading that for prefetching from the third read instead of the sixth is worth it, and the number a user sets is now the number the detector uses.

## Scope

The `confidence` field is **deleted** rather than left computed-and-unread. It was read at exactly one place, the gate, and a score derived from the threshold it guards is not independent evidence and cannot become any.

The paragraph in `examples/config.yaml` explaining why the number did not mean what it said is deleted too — the issue's own stated test of whether this was fixed rather than documented: *"that comment should be deletable."*

`internal/config/doc.go`'s high-throughput profile no longer recommends `min_sequential: 6` with the comment "6 is the effective floor whatever is set." It recommends 2, because committing to a prefetch early is the actual advice for a reader that does not stop.

## The test

The gate test now drives **both** sides of the threshold — nothing on the read before it, a prefetch on the read at it. It previously read six times at `min_sequential: 3` and asserted a prefetch, with a comment explaining that six was required; so it documented the defect instead of catching it, and would have passed identically if `MinSequential` were ignored altogether. A gate test that only drives the satisfying case cannot tell a threshold of 3 from a threshold of 6.

Mutation-verified in both directions:

| mutation | result |
|---|---|
| restore the confidence floor | *"no prefetch scheduled on read 3 at min_sequential=3, want one"* |
| replace the gate with `>= 1` | *"2 prefetch(es) scheduled after 2 sequential reads at min_sequential=3, want 0"* |

One detail worth recording: the threshold lands on read N rather than N+1, because the first read of a file counts as sequential — a fresh `ReadPattern` has `lastOffset` and `lastSize` both zero, so `offset == lastOffset+lastSize` holds at offset 0. That makes `min_sequential: 3` mean the third read of a file, which is what the configuration documentation says. I had the arithmetic off by one on the first attempt and the test caught it.

Two stale comments elsewhere were corrected rather than left: `ReadAheadConfig`'s note on the removed `MaxDistance` field, and `TestPrefetchStopsAtEndOfFile`'s explanation of why its file is 16 steps long — which had relied on the seven-read figure, and which the new threshold makes generous rather than marginal.

## Gates

`go build ./...` · `go vet ./...` · `gofmt -l .` — clean
`go test -count=1 -race -covermode=atomic ./...` — exit 0
`./scripts/coverage-gate.sh` — 35 packages at or above floor
`golangci-lint --new-from-merge-base=origin/main` — 0 issues
`gosec ./internal/fuse/ ./internal/config/` — no findings
`go test ./internal/config/` (doc/changelog gates) — ok