### PR TITLE
fix(ci): fuzz-smoke fails on crashers, not on go's shutdown race

### DIFF
--- a/.github/scripts/fuzz-smoke.sh
+++ b/.github/scripts/fuzz-smoke.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# fuzz-smoke.sh — fuzz one target for a fixed budget, then decide whether the failure was real.
+#
+# `go test -fuzz` fails for two unrelated reasons, and CI cannot tell them apart from the exit
+# status alone:
+#
+#   1. It found a counterexample. That is the entire point of the job and must fail the build.
+#   2. Its own coordinator lost a shutdown race, or the runner was preempted. Neither is a
+#      property of the code under test, and failing on them trains people to re-run a red job
+#      without reading it — which costs more than the gate is worth (#218).
+#
+# The two are distinguishable, because a real find leaves evidence a timeout cannot fabricate: a
+# new file under testdata/fuzz/<Target>/ and the line `Failing input written to`. So this script
+# keys on **the presence of a counterexample**, not on the exit status, and tolerates exactly two
+# shapes of failure when no counterexample exists:
+#
+#   - `--- FAIL: <Target>` whose only detail is `context deadline exceeded`, reported after the
+#     target actually ran for its budget. That is $GOROOT/src/internal/fuzz/fuzz.go:228 calling
+#     `stop(ctx.Err())` while the suppression at :130 compares against the *child* context's
+#     `Err()`, which can still be nil because `cancelCtx.cancel` closes its own `done` before
+#     propagating to children. Reproduced standalone at 12 in 20,000.
+#   - SIGTERM (143) or `The runner has received a shutdown signal` — GitHub reclaiming the runner.
+#
+# Everything else fails, including a deadline error that arrives early, a panic, a data race, a
+# seed-corpus failure, and the OOM-shaped `fuzzing process hung or terminated unexpectedly`. That
+# last one writes an input to testdata, so it is caught by the counterexample check rather than by
+# a message match.
+#
+# Deliberately NOT done here: dropping -fuzztime, or making the job non-blocking. Either would
+# turn a flaky gate into no gate.
+#
+# Usage: fuzz-smoke.sh <package> <FuzzTarget> <seconds>
+#
+# `set -e` is absent on purpose: the whole job of this script is to survive a failing command and
+# look at what it left behind.
+set -uo pipefail
+
+if [ "$#" -ne 3 ]; then
+	echo "usage: $0 <package> <FuzzTarget> <seconds>" >&2
+	exit 2
+fi
+
+pkg=$1
+target=$2
+seconds=$3
+
+case $seconds in
+'' | *[!0-9]*)
+	echo "fuzz-smoke: <seconds> must be a whole number of seconds, got '$seconds'" >&2
+	exit 2
+	;;
+esac
+
+# The corpus directory is derived from the package path rather than from `go list`, so that this
+# script's decision-making can be exercised against a stub `go` on PATH — which is what
+# internal/config/fuzz_smoke_script_test.go does.
+corpus="${pkg#./}/testdata/fuzz/${target}"
+
+log=$(mktemp)
+before=$(mktemp)
+after=$(mktemp)
+trap 'rm -f "$log" "$before" "$after"' EXIT
+
+list_corpus() {
+	if [ -d "$corpus" ]; then
+		find "$corpus" -type f | LC_ALL=C sort
+	fi
+}
+
+list_corpus >"$before"
+
+start=$SECONDS
+# tee, not a redirect: a preempted runner is killed mid-run, and output buffered into a file it
+# never gets to cat is output nobody sees. Streaming it is also what makes a 60-second step
+# readable while it runs.
+go test "$pkg" -run "^${target}\$" -fuzz "^${target}\$" -fuzztime="${seconds}s" 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+wall=$((SECONDS - start))
+
+list_corpus >"$after"
+new_inputs=$(comm -13 "$before" "$after")
+
+fail() {
+	echo "::error title=fuzz-smoke $target::$1"
+	echo "fuzz-smoke: FAIL ($target, exit $status, ${wall}s wall) — $1" >&2
+	exit 1
+}
+
+tolerate() {
+	echo "::warning title=fuzz-smoke $target::$1 — tolerated, no counterexample was produced"
+	echo "fuzz-smoke: tolerated ($target, exit $status, ${wall}s wall) — $1"
+	exit 0
+}
+
+# A counterexample first, before the exit status is consulted at all. `go test` has reported a
+# written input alongside a zero exit before (the minimizer's hung-process path), so this cannot
+# be nested under the failure branch.
+if [ -n "$new_inputs" ]; then
+	echo "fuzz-smoke: new file(s) under $corpus:" >&2
+	echo "$new_inputs" >&2
+	fail "a new input was written to $corpus — that is a counterexample, commit it and fix the target"
+fi
+
+if grep -q 'Failing input written to' "$log"; then
+	fail "output reports 'Failing input written to' — that is a counterexample"
+fi
+
+if [ "$status" -eq 0 ]; then
+	echo "fuzz-smoke: ok ($target, ${wall}s wall)"
+	exit 0
+fi
+
+# Runner preemption. 143 is SIGTERM; the message is what the runner logs when it is reclaimed.
+if [ "$status" -eq 143 ] || grep -q 'The runner has received a shutdown signal' "$log"; then
+	tolerate "the runner was preempted (exit $status)"
+fi
+
+# From here the only tolerated shape is the coordinator's shutdown race. Every condition below is
+# required, so that nothing else can wear its clothes.
+for marker in 'panic:' 'WARNING: DATA RACE' 'test timed out after' \
+	'fuzzing process hung or terminated unexpectedly'; do
+	if grep -qF "$marker" "$log"; then
+		fail "output contains '$marker' — a real failure, not a shutdown race"
+	fi
+done
+
+target_fails=$(grep -c "^--- FAIL: ${target} " "$log")
+other_fails=$(grep -cE '^[[:space:]]+--- FAIL: ' "$log")
+
+if [ "$target_fails" -ne 1 ] || [ "$other_fails" -ne 0 ]; then
+	fail "expected exactly one '--- FAIL: $target' and no subtest failures, got $target_fails and $other_fails"
+fi
+
+if ! grep -q 'context deadline exceeded' "$log"; then
+	fail "failed without a counterexample and without 'context deadline exceeded' — unexplained"
+fi
+
+# A deadline error is only the coordinator's shutdown race if the target actually *reached* its
+# deadline. The same message arriving early is something else wearing it — a context canceled
+# inside the target, say — and the duration is what tells them apart.
+#
+# The duration comes from the `--- FAIL: <Target> (60.11s)` line rather than from wall clock,
+# because wall clock includes compilation and module loading and so is only ever an overestimate:
+# a target that failed at 0.01s inside a run whose build took a minute would clear a wall-clock
+# floor while being exactly the case this check exists to reject. The line is guaranteed present
+# and unique by the count above.
+#
+# awk for the comparison — the duration is fractional and `[` is integer-only. 90% of the budget
+# rather than the budget itself: the coordinator reports slightly *over* (60.11s of 60s), but a
+# worker that finishes its last input just under is a normal shutdown too.
+reported=$(sed -n "s/^--- FAIL: ${target} (\([0-9.]*\)s)\$/\1/p" "$log" | head -1)
+
+if [ -z "$reported" ]; then
+	fail "could not read a duration from the '--- FAIL: $target' line, so the deadline cannot be confirmed"
+fi
+
+if ! awk -v got="$reported" -v budget="$seconds" 'BEGIN { exit !(got >= budget * 0.9) }'; then
+	fail "'context deadline exceeded' after ${reported}s of a ${seconds}s budget — too early to be the shutdown race"
+fi
+
+tolerate "'context deadline exceeded' at ${reported}s of a ${seconds}s budget, zero new inputs (go's fuzzing coordinator shutdown race, #218)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,14 @@ jobs:
   # It is set for every target rather than just the one that died, because the cause is the
   # per-worker runtime's view of memory, which every target shares. A target that allocates less
   # simply never reaches the limit.
