### PR TITLE
docs: the Raft closure list is five, not four

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **The recommendation has been adopted.** The Raft build-out is closed as not-the-direction — [#128]
   (`ConsensusLog`), [#130] (`PersistentState`, the only one labeled `priority: critical`), [#133]
-  (real proposal broadcast) and [#151] (log compaction) — and the work is filed as [#282]
+  (real proposal broadcast), [#151] (log compaction) and [#150] (the bbolt implementations of the two
+  interfaces #128 and #130 defined, which the design doc's own closure list had missed) — and the work
+  is filed as [#282]
   (`Backend.PutObjectIf`, the sentinel errors, and a capability probe that detects by attempt rather
   than by configuration), [#283] (a lease whose every guarded action re-asserts the CAS), [#284]
   (replacing `executeStrongConsistency`'s N-identical-PUT fan-out and fixing the consistency
@@ -409,6 +411,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#133]: https://github.com/scttfrdmn/objectfs/issues/133
+[#150]: https://github.com/scttfrdmn/objectfs/issues/150
 [#151]: https://github.com/scttfrdmn/objectfs/issues/151
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#240]: https://github.com/scttfrdmn/objectfs/issues/240

--- a/docs/design/conditional-writes-vs-raft.md
+++ b/docs/design/conditional-writes-vs-raft.md
@@ -282,14 +282,16 @@ corrections to what is below. Both are recorded here rather than silently edited
 because a plan that turns out to have been slightly wrong is more useful with the correction visible
 than with the seam smoothed over.
 
-1. **The closure list of four below is incomplete — it should have named
+1. **The closure list of four below was incomplete — it should have named
    [#150](https://github.com/scttfrdmn/objectfs/issues/150)** (`BboltPersistentState` /
    `BboltConsensusLog`). That issue's own premise is *"the `ConsensusLog` and `PersistentState`
    interfaces were defined in A1-1 and A1-3"* — i.e. #128 and #130, both closed here — so nothing
-   remains for it to implement. It would also have added `go.etcd.io/bbolt` and a
+   remained for it to implement. It would also have added `go.etcd.io/bbolt` and a
    `/var/lib/objectfs` data path for durable Raft storage, neither of which CAS needs, since
-   coordination state lives in S3 objects guarded by `If-Match`. It is **still open**, flagged rather
-   than closed, because it was outside the approved set.
+   coordination state lives in S3 objects guarded by `If-Match`. **Closed 2026-08-03**, after being
+   flagged separately rather than swept in with the other four, because it was outside the set the
+   decision authorized. So the closure list is five, and the list below reads as it was written plus
+   this correction.
 2. **The `doc.go` correction below was already done** before adoption. Grep for `Linearizable`
    returns nothing.
 


### PR DESCRIPTION
#150 (`BboltPersistentState` / `BboltConsensusLog`) is now closed alongside #128, #130, #133 and #151, so the two places that said otherwise are updated.

Its premise was that it implements the interfaces A1-1 and A1-3 defined — #128 and #130 — so there was nothing left to back with bbolt. It would also have added `go.etcd.io/bbolt` and a `/var/lib/objectfs` data path, neither of which CAS needs: a lease is an object in the bucket guarded by `If-Match`.

It was closed separately, and after an explicit check, because `docs/design/conditional-writes-vs-raft.md` §5 omitted it from its list of four — so it fell outside what the direction decision had authorized. **That omission stays visible in the doc** rather than being edited into the list, on the same principle as the rest of that section: a plan that turned out slightly wrong is more useful with the correction shown than with the seam smoothed over.

Changes: the design doc's correction #1 now reads as closed rather than flagged-and-open; the CHANGELOG entry names #150 in the closure list with the reason it was missed; milestone v0.13.0's description notes both its Raft issues are closed.

Gates: `go build` / `go vet` / `gofmt -l` clean, doc and changelog gates in `./internal/config/` ok. Docs-only; no code touched.