### PR TITLE
test(ci): fail when a package.json and its lockfile disagree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A gate that fails when a `package.json` and its `package-lock.json` disagree, so `npm ci` cannot
+  refuse to install in a later job** ([#332]). `TestNPMLockfilesAgreeWithTheirManifests` compares
+  each manifest's four dependency tables against the same tables in the lockfile's `packages[""]`
+  entry — npm's own record of what the manifest said when the lock was generated — and reports the
+  directory and package name in seconds, in the `test` job, before anything installs.
+
+  The failure it replaces was real and badly phrased. `npm ci` refuses to run on a mismatch, so a
+  manifest edited without regenerating the lock surfaced as an npm error deep in whichever job
+  installed first: `` `npm ci` can only install packages when your package.json and
+  package-lock.json are in sync [...] Invalid: lock file's @types/node@18.19.130 does not satisfy
+  @types/node@26.1.2 ``. Nothing in that names the actual mistake.
+
+  Comparing the lockfile's own root entry, rather than diffing the two files a pull request touched,
+  is deliberate. A changed-files check needs a base ref, does not work under a plain `go test`, and
+  passes a hand edit that touches both files without regenerating the tree. This runs from a single
+  checkout and asks the question npm asks.
+
+  Both directions are checked — a range the lockfile does not record, a range recorded at a
+  different version, and a package the lockfile still records after the manifest dropped it — and
+  all three were mutation-checked against the real tree rather than predicted. A fourth subtest
+  globs `git ls-files` for tracked `package.json` files and fails on any directory not in the list,
+  so a third npm directory cannot be added without a lockfile gate; that one was mutation-checked
+  too. What this does *not* verify is the resolved tree below the root: whether the locked versions
+  satisfy the ranges, and whether every transitive dependency is present. Only `npm ci` answers
+  that, and `sdk-metrics` and `docs-site` both run it.
+
+[#332]: https://github.com/scttfrdmn/objectfs/issues/332
+
 - **`build` and `lint` steps in CI for the JavaScript SDK, which is the gate whose absence let 48 type
   errors ship** ([#314]). The `sdk-metrics` job ran `npm ci && npm test` as a single step; `tsc` was
   never invoked by anything, in any job, ever. It now runs as its own step, so a type error fails the

--- a/internal/config/docs_test.go
+++ b/internal/config/docs_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -174,33 +173,19 @@ var docsExemptFromConfigSchema = map[string]string{
 // brand-new markdown file is not checked until it is `git add`ed — which is the right boundary for
 // a gate on what the repository publishes, and is moot in CI, where every file is tracked by
 // definition.
+// The `git ls-files` call itself is trackedFiles, in lockfile_test.go — the npm lockfile gate needs
+// the same "tracked, not walked" set for a different pathspec, and the reasoning above is the
+// reasoning there.
 func markdownFiles(t *testing.T) []string {
 	t.Helper()
 
 	root := repoRoot(t)
 
-	cmd := exec.CommandContext(t.Context(), "git", "ls-files", "-z", "*.md")
-	cmd.Dir = root
+	rels := trackedFiles(t, "*.md")
 
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git ls-files in %s: %v", root, err)
-	}
-
-	var paths []string
-
-	// -z, so NUL-separated: a path may contain a newline, and `git ls-files` without -z quotes
-	// those rather than emitting them, which would need unquoting here to match the filesystem.
-	for rel := range strings.SplitSeq(string(out), "\x00") {
-		if rel == "" {
-			continue
-		}
-
+	paths := make([]string, 0, len(rels))
+	for _, rel := range rels {
 		paths = append(paths, filepath.Join(root, rel))
-	}
-
-	if len(paths) == 0 {
-		t.Fatalf("found no tracked markdown under %s, and an empty set passes every assertion below", root)
 	}
 
 	return paths

--- a/internal/config/lockfile_test.go
+++ b/internal/config/lockfile_test.go
@@ -1,0 +1,222 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// npmManifest is the subset of package.json this test compares. Only the dependency tables: the
+// lockfile's root entry mirrors these four and nothing else about the manifest.
+type npmManifest struct {
+	Dependencies         map[string]string `json:"dependencies"`
+	DevDependencies      map[string]string `json:"devDependencies"`
+	OptionalDependencies map[string]string `json:"optionalDependencies"`
+	PeerDependencies     map[string]string `json:"peerDependencies"`
+}
+
+// npmLockfile is the subset of package-lock.json this test reads.
+//
+// `packages[""]` — the empty-string key — is the lockfile's record of the root project, and npm
+// writes the manifest's own dependency ranges into it verbatim. That is what makes this test
+// possible from a single commit: the lockfile carries a copy of what the manifest said when it was
+// generated, so the two can be compared without knowing what the base branch looked like.
+type npmLockfile struct {
+	LockfileVersion int                    `json:"lockfileVersion"`
+	Packages        map[string]npmManifest `json:"packages"`
+}
+
+// npmDirectories are the directories in this repository with a package.json.
+//
+// Listed rather than discovered, and the first subtest below is what keeps the list honest: it
+// globs for package.json and fails if it finds one not named here. A discovered list would have to
+// exclude node_modules and would quietly pass on a directory nobody had noticed; a named list plus
+// a completeness check fails loudly on the same input.
+var npmDirectories = []string{
+	"docs-platform",
+	"sdks/javascript",
+}
+
+// TestNPMLockfilesAgreeWithTheirManifests is the durable half of #332.
+//
+// `npm ci` refuses to install when package.json and package-lock.json disagree, and it says so at
+// install time — which means the failure lands in whichever job happens to install first, phrased
+// as an npm error about a version mismatch rather than as "someone edited a manifest by hand".
+// #332 hit exactly that: Dependabot PRs opened before the lockfile existed edited the manifest
+// only, and after the lockfile landed they failed with
+//
+//	npm error `npm ci` can only install packages when your package.json and package-lock.json
+//	npm error are in sync. [...] Invalid: lock file's @types/node@18.19.130 does not satisfy
+//	npm error @types/node@26.1.2
+//
+// This runs the same comparison in the `test` job, so it fails in seconds with the directory and
+// package named, before any install. It also runs for `docs-platform`, whose lockfile arrived later
+// (#214) and which has the same exposure.
+//
+// Why compare the lockfile's own root entry rather than diffing the two files a PR touched: a
+// changed-files check needs a base ref, does not work on a local `go test`, and passes a hand edit
+// that touches both files without regenerating the tree. `packages[""]` is npm's own copy of the
+// manifest's ranges, so comparing against it is the check npm makes, available from one checkout.
+//
+// What this does not check is the resolved tree below the root — whether the locked versions
+// actually satisfy the ranges, and whether every transitive dependency is present. Only `npm ci`
+// answers that, and the `sdk-metrics` and `docs-site` jobs run it. This is the cheap gate that
+// catches the common case: a manifest edited without regenerating the lock.
+func TestNPMLockfilesAgreeWithTheirManifests(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	t.Run("every-package-json-is-listed", func(t *testing.T) {
+		t.Parallel()
+
+		listed := make(map[string]bool, len(npmDirectories))
+		for _, dir := range npmDirectories {
+			listed[dir] = true
+		}
+
+		// Tracked files, via the same helper the markdown gates use, so node_modules and any other
+		// ignored tree are excluded by .gitignore rather than by a skip-list here.
+		//
+		// `*package.json`, with the leading star, because a git pathspec without one is anchored:
+		// bare `package.json` matches the repository root and nothing else, which found zero files
+		// here and would have made this check vacuous rather than failing. The star matches any
+		// path *ending* in that string, so `my-package.json` would match too — hence the base-name
+		// test below.
+		for _, path := range trackedFiles(t, "*package.json") {
+			if filepath.Base(path) != "package.json" {
+				continue
+			}
+
+			dir := filepath.Dir(path)
+			if !listed[dir] {
+				t.Errorf("%s/package.json is not in npmDirectories, so nothing checks it against a "+
+					"lockfile; add it there (and commit a lockfile for it if there is none)", dir)
+			}
+		}
+	})
+
+	for _, dir := range npmDirectories {
+		t.Run(dir, func(t *testing.T) {
+			t.Parallel()
+
+			var manifest npmManifest
+			readJSON(t, filepath.Join(root, dir, "package.json"), &manifest)
+
+			var lock npmLockfile
+			readJSON(t, filepath.Join(root, dir, "package-lock.json"), &lock)
+
+			// v2 and v3 both carry `packages`; v1 carried only `dependencies` and has no root entry
+			// to compare against. npm 7 shipped v2 in 2020, so requiring v2+ costs nothing and
+			// means the assertions below cannot silently read a zero value.
+			if lock.LockfileVersion < 2 {
+				t.Fatalf("lockfileVersion is %d; this test reads packages[\"\"], which v1 lockfiles "+
+					"do not have. Regenerate with npm 7 or later", lock.LockfileVersion)
+			}
+
+			rootEntry, ok := lock.Packages[""]
+			if !ok {
+				t.Fatal(`the lockfile has no packages[""] entry, so there is nothing recording what ` +
+					`the manifest said when it was generated`)
+			}
+
+			for _, field := range []struct {
+				name           string
+				inManifest     map[string]string
+				inLockfileRoot map[string]string
+			}{
+				{"dependencies", manifest.Dependencies, rootEntry.Dependencies},
+				{"devDependencies", manifest.DevDependencies, rootEntry.DevDependencies},
+				{"optionalDependencies", manifest.OptionalDependencies, rootEntry.OptionalDependencies},
+				{"peerDependencies", manifest.PeerDependencies, rootEntry.PeerDependencies},
+			} {
+				for name, want := range field.inManifest {
+					got, present := field.inLockfileRoot[name]
+
+					switch {
+					case !present:
+						t.Errorf("%s: package.json requires %s@%s and the lockfile does not record it "+
+							"at all, so `npm ci` will refuse to install. Run `npm install` in %s and "+
+							"commit the lockfile alongside the manifest change",
+							field.name, name, want, dir)
+					case got != want:
+						t.Errorf("%s: package.json requires %s@%s but the lockfile was generated "+
+							"against %s@%s, so `npm ci` will refuse to install. Run `npm install` in "+
+							"%s and commit the lockfile alongside the manifest change",
+							field.name, name, want, name, got, dir)
+					}
+				}
+
+				for name, stale := range field.inLockfileRoot {
+					if _, present := field.inManifest[name]; !present {
+						t.Errorf("%s: the lockfile records %s@%s but package.json no longer requires "+
+							"it, so the lockfile predates a removal. Run `npm install` in %s and "+
+							"commit the result", field.name, name, stale, dir)
+					}
+				}
+			}
+		})
+	}
+}
+
+// trackedFiles returns the absolute path of every file in the repository whose name matches a
+// `git ls-files` pathspec.
+//
+// Tracked, and not a filesystem walk, for the reason `markdownFiles` records: `git ls-files`
+// inherits .gitignore, so `node_modules` is excluded because the repository ignores it rather than
+// because a skip-list here happens to name it. That matters more for package.json than for
+// markdown — a walk would return several hundred of them, all vendored, and the completeness check
+// above would be a wall of errors about other people's packages.
+func trackedFiles(t *testing.T, pathspec string) []string {
+	t.Helper()
+
+	root := repoRoot(t)
+
+	// G204 fires because `pathspec` is a variable rather than a literal, which it was before this
+	// helper was shared. Suppressed rather than reworked: both call sites pass a compile-time
+	// constant, and `exec` builds an argv directly with no shell, so a pathspec cannot become a
+	// second command. If a caller ever passes something derived from a file or an environment
+	// variable, this suppression stops being honest and the check should come back.
+	cmd := exec.CommandContext(t.Context(), "git", "ls-files", "-z", pathspec) //nolint:gosec // literal pathspec, no shell
+	cmd.Dir = root
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git ls-files %q in %s: %v", pathspec, root, err)
+	}
+
+	var paths []string
+
+	// -z, so NUL-separated: a path may contain a newline, which `git ls-files` would otherwise
+	// quote rather than emit.
+	for rel := range strings.SplitSeq(string(out), "\x00") {
+		if rel == "" {
+			continue
+		}
+
+		paths = append(paths, rel)
+	}
+
+	if len(paths) == 0 {
+		t.Fatalf("no tracked files match %q, and an empty set passes every assertion above", pathspec)
+	}
+
+	return paths
+}
+
+// readJSON decodes a file, failing the test with the path on any error.
+func readJSON(t *testing.T, path string, into any) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path) //nolint:gosec // a fixed path under this repository
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	if err := json.Unmarshal(raw, into); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Closes #332 — its fourth checkbox, the one it calls "the durable fix." The other three were cleanup of a queue that has since drained: #310 merged, #309 was closed and superseded by #335, and every npm PR opened before the lockfile has been re-run or closed.

## The failure this replaces

`npm ci` refuses to install when `package.json` and `package-lock.json` disagree. So a manifest edited without regenerating the lock does not fail where the mistake is — it fails inside whichever job installs first, saying:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Invalid: lock file's @types/node@18.19.130 does not satisfy @types/node@26.1.2
```

Nothing in that names the directory or the actual error. This now fails in the `test` job, in under a second, before anything installs.

## Why compare the lockfile's root entry rather than diff the PR's files

`packages[""]` is npm's record of the root project, and npm writes the manifest's own ranges into it verbatim. Comparing against it asks the same question `npm ci` asks, from a single checkout.

The obvious alternative — fail when a PR touches `package.json` without touching `package-lock.json` — is worse on three counts: it needs a base ref, so it cannot run under a plain `go test`; it does not run at all on a direct push to `main`; and it passes a hand edit that touches both files without regenerating the tree, which is a mismatch it exists to catch.

## Mutation-checked, not predicted

Each direction was verified by breaking the real tree and watching the failure, per the standing practice on this repository:

| mutation | result |
|---|---|
| bump `@types/node` to `^99.0.0` in the manifest, leave the lock | fails: "requires @types/node@^99.0.0 but the lockfile was generated against @types/node@^26.1.2" |
| add `left-pad` to `dependencies` only | fails: "the lockfile does not record it at all" |
| delete `axios` from the manifest | fails: "the lockfile records axios@^1.4.0 but package.json no longer requires it, so the lockfile predates a removal" |
| add an unlisted `sdks/c/package.json` | fails: "not in npmDirectories, so nothing checks it against a lockfile" |

That last one is why the directory list is written out rather than discovered. A discovered list would need to exclude `node_modules` itself; a named list plus a completeness check fails loudly instead of quietly skipping a directory nobody noticed.

## Scope

Both npm directories are covered — `sdks/javascript` (#201) and `docs-platform` (#214), which arrived at lockfiles two releases apart and have the same exposure. Both pass today, and the three currently-open Dependabot PRs against `docs-platform` (#339, #340, #341) each carry both files, which is Dependabot behaving correctly now that a lockfile exists for it to regenerate.

What this does **not** check is the resolved tree below the root: whether the locked versions satisfy the ranges, and whether every transitive dependency is present. Only `npm ci` answers that, and `sdk-metrics` and `docs-site` both run it. This is the cheap gate for the common case, not a replacement for the install.

## Also here

`markdownFiles` in `docs_test.go` now calls the `trackedFiles` helper this adds instead of carrying its own copy of the `git ls-files` call — #338 introduced that call one commit ago, and this needed the same set for a different pathspec.

One lint finding, fixed rather than ignored: `G204` fires on `exec.CommandContext` with a variable pathspec, which it was not before the helper was shared. Suppressed with the reasoning inline — both callers pass a compile-time constant and `exec` builds argv with no shell — and the comment says what would make the suppression dishonest.

## Verification

```
go test ./internal/config/ -count=1 -race                                    ok
golangci-lint run --new-from-merge-base=origin/main --timeout=10m            0 issues
npx markdownlint-cli CHANGELOG.md                                            361 (baseline)
```
