### PR TITLE
fix(ci): typedoc in the toolchain group, PR limits that were hiding work, and three TTL tests that raced themselves

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -163,6 +163,19 @@ updates:
   # Both are correct bumps proposed in an order that cannot install. Grouping makes Dependabot move
   # each set in one PR, which is the only form that resolves. Note this does not make the majors
   # automatic — they are still majors, so dependabot-automerge.yml comments and waits for a human.
+  #
+  # `typedoc` is in the typescript-toolchain group for the same reason, and it was missed the first
+  # time: it constrains the TypeScript version as tightly as ts-jest does, just less visibly. The
+  # regrouped #308 still failed to install because of it, which is the evidence that a group is only
+  # as good as its membership. Two consequences worth knowing before touching these versions:
+  #
+  #   - typedoc@0.24 peers `typescript@"4.6.x || ... || 5.1.x"`, so `typescript: ^5.0.0` in
+  #     package.json silently resolves to 5.1.6 — three minors behind what the range suggests.
+  #   - TypeScript 7 is not reachable at any grouping. ts-jest's latest (29.4.12) peers `<7` and has
+  #     no release above it. The ceiling is TypeScript 6, which typedoc@0.28 allows. See #314.
+  #
+  # #314 also records why none of this is caught: nothing in CI runs `tsc`, so the SDK's 48 build
+  # errors are invisible and only `npm install` failures ever show up here.
 - package-ecosystem: npm
   directory: /sdks/javascript
   schedule:
@@ -186,6 +199,7 @@ updates:
       - ts-jest
       - '@types/jest'
       - jest
+      - typedoc
     typescript-eslint:
       patterns:
       - '@typescript-eslint/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,13 +25,23 @@
 version: 2
 updates:
   # Enable version updates for Go modules
+  #
+  # The limit is 8, not the default 5, and the reason generalises to every entry in this file: a
+  # saturated queue makes Dependabot silent, and a silent Dependabot is indistinguishable from an
+  # up-to-date one. Three outdated GitHub Actions majors were never proposed at all because
+  # #254-#258 held all five slots (#304 bumped them by hand once that was noticed). At the same
+  # moment, `go list -u -m all` showed twelve outdated direct modules against five slots, with
+  # prometheus/client_golang, redis/go-redis, substrate and golang.org/x/sys absent from every open
+  # PR — not because they were current, but because there was no room to say otherwise.
+  #
+  # If you lower this, check `go list -u -m all` afterwards rather than trusting the PR list.
 - package-ecosystem: gomod
   directory: /
   schedule:
     interval: weekly
     day: monday
     time: "09:00"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 8
   reviewers:
   - scttfrdmn
   commit-message:
@@ -108,13 +118,17 @@ updates:
 
   # Java SDK. Five open alerts against jackson-databind (two high) were generated here with no
   # ecosystem entry to act on them.
+  #
+  # Limit 6 rather than 3 for the reason given on the gomod entry above. pom.xml declares nine
+  # artifacts across seven distinct version properties; three slots held jackson, okhttp and
+  # surefire, leaving slf4j, junit, mockito and maven-compiler-plugin with no way to be proposed.
 - package-ecosystem: maven
   directory: /sdks/java
   schedule:
     interval: weekly
     day: monday
     time: "09:00"
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 6
   reviewers:
   - scttfrdmn
   commit-message:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Both are the right target version proposed in an order that cannot resolve. `groups:` on the
   `/sdks/javascript` npm entry now moves each set in one PR, which is the only form that installs. It
   does not make them automatic — they are still majors, so `dependabot-automerge.yml` comments and
