### PR TITLE
fix: the overflow guard overflowed, and armv7 shipped from an unbuilt matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,19 @@ jobs:
   # no Windows FUSE binding, and a binary that cannot mount anything is not a supported target.
   # internal/fuse carries a build constraint that makes any other GOOS fail with a message naming
   # the reason.
+  #
+  # The 32-bit cells (linux/arm, linux/386) are here because a whole word width was missing from the
+  # matrix, and `int` is 32 bits wide on those targets. `safeIntToUint32` guarded its conversion with
+  # `i > 0xFFFFFFFF` — a constant that does not fit a 32-bit `int` — so `internal/fuse` did not
+  # compile for any of them. On this matrix as it stood, that was invisible: every cell was 64-bit,
+  # every cell was green, and no test on a 64-bit host can see the difference either, because the
+  # defect is a compile error rather than a wrong answer. linux/armv7 was dropped from the release
+  # matrix rather than fixed as a result (#198).
+  #
+  # The vet step is what covers _test.go files. `go build` does not compile them, so a width bug in a
+  # test — `int(math.MaxUint32)` is the same error in the same shape — would still slip through a
+  # green build cell. Scoped to the first-party non-cgo trees: `sdks/c` is cgo and cannot be vetted
+  # under CGO_ENABLED=0 for any target (#200 covers that surface separately).
   # ---------------------------------------------------------------------------------------------
   cross-build:
     runs-on: ubuntu-latest
@@ -277,11 +290,16 @@ jobs:
         include:
           - {goos: linux, goarch: amd64}
           - {goos: linux, goarch: arm64}
+          - {goos: linux, goarch: arm, goarm: '7'}
+          - {goos: linux, goarch: '386'}
           - {goos: darwin, goarch: amd64}
           - {goos: darwin, goarch: arm64}
     steps:
       - uses: actions/checkout@v7
 
+      # setup-go runs before GOOS/GOARCH are in scope, deliberately: those are set per step below
+      # rather than on the job, so nothing about the toolchain install or its cache keys is asked to
+      # reason about a cross-compilation target.
       - uses: actions/setup-go@v7
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
@@ -292,7 +310,17 @@ jobs:
           CGO_ENABLED: 0
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          # Empty for every non-arm cell, which the toolchain ignores.
+          GOARM: ${{ matrix.goarm }}
         run: go build ./cmd/objectfs
+
+      - name: Type-check tests for ${{ matrix.goos }}/${{ matrix.goarch }}
+        env:
+          CGO_ENABLED: 0
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+        run: go vet ./internal/... ./pkg/... ./cmd/...
 
   # ---------------------------------------------------------------------------------------------
   # sdk-metrics — the two SDK suites that parse sdks/testdata/metrics-scrape.txt.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,18 @@ jobs:
       contents: read
     # Linux and macOS only, because that is what builds. `internal/fuse` carries
     # `//go:build linux || darwin` and `platform_unsupported.go` fails the build on anything else by
-    # design, so windows/amd64 and freebsd/amd64 could never have produced an artifact — and
-    # linux/armv7 fails separately on a 32-bit `int` overflow in `safeIntToUint32`. Three of the
-    # previous seven matrix entries were guaranteed-red jobs. Adding a platform back means adding a
-    # FUSE binding for it first; see internal/fuse/doc.go.
+    # design, so windows/amd64 and freebsd/amd64 could never have produced an artifact. Adding a
+    # GOOS back means adding a FUSE binding for it first; see internal/fuse/doc.go.
+    #
+    # linux/armv7 is back (#198). It was dropped alongside those two, but for a different reason: not
+    # a missing binding, a one-line compile error — `safeIntToUint32` bounded an `int` against
+    # `0xFFFFFFFF`, which does not fit a 32-bit `int`. The guard against overflow overflowed. Fixed by
+    # comparing as uint64, and ci.yml's cross-build matrix now carries linux/arm and linux/386 cells
+    # so a 32-bit break is a red PR rather than a platform quietly leaving the matrix.
+    #
+    # 32-bit ARM is a real target here — Raspberry Pi collectors and edge instruments writing to S3 —
+    # and shipping it is part of testing it: a platform that builds but is never shipped gets no
+    # runtime exposure at all.
     strategy:
       matrix:
         include:
@@ -65,6 +73,10 @@ jobs:
         - goos: linux
           goarch: arm64
           name: linux-arm64
+        - goos: linux
+          goarch: arm
+          goarm: '7'
+          name: linux-armv7
         - goos: darwin
           goarch: amd64
           name: darwin-amd64
