### PR TITLE
ci: action majors, the Go toolchain switch, and dependabot auto-merge cause 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
@@ -108,7 +108,7 @@ jobs:
           # golangci-lint needs the merge base to diff against, which a shallow clone does not have.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
@@ -202,7 +202,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
@@ -240,7 +240,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
@@ -274,7 +274,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -289,9 +289,12 @@ jobs:
           pip install --quiet pytest .
           pytest tests/ -q
 
-      - uses: actions/setup-node@v4
+      # Node 22, not 20: 20 went end-of-life in April 2026, so it stops receiving security fixes
+      # while this job keeps installing it. sdks/javascript declares `node >=16`, so nothing here
+      # constrains the upper end — the pin was just never revisited. 22 is the active LTS.
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: TypeScript SDK metrics parsing
         working-directory: sdks/javascript
@@ -326,7 +329,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
@@ -361,7 +364,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
@@ -406,7 +409,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - name: Dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v2
+      uses: dependabot/fetch-metadata@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,7 +3,8 @@ name: Dependabot Auto-Merge
 # Enable GitHub's native auto-merge on minor/patch dependency PRs; comment on majors.
 #
 # This workflow previously merged nothing at all — 46 Dependabot PRs were opened and none were ever
-# merged — for three independent reasons, each of which would have been enough on its own:
+# merged — for FIVE independent reasons, each of which would have been enough on its own. They were
+# found one at a time, in this order, because each one hid the next:
 #
 #   1. Every approve/merge step was gated on `contains(labels.*.name, 'automerge')`, and the
 #      `automerge` label did not exist in the repository. Dependabot drops labels it cannot find
@@ -15,6 +16,17 @@ name: Dependabot Auto-Merge
 #      anchored at the start, so it matched `test` and `lint` and ignored `coverage`,
 #      `config-examples`, `cross-build`, `sdk-metrics`, `fuzz-smoke` and `Security Scan` — six of
 #      the eight jobs, including every cross-platform build.
+#   4. `.github/dependabot.yml` was INVALID, so `labels:` never applied even after (1) was fixed.
+#      `time: 09:00` unquoted parses as a sexagesimal integer where Dependabot's schema wants a
+#      string, and an invalid config is not partially applied — it is ignored entirely. So the
+#      label fix in (1) was inert for a second, independent reason. See #288.
+#   5. `gh pr review --approve` failed with "GitHub Actions is not permitted to approve pull
+#      requests," and because the step runs under `bash -e` that aborted it before the merge
+#      command. This only became visible once (1) and (4) were fixed and the step started
+#      executing at all instead of being skipped. See the note on the step below.
+#
+# The pattern is the lesson: a fix that "should have worked" and didn't usually means a second cause,
+# not a wrong diagnosis. Four of these five were confirmed only by watching a real Dependabot PR.
 #
 # The wait step is gone rather than fixed. Which checks must pass now lives in branch protection on
 # `main`, which is the one place that also governs human PRs and cannot be bypassed by a workflow
@@ -45,13 +57,25 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Approve and enable auto-merge for minor and patch updates
+    # No `gh pr review --approve` here, and that is not an omission.
+    #
+    # It used to be the first line of this step, and it failed every time: "GitHub Actions is not
+    # permitted to approve pull requests" (GraphQL addPullRequestReview), because
+    # `can_approve_pull_request_reviews` is false at the repository level. The step runs under
+    # `bash -e`, so that failure aborted before `gh pr merge --auto` was reached — cause 4 of the
+    # 46-PR problem, and the one that only became visible after causes 1 and 3 were fixed and the
+    # step finally started executing instead of being skipped.
+    #
+    # The approval was never needed. Branch protection on `main` requires status checks and
+    # `required_pull_request_reviews` is null, so nothing is waiting on a review. Dropping the line
+    # is the fix; enabling Actions-can-approve would grant every workflow in the repository the
+    # ability to satisfy a review requirement, to buy something not being asked for.
+    - name: Enable auto-merge for minor and patch updates
       if: |
         contains(github.event.pull_request.labels.*.name, 'automerge') &&
         (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
          steps.metadata.outputs.update-type == 'version-update:semver-minor')
       run: |
-        gh pr review --approve "$PR_URL"
         gh pr merge --auto --squash "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     # keyed on go.mod and go.sum but cached only ~/go/pkg/mod, leaving the build cache out — so
     # every release rebuilt the whole standard library four times over.
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version-file: ${{ env.GO_VERSION_FILE }}
         cache: true