+  #
+  # The step runs through .github/scripts/fuzz-smoke.sh rather than calling `go test` directly,
+  # because `go test -fuzz` exits non-zero for two unrelated reasons and this job has to tell them
+  # apart: it found a counterexample (fail the build), or its own coordinator lost a shutdown race
+  # / the runner was preempted (neither is a property of the code under test). ~1 run in 10 was the
+  # latter — see #218 for the race in $GOROOT/src/internal/fuzz/fuzz.go and the standalone
+  # reproduction. The script keys on the presence of a counterexample, never on the exit status
+  # alone, and the reasoning for each tolerated shape is in its header.
   # ---------------------------------------------------------------------------------------------
   fuzz-smoke:
     runs-on: ubuntu-latest
@@ -208,7 +216,7 @@ jobs:
           cache: true
 
       - name: Fuzz ${{ matrix.target }}
-        run: go test ${{ matrix.pkg }} -run '^${{ matrix.target }}$' -fuzz '^${{ matrix.target }}$' -fuzztime=60s
+        run: .github/scripts/fuzz-smoke.sh '${{ matrix.pkg }}' '${{ matrix.target }}' 60
 
       # A counterexample is the whole point of the job, so it has to leave the machine.
       - uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fuzz-smoke` no longer fails on Go's own fuzzing-coordinator shutdown race, and still fails on
+  every real find** ([#218]). The job failed roughly 1 run in 10 with `context deadline exceeded`
+  and **zero** new crashers — the surveyed failure was `FuzzSliceRange`, a pure-function target over
+  `sliceRange(data, offset, size)` whose test file contains no `context` at all, reported at 60.11s
+  against `-fuzztime=60s`. The uploaded artifact held only the already-committed corpus.
+
+  The cause is upstream, in `$GOROOT/src/internal/fuzz/fuzz.go`: the coordinator builds a timeout
+  context and a child of it, waits on the *parent*'s channel, calls `stop(ctx.Err())` with the
+  parent's error, and then suppresses that error only if it equals the *child*'s. Because
+  `cancelCtx.cancel` closes its own `done` before propagating into `c.children`, the child's `Err()`
+  can still be `nil` at that moment, the comparison misses, and a normal timeout is reported as a
+  failure. Reproduced standalone at 12 in 20,000 trials. The window is scheduling-dependent, which
+  is why CI saw it and a fast local machine did not — the runner managed 3,323 execs/sec against
+  36,819 locally.
+
+  The step now runs through `.github/scripts/fuzz-smoke.sh`, which keys on **the presence of a
+  counterexample** rather than on the exit status: a new file under `testdata/fuzz/<Target>/`, or
+  `Failing input written to` in the output, fails the job unconditionally — checked before the exit
+  status is consulted at all, because `go test` has reported a written input alongside a zero exit.
+  Only two shapes are tolerated, and only with no counterexample present: a lone
+  `--- FAIL: <Target>` whose one detail is `context deadline exceeded` *and* which ran for at least
+  90% of its budget, and SIGTERM/`The runner has received a shutdown signal` — the second failure
+  mode the survey found, runner preemption on `FuzzOperationSequence`. A panic, a data race, a
+  nested subtest failure (which is what a committed seed input failing looks like), a
+  hung-worker/OOM message, a non-zero exit with no `--- FAIL:` line, and a deadline message arriving
+  early are all still failures.
+
+  The elapsed check reads `go test`'s own `--- FAIL: <Target> (60.11s)` line rather than wall clock,
+  because wall clock includes compilation and would let a target that failed in 0.01s inside a slow
+  build clear the floor — which is precisely the case that check exists to reject.
+
+  `-fuzztime` is unchanged and the job stays blocking; the point was to make the gate readable, not
+  to remove it. `TestFuzzSmokeScriptDistinguishesCounterexamplesFromShutdownNoise` drives the script
+  against a stub `go` across ten cases, and each of its six checks was verified by mutation: deleting
+  any one of them makes a named case fail. `TestCIRunsFuzzTargetsThroughTheSmokeScript` fails if the
+  workflow goes back to calling `go test -fuzz` directly or drops the per-target artifact upload.
+
+  Worth reporting upstream: the suppression should compare against the context it just read, or use
+  `errors.Is(err, context.DeadlineExceeded)`. It is correct in intent and races in implementation.
+
+[#218]: https://github.com/scttfrdmn/objectfs/issues/218
+
 - **`docs-platform` commits a lockfile, so its dependency tree is reproducible and `npm audit` can
   run at all** ([#214]). 741 packages resolved into `docs-platform/package-lock.json`, and the
   `docs-site` job moves from `npm install` to `npm ci`. Before this the job resolved every `^x.y.z`

--- a/internal/config/fuzz_smoke_script_test.go
+++ b/internal/config/fuzz_smoke_script_test.go
@@ -1,0 +1,287 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFuzzSmokeScriptDistinguishesCounterexamplesFromShutdownNoise exercises
+// .github/scripts/fuzz-smoke.sh against a stub `go` and asserts what it decides.
+//
+// The script exists because `go test -fuzz` exits non-zero for two unrelated reasons — it found a
+// counterexample, or its own coordinator lost a shutdown race — and ~1 CI run in 10 was the second
+// one (#218). A gate that fails on noise trains people to re-run it without reading it, which is
+// worse than no gate; a gate that tolerates noise too broadly swallows real crashers, which is
+// worse still. So the script's discrimination *is* the deliverable, and it needs a test rather than
+// the observation that CI stopped being red.
+//
+// A stub `go` on PATH, not the real one: reproducing the coordinator race takes ~10 fuzzing runs on
+// average and cannot be asked for on demand, and a real crasher would mean committing a broken
+// target. Both are trivially expressible as output plus an exit status, which is all the script
+// reads. This is the seam the script was written against — corpus paths are derived from the
+// package argument rather than from `go list` precisely so the stub does not have to implement `go
+// list` too.
+//
+// Each case asserts the exit status *and* a fragment of the reason, because the two failure
+// verdicts ("counterexample" and "unexplained") are both exit 1 and confusing them would hide a
+// regression where a real find is reported as an unexplained failure.
+func TestFuzzSmokeScriptDistinguishesCounterexamplesFromShutdownNoise(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not on PATH; skipping the fuzz-smoke script gate")
+	}
+
+	script := filepath.Join(repoRoot(t), ".github", "scripts", "fuzz-smoke.sh")
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("stat %s: %v", script, err)
+	}
+
+	// The budget the script is invoked with, in seconds. The stubs return instantly regardless: the
+	// script reads the elapsed time out of `go test`'s own `--- FAIL: <Target> (60.11s)` line rather
+	// than off the wall clock, so a case can claim to have run for a minute without the test taking
+	// one. That is also why it reads that line — wall clock includes compilation, so a target that
+	// failed instantly inside a slow build would clear a wall-clock floor.
+	const budget = "60"
+
+	tests := []struct {
+		name string
+		// stub is the body of the case arm in the fake `go`. It runs with the scratch directory as
+		// its working directory.
+		stub     string
+		wantExit int
+		wantLog  string
+	}{
+		{
+			name: "clean pass",
+			stub: `echo "fuzz: elapsed: 60s, execs: 3000 (50/sec), new interesting: 0 (total: 1)"
+				echo PASS
+				exit 0`,
+			wantExit: 0,
+			wantLog:  "fuzz-smoke: ok",
+		},
+		{
+			// The #218 shape: a deadline error at the deadline, no new inputs. The only thing the
+			// script is meant to tolerate on a non-zero exit besides preemption.
+			name: "coordinator shutdown race at the deadline",
+			stub: `echo "fuzz: elapsed: 1m0s, execs: 194204 (3323/sec), new interesting: 1 (total: 24)"
+				echo "--- FAIL: FuzzThing (60.11s)"
+				echo "    context deadline exceeded"
+				echo FAIL
+				exit 1`,
+			wantExit: 0,
+			wantLog:  "shutdown race",
+		},
+		{
+			// Same message, arriving immediately. Something other than the shutdown race is wearing
+			// its clothes — a canceled context inside the target, say — and it must not be
+			// tolerated just because the string matches.
+			name: "deadline message too early to be the race",
+			stub: `echo "--- FAIL: FuzzThing (0.01s)"
+				echo "    context deadline exceeded"
+				echo FAIL
+				exit 1`,
+			wantExit: 1,
+			wantLog:  "too early to be the shutdown race",
+		},
+		{
+			// A real find, announced in the output. Note the stub *also* prints the tolerated
+			// deadline message, because that is what a genuine crasher discovered late in the run
+			// looks like: the counterexample check has to win.
+			name: "counterexample named in the output",
+			stub: `echo "--- FAIL: FuzzThing (59.8s)"
+				echo "    Failing input written to testdata/fuzz/FuzzThing/bbbb"
+				echo "    context deadline exceeded"
+				echo FAIL
+				exit 1`,
+			wantExit: 1,
+			wantLog:  "counterexample",
+		},
+		{
+			// A real find that only left a file — the shape `go test` produces when a worker dies
+			// while minimizing, which prints no "Failing input written to" line. Keyed on the
+			// filesystem, not on a message, so this is caught even when the wording changes.
+			name: "counterexample only on disk",
+			stub: `echo "new" > internal/target/testdata/fuzz/FuzzThing/cccc
+				echo "--- FAIL: FuzzThing (60.11s)"
+				echo "    context deadline exceeded"
+				echo FAIL
+				exit 1`,
+			wantExit: 1,
+			wantLog:  "that is a counterexample",
+		},
+		{
+			name: "panic alongside the deadline message",
+			stub: `echo "panic: runtime error: index out of range [5]"
+				echo "--- FAIL: FuzzThing (60.11s)"
+				echo "    context deadline exceeded"
+				echo FAIL
+				exit 1`,
+			wantExit: 1,
+			wantLog:  "a real failure, not a shutdown race",
+		},
+		{
+			name: "data race alongside the deadline message",
+			stub: `echo "WARNING: DATA RACE"
+				echo "--- FAIL: FuzzThing (60.11s)"
+				echo "    context deadline exceeded"
+				echo FAIL
+				exit 1`,
+			wantExit: 1,
+			wantLog:  "a real failure, not a shutdown race",
+		},
+		{
+			// A seed-corpus input failing is a real failure that reports no *new* input, because
+			// the input is already committed. It surfaces as a nested `--- FAIL:` subtest, which is
+			// why the script counts subtest failures separately.
+			name: "committed seed input fails",
+			stub: `echo "--- FAIL: FuzzThing (60.11s)"
+				echo "    --- FAIL: FuzzThing/aaaa (0.00s)"
+				echo "        fuzz_test.go:9: mismatch"
+				echo "    context deadline exceeded"
+				echo FAIL
+				exit 1`,
+			wantExit: 1,
+			wantLog:  "no subtest failures",
+		},
+		{
+			// A build failure, a vet failure, a missing target: non-zero with no `--- FAIL:` line at
+			// all. Must fail, and must say it does not understand why rather than guessing.
+			name: "non-zero with no explanation",
+			stub: `echo "FAIL	example/internal/target [build failed]"
+				exit 1`,
+			wantExit: 1,
+			wantLog:  "expected exactly one",
+		},
+		{
+			name: "runner preempted",
+			stub: `echo "Error: The runner has received a shutdown signal."
+				exit 143`,
+			wantExit: 0,
+			wantLog:  "preempted",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scratch := t.TempDir()
+
+			corpus := filepath.Join(scratch, "internal", "target", "testdata", "fuzz", "FuzzThing")
+			if err := os.MkdirAll(corpus, 0o750); err != nil {
+				t.Fatalf("mkdir corpus: %v", err)
+			}
+
+			// A committed seed, so "no new files" is a real comparison against a non-empty set
+			// rather than against nothing.
+			if err := os.WriteFile(filepath.Join(corpus, "aaaa"), []byte("seed"), 0o600); err != nil {
+				t.Fatalf("write seed: %v", err)
+			}
+
+			bin := filepath.Join(scratch, "bin")
+			if err := os.MkdirAll(bin, 0o750); err != nil {
+				t.Fatalf("mkdir bin: %v", err)
+			}
+
+			stub := "#!/usr/bin/env bash\n" + tc.stub + "\n"
+			if err := os.WriteFile(filepath.Join(bin, "go"), []byte(stub), 0o700); err != nil { //nolint:gosec // an executable stub is the point
+				t.Fatalf("write stub go: %v", err)
+			}
+
+			//nolint:gosec // script path derived from the module root this test located itself
+			cmd := exec.CommandContext(t.Context(), "bash", script, "./internal/target", "FuzzThing", budget)
+			cmd.Dir = scratch
+			// PATH only, and deliberately not the ambient environment: the stub must be the `go`
+			// the script finds, and nothing here should be able to reach a real toolchain or a real
+			// GOCACHE.
+			cmd.Env = []string{"PATH=" + bin + string(os.PathListSeparator) + "/usr/bin:/bin"}
+
+			out, err := cmd.CombinedOutput()
+
+			gotExit := 0
+			if err != nil {
+				var exitErr *exec.ExitError
+				if !asExitError(err, &exitErr) {
+					t.Fatalf("run script: %v\noutput:\n%s", err, out)
+				}
+
+				gotExit = exitErr.ExitCode()
+			}
+
+			if gotExit != tc.wantExit {
+				t.Errorf("exit status = %d, want %d\noutput:\n%s", gotExit, tc.wantExit, out)
+			}
+
+			if !strings.Contains(string(out), tc.wantLog) {
+				t.Errorf("output does not mention %q — the verdict is not the one this case is "+
+					"about, even if the exit status matched\noutput:\n%s", tc.wantLog, out)
+			}
+		})
+	}
+}
+
+// asExitError is errors.As specialised, kept local so the import list stays honest about there
+// being exactly one use.
+func asExitError(err error, target **exec.ExitError) bool {
+	e, ok := err.(*exec.ExitError) //nolint:errorlint // exec never wraps this
+	if ok {
+		*target = e
+	}
+
+	return ok
+}
+
+// TestCIRunsFuzzTargetsThroughTheSmokeScript keeps the workflow pointed at the script.
+//
+// The script's discrimination is worthless if the workflow calls `go test -fuzz` directly, and that
+// is a one-line edit away in a file the test above never reads. Both halves are needed: the step
+// must invoke the script, and it must not reintroduce a bare `-fuzz` invocation beside it.
+func TestCIRunsFuzzTargetsThroughTheSmokeScript(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(repoRoot(t), ".github", "workflows", "ci.yml")
+
+	//nolint:gosec // a path built from the module root this test located itself
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read .github/workflows/ci.yml: %v", err)
+	}
+
+	workflow := string(raw)
+
+	if !strings.Contains(workflow, ".github/scripts/fuzz-smoke.sh") {
+		t.Error(".github/workflows/ci.yml does not invoke .github/scripts/fuzz-smoke.sh.\n" +
+			"Calling `go test -fuzz` directly makes the job fail on go's own coordinator shutdown " +
+			"race — measured at ~1 run in 10 (#218) — which is how a gate stops being read.")
+	}
+
+	// Line by line and skipping comments, because the job's header explains the whole failure mode
+	// and necessarily quotes `go test -fuzz` while doing so. A whole-file Contains would therefore
+	// fail on the documentation of the fix, which is the sort of check that gets deleted rather than
+	// satisfied.
+	for i, line := range strings.Split(workflow, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if strings.Contains(trimmed, "go test") && strings.Contains(trimmed, "-fuzz") {
+			t.Errorf(".github/workflows/ci.yml:%d invokes `go test ... -fuzz` directly:\n\t%s\n"+
+				"Fuzz targets go through .github/scripts/fuzz-smoke.sh so that a deadline-shaped "+
+				"failure with no counterexample is distinguishable from a real find.", i+1, trimmed)
+		}
+	}
+
+	// The artifact upload is the only way a counterexample leaves the runner, and the script's
+	// tolerated exits are zero — so `if: failure()` still fires exactly when there is something to
+	// collect, and removing it would make a real find invisible.
+	if !strings.Contains(workflow, "fuzz-failure-${{ matrix.target }}") {
+		t.Error(".github/workflows/ci.yml no longer uploads a fuzz-failure artifact per target.\n" +
+			"A counterexample has to leave the machine; the script fails the job but cannot " +
+			"exfiltrate the input it found.")
+	}
+}


