### PR TITLE
docs: record the CAS decision where the code claims otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closed — an unconditional fallback would turn "exactly one node performs this tier transition" into
   "every node does," which is the failure the coordination exists to prevent, occurring silently.
 
+  **The recommendation has been adopted.** The Raft build-out is closed as not-the-direction — [#128]
+  (`ConsensusLog`), [#130] (`PersistentState`, the only one labeled `priority: critical`), [#133]
+  (real proposal broadcast) and [#151] (log compaction) — and the work is filed as [#282]
+  (`Backend.PutObjectIf`, the sentinel errors, and a capability probe that detects by attempt rather
+  than by configuration), [#283] (a lease whose every guarded action re-asserts the CAS), [#284]
+  (replacing `executeStrongConsistency`'s N-identical-PUT fan-out and fixing the consistency
+  taxonomy) and [#285] (verifying MinIO and Wasabi against real endpoints). Gossip stats ([#132]) and
+  gossip authentication ([#206]) are unaffected; rendezvous hashing ([#131]) had already landed.
+
+  Closing the issues stopped the build-out but did not remove the ~6,000 lines that already elect
+  leaders and replicate nothing — [#284] is where the first of that comes out, and it is a breaking
+  change to the distributed configuration surface, because the three consistency levels it removes
+  turn out to be three names for two behaviours: `ConsistencySession` and `ConsistencyEventual` are
+  now nearly the same function, both executing on `targetNodes[0]` and then replicating
+  asynchronously, and `ConsistencyStrong` is the mislabeled fan-out.
+
 ### Security
 
 - **Gossip messages are authenticated, and a cluster will not start without a shared secret**
@@ -388,10 +404,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   simultaneous leaders that the single-node fix alone produced. `TestMultiNodeCluster` now passes under
   `-race`; the whole `-tags=distributed` suite is green for the first time.
 
+[#128]: https://github.com/scttfrdmn/objectfs/issues/128
+[#130]: https://github.com/scttfrdmn/objectfs/issues/130
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
+[#133]: https://github.com/scttfrdmn/objectfs/issues/133
+[#151]: https://github.com/scttfrdmn/objectfs/issues/151
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#240]: https://github.com/scttfrdmn/objectfs/issues/240
+[#282]: https://github.com/scttfrdmn/objectfs/issues/282
+[#283]: https://github.com/scttfrdmn/objectfs/issues/283
+[#284]: https://github.com/scttfrdmn/objectfs/issues/284
+[#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#267]: https://github.com/scttfrdmn/objectfs/issues/267
 [#269]: https://github.com/scttfrdmn/objectfs/issues/269
 [#272]: https://github.com/scttfrdmn/objectfs/issues/272

--- a/docs/design/conditional-writes-vs-raft.md
+++ b/docs/design/conditional-writes-vs-raft.md
@@ -1,6 +1,9 @@
 # S3 Conditional Writes as a Coordination Primitive
 
-**Status:** evaluation complete, recommendation below is not yet implemented
+**Status:** **adopted 2026-08-03.** The recommendation below is the project's direction. The Raft
+build-out is closed ([#128], [#130], [#133], [#151]) and the CAS work is filed ([#282], [#283],
+[#284], [#285]) — see [§5, Consequences](#5-consequences), which records two corrections found while
+acting on it.
 **Issue:** [#169](https://github.com/scttfrdmn/objectfs/issues/169)
 
 ## Recommendation, first
@@ -272,7 +275,30 @@ one a feature-flag approach would never notice.
 
 ## 5. Consequences
 
-### If adopted
+### Adopted — what actually happened
+
+This section was written as "if adopted." It was adopted on 2026-08-03, and acting on it surfaced two
+corrections to what is below. Both are recorded here rather than silently edited into the lists,
+because a plan that turns out to have been slightly wrong is more useful with the correction visible
+than with the seam smoothed over.
+
+1. **The closure list of four below is incomplete — it should have named
+   [#150](https://github.com/scttfrdmn/objectfs/issues/150)** (`BboltPersistentState` /
+   `BboltConsensusLog`). That issue's own premise is *"the `ConsensusLog` and `PersistentState`
+   interfaces were defined in A1-1 and A1-3"* — i.e. #128 and #130, both closed here — so nothing
+   remains for it to implement. It would also have added `go.etcd.io/bbolt` and a
+   `/var/lib/objectfs` data path for durable Raft storage, neither of which CAS needs, since
+   coordination state lives in S3 objects guarded by `If-Match`. It is **still open**, flagged rather
+   than closed, because it was outside the approved set.
+2. **The `doc.go` correction below was already done** before adoption. Grep for `Linearizable`
+   returns nothing.
+
+One finding worth carrying into item 3 of the "Opened" list: **`ConsistencySession` and
+`ConsistencyEventual` are now nearly the same function.** Both execute on `targetNodes[0]` and then
+`replicateAsync` the remainder; session's only distinguishing feature is a comment promising it will
+"try to use the same node for related operations," and no session state exists to make that true. So
+the taxonomy is not merely three levels differing in PUT count — it is three names for two
+behaviours, one of which is mislabeled.
 
 **Closed as not-the-direction** (the Raft build-out, ~4 issues):
 
@@ -296,36 +322,55 @@ one a feature-flag approach would never notice.
 - [#206](https://github.com/scttfrdmn/objectfs/issues/206) — gossip message authentication. A real
   security defect either way.
 
-**Opened:**
+Also note [#131](https://github.com/scttfrdmn/objectfs/issues/131) has since landed, so
+`selectConsistentHash` is a real rendezvous/HRW ring and no longer `nodes[:count]`.
 
-1. `Backend.PutObjectIf` plus the two sentinel errors and the S3 implementation, with the
-   capability probe. The unit of work §3 sketches.
-2. A lease type built on it — acquire, renew, release, and the rule that **every guarded action
-   re-asserts the CAS** rather than trusting a prior check. The ceiling's item 2 is the whole reason
-   this is its own issue and not a footnote on the first.
-3. Replace `executeStrongConsistency`'s N-redundant-PUT fan-out with a single conditional write, and
-   delete the `ConsistencyStrong` / `ConsistencySession` / `ConsistencyEventual` taxonomy or redefine
-   it against what the code does. It currently offers three levels that differ in how many identical
-   PUTs are issued.
-4. Verify conditional-write semantics against a real MinIO and a real Wasabi endpoint, since §4 rests
-   on a source read for one and nothing for the other.
+**Opened** — filed as [#282], [#283], [#284], [#285] respectively:
 
-### Correcting `doc.go` regardless
+1. [#282] — `Backend.PutObjectIf` plus the two sentinel errors and the S3 implementation, with the
+   capability probe. The unit of work §3 sketches. Blocks the other three.
+2. [#283] — A lease type built on it — acquire, renew, release, and the rule that **every guarded
+   action re-asserts the CAS** rather than trusting a prior check. The ceiling's item 2 is the whole
+   reason this is its own issue and not a footnote on the first.
+3. [#284] — Replace `executeStrongConsistency`'s N-redundant-PUT fan-out with a single conditional
+   write, and delete the `ConsistencyStrong` / `ConsistencySession` / `ConsistencyEventual` taxonomy
+   or redefine it against what the code does. It currently offers three levels that differ in how
+   many identical PUTs are issued. Coordinates with
+   [#129](https://github.com/scttfrdmn/objectfs/issues/129), which proposes promoting that taxonomy
+   into `pkg/types`, and [#144](https://github.com/scttfrdmn/objectfs/issues/144), which is defined
+   entirely in terms of it.
+4. [#285] — Verify conditional-write semantics against a real MinIO and a real Wasabi endpoint, since
+   §4 rests on a source read for one and nothing for the other.
 
-`internal/distributed/doc.go:64` claims "Linearizable operations across cluster" under Strong
-Consistency. That is inaccurate on today's code whichever direction is chosen — N identical PUTs to
-one key, accepted on a majority, is a reachability signal. This is fixed as part of adopting the
-recommendation, but it is not contingent on it.
+[#128]: https://github.com/scttfrdmn/objectfs/issues/128
+[#130]: https://github.com/scttfrdmn/objectfs/issues/130
+[#133]: https://github.com/scttfrdmn/objectfs/issues/133
+[#151]: https://github.com/scttfrdmn/objectfs/issues/151
+[#282]: https://github.com/scttfrdmn/objectfs/issues/282
+[#283]: https://github.com/scttfrdmn/objectfs/issues/283
+[#284]: https://github.com/scttfrdmn/objectfs/issues/284
+[#285]: https://github.com/scttfrdmn/objectfs/issues/285
 
-### If not adopted
+### `doc.go` — done before adoption
+
+`internal/distributed/doc.go:64` claimed "Linearizable operations across cluster" under Strong
+Consistency. That was inaccurate on today's code whichever direction was chosen — N identical PUTs to
+one key, accepted on a majority, is a reachability signal — so it was fixed without waiting for the
+decision. Grep for `Linearizable` returns nothing.
+
+### The road not taken
+
+Kept as written, because the case against a decision is worth preserving next to the decision — and
+because if CAS hits the ceiling in §2, this is where the alternative is already costed. This describes
+what *would* have followed from declining; it did not happen.
 
 The Raft direction is coherent and the issues are well-specified; nothing here says it *cannot* be
-built. The cost is roughly: a persistent log with fsync-before-ack ([#130](https://github.com/scttfrdmn/objectfs/issues/130)),
-a real state machine with apply semantics, real proposal broadcast, and the test infrastructure to
-show that a partitioned or restarted node cannot elect a second leader in one term — against a
-problem whose state already lives in a service with 11 nines of durability that every node can reach.
+built. The cost is roughly: a persistent log with fsync-before-ack ([#130]), a real state machine with
+apply semantics, real proposal broadcast, and the test infrastructure to show that a partitioned or
+restarted node cannot elect a second leader in one term — against a problem whose state already lives
+in a service with 11 nines of durability that every node can reach.
 
-The reason to decide now rather than later is that the decision gets more expensive with every issue
-in the [#128](https://github.com/scttfrdmn/objectfs/issues/128)–[#133](https://github.com/scttfrdmn/objectfs/issues/133)
-series that lands. Today the sunk cost is ~6,000 lines that, per §1, elects leaders and replicates
-nothing.
+The reason to decide now rather than later was that the decision gets more expensive with every issue
+in the [#128]–[#133] series that lands. At the time of the decision the sunk cost was ~6,000 lines
+that, per §1, elects leaders and replicates nothing. That code is still there: closing the issues
+stopped the build-out, it did not remove what exists. [#284] is where the first of it comes out.

--- a/internal/distributed/consensus.go
+++ b/internal/distributed/consensus.go
@@ -12,7 +12,17 @@ import (
 	"time"
 )
 
-// ConsensusEngine implements a Raft-like consensus algorithm for leader election
+// ConsensusEngine elects a leader using Raft's election mechanics — terms, votes, and a randomized
+// election timeout — over gossip. It is not a consensus engine in the sense the name implies: the log
+// below holds one bootstrap noop plus one entry per election win, applyLogEntry has three empty arms,
+// and nothing appends an operation entry. Leader election works and is tested (#279); replication
+// does not exist.
+//
+// It is not going to. #169 concluded that Raft has nothing to replicate here — nodes hold no
+// authoritative state, the bucket does — and the CAS direction was adopted on 2026-08-03, closing
+// #128 (the log interface), #130 (persistent state), #133 (proposal broadcast) and #151 (compaction).
+// The log, commitIndex, lastApplied, nextIndex and matchIndex fields serve the election only; #284 is
+// where the unused machinery comes out.
 type ConsensusEngine struct {
 	mu          sync.RWMutex
 	cluster     *ClusterManager

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -12,9 +12,18 @@ the coordination mechanisms needed for multi-node deployments.
 Read [#Consistency Levels] before relying on anything here. The short version is that the consensus
 engine elects leaders and replicates nothing — applyLogEntry has three empty arms and no caller
 appends an operation entry — and that the coordinator's data path calls the backend directly without
-consulting the log, the commit index, the term, or leadership. Whether that gets built out as Raft or
-replaced by per-key conditional writes is the open question in
-docs/design/conditional-writes-vs-raft.md (#169).
+consulting the log, the commit index, the term, or leadership.
+
+That is not going to be built out. As of 2026-08-03 the direction is per-key S3 compare-and-swap:
+docs/design/conditional-writes-vs-raft.md (#169) was adopted, on the grounds that Raft replicates a
+log so N nodes can agree on state they each hold a copy of, and these nodes hold no such state — the
+bucket does. The Raft issues are closed (#128, #130, #133, #151) and the replacement is filed as #282
+(Backend.PutObjectIf), #283 (a lease over it), #284 (removing the fan-out and this taxonomy) and #285
+(verifying non-AWS backends).
+
+So what is below describes code that exists and will shrink, not a design being completed. The
+consistency levels in particular are on their way out via #284; gossip-based membership and leader
+election stay.
 
 Architecture
 
@@ -308,11 +317,18 @@ the first value ever received, so anything reading them was reading a snapshot o
 
 Leader Election:
 
-	// Automatic leader election using Raft-inspired consensus
-	// Leader handles:
+	// Automatic leader election over gossip, with terms and votes.
+	// A leader is elected and is used for:
 	// - Cluster-wide operations
-	// - Configuration changes
-	// - Quorum decisions
+	//
+	// Configuration changes and quorum decisions were listed here and are not implemented:
+	// broadcastProposal never sent a proposal (it slept and accepted its own), and #133 was
+	// closed rather than fixed because proposals are a consensus concept and consensus is not
+	// the direction (#169).
+	//
+	// Leadership is a hint, not a guard. A leader that loses its network still believes it
+	// leads, so an action that matters must re-assert its own precondition at the backend
+	// rather than trusting IsLeader() — that is what #283's lease is for.
 
 A cluster of one elects itself, within one election timeout of [ClusterManager.Start] and without any
 message being sent. That is worth stating because until v0.11.0 it did not: the majority comparison
@@ -430,10 +446,12 @@ and optimization planned for post-v0.2.0.
 
 Planned for future releases:
 - SWIM-based gossip protocol
-- Multi-Raft for better scalability
 - Cross-datacenter replication
 - Dynamic sharding
-- Consistent snapshots
+
+"Multi-Raft for better scalability" and "consistent snapshots" were listed here and have been
+removed rather than reworded: both presuppose the replicated log that #169 concluded there is nothing
+to put in. Coordination is per-key compare-and-swap against the bucket (#282, #283).
 
 Example: Complete Cluster Setup
 


### PR DESCRIPTION
Follow-through on the direction decision for [#169](https://github.com/scttfrdmn/objectfs/issues/169): per-key S3 compare-and-swap replaces the Raft build-out.

Issue changes already made outside this PR: **closed** #128, #130, #133, #151 (`resolution: wontfix`, each with its specific reason); **opened** #282 (`Backend.PutObjectIf` + sentinels + capability probe), #283 (a lease whose every guarded action re-asserts the CAS), #284 (remove the fan-out, fix the taxonomy), #285 (verify MinIO/Wasabi against real endpoints); **commented** #129 and #144, both of which consume the taxonomy #284 removes, so they are not implemented as written.

## What this PR changes

`internal/distributed/doc.go` and `consensus.go` both documented the Raft direction as live. Specifically:

| was | now |
|---|---|
| `doc.go`: "Whether that gets built out as Raft or replaced by per-key conditional writes is the open question" | the question is answered; states the direction, the closed issues and the replacements |
| `doc.go`: leader handles "configuration changes" and "quorum decisions" | neither is implemented — `broadcastProposal` slept and accepted its own proposal — and leadership is documented as a hint, not a guard |
| `doc.go`: future enhancements include "Multi-Raft for better scalability", "consistent snapshots" | removed, with a line saying why: both presuppose the log there is nothing to put in |
| `consensus.go`: "implements a Raft-like consensus algorithm" | elects leaders using Raft's *election* mechanics and replicates nothing, with the evidence |

Removed rather than reworded wherever the claim presupposed the replicated log. A "planned for future releases" list is the easiest place for a dropped direction to survive, because nothing compiles against it.

## Two corrections to the design doc

Both found by acting on it, and recorded in the doc rather than smoothed over:

1. **§5's closure list of four omitted #150** (`BboltPersistentState`/`BboltConsensusLog`), whose own Background says it implements the #128 and #130 interfaces. It is **left open and commented**, not closed — it was outside the four-issue set that was approved, so closing it would be extending scope on my own inference. Recommendation on the issue is to close it alongside the others.
2. **The `doc.go` linearizability correction had already landed** before adoption; §5 still listed it as owed.

The "If not adopted" section is kept, retitled "The road not taken," because the case against a decision is worth preserving beside it — and if CAS hits the §2 ceiling, the alternative is already costed there.

## Worth knowing for #284

The taxonomy is not three levels differing in PUT count. It is **three names for two behaviours**: `ConsistencySession` and `ConsistencyEventual` are now nearly the same function — both execute on `targetNodes[0]` then `replicateAsync` the remainder — and session has no session state anywhere to make its "same node for related operations" comment true. `ConsistencyStrong` is the mislabeled fan-out. That is why #284 carries `breaking change`.

Note also that closing the issues stopped the build-out but did **not** remove the ~6,000 lines that already elect leaders and replicate nothing. #284 is where the first of that comes out.

Milestones retitled: v0.13.0 was "Cache Warming, Raft Persistence & Operational Excellence" — #150 and #151 were the Raft Persistence.

## Gates

| gate | result |
|---|---|
| `go build ./...` / `go vet ./...` / `gofmt -l .` | clean |
| `go test -count=1 -race -covermode=atomic ./...` | **exit 0, 0 races** |
| `coverage-gate.sh` | 35 packages at or above floor |
| `golangci-lint --new-from-merge-base=origin/main` | 0 issues |
| gosec `./internal/distributed/` | 2 findings, both the pre-existing `G404`s in the election-timeout jitter |
| doc/changelog gates (`./internal/config/`) | ok |
| `go test -race ./internal/distributed/` | ok |

Docs-only; no behaviour change.