### PR TITLE
fix(ci): group the npm packages that can't move alone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -151,6 +151,18 @@ updates:
 
   # JavaScript SDK. No alerts today, but ci.yml runs `npm install && npm test` in this directory
   # (ci.yml:289), so its dependencies are executed on every PR and belong under the same watch.
+  #
+  # The groups below exist because two of these packages cannot move alone. `npm install` enforces
+  # peer ranges, so bumping half of a coupled pair fails at install time, not at test time:
+  #
+  #   #298  typescript 5.9.3 -> 7.0.2, alone:
+  #         peer typescript@">=4.3 <7" from ts-jest@29.4.12 -> ERESOLVE, sdk-metrics fails
+  #   #297  @typescript-eslint/eslint-plugin 5.62.0 -> 8.65.0, alone:
+  #         peer @typescript-eslint/parser@"^8.66.0" from the plugin, while parser is still ^5.59.0
+  #
+  # Both are correct bumps proposed in an order that cannot install. Grouping makes Dependabot move
+  # each set in one PR, which is the only form that resolves. Note this does not make the majors
+  # automatic — they are still majors, so dependabot-automerge.yml comments and waits for a human.
 - package-ecosystem: npm
   directory: /sdks/javascript
   schedule:
@@ -167,3 +179,14 @@ updates:
   - dependencies
   - javascript
   - automerge
+  groups:
+    typescript-toolchain:
+      patterns:
+      - typescript
+      - ts-jest
+      - '@types/jest'
+      - jest
+    typescript-eslint:
+      patterns:
+      - '@typescript-eslint/*'
+      - eslint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two JavaScript SDK dev-dependency bumps could not install, because Dependabot proposed half of a
+  peer-coupled pair** ([#306]). `npm` enforces peer ranges, so these fail at `npm install` rather than
+  at test time — the `sdk-metrics` job's `ERESOLVE`, not a test failure:
+
+  - `typescript` 5.9.3 → 7.0.2 alone: `peer typescript@">=4.3 <7" from ts-jest@29.4.12`
+  - `@typescript-eslint/eslint-plugin` 5.62.0 → 8.65.0 alone: the plugin wants
+    `peer @typescript-eslint/parser@"^8.66.0"` while `parser` is still pinned `^5.59.0`
+
+  Both are the right target version proposed in an order that cannot resolve. `groups:` on the
+  `/sdks/javascript` npm entry now moves each set in one PR, which is the only form that installs. It
+  does not make them automatic — they are still majors, so `dependabot-automerge.yml` comments and
+  waits for a human, which is right for a TypeScript 5 → 7 jump.
+
+  The `gomod` entry has had groups all along; neither npm entry did, which is why this surfaced only on
+  the JavaScript side — and only now, since before [#288] the whole config was ignored and these were
+  never proposed at all. `/docs-platform` was checked and is not affected: it has `jest` and
+  `typescript` but no `ts-jest`, so nothing there declares a peer range on the TypeScript version.
+
+  Recorded on [#306] while looking: the three `vite` alerts need a **`vitepress` major**, not a `vite`
+  bump. `vitepress@1.6.4` depends on `vite: ^5.4.14`, so `vite` cannot reach the patched 6.4.3 while
+  `vitepress` is on 1.x — the missing lockfile ([#214]) is a second blocker, not the only one.
+
+[#306]: https://github.com/scttfrdmn/objectfs/issues/306
+[#214]: https://github.com/scttfrdmn/objectfs/issues/214
+
 - **`.github/dependabot.yml` was invalid, so none of it applied** ([#288]). `schedule.time: 09:00` was
   unquoted, and Dependabot's YAML 1.1 parser reads that as a sexagesimal integer where its schema
   requires a string: *"The property '#/updates/0/schedule/time' of type integer did not match the


### PR DESCRIPTION
Closes #306.

Two of the 14 PRs Dependabot opened once `.github/dependabot.yml` became valid (#288/#289) fail `sdk-metrics` — and not on a test. They fail at `npm install`, because `npm` enforces peer ranges and each moves one half of a pair that has to move together.

**#298** — `typescript` 5.9.3 → 7.0.2:

```
npm error Found: typescript@7.0.2
npm error   dev typescript@"^7.0.2" from the root project
npm error Could not resolve dependency:
npm error peer typescript@">=4.3 <7" from ts-jest@29.4.12
```

**#297** — `@typescript-eslint/eslint-plugin` 5.62.0 → 8.65.0:

```
npm error Found: @typescript-eslint/parser@5.62.0
npm error   dev @typescript-eslint/parser@"^5.59.0" from the root project
npm error Could not resolve dependency:
npm error peer @typescript-eslint/parser@"^8.66.0" from @typescript-eslint/eslint-plugin@8.66.0
```

Neither is a bad bump. Both are the right target version, proposed in an order that cannot install.

## Why here and not for Go

The `gomod` entry has had a `groups:` block all along — `aws-sdk`, `production-dependencies`, `development-dependencies`. **Neither npm entry did.** Ungrouped, Dependabot opens one PR per package and has no way to know two of them are a set.

This surfaced only now because before #288 the whole config was ignored, so Dependabot ran on its defaults and never proposed these at all.

## The fix

Two groups on the `/sdks/javascript` npm entry:

| group | patterns |
|---|---|
| `typescript-toolchain` | `typescript`, `ts-jest`, `jest`, `@types/jest` |
| `typescript-eslint` | `@typescript-eslint/*`, `eslint` |

It does **not** make these automatic — they are still majors, so `dependabot-automerge.yml` comments and waits for a human. That is the right outcome for a TypeScript 5 → 7 jump.

`/docs-platform` was checked and is not affected: it has `jest` and `typescript` but **no `ts-jest`**, so nothing there declares a peer range on the TypeScript version.

## Found while looking: the vite alerts need a vitepress major

Recorded rather than fixed here. `docs-platform` has 3 open `vite` alerts (one high) patched at 6.4.3, and **`vitepress@1.6.4` depends on `vite: ^5.4.14`** — so `vite` cannot reach 6.x while `vitepress` is on 1.x. The missing lockfile (#214) is a *second* blocker, not the only one; committing a lockfile will not close these alerts by itself. Noted on #306 so #214 is not expected to do more than it can.

## On not adding a test

A test asserting `groups:` names particular packages would restate the config rather than check it. The thing that can actually be wrong is the peer range, and only `npm` knows that. `sdk-metrics` runs `npm install` on every PR and is what caught this — that is the gate.

## Gates

`go build ./...` · `gofmt -l .` clean · `go test ./internal/config/` ok (the dependabot config gates live there, including `TestDependabotScheduleTimesAreQuoted` and `TestDependabotLabelsAreDefined`).