### PR TITLE
fix(sdks/python): pin the CI tree, and make the SDK visible to a scanner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -251,3 +251,40 @@ updates:
       patterns:
       - '@typescript-eslint/*'
       - eslint
+
+  # Python SDK.
+  #
+  # Added with #343, and it needed a requirements.txt to exist first. Dependabot's `pip` ecosystem
+  # reads requirements.txt, pyproject.toml, Pipfile and setup.py — so it *can* see setup.py's ranges,
+  # but with only ranges and no pinned tree its security updates hit the same wall the docs-platform
+  # comment above describes: no installed version is known, so a vulnerable dependency cannot be
+  # identified as vulnerable. requirements.txt is the pinned tree, and is also the only filename
+  # `trivy fs` detects — verified, including that `requirements-ci.txt` and `requirements-dev.txt`
+  # are both invisible to it.
+  #
+  # Two things this will propose that are worth expecting rather than being surprised by. The tree is
+  # frozen at 21 packages including transitives, so a bump to a transitive dependency arrives as a
+  # requirements.txt-only PR with no manifest change — which is correct here and is the opposite of
+  # the npm case, where a manifest change without a lockfile change is now a test failure (#332).
+  # And setup.py's `install_requires` stays as ranges on purpose, so Dependabot proposing a floor
+  # bump there is a separate, usually-declinable thing from proposing a pin bump here.
+  #
+  # Limit 4, not 3: the pinned tree has four direct dependencies (requests, pyyaml, psutil, aiohttp)
+  # plus pytest, and the gomod comment above explains why a limit at or below the number of things
+  # that can move means some of them can never be proposed.
+- package-ecosystem: pip
+  directory: /sdks/python
+  schedule:
+    interval: weekly
+    day: monday
+    time: "09:00"
+  open-pull-requests-limit: 4
+  reviewers:
+  - scttfrdmn
+  commit-message:
+    prefix: deps
+    include: scope
+  labels:
+  - dependencies
+  - python
+  - automerge

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -359,6 +359,14 @@
   description: npm dependency (docs-platform, sdks/javascript)
   color: f1e05a
 
+# Added here first, deliberately, alongside the `pip` ecosystem entry for /sdks/python — not created
+# by the first Dependabot PR the way `java` above was. That is the drift this file exists to prevent,
+# and the comment on `java` records it happening; doing the same thing again with the note already
+# written would be hard to defend.
+- name: python
+  description: pip dependency (sdks/python)
+  color: 3572a5
+
 # Created by Dependabot itself, on the first maven PR after sdks/java gained an ecosystem entry —
 # which is the drift this file exists to prevent happening while the issue about it was open. Its
 # description is Dependabot's wording, not ours, because that is what exists on the repository and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,12 +284,25 @@ jobs:
       - name: Python SDK tests
         working-directory: sdks/python
         run: |
-          # The package rather than a hand-listed subset of its requirements. The tests exercise
-          # parsing, which needs no transport, but they import objectfs.monitoring, and
-          # objectfs/__init__.py imports the client — so the whole install_requires set has to
-          # resolve. Installing `.` also means this job fails if setup.py stops being installable,
-          # which nothing else in CI checks.
-          pip install --quiet pytest .
+          # `-r requirements.txt` first, then the package with --no-deps, so the tree installed here
+          # is the frozen one and not a fresh resolution of six `>=` floors. Before this the job
+          # resolved every floor on every run, which is the defect #337 fixed for docs-site in a
+          # different language: a break could appear or vanish with no commit behind it.
+          #
+          # --no-deps on the second line is what makes the first line authoritative. Without it pip
+          # re-resolves install_requires and can move a version the requirements file pinned.
+          #
+          # setup.py is still installed rather than the sources being put on sys.path, and still
+          # matters: the tests import objectfs.monitoring, objectfs/__init__.py imports the client,
+          # and installing `.` means this job fails if setup.py stops being installable — which
+          # nothing else in CI checks.
+          #
+          # `pip check` afterwards catches the one thing this arrangement can get wrong: a pin in
+          # requirements.txt that does not satisfy install_requires. Cheap, and it fails with the
+          # conflicting package named.
+          pip install --quiet -r requirements.txt
+          pip install --quiet --no-deps .
+          pip check
           pytest tests/ -q
 
       # Node 22, not 20: 20 went end-of-life in April 2026, so it stops receiving security fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sdks/python/requirements.txt`, which is both the pinned tree CI installs and the only reason