@@ -149,10 +149,10 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -160,7 +160,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -172,7 +172,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version-file: ${{ env.GO_VERSION_FILE }}
         cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dependabot auto-merge, cause five: GitHub Actions cannot approve pull requests** ([#305]). Fixing
+  [#288] made `.github/dependabot.yml` valid, Dependabot re-evaluated it within minutes, and the
+  `automerge` label arrived on all 14 PRs it then opened — the label plumbing works. And still nothing
+  merged, because the step finally *ran* and failed: *"GitHub Actions is not permitted to approve pull
+  requests"* (`can_approve_pull_request_reviews` is false at the repository level). The step body was
+  `gh pr review --approve` followed by `gh pr merge --auto --squash`, under `bash -e` — so the failing
+  first line aborted before the line that does the work.
+
+  The approval was never needed. Branch protection on `main` requires status checks and has
+  `required_pull_request_reviews: null`, so nothing waits on a review. The line is deleted rather than
+  the permission enabled: allowing Actions to approve would let *every* workflow in the repository
+  satisfy a review requirement, to buy something no rule asks for.
+
+  That makes five independent causes for one symptom — 46 PRs opened, 0 merged — and the shape of it is
+  the part worth keeping. Causes 1 and 4 both left the `if:` condition false, so the step was *skipped*
+  and cause 5 could not produce a symptom at all; it became visible minutes after the config fix
+  landed. All five are now enumerated in the workflow header, in the order they were found, with why
+  each hid the next. A fix that should have worked and didn't usually means another cause, not a wrong
+  diagnosis.
+
+[#305]: https://github.com/scttfrdmn/objectfs/issues/305
+
 - **`.github/dependabot.yml` was invalid, so none of it applied** ([#288]). `schedule.time: 09:00` was
   unquoted, and Dependabot's YAML 1.1 parser reads that as a sexagesimal integer where its schema
   requires a string: *"The property '#/updates/0/schedule/time' of type integer did not match the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Every GitHub Action is on its current major, and CI no longer downloads a Go toolchain mid-build.**
+  Eight actions moved: `setup-go` 5 → 7, `setup-node` 4 → 7, `setup-python` 5 → 7,
+  `docker/metadata-action` 5 → 6, `docker/setup-buildx-action` 3 → 4, `docker/build-push-action`
+  5 → 7, `docker/login-action` 3 → 4, `dependabot/fetch-metadata` 2 → 3. Five of these Dependabot had
+  proposed and five is also `open-pull-requests-limit`, so the other three were never proposed at all —
+  the queue was saturated, which is a thing to watch for rather than a thing to trust.
+
+  The `setup-go` bump changes real behavior, so it was traced rather than assumed. v5 read the `go`
+  line and installed go1.26.0; Go's own toolchain switching then fetched go1.26.5 on the first build,
+  because `toolchain go1.26.5` says to. The right compiler was used, but it arrived at build time,
+  over the network, once per job — the `tar: ... gotoolchain_local.txt: Cannot open: File exists`
+  warnings in every job log were that download racing the module-cache restore. v6 reads the
+  `toolchain` directive directly and exports `GOTOOLCHAIN=local`, so 1.26.5 is installed up front and
+  nothing switches. Same compiler, one fewer moving part, and the log noise is gone. The tradeoff is
+  recorded next to the directive in `go.mod`: under `GOTOOLCHAIN=local` a version setup-go cannot
+  install now fails the build instead of silently falling back.
+
+  Checked for each of the others rather than taken on the release notes: the deprecated `config`,
+  `config-inline` and `install` inputs that buildx v4 removed are not used here; neither are the
+  `DOCKER_BUILD_NO_SUMMARY`/`DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs dropped by build-push-action v7
+  or the `pip-install` input dropped by setup-python v7; and the setup-node v6 change limiting
+  automatic caching to npm cannot apply, because no `cache:` input is set on the Node or Python steps.
+  All eight now require Actions runner ≥ v2.327.1 for their Node 24 runtime, which `ubuntu-latest`
+  satisfies.
+
+  Node itself went 20 → 22 in the `sdk-metrics` job while it was open: 20 reached end of life in
+  April 2026, and `sdks/javascript` declares `node >=16`, so nothing was holding the pin down except
+  never having revisited it. ([#254], [#255], [#256], [#257], [#258])
+
+[#254]: https://github.com/scttfrdmn/objectfs/pull/254
+[#255]: https://github.com/scttfrdmn/objectfs/pull/255
+[#256]: https://github.com/scttfrdmn/objectfs/pull/256
+[#257]: https://github.com/scttfrdmn/objectfs/pull/257
+[#258]: https://github.com/scttfrdmn/objectfs/pull/258
+
 - Updated five direct dependencies: `aws-sdk-go-v2` 1.41.5 → 1.43.2, `aws-sdk-go-v2/config`
   1.31.12 → 1.32.33, `klauspost/compress` 1.18.7 → 1.19.1, `pierrec/lz4/v4` 4.1.22 → 4.1.27, and
   `redis/go-redis/v9` 9.18.0 → 9.21.0. Two consequences are worth naming rather than leaving in the

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,20 @@ go 1.26.0
 // library advisories** against those builds, among them crypto/tls fixed in 1.26.5, crypto/x509 in
 // 1.26.4, and net/http in 1.26.3. None was a defect in this code; all were shipped by it.
 //
-// setup-go prefers `toolchain` over `go` when both are present, so this is the line that decides
-// what CI installs. Bump it when a patch release carries a fix worth having, which for a filesystem
-// handling other people's data is most of them.
+// `toolchain` is therefore the line that decides what CI compiles with. Bump it when a patch
+// release carries a fix worth having, which for a filesystem handling other people's data is most
+// of them.
+//
+// How it gets honoured changed with setup-go v7, and the mechanism is worth knowing because the
+// two paths fail differently. v5 installed the `go` line (1.26.0) and Go's own toolchain switching
+// then downloaded go1.26.5 on the first build — correct result, but reached at build time, over the
+// network, per job, and visibly: the `tar: ... gotoolchain_local.txt: Cannot open: File exists`
+// noise in every v5 job log is that download racing the module cache restore. v7 parses `toolchain`
+// directly and exports `GOTOOLCHAIN=local`, so 1.26.5 is installed up front and nothing switches.
+//
+// The consequence to remember: under `GOTOOLCHAIN=local` there is no longer a safety net. If this
+// line names a version setup-go cannot install, the build fails outright rather than quietly
+// switching to something that works.
 toolchain go1.26.5
 
 require (
@@ -23,6 +34,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.32
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/aws/smithy-go v1.27.5
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/hanwen/go-fuse/v2 v2.11.0
 	github.com/klauspost/compress v1.19.1
 	github.com/pierrec/lz4/v4 v4.1.27
@@ -55,7 +67,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect


### PR DESCRIPTION
Supersedes and closes #254, #255, #256, #257, #258 — plus three majors Dependabot never proposed.

## Why one PR instead of five

Dependabot opened five of these. Five is also `open-pull-requests-limit` for the `github-actions` ecosystem, so **three further outdated majors were never proposed at all** — the queue was saturated. Enumerating every `uses:` pin against its latest release found them:

| action | was | now | Dependabot proposed it? |
|---|---|---|---|
| `actions/setup-go` | v5 | **v7** | #258 |
| `actions/setup-node` | v4 | **v7** | #256 |
| `actions/setup-python` | v5 | **v7** | #254 |
| `docker/metadata-action` | v5 | **v6** | #257 |
| `docker/setup-buildx-action` | v3 | **v4** | #255 |
| `docker/build-push-action` | v5 | **v7** | no |
| `docker/login-action` | v3 | **v4** | no |
| `dependabot/fetch-metadata` | v2 | **v3** | no |

A quiet Dependabot can mean "nothing to do" or "no room to say so." This was the second.

## setup-go actually changes behavior

The only bump here with a real mechanism change, so it was traced rather than assumed.

**Before (v5):** reads the `go` line → installs **go1.26.0**. Go's own toolchain switching then downloads **go1.26.5** on the first build, because `toolchain go1.26.5` says to. The right compiler got used — `go version go1.26.5 linux/amd64` in the logs — but it arrived at build time, over the network, once per job. Those `tar: ... gotoolchain_local.txt: Cannot open: File exists` warnings in every job log are that download racing the module-cache restore.

**After (v6+):** parses `toolchain` directly and exports `GOTOOLCHAIN=local`, so 1.26.5 installs up front and nothing switches. Same compiler, one fewer moving part, no log noise.

Verified against the v7 sources rather than the PR discussion, since the discussion on actions/setup-go#460 records a behavior change that was then partly reverted:

- `installer.ts` `parseGoVersionFile` matches `/^toolchain go(1\.\d+(?:\.\d+|rc\d+)?)/m` and prefers it **unless** `GOTOOLCHAIN` is already `local`
- `main.ts` calls `setGoToolchain()`, which sets exactly that — and calls it *after* `resolveVersionInput()`, so the toolchain line still wins on the first read

The `go.mod` comment is updated to describe this, including the new failure mode it introduces: **under `GOTOOLCHAIN=local` there is no safety net** — a toolchain version setup-go cannot install now fails the build outright instead of quietly switching to one that works. That is the better behavior for a filesystem, but it should be written down.

## The other seven, checked rather than assumed

Each release's removals were grepped for in this repo:

- **buildx v4** removed the deprecated `config`, `config-inline` and `install` inputs → not used here
- **build-push-action v7** removed `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` → neither appears anywhere in `.github/`
- **setup-python v7** removed the `pip-install` input → not used
- **setup-node v6** limited automatic caching to npm → cannot apply, no `cache:` input is set on the Node or Python steps
- **metadata-action v6** changed `#` handling inside list values → the `tags:` list has no `#` in any value
- all eight require Actions runner **≥ v2.327.1** for their Node 24 runtime, which `ubuntu-latest` satisfies

## One thing found while in here

The `sdk-metrics` job pinned **Node 20, which reached end of life in April 2026** — so CI kept installing a runtime that no longer gets security fixes. `sdks/javascript` declares `node >=16`, so nothing was holding the pin down except never having revisited it. Now 22, the active LTS.

## Gates

`go build ./...` · `go vet ./...` · `gofmt -l .` clean · `go test ./internal/config/` ok (the doc and changelog gates live there). The actions themselves are verified by this PR's own CI running on them.