### PR DESCRIPTION
Closes #218.

`fuzz-smoke` failed roughly **1 run in 10** with `context deadline exceeded` and **zero** new crashers. It was not finding anything — the job was failing on the fuzzing coordinator's own shutdown, and failing the whole CI run when it did. A gate that red 10% of the time trains people to re-run it rather than read it, which costs more than the gate is worth.

## The cause is upstream, not in a target

The surveyed case was `FuzzSliceRange` in `./internal/storage/s3` — a pure-function target over `sliceRange(data, offset, size)` whose test file contains **no `context` at all** — reported at **60.11s** against `-fuzztime=60s`, with an uploaded artifact holding only the already-committed corpus.

`$GOROOT/src/internal/fuzz/fuzz.go` builds a timeout context and a child of it, waits on the **parent**'s channel, calls `stop(ctx.Err())` with the parent's error, and then suppresses that error only if it equals the **child**'s (`:107`, `:115`, `:117`, `:228`, `:130`). Because `cancelCtx.cancel` closes its own `done` before propagating into `c.children`, the child's `Err()` can still be `nil` at that moment, the comparison misses, and a normal timeout is reported as a failure. Reproduced standalone at **12 in 20,000** trials.

The window is scheduling-dependent, which is why CI sees it and a fast local machine does not: the runner managed 3,323 execs/sec against 36,819 locally.