@@ -105,6 +117,11 @@ jobs:
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
+        # Empty for every non-arm cell, which the toolchain ignores. Set explicitly for linux/arm
+        # rather than left to whatever the toolchain defaults to: armv6 and armv7 are not
+        # interchangeable binaries, and the artifact is named linux-armv7, so the flag has to say 7
+        # rather than trusting that it will keep meaning 7.
+        GOARM: ${{ matrix.goarm }}
         CGO_ENABLED: 0
       run: |
         # No -X ldflags: `main.Version` does not exist. cmd/objectfs/main.go declares an untyped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`internal/fuse` compiles for 32-bit targets again, and `linux/armv7` is back in the release
+  matrix** ([#198]).
+
+  `safeIntToUint32` bounded its conversion with `if i > 0xFFFFFFFF`. `int` is 32 bits wide on 32-bit
+  platforms and that constant is not, so the guard against overflow overflowed — a compile error, not
+  a wrong answer:
+
+  ```text
+  $ CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build ./internal/fuse/
+  internal/fuse/filesystem.go:37:9: 0xFFFFFFFF (untyped int constant 4294967295) overflows int
+  ```
+
+  It is now compared as `uint64(i) > math.MaxUint32`, which holds the value on every word width. The
+  negative check stays first, and has to: `uint64(-1)` is 2^64-1, which would clamp to `MaxUint32`
+  rather than to zero. `safeInt64ToUint64` beside it was audited too and has no equivalent defect —
+  int64 and uint64 are both 64 bits everywhere Go targets, so it has no upper bound to test and no
+  constant to overflow. That is now stated in its doc comment, because "why does the function above
+  check two things and this one check one" is a reasonable question to have answered in place.
+
+  **Why it survived to a release, which is the more interesting half.** That single line was the only
+  error on the target — the whole tree cross-builds for `linux/arm` and `linux/386` with it fixed. But
+  `linux/armv7` appeared in `release.yml`'s matrix and in nothing else: every `cross-build` cell in
+  `ci.yml` was 64-bit, and no test on a 64-bit host can see this class of defect, because
+  `i > 0xFFFFFFFF` compiles and behaves correctly on amd64 and arm64. So the break first appeared when
+  a tag was pushed, where the cheapest response was to delete the cell — and in v0.10.1 that is what
+  happened, taking the platform with it.
+
+  So the durable fix is a coupling rather than a line. `ci.yml`'s `cross-build` matrix gains
+  `linux/arm` (GOARM=7) and `linux/386` cells, and `TestEveryReleasePlatformIsCompiledInCI` fails if
+  `release.yml` publishes a platform that matrix does not build. The relation is deliberately
+  release ⊆ ci, not equality: `linux/386` is compiled and not published, as a second 32-bit
+  word-width canary. `TestThirtyTwoBitIsStillInTheCrossBuildMatrix` asserts at least one cell has a
+  32-bit `int` at all, stated by word width rather than by naming `arm`, so dropping one 32-bit
+  platform while keeping another stays green and going all-64-bit does not. Same shape of gate as
+  #240's build-tags matrix, and the same reasoning: an unbuilt target is not merely untested.
+
+  Each cross-build cell also now runs `go vet ./internal/... ./pkg/... ./cmd/...` alongside its
+  build. `go build` does not compile `_test.go` files, so a width bug in a test — `int(math.MaxUint32)`
+  is the same error in the same shape, and the new test had to route around it — would still pass a
+  green build cell. Scoped away from `sdks/c`, which is cgo and cannot be vetted under
+  `CGO_ENABLED=0` for any target ([#200] covers that surface).
+
+  `GOARM` is set explicitly rather than left to the toolchain default in both workflows: armv6 and
+  armv7 binaries are not interchangeable and the artifact is named `linux-armv7`, so the flag should
+  say 7 rather than trust that it will keep meaning 7.
+
+  Verified five ways. Restoring the original comparison passes `go build`, `go vet` and the full test
+  suite on this 64-bit host and fails `linux/arm`, `linux/386` and `./cmd/objectfs` for arm — the
+  measurement that says where the gate has to live. Swapping the two branches, deleting the negative
+  check, and deleting `safeInt64ToUint64`'s negative check each fail the new table tests. Removing the
+  `linux/arm` cell from `ci.yml`, removing both 32-bit cells, adding an unbuilt platform to
+  `release.yml`, and renaming the `cross-build` job all fail the coupling tests — the last one
+  because a parser that reads nothing would otherwise pass vacuously, which is the failure mode a test
+  that reads a workflow is most likely to have.
+
+  One mutation is deliberately not claimed: `>` versus `>=` on the boundary is an equivalent mutant,
+  since clamping `MaxUint32` to `MaxUint32` returns the same value either way.
+
+  `DEVELOPMENT.md`'s cross-build section listed three of the five shipped platforms plus a
+  `GOOS=windows` build that has never produced a binary — `internal/fuse` is `linux || darwin` and
+  `platform_unsupported.go` fails deliberately. It now lists what `release.yml` publishes, notes the
+  386 canary, and says why Windows is absent. Its local-build snippet also passed
+  `-ldflags "-X main.Version=$VERSION"`, which does nothing: `version` is a `const` and the linker
+  cannot rewrite a constant. Two other copies of that dead injection survive, in `Makefile:11` and
+  `OBJECTFS.md:613`, and are filed rather than fixed here ([#353]).
+
+[#198]: https://github.com/scttfrdmn/objectfs/issues/198
+[#200]: https://github.com/scttfrdmn/objectfs/issues/200
+[#353]: https://github.com/scttfrdmn/objectfs/issues/353
+
 - **Every build tag is compiled in CI, and the two tagged files that had stopped compiling now
   compile** ([#240], [#197]).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -439,29 +439,49 @@ go tool trace trace.out
 # Build for current platform
 go build -o objectfs ./cmd/objectfs
 
-# Build with version info
-VERSION=$(git describe --tags --always --dirty)
-go build -ldflags "-X main.Version=$VERSION" -o objectfs ./cmd/objectfs
-
 # Run
 ./objectfs --version
 ```
 
+There is no version to inject. `cmd/objectfs/main.go` declares `version` inside a `const` block, and
+the linker cannot rewrite a constant — so the `-ldflags "-X main.Version=$VERSION"` line this section
+used to show did nothing, silently, and `--version` reported whatever was hardcoded. That constant is
+the single authority for the version; `release.yml` asserts the release tag matches it rather than
+overwriting it at link time.
+
 ### Cross-Platform Build
+
+These are the five platforms `.github/workflows/release.yml` publishes, and every one of them is
+compiled by `ci.yml`'s `cross-build` job on each PR — a coupling `TestEveryReleasePlatformIsCompiledInCI`
+enforces, because linux/armv7 was once shipped from a matrix nothing else built and left the matrix
+when it stopped compiling ([#198](https://github.com/scttfrdmn/objectfs/issues/198)).
 
 ```bash
 # Linux AMD64
 GOOS=linux GOARCH=amd64 go build -o objectfs-linux-amd64 ./cmd/objectfs
+
+# Linux ARM64
+GOOS=linux GOARCH=arm64 go build -o objectfs-linux-arm64 ./cmd/objectfs
+
+# Linux ARMv7 — Raspberry Pi and other 32-bit ARM. Set GOARM explicitly: armv6 and armv7
+# binaries are not interchangeable.
+GOOS=linux GOARCH=arm GOARM=7 go build -o objectfs-linux-armv7 ./cmd/objectfs
 
 # macOS AMD64
 GOOS=darwin GOARCH=amd64 go build -o objectfs-darwin-amd64 ./cmd/objectfs
 
 # macOS ARM64 (M1/M2/M3)
 GOOS=darwin GOARCH=arm64 go build -o objectfs-darwin-arm64 ./cmd/objectfs
-
-# Windows
-GOOS=windows GOARCH=amd64 go build -o objectfs-windows-amd64.exe ./cmd/objectfs
 ```
+
+There is no Windows target. `internal/fuse` carries `//go:build linux || darwin` and
+`platform_unsupported.go` fails the build on anything else deliberately, so
+`GOOS=windows go build ./cmd/objectfs` — which this section used to list — has never produced a
+binary. Windows needs a WinFsp binding first.
+
+`ci.yml` additionally compiles linux/386, which is not published. It is there as a second 32-bit
+word-width canary: `int` is 32 bits on both `arm` and `386`, and that is the width on which #198's
+guard did not compile.
 
 ### Release Process
 

--- a/internal/config/release_platforms_test.go
+++ b/internal/config/release_platforms_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This file is #198's durable half, and it is the same shape of gate as build_tags_test.go is for
+// #240.
+//
+// The proximate defect was one line: `safeIntToUint32` bounded a 32-bit `int` against `0xFFFFFFFF`,
+// so internal/fuse did not compile for linux/arm. The reason it survived to a release is structural.
+// linux/armv7 was in release.yml's matrix and in *nothing* else: ci.yml's cross-build cells were all
+// 64-bit, and no test on a 64-bit host can see the difference, because the defect is a compile error
+// rather than a wrong answer. So the break only appeared when a tag was pushed, at which point the
+// cheapest response was to delete the cell — which is what happened, and it took the platform with
+// it.
+//
+// The fix is to couple the two matrices: a platform we ship is a platform every PR compiles. Then a
+// 32-bit break is one red cell on the PR that caused it, and removing a platform is a deliberate edit
+// to two files rather than the path of least resistance during a release.
+//
+// Note the direction. This asserts release ⊆ ci, not equality: ci.yml carries linux/386 as a second
+// 32-bit word-width canary and we do not publish a 386 binary. An extra CI cell costs a minute and
+// catches things; an unbuilt release cell ships them.
+
+// releaseMatrixEntry matches the `- goos: linux` line that opens a matrix entry.
+var releaseMatrixEntry = regexp.MustCompile(`^-\s+goos:\s*(\S+)`)
+
+// yamlKeyValue matches a `key: value` line, with optional quotes around the value. GOARCH values
+// like '386' are quoted in YAML because bare 386 parses as an integer.
+var yamlKeyValue = regexp.MustCompile(`^(\w+):\s*'?"?([^'"]+)'?"?$`)
+
+// TestEveryReleasePlatformIsCompiledInCI is the coupling itself.
+func TestEveryReleasePlatformIsCompiledInCI(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	shipped := releasePlatforms(t, readFile(t, filepath.Join(root, ".github", "workflows", "release.yml")))
+	if len(shipped) == 0 {
+		t.Fatal("read no platforms out of release.yml's build matrix — the job may have been renamed " +
+			"or its matrix reformatted, and an empty set satisfies the assertion below without " +
+			"checking anything")
+	}
+
+	compiled := crossBuildPlatforms(t, readFile(t, filepath.Join(root, ".github", "workflows", "ci.yml")))
+	if len(compiled) == 0 {
+		t.Fatal("read no platforms out of ci.yml's cross-build matrix — same problem as above, in " +
+			"the direction that makes this test vacuously pass")
+	}
+
+	for _, p := range shipped {
+		if compiled[p] {
+			continue
+		}
+
+		goos, goarch, _ := strings.Cut(p, "/")
+
+		t.Errorf("release.yml builds and publishes a %s binary, but ci.yml's cross-build matrix has "+
+			"no cell for it, so no PR compiles it.\n"+
+			"\tAdd `- {goos: %s, goarch: %s}` to that matrix. This is #198's failure mode: "+
+			"linux/armv7 was shipped from a matrix nothing else built, it stopped compiling on a "+
+			"32-bit `int`, and the break did not surface until a release tag — where the cheapest fix "+
+			"was to drop the platform.",
+			p, goos, goarch)
+	}
+}
+
+// TestThirtyTwoBitIsStillInTheCrossBuildMatrix guards the word width, not a specific platform.
+//
+// `int` is 32 bits on GOARCH=arm and GOARCH=386 and 64 bits everywhere else this project targets, and
+// every defect in #198's class — a constant that does not fit, a conversion that truncates — is
+// invisible unless something compiles for a 32-bit word. A matrix of six 64-bit cells looks thorough
+// and tests one word width.
+//
+// Stated as "at least one 32-bit cell" rather than by naming arm: if arm is ever genuinely dropped
+// while 386 stays, that is fine and this should keep passing. What must not happen silently is the
+// matrix going all-64-bit again.
+func TestThirtyTwoBitIsStillInTheCrossBuildMatrix(t *testing.T) {
+	t.Parallel()
+
+	// GOARCHes on which Go's `int` is 32 bits. Not exhaustive over everything Go supports — mips,
+	// mipsle, riscv32 and others qualify too — but this project builds for linux and darwin, and
+	// listing architectures it does not target would let an unrelated cell satisfy the check.
+	thirtyTwoBit := map[string]bool{"arm": true, "386": true}
+
+	root := repoRoot(t)
+
+	var found []string
+
+	for p := range crossBuildPlatforms(t, readFile(t, filepath.Join(root, ".github", "workflows", "ci.yml"))) {
+		if arch := strings.SplitN(p, "/", 2); len(arch) == 2 && thirtyTwoBit[arch[1]] {
+			found = append(found, p)
+		}
+	}
+
+	if len(found) == 0 {
+		t.Error("ci.yml's cross-build matrix has no 32-bit cell (no GOARCH of arm or 386).\n" +
+			"\tEvery remaining cell has a 64-bit `int`, which makes the whole #198 class of defect " +
+			"invisible: `if i > 0xFFFFFFFF` compiles and behaves correctly on all of them and does " +
+			"not compile on any 32-bit target. Restore a linux/arm or linux/386 cell.")
+	}
+
+	sort.Strings(found)
+	t.Logf("32-bit cells compiled by CI: %s", strings.Join(found, ", "))
+}
+
+// releasePlatforms reads goos/goarch pairs out of release.yml's build matrix.
+//
+// Parsed line-wise rather than by unmarshalling, matching build_tags_test.go's reasoning: the point
+// is to read what CI will actually run, and a YAML round-trip through a hand-written struct is one
+// more place for the two to disagree.
+func releasePlatforms(t *testing.T, workflow string) []string {
+	t.Helper()
+
+	var (
+		platforms []string
+		goos      string
+		inMatrix  bool
+	)
+
+	for line := range strings.SplitSeq(workflow, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "include:" {
+			inMatrix = true
+
+			continue
+		}
+
+		if !inMatrix {
+			continue
+		}
+
+		// Entries are `- goos: x` followed by indented keys. A line that is neither ends the matrix —
+		// including `steps:`, which is what actually follows it.
+		if m := releaseMatrixEntry.FindStringSubmatch(trimmed); m != nil {
+			goos = m[1]
+
+			continue
+		}
+
+		if goos == "" {
+			break
+		}
+
+		m := yamlKeyValue.FindStringSubmatch(trimmed)
+		if m == nil {
+			break
+		}
+
+		if m[1] == "goarch" {
+			platforms = append(platforms, goos+"/"+m[2])
+		}
+	}
+
+	sort.Strings(platforms)
+
+	return platforms
+}
+
+// crossBuildPlatforms reads goos/goarch pairs out of ci.yml's cross-build matrix, whose cells are
+// written in YAML flow style: `- {goos: linux, goarch: arm, goarm: '7'}`.
+func crossBuildPlatforms(t *testing.T, workflow string) map[string]bool {
+	t.Helper()
+
+	platforms := make(map[string]bool)
+
+	inJob := false
+
+	for line := range strings.SplitSeq(workflow, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "cross-build:" {
+			inJob = true
+
+			continue
+		}
+
+		if !inJob {
+			continue
+		}
+
+		// A new job starts at two-space indentation ending in a colon.
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") &&
+			strings.HasSuffix(trimmed, ":") {
+			break
+		}
+
+		if !strings.HasPrefix(trimmed, "- {") {
+			continue
+		}
+
+		fields := make(map[string]string)
+
+		for field := range strings.SplitSeq(strings.Trim(strings.TrimPrefix(trimmed, "- "), "{}"), ",") {
+			k, v, ok := strings.Cut(field, ":")
+			if !ok {
+				continue
+			}
+
+			fields[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `'"`)
+		}
+
+		if fields["goos"] != "" && fields["goarch"] != "" {
+			platforms[fields["goos"]+"/"+fields["goarch"]] = true
+		}
+	}
+
+	return platforms
+}

--- a/internal/fuse/filesystem.go
+++ b/internal/fuse/filesystem.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	iofs "io/fs"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,22 +22,43 @@ import (
 	"github.com/scttfrdmn/objectfs/pkg/types"
 )
 
-// safeInt64ToUint64 safely converts int64 to uint64, preventing negative values
+// safeInt64ToUint64 clamps a negative int64 to zero so the conversion cannot wrap.
+//
+// Only the sign needs checking: int64 and uint64 are 64 bits wide on every platform Go targets, so
+// the only values int64 can hold that uint64 cannot are the negative ones. There is no upper bound
+// to test — unlike safeIntToUint32 below, where the widths genuinely differ.
 func safeInt64ToUint64(i int64) uint64 {
 	if i < 0 {
 		return 0
 	}
+
 	return uint64(i)
 }
 
-// safeIntToUint32 safely converts int to uint32, preventing overflow
+// safeIntToUint32 clamps an int into uint32's range.
+//
+// The upper bound is compared as uint64 rather than as int, because `int` is 32 bits on 32-bit
+// platforms and the guard's own limit does not fit in it. Written as `i > 0xFFFFFFFF` this function
+// did not compile for any 32-bit target — the overflow guard overflowed:
+//
+//	$ CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build ./internal/fuse/
+//	internal/fuse/filesystem.go:37:9: 0xFFFFFFFF (untyped int constant 4294967295) overflows int
+//
+// That single error is why linux/armv7 was dropped from the release matrix in v0.10.1 rather than
+// fixed (#198). The negative check has to come first: uint64(-1) is 2^64-1, which would clamp to
+// MaxUint32 instead of to zero.
+//
+// On a 32-bit platform the upper branch is unreachable — math.MaxInt is 2^31-1 there, below
+// MaxUint32 — but it must still compile, which is the whole point.
 func safeIntToUint32(i int) uint32 {
 	if i < 0 {
 		return 0
 	}
-	if i > 0xFFFFFFFF {
-		return 0xFFFFFFFF
+
+	if uint64(i) > math.MaxUint32 {
+		return math.MaxUint32
 	}
+
 	return uint32(i)
 }
 

--- a/internal/fuse/width_guard_test.go
+++ b/internal/fuse/width_guard_test.go
@@ -1,0 +1,142 @@
+//go:build linux || darwin
+
+package fuse
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+// These tests cover the two width-clamping helpers in filesystem.go.
+//
+// A caveat worth stating plainly, because it decides where the real gate lives: #198's defect was a
+// *compile* error, and no test running on a 64-bit host can catch it. `i > 0xFFFFFFFF` and
+// `uint64(i) > math.MaxUint32` behave identically on amd64 and arm64; the difference only appears
+// when `int` is 32 bits, at which point the first form does not build at all. So the test that
+// guards the regression is the linux/arm cross-build cell in .github/workflows/ci.yml — the same
+// shape of gate as #240's build-tags matrix, and for the same reason: an unbuilt target is not
+// merely untested.
+//
+// What these tests do cover is the behavior, which had never been asserted at all: the clamps, the
+// boundaries, and the ordering of the two branches. The negative check must precede the upper-bound
+// check, because uint64(-1) is 2^64-1 and would clamp to MaxUint32 rather than to zero — a silent
+// off-by-4-billion in a function whose entire job is to not do that.
+
+func TestSafeIntToUint32(t *testing.T) {
+	t.Parallel()
+
+	// Built through a uint64 variable rather than written as `int(math.MaxUint32)`. That constant
+	// conversion is itself a compile error on a 32-bit platform, for exactly the reason this file
+	// exists — a test for a 32-bit compile bug that cannot be compiled on 32-bit would be no test.
+	// On a 32-bit build these two truncate to -1 and 0, which is why their cases are skipped there.
+	wide := uint64(math.MaxUint32)
+	maxUint32 := int(wide)
+	overMaxUint32 := int(wide + 1)
+
+	tests := []struct {
+		name    string
+		in      int
+		want    uint32
+		only64  bool
+		comment string
+	}{
+		{name: "zero", in: 0, want: 0},
+		{name: "one", in: 1, want: 1},
+		{name: "typical uid", in: 501, want: 501},
+		{
+			name: "negative one clamps to zero, not to MaxUint32",
+			in:   -1, want: 0,
+			comment: "the branch order case: uint64(-1) is 2^64-1",
+		},
+		{name: "most negative int clamps to zero", in: math.MinInt, want: 0},
+		{
+			name: "MaxUint32 passes through unclamped",
+			in:   maxUint32, want: math.MaxUint32, only64: true,
+			comment: "the boundary itself is representable and must not be clamped",
+		},
+		{
+			name: "MaxUint32+1 clamps",
+			in:   overMaxUint32, want: math.MaxUint32, only64: true,
+		},
+		{
+			name: "MaxInt clamps on a 64-bit platform",
+			in:   math.MaxInt, want: math.MaxUint32, only64: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.only64 && strconv.IntSize < 64 {
+				t.Skipf("int is %d bits here, so %s is not representable", strconv.IntSize, tt.name)
+			}
+
+			if got := safeIntToUint32(tt.in); got != tt.want {
+				t.Errorf("safeIntToUint32(%d) = %d, want %d%s", tt.in, got, tt.want, note(tt.comment))
+			}
+		})
+	}
+}
+
+// TestSafeIntToUint32OnA32BitInt checks the one boundary a 32-bit platform actually has.
+//
+// There, math.MaxInt is 2^31-1 — below MaxUint32 — so the largest possible input passes through
+// rather than clamping, and the upper branch is unreachable. Asserting it separately keeps the table
+// above from needing a second platform-dependent `want`.
+func TestSafeIntToUint32OnA32BitInt(t *testing.T) {
+	t.Parallel()
+
+	if strconv.IntSize != 32 {
+		t.Skipf("int is %d bits here; this asserts the 32-bit boundary", strconv.IntSize)
+	}
+
+	if got := safeIntToUint32(math.MaxInt); got != math.MaxInt32 {
+		t.Errorf("safeIntToUint32(math.MaxInt) = %d, want %d — on a 32-bit platform every "+
+			"non-negative int fits in uint32 and none should clamp", got, math.MaxInt32)
+	}
+}
+
+func TestSafeInt64ToUint64(t *testing.T) {
+	t.Parallel()
+
+	// This one has no upper bound to test, and that is the finding rather than an omission: int64 and
+	// uint64 are both 64 bits on every platform Go targets, so the only int64 values uint64 cannot
+	// represent are the negative ones. The #198 audit asked whether this function had the same defect
+	// as its neighbor; it does not, because it has no constant to overflow.
+	tests := []struct {
+		name string
+		in   int64
+		want uint64
+	}{
+		{name: "zero", in: 0, want: 0},
+		{name: "one", in: 1, want: 1},
+		{name: "a plausible file size", in: 4 << 30, want: 4 << 30},
+		{name: "negative one clamps to zero", in: -1, want: 0},
+		{name: "most negative int64 clamps to zero", in: math.MinInt64, want: 0},
+		{
+			name: "MaxInt64 passes through unclamped",
+			in:   math.MaxInt64, want: math.MaxInt64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := safeInt64ToUint64(tt.in); got != tt.want {
+				t.Errorf("safeInt64ToUint64(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// note renders a case's rationale into a failure message, or nothing when there is none.
+func note(comment string) string {
+	if comment == "" {
+		return ""
+	}
+
+	return " (" + comment + ")"
+}


### PR DESCRIPTION
Closes #198.

## The one-line defect

`safeIntToUint32` bounded its conversion with `if i > 0xFFFFFFFF`. `int` is 32 bits wide on 32-bit platforms and that constant is not, so the guard against overflow overflowed:

```
$ CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build ./internal/fuse/
internal/fuse/filesystem.go:37:9: 0xFFFFFFFF (untyped int constant 4294967295) overflows int
```

It is now `uint64(i) > math.MaxUint32`, which holds the value on every word width. The negative check stays first and has to: `uint64(-1)` is 2^64-1, which would clamp to `MaxUint32` rather than to zero.

That was the only error on the target — with it fixed the whole tree cross-builds for `linux/arm` and `linux/386`.

Per the issue, `safeInt64ToUint64` directly above it was audited too. It has no equivalent defect: int64 and uint64 are both 64 bits on every platform Go targets, so it has no upper bound to test and no constant to overflow. That is now stated in its doc comment, because "why does one of these check two things and the other check one" is a fair question to have answered in place.

## Why it reached a release, which is the part worth reviewing

`linux/armv7` appeared in `release.yml`'s matrix and in **nothing else**. Every `cross-build` cell in `ci.yml` was 64-bit, and no test running on a 64-bit host can see this class of defect — `i > 0xFFFFFFFF` compiles and behaves correctly on amd64 and arm64. So the break first appeared when a tag was pushed, at which point the cheapest response was to delete the cell. In v0.10.1 that is what happened, and the platform went with it.

Measured on this branch, with the original comparison restored:

| | result |
|---|---|
| `go build ./...` (this host, arm64) | exit 0 |
| `go vet ./...` (this host) | exit 0 |
| `go test -race ./internal/fuse/` | exit 0 |
| `GOOS=linux GOARCH=arm GOARM=7 go build ./internal/fuse/` | **exit 1** |
| `GOOS=linux GOARCH=386 go build ./internal/fuse/` | **exit 1** |
| `GOOS=linux GOARCH=arm GOARM=7 go build ./cmd/objectfs` | **exit 1** |

Everything a 64-bit host runs is green. That is where the gate has to live.

## The coupling

Same shape as #240's build-tags matrix, and the same reasoning — an unbuilt target is not merely untested:

- `ci.yml`'s `cross-build` matrix gains `linux/arm` (GOARM=7) and `linux/386`.
- `TestEveryReleasePlatformIsCompiledInCI` fails if `release.yml` publishes a platform that matrix does not build.
- The relation is deliberately **release ⊆ ci, not equality**: `linux/386` is compiled and not published, as a second 32-bit word-width canary. An extra CI cell costs a minute; an unbuilt release cell ships a broken platform.
- `TestThirtyTwoBitIsStillInTheCrossBuildMatrix` asserts at least one cell has a 32-bit `int`, stated by word width rather than by naming `arm` — so dropping one 32-bit platform while keeping another stays green, and going all-64-bit again does not.
- `linux/armv7` is back in `release.yml`. Per the issue: a platform that builds but is never shipped gets no runtime exposure either.

Each cross-build cell now also runs `go vet ./internal/... ./pkg/... ./cmd/...`. `go build` does not compile `_test.go` files, so a width bug in a *test* — `int(math.MaxUint32)` is the same error in the same shape, and the new test had to route around it — would still pass a green build cell. Scoped away from `sdks/c`, which is cgo and cannot be vetted under `CGO_ENABLED=0` for any target; #200 covers that surface.

`GOARM` is set explicitly in both workflows rather than left to the toolchain default. armv6 and armv7 binaries are not interchangeable and the artifact is named `linux-armv7`, so the flag should say 7 rather than trust that it will keep meaning 7.

## Tests

`internal/fuse/width_guard_test.go` — the table the issue asked for (`math.MaxUint32`, `MaxUint32+1` skipped on 32-bit, `-1`, `0`), plus `MinInt`, `MaxInt`, and the branch-order case. Table-driven, `t.Parallel()`.

The header states plainly what these tests cannot do: **no test on a 64-bit host catches the actual regression**, because the defect is a compile error. The gate for that is the cross-build cell. What the tests do cover is the behavior, which had never been asserted at all — the clamps, the boundaries, and the branch ordering.

One wrinkle worth flagging: the table's boundary values are built through a `uint64` variable rather than written as `int(math.MaxUint32)`, because that constant conversion is *itself* a compile error on 32-bit — a test for a 32-bit compile bug that cannot be compiled on 32-bit would be no test. Confirmed: `GOOS=linux GOARCH=arm go vet ./internal/fuse/` and `GOARCH=386` both pass, which type-checks the test file for those targets.

`internal/config/release_platforms_test.go` — the two coupling tests, in the package where `build_tags_test.go` already does this and `repoRoot` lives.

## Verification

**Mutations, eight.** Four behavioral, four structural:

| mutation | result |
|---|---|
| restore `i > 0xFFFFFFFF` | 64-bit build/vet/test all pass; arm, 386 and cmd/objectfs-for-arm fail |
| swap the two branches | `TestSafeIntToUint32` fails |
| delete the negative check | `TestSafeIntToUint32` fails |
| delete `safeInt64ToUint64`'s negative check | `TestSafeInt64ToUint64` fails |
| remove the `linux/arm` cell from ci.yml | coupling test fails, naming `linux/arm` |
| remove **both** 32-bit cells | both coupling tests fail |
| add `freebsd/amd64` to release.yml | coupling test fails, naming it |
| rename the `cross-build` job | coupling test **fatals** rather than passing vacuously |

That last one is the failure mode a test that parses a workflow is most likely to have, so it is checked explicitly.

**Not claimed:** `>` versus `>=` on the boundary is an equivalent mutant — clamping `MaxUint32` to `MaxUint32` returns the same value either way, so no test can distinguish them.

**Everything else:**

- `go test -race -timeout 20m ./...` — green, exit 0.
- `go vet -tags=<tag> ./...` clean for all six build tags.
- Six targets cross-build `./...` and `./cmd/objectfs`, and cross-vet `./internal/... ./pkg/... ./cmd/...`: linux/{amd64,arm64,arm,386}, darwin/{amd64,arm64}.
- `linux/arm GOARM=7` produces `ELF 32-bit LSB executable, ARM, EABI5`.
- `golangci-lint run --new-from-merge-base=origin/main` — 0 issues. `gofmt` clean.
- Both workflows parse; matrix contents and per-step env verified after editing.
- markdownlint at baseline: CHANGELOG 361, DEVELOPMENT 16.

## Two things found along the way

**`DEVELOPMENT.md`'s cross-build section** listed three of the five shipped platforms plus a `GOOS=windows` build that has never produced a binary — `internal/fuse` is `linux || darwin` and `platform_unsupported.go` fails deliberately. Corrected to what `release.yml` publishes, with the 386 canary noted and a sentence on why Windows is absent.

**A dead `-X main.Version` injection**, three copies. `cmd/objectfs/main.go` declares the version in a `const` block and the linker cannot rewrite a constant:

```
$ go build -ldflags="-X main.Version=FAKE-VERSION" -o /tmp/probe ./cmd/objectfs
$ /tmp/probe --version
objectfs version 0.11.0
```

`release.yml:127` already documents this and v0.10.3 removed it there and from the `Dockerfile`. The copy in `DEVELOPMENT.md:444` is fixed here since I was editing the file; `Makefile:11` and `OBJECTFS.md:613` are filed as #353 rather than fixed in a PR about a different thing — the Makefile one affects six targets and deserves its own review of whether commit and build time should be injected for real.