-  waits for a human, which is right for a TypeScript 5 → 7 jump.
+  waits for a human, which is right for a jump of this size. (The TypeScript half of it turned out to
+  need a third package and a lower target; see the `typedoc` entry below.)
 
   The `gomod` entry has had groups all along; neither npm entry did, which is why this surfaced only on
   the JavaScript side — and only now, since before [#288] the whole config was ignored and these were
@@ -135,6 +136,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#306]: https://github.com/scttfrdmn/objectfs/issues/306
 [#214]: https://github.com/scttfrdmn/objectfs/issues/214
+
+- **`typedoc` joins the `typescript-toolchain` Dependabot group; it constrains the TypeScript version
+  as tightly as `ts-jest` and was missed** ([#314]). The regrouped PR from [#306] still failed
+  `npm install`, which is the useful part: a group is only as good as its membership, and `typedoc`
+  gates the same range without being an obvious member of a "TypeScript toolchain."
+
+  Two things fell out of measuring the actual peer ranges rather than assuming them. `typedoc@0.24`
+  peers `typescript@"4.6.x || … || 5.1.x"`, so `typescript: ^5.0.0` in `package.json` has been
+  resolving to **5.1.6** — three minors behind what the range reads as, and a 2023 compiler. And
+  **TypeScript 7 is not reachable at any grouping**: `ts-jest`'s latest release peers `<7` and has
+  nothing above it, so the ceiling is TypeScript 6, which `typedoc@0.28` permits. Verified by
+  installing the four-package set, not by reading the manifests.
+
+  [#314] records what this was hiding, which is larger than the grouping: `npm run build` in
+  `sdks/javascript` fails with **48 `tsc` errors**, and nothing in CI or the Makefile runs `tsc` at
+  all. Two of the 48 name identifiers that do not exist — `Configuration` in `types.ts:308` and a
+  `StorageAdapter` re-export in `index.ts:32` where `storage.ts` exports `S3StorageAdapter` — both
+  dating to the commit that added the SDK in 2025-08. `sdk-metrics` passes because `ts-jest`
+  typechecks only the one test file and its imports, so the rest of the SDK is checked by nothing.
+
+[#314]: https://github.com/scttfrdmn/objectfs/issues/314
 
 - **`.github/dependabot.yml` was invalid, so none of it applied** ([#288]). `schedule.time: 09:00` was
   unquoted, and Dependabot's YAML 1.1 parser reads that as a sexagesimal integer where its schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reduction is a deliberate choice. Both npm limits are left at 3 on purpose: those queues are full
   of majors correctly waiting for a human, which is the limit doing its job rather than hiding work.
 
+- **Three cache TTL tests were flaky in a way that reported as a cache defect.** They configured a
+  100 ms TTL and then asserted that an entry exists "immediately after `Put`". But `Put` stamps
+  `Timestamp: now` on entry (`internal/cache/persistent.go:305`) and *then* gzip-encodes and writes to
+  disk, so the entry's clock starts before its bytes land. Any delay between `Put` returning and the
+  following `Get` — GC, scheduler contention on a shared runner, a slow temp filesystem — spends the
+  same 100 ms the assertion depends on.
+
+  `TestPersistentCache_TTLExpiration` failed on CI for a pull request that changed nothing but
+  `.github/dependabot.yml`, which is the tell. Reproduced deliberately by sleeping 120 ms after the
+  `Put`: the entry is gone before it is ever read. `TestPersistentCache_Optimize` was the more
+  fragile of the two — it asserts a final count of 1, so it needed a fourth `Put` *and* a full index
+  sweep to finish inside the window, and losing that race looks like `Optimize` evicting a fresh
+  entry. `TestLRUCache_TTLExpiration` has the same shape; being in-memory it is far less likely to
+  miss, which makes it the one that would have outlived the other two.
+
+  The tests are what changed, not the caches. TTL measured from the start of the write is the
+  defensible semantic — an entry is as old as its data — so the fix is a 2 s budget wide enough that
+  scheduling noise cannot reach it, plus an `expiryWait` helper that keeps runtime tied to the TTL
+  rather than to a second hardcoded sleep. Each of the three was confirmed to fail against a
+  `isExpired() { return false }` mutant before being called fixed.
+
 - **`.github/dependabot.yml` was invalid, so none of it applied** ([#288]). `schedule.time: 09:00` was
   unquoted, and Dependabot's YAML 1.1 parser reads that as a sexagesimal integer where its schema
   requires a string: *"The property '#/updates/0/schedule/time' of type integer did not match the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#314]: https://github.com/scttfrdmn/objectfs/issues/314
 
+- **Dependabot's `gomod` and `maven` queues were saturated, so outdated dependencies were silent
+  rather than current.** `open-pull-requests-limit` caps discovery, not just display: once the slots
+  are full Dependabot stops proposing, and there is nothing in the PR list to distinguish "nothing to
+  update" from "no room to say so." This is the same condition that hid three outdated GitHub Actions
+  majors behind [#254]-[#258] until #304 bumped them by hand.
+
+  Measured rather than assumed: `go list -u -m all` reported **twelve** outdated direct modules
+  against five slots, with `prometheus/client_golang`, `redis/go-redis`, `substrate` and
+  `golang.org/x/sys` absent from every open PR — not current, just unproposed. `sdks/java/pom.xml`
+  declares nine artifacts across seven version properties against three slots, and the three in
+  flight left `slf4j`, `junit`, `mockito` and `maven-compiler-plugin` with no way to be raised.
+
+  `gomod` goes 5 → 8 and `maven` 3 → 6, with the reasoning recorded in the config so a future
+  reduction is a deliberate choice. Both npm limits are left at 3 on purpose: those queues are full
+  of majors correctly waiting for a human, which is the limit doing its job rather than hiding work.
+
 - **`.github/dependabot.yml` was invalid, so none of it applied** ([#288]). `schedule.time: 09:00` was
   unquoted, and Dependabot's YAML 1.1 parser reads that as a sexagesimal integer where its schema
   requires a string: *"The property '#/updates/0/schedule/time' of type integer did not match the

--- a/internal/cache/lru_test.go
+++ b/internal/cache/lru_test.go
@@ -237,11 +237,18 @@ func TestLRUCache_EvictionBySize(t *testing.T) {
 	}
 }
 
-// TestLRUCache_TTLExpiration tests TTL-based expiration
+// TestLRUCache_TTLExpiration tests TTL-based expiration.
+//
+// 2s TTL, matching TestPersistentCache_TTLExpiration, which has the full reasoning. This cache is
+// in-memory so the window is far less likely to be missed than the persistent one's — but the shape
+// of the bug is identical, and a test that only usually passes is worth the same as one that
+// usually fails.
 func TestLRUCache_TTLExpiration(t *testing.T) {
+	const ttl = 2 * time.Second
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024 * 1024,
-		TTL:     100 * time.Millisecond, // Very short TTL
+		TTL:     ttl,
 	})
 
 	key := "test"
@@ -254,8 +261,7 @@ func TestLRUCache_TTLExpiration(t *testing.T) {
 		t.Error("item should exist immediately after Put")
 	}
 
-	// Wait for TTL to expire
-	time.Sleep(150 * time.Millisecond)
+	expiryWait(ttl)
 
 	// Should be expired
 	retrieved := cache.Get(key, 0, int64(len(data)))

--- a/internal/cache/persistent_test.go
+++ b/internal/cache/persistent_test.go
@@ -230,13 +230,28 @@ func TestPersistentCache_Compression(t *testing.T) {
 	}
 }
 
-// TestPersistentCache_TTLExpiration tests TTL-based expiration
+// TestPersistentCache_TTLExpiration tests TTL-based expiration.
+//
+// The TTL is 2s rather than the 100ms it used to be, because 100ms made this test flaky in a way
+// that reported as a cache defect. `Put` stamps `Timestamp: now` at entry (persistent.go:305) and
+// then gzip-encodes and writes to disk, so the item's clock starts before the write completes. Any
+// delay between `Put` returning and the "immediately after Put" `Get` — GC, scheduler contention on
+// a shared runner, a slow temp filesystem — eats into the same 100ms the assertion depends on. It
+// failed exactly that way on a config-only PR. Reproduced deliberately by sleeping 120ms after the
+// Put: the item is gone before it is ever read.
+//
+// 2s is not a cure for a race; it is a budget wide enough that scheduling noise cannot reach it,
+// while `expiryWait` keeps the test's runtime governed by the TTL rather than a hardcoded sleep.
+// Stamping the timestamp after the write would also fix the flake, but TTL-measured-from-write-start
+// is the defensible semantic — the entry is as old as its data — so the test is what changes.
 func TestPersistentCache_TTLExpiration(t *testing.T) {
+	const ttl = 2 * time.Second
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
 		MaxSize:   10 * 1024 * 1024,
-		TTL:       100 * time.Millisecond, // Very short TTL
+		TTL:       ttl,
 	})
 	if err != nil {
 		t.Fatalf("NewPersistentCache failed: %v", err)
@@ -252,14 +267,19 @@ func TestPersistentCache_TTLExpiration(t *testing.T) {
 		t.Error("item should exist immediately after Put")
 	}
 
-	// Wait for TTL to expire
-	time.Sleep(150 * time.Millisecond)
+	expiryWait(ttl)
 
 	// Should be expired
 	retrieved := cache.Get(key, 0, int64(len(data)))
 	if retrieved != nil {
 		t.Error("item should have expired")
 	}
+}
+
+// expiryWait sleeps until a TTL of the given length has certainly elapsed, with enough margin that
+// a slow runner cannot land inside the window. Callers assert on expiry after this returns.
+func expiryWait(ttl time.Duration) {
+	time.Sleep(ttl + ttl/2)
 }
 
 // TestPersistentCache_Delete tests Delete operation
@@ -386,13 +406,21 @@ func TestPersistentCache_Clear(t *testing.T) {
 	}
 }
 
-// TestPersistentCache_Optimize tests Optimize operation
+// TestPersistentCache_Optimize tests Optimize operation.
+//
+// 2s TTL for the reason given on TestPersistentCache_TTLExpiration, and this one was the more
+// fragile of the two at 100ms: it asserts `finalCount == 1`, which requires key4's own Put plus
+// Optimize to finish inside the TTL. Three writes, a sleep, a fourth write and a full index sweep
+// against a 100ms budget is a coin flip on a loaded runner, and losing it looks like Optimize
+// evicting a fresh entry.
 func TestPersistentCache_Optimize(t *testing.T) {
+	const ttl = 2 * time.Second
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
 		MaxSize:   10 * 1024 * 1024,
-		TTL:       100 * time.Millisecond, // Short TTL
+		TTL:       ttl,
 	})
 	if err != nil {
 		t.Fatalf("NewPersistentCache failed: %v", err)
@@ -404,7 +432,7 @@ func TestPersistentCache_Optimize(t *testing.T) {
 	cache.Put("key3", 0, []byte("data3"))
 
 	// Wait for items to expire
-	time.Sleep(150 * time.Millisecond)
+	expiryWait(ttl)
 
 	// Add fresh item
 	cache.Put("key4", 0, []byte("data4"))


### PR DESCRIPTION
The regrouped PR from #306 (#308) still failed `npm install`. `typedoc` constrains the TypeScript version as tightly as `ts-jest` does, and was left out of the group because it does not read like a member of one.

Measuring the peer ranges rather than assuming them turned up two things worth recording in the config comment:

- `typedoc@0.24` peers `typescript@"4.6.x || … || 5.1.x"`, so `typescript: ^5.0.0` in `package.json` has been resolving to **5.1.6** — a 2023 compiler, three minors behind what the range reads as.
- **TypeScript 7 is unreachable at any grouping.** `ts-jest`'s latest release (29.4.12) peers `<7` with nothing above it. The ceiling is TypeScript 6, which `typedoc@0.28` permits. Verified by installing the four-package set (`typescript ^6.0.3`, `typedoc ^0.28.20`, `jest ^30.4.2`, `@types/jest ^30`) — resolves clean.

This PR only fixes the grouping. It does not bump anything: the bump needs #314 first, because a `typescript ^6` PR would fail `tsc` if `tsc` were ever run.

## What the install failure was hiding — #314

`npm run build` in `sdks/javascript` fails with **48 `tsc` errors**, and nothing in CI or the Makefile runs `tsc`:

```
$ grep -rn 'npm run build\|npm run docs\|tsc' .github/workflows/ Makefile
.github/workflows/ci.yml:304:  # tsconfig.json excludes **/*.test.ts from the build.
```

Two of the 48 name identifiers that do not exist — `Configuration` (`types.ts:308`) and a `StorageAdapter` re-export (`index.ts:32`, where `storage.ts` exports `S3StorageAdapter`) — both dating to `bf9c916`, the 2025-08 commit that added the SDK. `sdk-metrics` is green because `ts-jest` typechecks only `prometheus.test.ts` and its imports; the rest of the SDK is checked by nothing.

Filed against v0.15.0 with a proposed order that puts `npm run build` in CI **before** the toolchain bump, so the fix has a guard.

Closes #314 partially — the grouping half only.