## What this does

The step now runs through `.github/scripts/fuzz-smoke.sh`, which keys on **the presence of a counterexample**, never on the exit status alone.

**Always fails, checked before the exit status is consulted at all:**

- a new file appeared under `testdata/fuzz/<Target>/`
- the output contains `Failing input written to`

Both, not one: `go test` has reported a written input alongside a zero exit (the minimizer's hung-process path), so the disk check cannot be nested under the failure branch. And the disk check is what catches an OOM-shaped `fuzzing process hung or terminated unexpectedly`, which writes an input without printing that line.

**Tolerated, and only with no counterexample present:**

| shape | why |
|---|---|
| one `--- FAIL: <Target>` whose only detail is `context deadline exceeded`, having consumed ≥90% of its budget | the #218 race |
| exit 143, or `The runner has received a shutdown signal` | runner preemption — the survey's second failure mode, on `FuzzOperationSequence` ×2 |

**Still fails:** a panic, a data race, `test timed out after`, `fuzzing process hung or terminated unexpectedly`, a nested `--- FAIL:` subtest (which is what a *committed seed input* failing looks like — a real failure that produces no *new* file), a non-zero exit with no `--- FAIL:` line at all (build failure, vet failure, missing target), and a deadline message arriving early.

The elapsed check reads `go test`'s own `--- FAIL: <Target> (60.11s)` line rather than wall clock. Wall clock includes compilation and module loading, so a target that failed in 0.01s inside a slow build would clear a wall-clock floor — precisely the case the check exists to reject.

`-fuzztime` is unchanged and the job stays blocking. The artifact upload stays `if: failure()`; the script's tolerated exits are zero, so it fires exactly when there is something to collect.

## Verification

**Against a stub `go`** — `TestFuzzSmokeScriptDistinguishesCounterexamplesFromShutdownNoise`, 10 cases, each asserting the exit status *and* a fragment of the verdict (the two failure verdicts are both exit 1, and confusing them would hide a regression where a real find is reported as unexplained).

**Each of the six checks verified by mutation** — deleting any one makes a named case fail:

| removed | case that fails |
|---|---|
| the panic/data-race marker loop | `panic_alongside_the_deadline_message`, `data_race_alongside_the_deadline_message` |
| the subtest-failure count | `committed_seed_input_fails` |
| the reported-duration floor | `deadline_message_too_early_to_be_the_race` |
| the on-disk new-input check | `counterexample_only_on_disk` |
| the `Failing input written to` check | `counterexample_named_in_the_output` |
| the 143-only guard on preemption | 6 cases, including the deadline case itself |

**Against the real `FuzzSliceRange`**, with crashers injected into the target and then reverted:

- clean run → `fuzz-smoke: ok (FuzzSliceRange, 24s wall)`, exit 0
- `panic()` on a reachable input → `output contains 'panic:' — a real failure, not a shutdown race`, exit 1
- `t.Fatal` reached from a committed seed → `expected exactly one '--- FAIL: FuzzSliceRange' and no subtest failures, got 1 and 1`, exit 1
- a crasher the fuzzer discovers, corpus dir empty → **`a new input was written to internal/storage/s3/testdata/fuzz/FuzzSliceRange`**, exit 1, and the file is named in the log

Corpus and target restored afterwards; `git status` clean.

**Workflow gate** — `TestCIRunsFuzzTargetsThroughTheSmokeScript` fails if the workflow reverts to `go test -fuzz` (verified: reports `ci.yml:219`) or drops the per-target artifact upload (verified). It reads line by line skipping comments, because the job's own header necessarily quotes `go test -fuzz` while explaining the failure mode — a whole-file `Contains` would fail on the documentation of the fix.

`shellcheck` clean · `golangci-lint --new-from-merge-base=origin/main` 0 issues · `go test -race ./internal/config/` ok · markdownlint on CHANGELOG.md holds at its 361-line baseline.

## Also worth doing, not done here

An upstream Go report: `stop(ctx.Err())` should compare against the context it just read, or use `errors.Is(err, context.DeadlineExceeded)`. The suppression is correct in intent and races in implementation.