### PR TITLE
fix(ci): quote schedule.time — the whole dependabot config was being discarded

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,24 @@
 # Dependabot configuration.
 #
-# Two things to know before editing, both learned the hard way:
+# Three things to know before editing, all learned the hard way:
 #
-#  1. `labels:` must name labels that EXIST. Dependabot silently drops unknown ones, so
+#  1. `time:` MUST be quoted. `time: 09:00` is not a string in YAML — it parses as an integer, and
+#     Dependabot rejects the WHOLE FILE for it: "The property '#/updates/0/schedule/time' of type
+#     integer did not match the following type: string", once per ecosystem. An invalid file is not
+#     partially applied, it is ignored entirely, so every `labels:`, `groups:`, `reviewers:` and
+#     `ignore:` block below was dead and Dependabot ran on its defaults instead. This was true from
+#     2025-10-15 (d4ff903, where the key was introduced unquoted) until 2026-08-03, and it is why
+#     item 2's fix did not take effect: the `automerge` label exists in .github/labels.yml and on the
+#     repository, and still no Dependabot PR carried it. Two independent causes for one symptom, and
+#     fixing the visible one first left the other invisible.
+#
+#     It reports as a failing `.github/dependabot.yml` check on every PR, which is easy to read as
+#     "a dependabot job failed" rather than "the config is invalid." It is the latter.
+#  2. `labels:` must name labels that EXIST. Dependabot silently drops unknown ones, so
 #     `automerge` — which .github/workflows/dependabot-automerge.yml gates every approve and merge
 #     step on — was never applied to a single PR. 46 PRs were opened and 0 were ever merged. Adding
 #     a label here without adding it to .github/labels.yml re-breaks auto-merge silently.
-#  2. Every manifest that generates a Dependabot ALERT should have an ecosystem entry here, or the
+#  3. Every manifest that generates a Dependabot ALERT should have an ecosystem entry here, or the
 #     alert has nothing to act on it. sdks/java/pom.xml (5 alerts) and docs-platform/package.json
 #     (3 alerts) sat unmonitored; GitHub opened one-off security-update jobs against them anyway,
 #     which is how the missing coverage surfaced.
@@ -18,7 +30,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 09:00
+    time: "09:00"
   open-pull-requests-limit: 5
   reviewers:
   - scttfrdmn
@@ -57,7 +69,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 09:00
+    time: "09:00"
   open-pull-requests-limit: 5
   reviewers:
   - scttfrdmn
@@ -82,7 +94,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 09:00
+    time: "09:00"
   open-pull-requests-limit: 3
   reviewers:
   - scttfrdmn
@@ -101,7 +113,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 09:00
+    time: "09:00"
   open-pull-requests-limit: 3
   reviewers:
   - scttfrdmn
@@ -125,7 +137,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 09:00
+    time: "09:00"
   open-pull-requests-limit: 3
   reviewers:
   - scttfrdmn
@@ -144,7 +156,7 @@ updates:
   schedule:
     interval: weekly
     day: monday