+  anything scans this SDK's dependencies** ([#343]). 21 packages, transitives included, resolved on
+  Python 3.12 to match `actions/setup-python`. The `sdk-metrics` job installs `-r requirements.txt`
+  then the package with `--no-deps`, so what CI tests is a tree a reader can reproduce rather than a
+  fresh resolution of six `>=` floors on every run — the defect #337 fixed for `docs-site`, in a
+  different language.
+
+  The scanning half is the more serious one, and it was measured. `trivy fs` over this repository
+  reported four targets — `go.mod`, `sdks/java/pom.xml`, and the two `package-lock.json` files — and
+  `sdks/python` was absent, because Trivy detects Python from `requirements.txt`, `poetry.lock`,
+  `Pipfile.lock` or an installed `.dist-info`, and the only manifest here was `setup.py`. It now
+  reports five targets. That is #201's complaint about the JavaScript SDK, in the one directory that
+  closing #201 did not reach.
+
+  **The filename is load-bearing, which cost a rewrite to discover.** This was first written as
+  `requirements-ci.txt`, the more descriptive name — and Trivy does not detect that. Scanned in a
+  scratch directory it reported no targets at all, so the file would have read as the fix while
+  leaving the gap exactly where it was. `requirements-dev.txt`, `dev-requirements.txt` and
+  `requirements/ci.txt` are equally invisible; only the literal `requirements.txt` matches. A bare
+  `pyproject.toml` is not detected either, which is worth stating because it is the modern-practice
+  answer and it does not solve this problem.
+
+  `install_requires` deliberately stays as ranges: a library that pins its transitive tree pins it
+  for every consumer. `pip check` now runs between install and test, which catches the one thing that
+  split can get wrong — a pin here that does not satisfy a range there. Verified by mutation rather
+  than assumed: pinning `psutil==5.7.0` against a `>=5.8.0` floor gives
+  `objectfs 0.1.0 has requirement psutil>=5.8.0, but you have psutil 5.7.0` and exit 1.
+
+  Two dependencies were removed rather than pinned, because neither was one. **`asyncio`** has been a
+  stdlib module since Python 3.4 and this package requires >=3.8; the PyPI distribution is a 3.3-era
+  backport, now a deliberate empty stub whose own summary reads "Deprecated backport of asyncio; use
+  the stdlib package instead." Checked in a scratch venv: `asyncio.__file__` still resolves to the
+  stdlib with it installed, so it shadowed nothing — but it declared a dependency this SDK does not
+  have, and older resolutions of that range are not empty stubs. **`typing-extensions`** is imported
+  nowhere in the package. The suite's 71 tests pass with both gone.
+
+  A `pip` ecosystem entry for `/sdks/python` is added to `dependabot.yml`, which needed the pinned
+  tree to exist first for the same reason `docs-platform`'s security updates needed a lockfile. Its
+  `python` label was added to `.github/labels.yml` and synced from there rather than being created by
+  the first PR that applies it — which is how `java` got onto the repository, and is the drift that
+  file exists to prevent.
+
+[#343]: https://github.com/scttfrdmn/objectfs/issues/343
+
 - **A gate that fails when a `package.json` and its `package-lock.json` disagree, so `npm ci` cannot
   refuse to install in a later job** ([#332]). `TestNPMLockfilesAgreeWithTheirManifests` compares
   each manifest's four dependency tables against the same tables in the lockfile's `packages[""]`

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -30,6 +30,19 @@ pip install -e .
 For development and monitoring extras, `pip install -e '.[dev]'` and `pip install -e '.[monitoring]'`
 from that same directory.
 
+That installs the four runtime dependencies as ranges, which is what a library should declare. To
+reproduce the tree CI tests against instead — pinned exactly, transitives included — use
+`requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+pip install --no-deps .
+```
+
+`--no-deps` on the second command is what keeps the first one authoritative; without it pip
+re-resolves the ranges and can move a pinned version. Reach for this when reproducing a CI failure
+or a bug report; use `pip install -e .` for ordinary development, where a range is what you want.
+
 ## Quick Start
 
 ### Basic Usage

--- a/sdks/python/requirements.txt
+++ b/sdks/python/requirements.txt
@@ -1,0 +1,58 @@
+# Fully pinned dependency tree for the Python SDK's CI job. Generated, not hand-maintained:
+#
+#   python3.12 -m venv .venv && .venv/bin/pip install 'requests>=2.25.0' 'pyyaml>=6.0' \
+#     'psutil>=5.8.0' 'aiohttp>=3.8.0' pytest && .venv/bin/pip freeze
+#
+# Python 3.12, matching `actions/setup-python` in the `sdk-metrics` job. Resolving on a different
+# minor can produce different transitive pins, so the version that generates this file has to be the
+# version that installs it.
+#
+# **This is not the SDK's dependency declaration.** `setup.py`'s `install_requires` is, and it stays
+# as ranges — a library that pins its transitive tree pins it for every consumer, which is the wrong
+# tradeoff for something meant to be installed alongside other packages. This file exists so the
+# *test job* runs against a tree a reader can reproduce, which is a different question from what the
+# SDK requires. That split is standard practice and is why "add a lockfile" was not by itself the
+# right instruction here (#343).
+#
+# Two consequences, both verified rather than assumed:
+#
+#   - `trivy fs` detects Python from `requirements.txt` / `poetry.lock` / `Pipfile.lock` and an
+#     installed `.dist-info` — *not* from `setup.py`, and not from a bare `pyproject.toml` either,
+#     which was checked in a scratch directory and reported no targets at all. So before this file
+#     existed, the repository-wide scan reported four targets (`go.mod`, `sdks/java/pom.xml`, and the
+#     two `package-lock.json` files) and this SDK's 16 dependencies were scanned by nothing.
+#
+#     **The filename is load-bearing, and exactly this.** This file was first written as
+#     `requirements-ci.txt`, which is the more descriptive name and which Trivy does not detect —
+#     scanned in a scratch directory, it reported no targets, so the file would have looked like the
+#     fix while leaving the scanning gap exactly as it was. `requirements-dev.txt`,
+#     `dev-requirements.txt` and `requirements/ci.txt` are all equally invisible; only the literal
+#     `requirements.txt` is matched. Do not rename this for tidiness.
+#   - the `sdk-metrics` job installed all six `install_requires` floors fresh on every run, so a
+#     break could appear or vanish with no commit behind it. Same defect `docs-site` had before #337,
+#     in a different language.
+#
+# Regenerate when a dependency needs to move — including when Trivy reports an advisory here, which
+# is now possible. Do not edit a single line by hand: the point of a frozen tree is that every line
+# came from one resolution, and a hand edit makes the file describe a tree nothing ever installed.
+aiohappyeyeballs==2.7.1
+aiohttp==3.14.3
+aiosignal==1.4.0
+attrs==26.1.0
+certifi==2026.7.22
+charset-normalizer==3.4.9
+frozenlist==1.8.0
+idna==3.18
+iniconfig==2.3.0
+multidict==6.7.1
+packaging==26.2
+pluggy==1.6.0
+propcache==0.5.2
+psutil==7.2.2
+Pygments==2.20.0
+pytest==9.1.1
+PyYAML==6.0.3
+requests==2.34.2
+typing_extensions==4.16.0
+urllib3==2.7.0
+yarl==1.24.5

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -41,13 +41,32 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     python_requires='>=3.8',
+    # Ranges, deliberately, and not pins: a library that pins its transitive tree pins it for every
+    # consumer. The pinned tree lives in requirements.txt, which is what CI installs and what
+    # `trivy fs` scans — see the header there for why that split is the standard one, and why the
+    # filename cannot be changed.
+    #
+    # Two entries were removed rather than bumped, because neither was a dependency of this package:
+    #
+    #   asyncio — a *stdlib module* since Python 3.4. The PyPI distribution of that name is a
+    #   backport for 3.3, and `python_requires` here is >=3.8. Verified in a scratch venv: with the
+    #   package installed, `asyncio.__file__` still resolves to the stdlib, and asyncio 4.0.0 is now
+    #   a deliberate empty stub ("Deprecated backport of asyncio; use the stdlib package instead")
+    #   that ships dist-info and no modules. So it shadowed nothing — but it declared a dependency
+    #   the SDK does not have, and older resolutions of that range are not empty stubs.
+    #
+    #   typing-extensions — imported nowhere in this package. `grep -rn typing_extensions
+    #   sdks/python/` finds no hit outside egg-info. It still appears in requirements.txt because
+    #   pytest pulls it in transitively, which is the difference between "what CI installs" and
+    #   "what this package requires."
+    #
+    # The four that remain are each imported by name: requests, yaml (pyyaml), psutil, aiohttp. The
+    # suite's 71 tests pass with the two removals applied.
     install_requires=[
         'requests>=2.25.0',
         'pyyaml>=6.0',
         'psutil>=5.8.0',
         'aiohttp>=3.8.0',
-        'asyncio>=3.4.3',
-        'typing-extensions>=4.0.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Closes #343.

Two problems, one file. Both were measured rather than reasoned about, and one of them was measured *wrong* first — see the filename note below, which is the most useful thing in this PR.

## The scanning gap

`trivy fs` over `main` reports four targets. `sdks/python` is not one of them:

```
docs-platform/package-lock.json    npm
go.mod                             gomod
sdks/java/pom.xml                  pom
sdks/javascript/package-lock.json  npm
```

Trivy detects Python from `requirements.txt`, `poetry.lock`, `Pipfile.lock`, or an installed `.dist-info`. The only manifest in `sdks/python` was `setup.py`, which is on none of those lists. So this SDK's 16 declared dependencies were scanned by nothing — the exact complaint #201 filed against the JavaScript SDK, in the one directory closing #201 did not reach. With this branch it reports five targets, `sdks/python/requirements.txt` among them, 0 vulnerabilities.

## The filename is load-bearing, and I got it wrong first

I wrote this file as `requirements-ci.txt`, because that name says what it is. **Trivy does not detect that name.** Scanned in a scratch directory it reported no targets at all — so the file would have looked exactly like the fix, passed review, and left the scanning gap precisely where it was.

Tested each candidate:

| filename | detected |
|---|---|
| `requirements.txt` | **yes** |
| `requirements-ci.txt` | no |
| `requirements-dev.txt` | no |
| `dev-requirements.txt` | no |
| `requirements/ci.txt` | no |
| `pyproject.toml` (bare, with `[project].dependencies`) | no |

That last row is worth stating on its own: `pyproject.toml` is the modern-practice answer and it does **not** solve this problem. #343's body says otherwise; I wrote that before testing it, and the issue is wrong on that point.

The header comment in the file says all of this and says not to rename it for tidiness, because the failure mode is silent.

## The unpinned tree

`ci.yml` ran `pip install --quiet pytest .`, resolving six `>=` floors fresh on every run — same defect as `docs-site` before #337, so a break could appear or vanish with no commit behind it. Now:

```yaml
pip install --quiet -r requirements.txt
pip install --quiet --no-deps .
pip check
pytest tests/ -q
```

`--no-deps` is what makes the first line authoritative; without it pip re-resolves `install_requires` and can move a pinned version.

`install_requires` deliberately stays as **ranges**. A library that pins its transitive tree pins it for every consumer, so "add a lockfile" is not the right instruction for a library — the split is the standard one, and `requirements.txt` answers "what does CI test" while `setup.py` answers "what does this package require."

`pip check` guards the seam between them. Mutation-checked rather than assumed:

```
$ # requirements.txt pinned to psutil==5.7.0, install_requires says >=5.8.0
$ pip check
objectfs 0.1.0 has requirement psutil>=5.8.0, but you have psutil 5.7.0.
exit=1
```

(First attempt at that mutation used `requests==2.24.0`, which fails at *install* with `ResolutionImpossible` on an idna conflict — so it never reached `pip check` and proved nothing. `psutil` has no transitive dependencies, which is why it's the right probe.)

## Two dependencies removed rather than pinned

Neither was a dependency of this package:

- **`asyncio>=3.4.3`** — a stdlib module since Python 3.4; `python_requires` here is `>=3.8`. The PyPI distribution of that name is a 3.3-era backport, and at 4.0.0 it is now a deliberate empty stub whose own summary reads *"Deprecated backport of asyncio; use the stdlib package instead"* — dist-info and no modules. Checked in a scratch venv: with it installed, `asyncio.__file__` still resolves to the stdlib, so it shadowed nothing. It still declared a dependency the SDK does not have, and older resolutions of that range are not empty stubs.
- **`typing-extensions>=4.0.0`** — imported nowhere. It still appears in `requirements.txt`, because pytest pulls it in transitively, which is the difference between the two files in one line.

The four that remain are each imported by name: `requests`, `yaml`, `psutil`, `aiohttp`. **71 tests pass** with both removals applied.

## Dependabot

A `pip` ecosystem entry for `/sdks/python`, which needed the pinned tree to exist first for the same reason `docs-platform`'s security updates needed a lockfile: with only ranges, no installed version is known, so a vulnerable dependency cannot be identified as vulnerable.

Its `python` label was added to `.github/labels.yml` and synced with `.github/scripts/sync-labels.sh --apply`, not created by the first PR that applies it. That is how `java` got onto the repository, and the comment recording it sits four lines above where I added `python` — doing it again with the note already written would be hard to defend. `TestLabelsYAMLMatchesTheRepository` failed on the declared-but-missing label first, which is the check working.

Expect one non-obvious PR shape from this entry: because the tree is frozen including transitives, a transitive bump arrives as a **`requirements.txt`-only** change with no manifest edit. That is correct here, and the opposite of the npm case, where a manifest change without a lockfile change is now a test failure (#332, merged as #345).

## Verification

```
trivy fs --scanners vuln .                              5 targets, sdks/python present, 0 vulns
pip install -r requirements.txt && pip install --no-deps .
pip check                                               No broken requirements found.
pytest tests/ -q                                        71 passed, 25 subtests passed
go test ./internal/config/ -count=1 -race               ok  (labels + lockfile gates)
npx markdownlint-cli CHANGELOG.md                       361 (baseline)
```