-    time: 09:00
+    time: "09:00"
   open-pull-requests-limit: 3
   reviewers:
   - scttfrdmn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`.github/dependabot.yml` was invalid, so none of it applied** ([#288]). `schedule.time: 09:00` was
+  unquoted, and Dependabot's YAML 1.1 parser reads that as a sexagesimal integer where its schema
+  requires a string: *"The property '#/updates/0/schedule/time' of type integer did not match the
+  following type: string"*, once for each of the six ecosystem entries. An invalid configuration is not
+  partially applied — it is ignored — so every `labels:`, `groups:`, `reviewers:` and `ignore:` block in
+  the file was dead and Dependabot ran on its defaults. True since 2025-10-15, when the key was
+  introduced unquoted.
+
+  This is also why the earlier `automerge` fix never took effect. That label was added to
+  `.github/labels.yml` and to the repository because Dependabot silently drops labels it cannot find
+  and every approve/merge step in `dependabot-automerge.yml` is gated on it — and still no Dependabot
+  PR carried it, because `labels:` sat inside a file being discarded wholesale. Two independent causes
+  for one symptom, and fixing the visible one left the other invisible. Confirmed on the open PRs:
+  #210, #249, #254 and #258 all arrived with `dependencies` plus an ecosystem label and no `automerge`.
+
+  Guarded by `TestDependabotScheduleTimesAreQuoted`, which checks the **file text** rather than the
+  decoded value. That is deliberate and was arrived at by mutation: `gopkg.in/yaml.v2` and
+  `gopkg.in/yaml.v3` both decode `09:00`, `9:00`, `10:30` and `05:00` as Go `string`, because Go's YAML
+  1.2 core schema has no sexagesimal integer type. So a decode-based assertion passes on exactly the
+  input that breaks the file, and the first version of this test did.
+
+[#288]: https://github.com/scttfrdmn/objectfs/issues/288
+
 - **`min_sequential` now means what it says: read-ahead had two thresholds over the same counter, and
   only one was configurable** ([#247]). The prefetch gate required `sequentialHits >= MinSequential`
   *and* `confidence > 0.5`, where confidence was assigned `sequentialHits / 10.0` a few lines above — so

--- a/internal/config/labels_test.go
+++ b/internal/config/labels_test.go
@@ -177,6 +177,81 @@ func dependabotLabelRefs(t *testing.T) []struct {
 	return refs
 }
 
+// dependabotTimeLine matches a `schedule.time` entry and captures its raw, undecoded value.
+var dependabotTimeLine = regexp.MustCompile(`(?m)^\s*time:\s*(\S+)\s*$`)
+
+// TestDependabotScheduleTimesAreQuoted asserts that every `schedule.time` in dependabot.yml is a
+// quoted scalar in the file text, because Dependabot's validator requires a string and rejects the
+// entire file when it sees anything else.
+//
+// `time: 09:00` — unquoted — was in this file from 2025-10-15, when the key was introduced, until
+// 2026-08-03. Dependabot answered with "The property '#/updates/0/schedule/time' of type integer did
+// not match the following type: string", once per ecosystem entry. **An invalid config is not
+// partially applied, it is ignored**, so every labels:, groups:, reviewers: and ignore: block in the
+// file was dead and Dependabot ran on its defaults instead.
+//
+// # Why this checks the text and not the decoded type
+//
+// Asserting the decoded Go type is the obvious design and it does not work. Verified by probe rather
+// than assumed: both gopkg.in/yaml.v2 and gopkg.in/yaml.v3 decode `09:00`, `9:00`, `10:30` and `05:00`
+// as **string**. Go's YAML 1.2 core schema has no sexagesimal integer type; Dependabot's YAML 1.1
+// parser does. So a Go decoder cannot reproduce the coercion — a decode-based test passes on exactly
+// the input that breaks the file, which is what the first version of this test did before being
+// mutation-checked against the unquoted form.
+//
+// The tradeoff that buys: this cannot tell `"9am"` from `"09:00"`, because both are quoted strings and
+// only Dependabot's own schema knows the difference. That is the narrower claim, and it is the one
+// that can actually be enforced from here. The failing `.github/dependabot.yml` check on the pull
+// request remains the authority on validity; this test exists to stop the *known* regression.
+//
+// # Why it is worth a test at all
+//
+// The fix is one line of quoting. The reason it hid for nine months is that it presents as a failing
+// `.github/dependabot.yml` check, which reads like "a dependabot job failed" rather than "your
+// configuration is invalid" — and the file has a `version: 2` key and six well-formed-looking
+// entries, so nothing about reading it suggests it is being discarded.
+//
+// It also masked the fix for the defect in TestDependabotLabelsAreDefined below. The `automerge` label
+// was added to .github/labels.yml and to the repository, and *still* no Dependabot PR carried it,
+// because labels: sat inside a file being ignored wholesale. Two independent causes for one symptom;
+// fixing the visible one left the other invisible.
+func TestDependabotScheduleTimesAreQuoted(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), ".github", "dependabot.yml")
+
+	//nolint:gosec // a path built from the module root this test located itself
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read .github/dependabot.yml: %v", err)
+	}
+
+	matches := dependabotTimeLine.FindAllStringSubmatch(string(raw), -1)
+
+	if len(matches) < 5 {
+		t.Fatalf("found %d schedule.time lines in .github/dependabot.yml, want at least 5 (one per "+
+			"ecosystem entry). Either the key was renamed or this scan has stopped matching, and a "+
+			"test that silently checks nothing is worse than no test.", len(matches))
+	}
+
+	for _, m := range matches {
+		value := m[1]
+
+		if strings.HasPrefix(value, `"`) || strings.HasPrefix(value, "'") {
+			continue
+		}
+
+		t.Errorf("dependabot.yml has `time: %s`, which is not a quoted scalar.\n"+
+			"Quote it: `time: \"09:00\"`. Dependabot's YAML 1.1 parser reads an unquoted 09:00 as a "+
+			"sexagesimal integer, its schema requires a string, and it rejects the WHOLE FILE — not "+
+			"just this entry — so every labels:, groups:, reviewers: and ignore: block stops applying "+
+			"and Dependabot falls back to its defaults. It surfaces only as a failing "+
+			"`.github/dependabot.yml` check, which looks like a failed job rather than an invalid "+
+			"config. Note Go's yaml.v2/v3 decode it as a string, so no decode-based test catches "+
+			"this — only the file text does.", value)
+	}
+}
+
 // TestDependabotLabelsAreDefined is the offline half, and the one with a proven failure behind it.
 //
 // dependabot.yml labeled every PR `automerge`; that label did not exist; Dependabot drops unknown


### PR DESCRIPTION
Closes #288.

## The defect

`.github/dependabot.yml` had `time: 09:00` unquoted in all six ecosystem entries. Dependabot's YAML 1.1 parser reads that as a **sexagesimal integer**; its schema requires a string; it rejects the **entire file**, once per entry:

```
The property '#/updates/0/schedule/time' of type integer did not match the following type: string
```

**An invalid config is not partially applied — it is ignored.** Every `labels:`, `groups:`, `reviewers:` and `ignore:` block in the file was dead, and Dependabot ran on its defaults. Present since 2025-10-15 (`d4ff903`), where the key was introduced unquoted and never quoted after.

You can see it failing right now on #210 as the `.github/dependabot.yml` check.

## Why this is more than a quoting nit

**It masked a fix that appeared to land and didn't.** The `automerge` label was missing from the repository; Dependabot drops unknown labels silently; every approve and merge step in `dependabot-automerge.yml` is gated on `contains(labels.*.name, 'automerge')`. 46 PRs opened, 0 merged. That was diagnosed and fixed — the label is in `.github/labels.yml` and on the repository, guarded by `TestDependabotLabelsAreDefined`.

And it still did not work, because `labels:` sat inside a file being discarded wholesale. Confirmed on the currently-open PRs:

| PR | labels |
|---|---|
| #210 | `dependencies`, `java` |
| #249 | `dependencies`, `go` |
| #254 | `dependencies`, `github-actions` |
| #258 | `dependencies`, `github-actions` |

No `automerge` on any of them. Two independent causes for one symptom; fixing the visible one left the other invisible.

It hid for nine months because it surfaces as a **failing check** rather than a validation message — that reads like "a dependabot job failed," and the file has a `version: 2` key and six well-formed-looking entries, so nothing about reading it suggests it is being thrown away.

## The test checks the file text, and that is deliberate

`TestDependabotScheduleTimesAreQuoted` (in `internal/config/labels_test.go`, next to the existing label gate) matches the raw text rather than asserting the decoded Go type.

Asserting the decoded type is the obvious design and it **cannot work**. Probed rather than assumed: `gopkg.in/yaml.v2` and `gopkg.in/yaml.v3` both decode `09:00`, `9:00`, `10:30` and `05:00` as Go **`string`**, because Go's YAML 1.2 core schema has no sexagesimal integer type while Dependabot's YAML 1.1 parser does. So a decode-based assertion passes on exactly the input that breaks the file — the first version of this test did, and mutation-checking it is what caught that.

The narrower claim that buys: it cannot tell `"9am"` from `"09:00"`, since both are quoted strings and only Dependabot's schema knows the difference. The failing check on the PR remains the authority on validity; this test exists to stop the known regression.

Mutation-verified three ways:

| mutation | result |
|---|---|
| unquote one `time` (the original bug) | **FAIL** — "`time: 09:00`, which is not a quoted scalar" |
| single-quote it (a valid YAML string) | passes, as intended |
| rename the key to `tyme:` | **FAIL** — the scan-found-nothing guard fires |

The config's header comment went from "Two things to know before editing" to three, with this as item 1.

## Gates

`go build ./...` · `go vet ./...` · `gofmt -l .` clean · `go test -count=1 -race ./internal/config/` ok · `golangci-lint --new-from-merge-base=origin/main` 0 issues.

## After this lands

Dependabot re-evaluates the config on its next run, so the open PRs will not retroactively gain `automerge` — worth confirming on the next batch that the label arrives, since this has now appeared fixed twice without being fixed.

Then #210 becomes mergeable, clearing all six jackson-databind alerts (2 high). The three vite alerts are **not** covered: a security update needs a committed lockfile and `docs-platform/` has none (#214). That ceiling is documented in the config itself.