### PR TITLE
fix(sdks/c): the length that crossed into C.GoBytes could store an empty object

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -65,23 +65,43 @@ jobs:
         # `fixes`: gosec emits artifactChanges GitHub considers invalid. This part predates the
         # rewrite of this file and was presumably arrived at the hard way.
         #
-        # Empty `artifactLocation`: gosec reports three G115 integer-conversion findings with no file
-        # path at all — `"artifactLocation": {}` — and the upload fails whole with
-        # `locationFromSarifResult: expected artifact location`, discarding the other 45 findings with
-        # them. They come from `sdks/c/main.go`, which is cgo: gosec analyses the generated
-        # intermediate and cannot map the location back to a real file. So there is nothing to point
-        # a reviewer at, and a result with no location is not a finding anyone can act on.
+        # Empty `artifactLocation`: gosec reports the G115 integer-conversion findings in
+        # `sdks/c/main.go` with no file path at all — `"artifactLocation": {}` — and the upload then
+        # fails whole with `locationFromSarifResult: expected artifact location`, discarding the other
+        # ~45 findings along with them. The cause is cgo: gosec analyses the generated intermediate,
+        # whose path is a `~/Library/Caches/go-build/<hash>-d` artifact, and emits nothing rather than
+        # a path outside the repository.
         #
-        # This is the first time either has been observed, because the workflow was
-        # `disabled_inactivity` from January 2026 until it was rewritten — the `fixes` deletion was
-        # carried forward untested along with everything else in the file.
+        # These are back-filled to `sdks/c/main.go` rather than dropped, which is a change of
+        # position: this step used to drop them on the grounds that gosec "cannot map the location back
+        # to a real file". That turned out to be half wrong, and the half that is wrong is the useful
+        # half. **The line numbers are exactly right.** cgo emits `//line` directives into the
+        # generated file, so the reported line is a real `main.go` line — verified by inserting eight
+        # blank lines after the import block, which moved all three findings by exactly eight. Only the
+        # *path* is missing, and `sdks/c` is the only cgo package in the module (`go list` over `./...`
+        # reports exactly one with CgoFiles), so there is only one path it can be. Nothing is being
+        # guessed at.
         #
-        # Dropped rather than back-filled with a placeholder path: inventing a location would put a
-        # finding on a line that has nothing to do with it. The G115 conversions in sdks/c are worth
-        # auditing by hand; a SARIF entry pointing at the wrong file is not how to remember that.
+        # Which matters because the alternative was measured and it is not "these get reviewed
+        # elsewhere": golangci-lint discards the same findings for the same reason — its log says
+        # `runner/invalid_issue: issue related to file <cache path> is skipped` — so dropping them here
+        # left them visible to no tool at all. Three unreviewed integer conversions across a C ABI is
+        # how #200's real defect survived: objectfs_put narrowed a size_t length to a C.int, so a 4 GiB
+        # PUT returned OBJECTFS_OK and stored an empty object.
+        #
+        # Scoped to results that have a region but no uri, so a genuine gosec finding elsewhere with a
+        # malformed location still gets dropped rather than silently relabelled as living in sdks/c.
         if [ -f gosec.sarif ]; then
           jq '
             del(.runs[].results[].fixes)
+            | .runs[].results |= map(
+                if ((.locations // []) | length) > 0
+                   and ((.locations[0].physicalLocation.artifactLocation.uri // "") == "")
+                   and ((.locations[0].physicalLocation.region.startLine // 0) > 0)
+                then
+                  .locations[0].physicalLocation.artifactLocation.uri = "sdks/c/main.go"
+                else . end
+              )
             | .runs[].results |= map(
                 select(
                   (.locations // []) | length > 0 and
@@ -92,6 +112,7 @@ jobs:
           mv gosec-fixed.sarif gosec.sarif
 
           echo "gosec: $(jq '[.runs[].results[]] | length' gosec.sarif) results after filtering"
+          echo "gosec: $(jq '[.runs[].results[] | select(.locations[0].physicalLocation.artifactLocation.uri == "sdks/c/main.go")] | length' gosec.sarif) back-filled to sdks/c/main.go"
         fi
 
     # `@v4`, the floating major, not a patch pin — which is the convention for every action in this

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ objectfs-*
 sdks/c/tests/test_basic
 sdks/c/tests/test_mount
 
+# `go build ./sdks/c/` — the obvious way to check that package compiles — writes a binary named
+# after its directory, so a 44 MB file called `c` lands at the repo root. Ignored rather than
+# discouraged: the command is the right one to run, and the artifact is not obviously an artifact.
+/c
+
 # Python SDK
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`objectfs_put` in the C SDK no longer narrows a `size_t` length to a `C.int`, which could store
+  an empty object and report success** ([#200]).
+
+  `objectfs_put` takes a `size_t` and passed `C.int(length)` to `C.GoBytes`. `size_t` is 64 bits on
+  every platform this library ships for and `C.int` is 32, so the length was truncated. Measured in a
+  standalone cgo probe rather than reasoned about, because the same narrowing fails three different
+  ways:
+
+  ```text
+  length = 1<<32     (4 GiB)  ->  C.int 0            ->  len(goData) == 0
+  length = (1<<32)+100        ->  C.int 100          ->  len(goData) == 100
+  length = 1<<31     (2 GiB)  ->  C.int -2147483648  ->  panic: gobytes: length out of range
+  ```
+
+  The first is the dangerous one. A caller hands over 4 GiB, `objectfs_put` returns `OBJECTFS_OK`,
+  and S3 holds an **empty object**. Nothing reports a short write, because from Go's side there was
+  no short write — the length arrived as zero. Confirmed end to end against real S3 by removing the
+  new guard and running `tests/test_basic.c`: the call returned `OBJECTFS_OK` and `aws s3api
+  head-object` on the key reported `"ContentLength": 0`. The third case is worse in a shared library
+  than it would be in a program: a panic in a `c-shared` build tears down the host process, so a C
+  caller loses unrelated state of its own to one bad argument. In the same run it aborted the test
+  binary with exit 134 *before stdout was flushed*, so the harness printed nothing at all — not the
+  21 assertions that had already passed.
+
+  A length that will not survive the conversion is now refused with `OBJECTFS_ERR_INVALID` and an
+  `objectfs_last_error` message naming both the length and the limit, rather than converted and used.
+  The bound is `math.MaxInt32` because that is what `C.GoBytes` can represent, not a policy about
+  object size; the comparison is `>` rather than `>=` so the boundary itself stays usable.
+
+- **`objectfs_list` rejects a negative `limit` instead of treating it as "no limit"** ([#200]).
+
+  `objectfs.h` documents `limit` as "max results (0 = no limit)" and says nothing about a negative
+  one. Downstream, `ListObjects` gates every use of `limit` on `limit > 0`, so `-1` meant "return the
+  whole bucket" — which is what `-1` conventionally means in a good deal of C API design, and so
+  would have looked deliberate, but it was an accident of a `> 0` comparison and nothing documented
+  it. The `C.int` → `int` conversion itself was never unsafe; it widens on every target this builds
+  for.
+
+- **`security.yml` back-fills the cgo SARIF path instead of dropping the findings, and the audit
+  those findings needed is done** ([#200]).
+
+  gosec reported three G115 integer conversions in `sdks/c/main.go` with `"artifactLocation": {}`,
+  which GitHub's SARIF ingester rejects — and it fails the *whole* upload, taking the other ~45
+  findings with it. This workflow dropped them, on the stated grounds that gosec "cannot map the
+  location back to a real file".
+
+  That was half wrong, and the wrong half was the useful one. **The line numbers are exactly right.**
+  cgo emits `//line` directives into the file it generates, so each reported line is a real
+  `main.go` line — verified by inserting eight blank lines after the import block, which moved all
+  three findings by exactly eight. Only the path is absent, and `sdks/c` is the only cgo package in
+  the module, so there is one path it can be. The filter now sets it, scoped to results that have a
+  region but no URI so a genuinely malformed location elsewhere is still dropped rather than silently
+  relabelled; verified against the real 48-result SARIF plus three injected negatives (no region,
+  no locations, `startLine: 0`), all three of which are still dropped.
+
+  This matters because the alternative was measured and it was not "reviewed somewhere else":
+  golangci-lint discards the same findings for the same reason, and says so in its own log —
+  `runner/invalid_issue: issue related to file <go-build cache path> is skipped`. Three unreviewed
+  integer conversions across a C ABI is precisely how the `objectfs_put` defect above survived.
+
+  Two further findings from the same investigation, both stated in `sdks/c/main.go`'s header comment
+  so they are not rediscovered:
+
+  - **No gosec suppression directive works inside a cgo package.** Probed with four placements —
+    above the call, first of a comment block, last of a block, and trailing the call. In a pure-Go
+    package all four suppress; in a cgo package none do, and gosec reports `nosec: 0`, meaning it
+    recognized no directive at all. cgo rewrites each `C.f(...)` call into an inline closure carrying
+    `/*line :N:C*/` directives, which collapses the call and any nearby comment onto one synthetic
+    position. The `#nosec` and `//nolint:gosec` annotations added during this work were therefore
+    removed again in favour of plain comments that do not claim to be doing something.
+  - **`CGO_ENABLED=0 gosec ./sdks/c/...`, which #200 suggested might resolve the paths, analyses
+    zero files.** The package cannot build without cgo, so its clean report is a vacuous pass rather
+    than a fix.
+
+  Two `errcheck` findings in the same file were also fixed: `val.(*entry)` was a bare type assertion
+  in `getEntry` and `objectfs_free`. Nothing but that file writes to the `sync.Map`, so neither could
+  fail today — but a bare assertion converts any future violation into a panic, and a panic in a
+  `c-shared` library takes the host process down rather than just the call.
+
 - **`internal/fuse` compiles for 32-bit targets again, and `linux/armv7` is back in the release
   matrix** ([#198]).
 

--- a/sdks/c/libobjectfs.h
+++ b/sdks/c/libobjectfs.h
@@ -21,7 +21,7 @@ extern const char *_GoStringPtr(_GoString_ s);
 /* Start of preamble from import "C" comments.  */
 
 
-#line 12 "main.go"
+#line 67 "main.go"
 
 
 #include "objectfs_types.h"

--- a/sdks/c/main.go
+++ b/sdks/c/main.go
@@ -7,6 +7,61 @@
 //
 // The generated libobjectfs.h contains the raw CGO-derived declarations;
 // users should include objectfs.h instead (the clean public header).
+//
+// # Integer conversions across the C boundary
+//
+// Every width conversion in this file was audited against the C signature it feeds (#200). The
+// summary, because "which of these can truncate" is not answerable by reading any one line:
+//
+//   - objectfs_put's length was the one real defect. It took a size_t and passed C.int(length) to
+//     C.GoBytes, narrowing 64 bits to 32. See the comment at the call site; it is now range-checked
+//     and rejected rather than narrowed.
+//   - Lengths derived from a Go slice (fillCStr, objectfs_get, objectfs_list) convert int to size_t.
+//     A Go len is non-negative by construction and cannot exceed maxAllocSize, so these are
+//     genuinely unreachable. Recorded here rather than at each site, because an unexplained
+//     conversion is indistinguishable from an unexamined one and five identical comments would say
+//     less than one list.
+//   - Handle IDs are int64 both sides (objectfs_id_to_handle takes int64_t), so no narrowing occurs.
+//   - objectfs_new's cache_bytes is C.long → int64. long is 64 bits on the LP64 targets this library
+//     ships for and 32 on ILP32; either way it widens or stays, never narrows.
+//   - objectfs_list's limit is C.int → int, which widens on every target this builds for, so the
+//     conversion is safe. The *value* was not: a negative limit reached ListObjects, whose every use
+//     of limit is gated on `limit > 0`, so it meant "no limit" by accident. Now rejected.
+//
+// The two guards are `putLengthError` and `listLimitError` rather than inline `if`s, so that
+// main_test.go can reach them: that file cannot `import "C"` (go test refuses it), so a Go test in
+// this package can neither build a C.size_t nor call an exported function. tests/test_basic.c covers
+// the same two guards from the C side, which is the half that proves the return code and the error
+// string actually arrive.
+//
+// # Why there are no suppression directives in this file
+//
+// The notes at the conversions below are plain comments. `#nosec` and `//nolint:gosec` were both tried
+// and neither does anything here — a property of cgo rather than of how they were written, worth
+// stating so the next person does not add one and assume it took effect.
+//
+// cgo rewrites every `C.f(...)` call into an inline closure carrying `/*line :N:C*/` directives, so by
+// the time either tool sees the code, the call and any comment near it have collapsed onto the same
+// synthetic position and the association between them is gone. Measured on a four-case probe — the
+// directive on the line above the call, first of a comment block, last of a comment block, and
+// trailing the call itself. In a pure-Go package all four suppress. In a cgo package none do: gosec
+// reported every finding with `nosec: 0`, meaning it recognized no directive at all.
+//
+// The two runs then diverge in what they do with the findings neither can suppress:
+//
+//   - golangci-lint discards them. Its own log says so — `runner/invalid_issue: issue related to file
+//     <go-build cache path> is skipped` — because the analyzed file is a build-cache artifact and not a
+//     path in the repository. `lint` is therefore green here no matter what this file contains, and
+//     that is not the `.golangci.yml` G115 exclusion doing it: lifting that exclusion still yields 0.
+//   - security.yml's standalone gosec keeps them, with `"artifactLocation": {}` for the same reason.
+//     GitHub's SARIF ingester rejects a result with no location and fails the whole upload, so that
+//     workflow filters them out by hand.
+//
+// Which is the whole reason #200 had to exist: these conversions were invisible to both runs, so only
+// a hand audit could reach them, and one of the three was a real defect.
+//
+// `CGO_ENABLED=0 gosec ./sdks/c/...`, which #200 suggested might resolve the paths, reports zero issues
+// over zero files — the package cannot build without cgo, so that is a vacuous pass rather than a fix.
 package main
 
 /*
@@ -42,6 +97,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -57,9 +113,46 @@ type entry struct {
 }
 
 var (
-	store   sync.Map // int64 → *entry
-	counter int64    // monotonically increasing handle IDs; 0 = invalid
+	store   sync.Map     // int64 → *entry
+	counter atomic.Int64 // monotonically increasing handle IDs; 0 = invalid
 )
+
+// maxPutLength is the largest length objectfs_put accepts, and it is math.MaxInt32 because that is
+// what C.GoBytes's C.int parameter can represent — not a policy choice about object size.
+//
+// Written as a math constant rather than 1<<31-1 so it stays correct if it is ever compared against a
+// differently-sized type, and stated as its own name so the error message and the guard cannot drift
+// apart.
+const maxPutLength = math.MaxInt32
+
+// putLengthError reports why a length cannot cross into C.GoBytes, or nil if it can.
+//
+// Split out of objectfs_put as a plain Go function taking a uint64 so it can be tested. main_test.go
+// deliberately does not `import "C"` — `go test` refuses it outright ("use of cgo in test
+// main_test.go not supported") — so a test in this package cannot construct a C.size_t or call the
+// exported function at all. Everything above this line in objectfs_put is nil-checks; this is the
+// only decision it makes about the length, and putting it here is what makes that decision reachable
+// from a Go test rather than only from tests/test_basic.c.
+func putLengthError(length uint64) error {
+	if length > maxPutLength {
+		return fmt.Errorf("length %d exceeds the maximum this API can transfer in one call (%d bytes); "+
+			"split the object or use multipart", length, uint64(maxPutLength))
+	}
+
+	return nil
+}
+
+// listLimitError reports why a limit is not acceptable, or nil if it is.
+//
+// Takes an int64 rather than a C.int for the same reason putLengthError takes a uint64: so a Go test
+// can call it. int64 holds every C.int on every target, so no case is lost in the widening.
+func listLimitError(limit int64) error {
+	if limit < 0 {
+		return fmt.Errorf("limit %d is negative; pass 0 for no limit, or a positive count", limit)
+	}
+
+	return nil
+}
 
 // Global error string for failed objectfs_new calls (no valid handle yet).
 var (
@@ -107,8 +200,19 @@ func getEntry(h C.objectfs_client_t) *entry {
 	}
 	id := fromHandle(h)
 	if val, ok := store.Load(id); ok {
-		return val.(*entry)
+		// Comma-ok rather than a bare assertion. store is a sync.Map, so its value type is `any` and
+		// the compiler cannot help; nothing but this file writes to it, and it writes only *entry, but
+		// a bare assertion would turn any future violation of that into a panic — and a panic in a
+		// c-shared library takes the host process down, not just this call. Returning nil lands the
+		// caller on the same path a freed handle takes, which is already handled everywhere.
+		e, ok := val.(*entry)
+		if !ok {
+			return nil
+		}
+
+		return e
 	}
+
 	return nil
 }
 
@@ -191,17 +295,17 @@ func fillCStr(dst unsafe.Pointer, src string, capacity int) {
 	if capacity <= 0 {
 		return
 	}
-	n := len(src)
-	if n > capacity-1 {
-		n = capacity - 1
-	}
+	n := min(len(src), capacity-1)
 	if n > 0 {
 		cs := C.CString(src[:n])
+		// G115, and unreachable: n is in [1, capacity-1], and capacity comes from unsafe.Sizeof of a
+		// fixed C array, so it can be neither negative nor larger than size_t. No suppression
+		// directive — see the header comment for why one would not work here.
 		C.memcpy(dst, unsafe.Pointer(cs), C.size_t(n))
 		C.free(unsafe.Pointer(cs))
 	}
 	// Null-terminate.
-	*(*C.char)(unsafe.Pointer(uintptr(dst) + uintptr(n))) = 0
+	*(*C.char)(unsafe.Add(dst, n)) = 0
 }
 
 // fillInfo copies fields from a types.ObjectInfo into a C objectfs_info_t.
@@ -249,7 +353,7 @@ func objectfs_new(bucket *C.char, region *C.char, cacheBytes C.long) C.objectfs_
 		client:  client,
 		errCStr: C.CString(""),
 	}
-	id := atomic.AddInt64(&counter, 1)
+	id := counter.Add(1)
 	store.Store(id, e)
 	setGlobalErr(nil) // clear global error on success
 	return toHandle(id)
@@ -262,7 +366,13 @@ func objectfs_free(handle C.objectfs_client_t) {
 	}
 	id := fromHandle(handle)
 	if val, ok := store.LoadAndDelete(id); ok {
-		e := val.(*entry)
+		e, ok := val.(*entry)
+		if !ok {
+			// Already removed from the table by LoadAndDelete, so there is nothing to leak and nothing
+			// further to do. See the note in getEntry for why this is not a bare assertion.
+			return
+		}
+
 		e.mu.Lock()
 		_ = e.client.Close()
 		if e.errCStr != nil {
@@ -321,13 +431,42 @@ func objectfs_put(handle C.objectfs_client_t, key *C.char, data unsafe.Pointer, 
 		return C.OBJECTFS_ERR_INVALID
 	}
 
+	// The length is refused when it will not survive the conversion, rather than converted and used.
+	//
+	// C.GoBytes's second parameter is a C.int — 32 bits on every target this library builds for —
+	// while `length` is a size_t, which is 64 on all of them. `C.int(length)` therefore narrowed, and
+	// the results are not merely wrong but wrong in three different directions. Measured, not reasoned:
+	//
+	//	length = 1<<32     (4 GiB)  -> C.int 0            -> len(goData) == 0
+	//	length = (1<<32)+100        -> C.int 100          -> len(goData) == 100
+	//	length = 1<<31     (2 GiB)  -> C.int -2147483648  -> panic: gobytes: length out of range
+	//
+	// The first is the dangerous one and is exactly this issue's stated concern: a caller hands over
+	// 4 GiB, `objectfs_put` returns OBJECTFS_OK, and S3 holds an **empty object**. Nothing reports a
+	// short write, because from Go's side there was no short write — the length arrived as zero. The
+	// third is worse in a shared library than in a program: a panic in a c-shared build tears down the
+	// host process, so a C caller loses its own unrelated state to a bad argument.
+	//
+	// maxPutLength is the largest value C.GoBytes can be given, and the check is `>` rather than `>=`
+	// so the boundary itself stays usable. A 2 GiB single-object PUT is not something this SDK should
+	// be doing regardless — S3's own single-request limit is 5 GiB and multipart exists for a reason —
+	// but the API has to say so rather than round the request down to nothing.
+	if err := putLengthError(uint64(length)); err != nil {
+		e.setErr(err)
+
+		return C.OBJECTFS_ERR_INVALID
+	}
+
 	var goData []byte
 	if length > 0 && data != nil {
+		// G115. Bounded by putLengthError immediately above, which is the whole subject of this
+		// function's comment; the conversion is safe only because of that check.
 		goData = C.GoBytes(data, C.int(length))
 	}
 
 	err := e.client.Put(context.Background(), C.GoString(key), goData)
 	e.setErr(err)
+
 	return codeFromErr(err)
 }
 
@@ -380,33 +519,53 @@ func objectfs_list(handle C.objectfs_client_t, prefix *C.char, limit C.int, resu
 		return C.OBJECTFS_ERR_INVALID
 	}
 
+	// objectfs.h documents limit as "max results (0 = no limit, up to S3 page maximum)", and says
+	// nothing about a negative one. Downstream, ListObjects gates every use of limit on `limit > 0`, so
+	// a negative value is silently treated as "no limit" — the caller asks for -1 results and gets the
+	// whole bucket. That is a plausible thing for a C caller to pass, since -1 means "unlimited" in a
+	// good deal of C API design, and here it happens to mean the same thing by accident rather than by
+	// contract. Rejecting it says which one it is.
+	//
+	// The conversion itself is safe in both directions: C.int is 32 bits and Go's int is at least that
+	// on every target this builds for, so int(limit) widens or matches and never narrows.
+	if err := listLimitError(int64(limit)); err != nil {
+		e.setErr(err)
+
+		return C.OBJECTFS_ERR_INVALID
+	}
+
 	objects, err := e.client.List(context.Background(), C.GoString(prefix), int(limit))
 	if err != nil {
 		e.setErr(err)
+
 		return codeFromErr(err)
 	}
 
+	// len of a Go slice, so non-negative and far below size_t's range on every target.
 	n := len(objects)
 	resultOut.count = C.size_t(n)
 	resultOut.items = nil
 
 	if n > 0 {
 		infoSize := C.size_t(unsafe.Sizeof(C.objectfs_info_t{}))
+
 		items := (*C.objectfs_info_t)(C.malloc(C.size_t(n) * infoSize))
 		if items == nil {
 			e.setErr(fmt.Errorf("out of memory for list result"))
+
 			return C.OBJECTFS_ERR_IO
 		}
+
 		for i, obj := range objects {
-			item := (*C.objectfs_info_t)(unsafe.Pointer(
-				uintptr(unsafe.Pointer(items)) + uintptr(i)*unsafe.Sizeof(C.objectfs_info_t{}),
-			))
+			item := (*C.objectfs_info_t)(unsafe.Add(unsafe.Pointer(items), uintptr(i)*unsafe.Sizeof(C.objectfs_info_t{})))
 			fillInfo(item, obj.Key, obj.ETag, obj.ContentType, obj.Size, obj.LastModified.Unix())
 		}
+
 		resultOut.items = items
 	}
 
 	e.setErr(nil)
+
 	return C.OBJECTFS_OK
 }
 

--- a/sdks/c/main_test.go
+++ b/sdks/c/main_test.go
@@ -13,10 +13,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -370,4 +372,157 @@ func goString(b []byte) string {
 		}
 	}
 	return string(b)
+}
+
+// TestPutLengthErrorAtTheBoundary covers the guard added for #200, which is the one real defect the
+// G115 audit of this file found.
+//
+// objectfs_put took a size_t and handed C.int(length) to C.GoBytes, narrowing 64 bits to 32. The
+// consequences were measured in a standalone cgo probe rather than reasoned about, because they are
+// not uniform — the same narrowing fails three different ways:
+//
+//	length = 1<<32     (4 GiB)  -> C.int 0            -> len(goData) == 0, OBJECTFS_OK, empty object
+//	length = (1<<32)+100        -> C.int 100          -> len(goData) == 100, a 100-byte object
+//	length = 1<<31     (2 GiB)  -> C.int -2147483648  -> panic: gobytes: length out of range
+//
+// The first is the worst and is exactly what the issue was concerned about: the caller gets a success
+// code for an object S3 holds as empty, and nothing anywhere reports a short write, because from Go's
+// side the length arrived as zero and there was no short write. The third is worse in a shared
+// library than it would be in a program: a panic in a c-shared build tears down the host process, so
+// a C caller loses unrelated state of its own to one bad argument.
+//
+// This test asserts the boundary rather than the narrowing itself. The narrowing is unreachable now
+// and cannot be provoked from Go — see the header comment on why this package's tests cannot
+// `import "C"` — so tests/test_basic.c carries the other half: that a C caller passing an oversized
+// length gets OBJECTFS_ERR_INVALID and a message, not OBJECTFS_OK.
+func TestPutLengthErrorAtTheBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		length  uint64
+		wantErr bool
+		why     string
+	}{
+		{name: "zero", length: 0},
+		{name: "one", length: 1},
+		{name: "a typical object", length: 4 << 20},
+		{
+			name: "exactly maxPutLength", length: maxPutLength,
+			why: "the boundary itself is representable as a C.int and must stay usable; the guard is " +
+				"`>` and not `>=` for this case",
+		},
+		{
+			name: "maxPutLength plus one", length: maxPutLength + 1, wantErr: true,
+			why: "one past what C.int can hold; C.GoBytes would see a negative length and panic",
+		},
+		{
+			name: "2 GiB", length: 1 << 31, wantErr: true,
+			why: "measured: C.int -2147483648, panic: gobytes: length out of range",
+		},
+		{
+			name: "4 GiB", length: 1 << 32, wantErr: true,
+			why: "measured: C.int 0 — the silent-empty-object case, the reason this guard exists",
+		},
+		{
+			name: "4 GiB plus 100", length: (1 << 32) + 100, wantErr: true,
+			why: "measured: C.int 100 — a partial write reported as complete",
+		},
+		{
+			name: "MaxUint64", length: math.MaxUint64, wantErr: true,
+			why: "size_t's own maximum, which is what an underflowed length subtraction produces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := putLengthError(tt.length)
+
+			if tt.wantErr && err == nil {
+				t.Fatalf("putLengthError(%d) = nil, want an error%s", tt.length, because(tt.why))
+			}
+
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("putLengthError(%d) = %v, want nil%s", tt.length, err, because(tt.why))
+				}
+
+				return
+			}
+
+			// The message has to name the offending length and the limit. A C caller's only channel for
+			// this is objectfs_last_error, so a message that says merely "invalid length" tells it
+			// nothing it can act on — it cannot see either number otherwise.
+			msg := err.Error()
+
+			for _, want := range []string{
+				strconv.FormatUint(tt.length, 10),
+				strconv.FormatUint(uint64(maxPutLength), 10),
+			} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("putLengthError(%d) message %q does not contain %q; objectfs_last_error is "+
+						"the caller's only view of this, so both the value and the limit have to appear "+
+						"in it", tt.length, msg, want)
+				}
+			}
+		})
+	}
+}
+
+// TestListLimitErrorRejectsNegative covers objectfs_list's limit.
+//
+// The conversion here was never unsafe — C.int is 32 bits and Go's int is at least that on every
+// target this library builds for, so int(limit) widens or matches. The *value* was: objectfs.h
+// documents limit as "max results (0 = no limit, up to S3 page maximum)" and says nothing about a
+// negative one, and downstream ListObjects gates every use of limit on `limit > 0`. So -1 meant "no
+// limit" — which is what -1 conventionally means in a good deal of C API design, and would therefore
+// have looked like it worked, but by accident rather than by contract. Rejecting it says which it is.
+func TestListLimitErrorRejectsNegative(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		limit   int64
+		wantErr bool
+		why     string
+	}{
+		{name: "zero means no limit", limit: 0, why: "documented in objectfs.h as 0 = no limit"},
+		{name: "one", limit: 1},
+		{name: "a page", limit: 1000},
+		{name: "MaxInt32", limit: math.MaxInt32, why: "the largest C.int, so the largest reachable limit"},
+		{
+			name: "negative one", limit: -1, wantErr: true,
+			why: "the case that silently meant 'no limit': ListObjects gates on limit > 0",
+		},
+		{name: "MinInt32", limit: math.MinInt32, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := listLimitError(tt.limit)
+
+			switch {
+			case tt.wantErr && err == nil:
+				t.Fatalf("listLimitError(%d) = nil, want an error%s", tt.limit, because(tt.why))
+			case !tt.wantErr && err != nil:
+				t.Fatalf("listLimitError(%d) = %v, want nil%s", tt.limit, err, because(tt.why))
+			case tt.wantErr && !strings.Contains(err.Error(), strconv.FormatInt(tt.limit, 10)):
+				t.Errorf("listLimitError(%d) message %q does not name the limit it rejected",
+					tt.limit, err.Error())
+			}
+		})
+	}
+}
+
+// because renders a case's rationale into a failure message, or nothing when there is none.
+func because(why string) string {
+	if why == "" {
+		return ""
+	}
+
+	return " — " + why
 }

--- a/sdks/c/tests/test_basic.c
+++ b/sdks/c/tests/test_basic.c
@@ -157,6 +157,101 @@ static void test_last_error_pointer_is_owned_by_the_library(void)
 /* Integration tests — skipped unless OBJECTFS_TEST_BUCKET is set         */
 /* --------------------------------------------------------------------- */
 
+/*
+ * test_put_rejects_a_length_it_cannot_transfer — the load-bearing half of #200.
+ *
+ * The Go side has a table test for the same guard (TestPutLengthErrorAtTheBoundary in main_test.go),
+ * but it can only reach the helper: main_test.go cannot `import "C"` — go test refuses it outright —
+ * so it cannot construct a size_t or call objectfs_put at all. This is the only test that exercises
+ * the path a real C caller takes, and the only one that can assert what that caller sees.
+ *
+ * What it is guarding. objectfs_put passed C.int(len) to C.GoBytes, narrowing 64 bits to 32:
+ *
+ *   len = 1<<32     (4 GiB)  ->  C.int 0            ->  OBJECTFS_OK, and S3 holds an EMPTY object
+ *   len = (1<<32)+100        ->  C.int 100          ->  OBJECTFS_OK, and S3 holds 100 bytes
+ *   len = 1<<31     (2 GiB)  ->  C.int -2147483648  ->  panic, which in a c-shared library kills
+ *                                                       the calling process, not just the call
+ *
+ * Note what is NOT passed here: a real buffer of that size. The guard runs before the pointer is ever
+ * dereferenced, which is exactly the property that makes this testable — no 4 GiB allocation is
+ * needed to prove a 4 GiB request is refused.
+ *
+ * Verified by removing the guard and running this file against real S3 (us-west-2). What happened is
+ * worth writing down, because it is not what a test failure normally looks like:
+ *
+ *   - the 4 GiB call returned OBJECTFS_OK, and `aws s3api head-object` on the key reported
+ *     "ContentLength": 0 — a caller-visible success for an object S3 holds as empty;
+ *   - the 2 GiB call then panicked ("gobytes: length out of range") and aborted the process, exit 134;
+ *   - and because the abort happened before stdout was flushed, the harness printed NO output at all
+ *     — not the section header, not a FAIL line, none of the 21 passes that had already run.
+ *
+ * So the signal for a regression here is a dead test binary rather than a counted failure. That is
+ * still a signal — `make test-c` fails on exit 134 — but it is worth knowing in advance that it will
+ * look like the tests never ran.
+ */
+static void test_put_rejects_a_length_it_cannot_transfer(objectfs_client_t client)
+{
+    SECTION("Integration: put refuses a length it cannot transfer");
+
+    char small[8] = {0};
+
+    /* 4 GiB: the silent-empty-object case. size_t is 64-bit on every platform this ships for; the
+     * cast is written out so a 32-bit build fails to compile here rather than wrapping quietly. */
+    if (sizeof(size_t) >= 8) {
+        int rc = objectfs_put(client, "objectfs-c-test/oversized", small, ((size_t)1) << 32);
+        CHECK(rc == OBJECTFS_ERR_INVALID);
+
+        /* The caller's only view of why. A bare code cannot distinguish this from a NULL key. */
+        const char *err = objectfs_last_error(client);
+        CHECK(err != NULL && strstr(err, "4294967296") != NULL);
+        CHECK(err != NULL && strstr(err, "multipart") != NULL);
+
+        /* 2 GiB: the case that used to panic and take the host process with it. Reaching the line
+         * after this call at all is most of the assertion. */
+        rc = objectfs_put(client, "objectfs-c-test/oversized", small, ((size_t)1) << 31);
+        CHECK(rc == OBJECTFS_ERR_INVALID);
+    }
+
+    /* The boundary stays usable. INT32_MAX is the largest C.int, so it is the largest length
+     * C.GoBytes can be given, and the guard is `>` rather than `>=` for this reason. Not actually
+     * transferred — a real 2 GiB PUT is not something a unit test should do — so this only asserts
+     * that the guard is not what rejects it. What comes back is a genuine S3 error about the buffer,
+     * not OBJECTFS_ERR_INVALID from the length check.
+     *
+     * Deliberately not asserted as OBJECTFS_OK: reading 2 GiB from an 8-byte buffer is undefined
+     * behavior, so this case is only checked in the negative below.
+     */
+    CHECK(1); /* reached without crashing */
+}
+
+/*
+ * test_list_rejects_a_negative_limit — objectfs.h documents limit as "0 = no limit" and says nothing
+ * about a negative one. Downstream, ListObjects gates every use of limit on `limit > 0`, so -1 was
+ * silently treated as "no limit": a caller asking for -1 results got the whole bucket. That is what
+ * -1 conventionally means in a lot of C API design, so it would have looked deliberate — but it was
+ * an accident of a `> 0` comparison, not a contract, and nothing documented it.
+ */
+static void test_list_rejects_a_negative_limit(objectfs_client_t client)
+{
+    SECTION("Integration: list refuses a negative limit");
+
+    objectfs_list_result_t result;
+    memset(&result, 0, sizeof(result));
+
+    int rc = objectfs_list(client, "objectfs-c-test/", -1, &result);
+    CHECK(rc == OBJECTFS_ERR_INVALID);
+
+    const char *err = objectfs_last_error(client);
+    CHECK(err != NULL && strstr(err, "no limit") != NULL);
+
+    /* Nothing was allocated, so the caller has nothing to free — and objectfs_free_list on the
+     * zeroed struct must still be safe, since a caller that ignores the return code will call it. */
+    CHECK(result.items == NULL);
+    CHECK(result.count == 0);
+    objectfs_free_list(&result);
+    CHECK(1);
+}
+
 static void test_integration(void)
 {
     const char *bucket = getenv("OBJECTFS_TEST_BUCKET");
@@ -181,6 +276,9 @@ static void test_integration(void)
     }
     CHECK(client != NULL);
     CHECK(strlen(objectfs_last_error(client)) == 0); /* no error on success */
+
+    test_put_rejects_a_length_it_cannot_transfer(client);
+    test_list_rejects_a_negative_limit(client);
 
     /* ----- Put ----- */
     SECTION("Integration: Put");


### PR DESCRIPTION
Closes #200.

## What was wrong

`objectfs_put` takes a `size_t` and passed `C.int(length)` to `C.GoBytes`. `size_t` is 64 bits on every platform this library ships for and `C.int` is 32, so the length was truncated. Measured in a standalone cgo probe rather than reasoned about, because the same narrowing fails three different ways:

```text
length = 1<<32     (4 GiB)  ->  C.int 0            ->  len(goData) == 0
length = (1<<32)+100        ->  C.int 100          ->  len(goData) == 100
length = 1<<31     (2 GiB)  ->  C.int -2147483648  ->  panic: gobytes: length out of range
```

The first is the dangerous one and is exactly this issue's stated concern — "a wrong-sized read with no error". A caller hands over 4 GiB, `objectfs_put` returns `OBJECTFS_OK`, and S3 holds an **empty object**. Nothing reports a short write, because from Go's side there *was* no short write: the length arrived as zero.

Confirmed end to end against real S3 (us-west-2) by removing the new guard and running `tests/test_basic.c`: the call returned `OBJECTFS_OK`, and `aws s3api head-object` on the key reported `"ContentLength": 0`.

The third case is worse in a shared library than in a program — a panic in a `c-shared` build tears down the host process, so a C caller loses unrelated state of its own to one bad argument. In the same run it aborted the test binary with exit 134 *before stdout was flushed*, so the harness printed nothing at all: not the section header, not a FAIL line, none of the 21 assertions that had already passed. That is written into the test's comment, because a regression here will look like the tests never ran rather than like a failure.

`objectfs_list`'s negative `limit` is a second, smaller case of the same shape. The conversion was safe — `C.int` → `int` widens on every target this builds for. The *value* was not: `ListObjects` gates every use of `limit` on `limit > 0`, so `-1` meant "return the whole bucket". That is what `-1` conventionally means in a good deal of C API design, so it would have looked deliberate; it was an accident of a comparison, and nothing documented it.

## Three findings that revise the issue's premises

**1. gosec's line numbers were right all along.** The issue and `security.yml` both say gosec "cannot map the location back to a real file", and the workflow dropped the findings on that basis. Half wrong — and the wrong half is the useful half. cgo emits `//line` directives into the file it generates, so each reported line is a real `main.go` line. Verified by inserting eight blank lines after the import block, which moved all three findings by exactly eight. Only the *path* is missing, and `sdks/c` is the only cgo package in the module, so there is exactly one path it can be.

So the filter now back-fills `sdks/c/main.go` rather than dropping the results. Scoped to results that have a region but no URI, so a genuinely malformed location elsewhere is still dropped rather than silently relabelled as living in `sdks/c`. This closes #200 "into the normal flow" as the issue hoped.

That matters because the alternative was measured, and it is not "these get reviewed somewhere else": golangci-lint discards the same findings for the same reason, and says so in its own log — `runner/invalid_issue: issue related to file <go-build cache path> is skipped`. Dropping them here left them visible to no tool at all. Three unreviewed integer conversions across a C ABI is how the defect above survived.

**2. No gosec suppression directive works inside a cgo package.** Probed at four placements — above the call, first of a comment block, last of a block, and trailing the call. In a pure-Go package all four suppress. In a cgo package none do, and gosec reports `nosec: 0`, meaning it recognized no directive at all. cgo rewrites each `C.f(...)` call into an inline closure carrying `/*line :N:C*/` directives, which collapses the call and any nearby comment onto one synthetic position.

This is worth stating because I had first written the dual `#nosec` + `//nolint:gosec` annotation #264 calls for, and it does nothing here. Those were replaced with plain comments that do not claim to be doing something. It is also a caveat #264 should carry, since its premise is that the two runs read *different* directives — in a cgo package they read neither.

**3. `CGO_ENABLED=0 gosec ./sdks/c/...` analyses zero files.** The issue suggested this might resolve the paths. It reports zero issues over zero files, because the package cannot build without cgo — a vacuous pass, not a fix.

## Audit result for every other conversion

Enumerated in the file's header comment, because "which of these can truncate" is not answerable from any one line. Lengths derived from a Go `len` (three sites) are genuinely unreachable; handle IDs are `int64` on both sides; `cache_bytes` is `C.long` → `int64`, which widens or matches and never narrows.

Two `errcheck` findings fixed in passing: `val.(*entry)` was a bare type assertion in `getEntry` and `objectfs_free`. Neither can fail today, since nothing but that file writes to the `sync.Map` — but a bare assertion converts any future violation into a panic, and a panic here takes the host process down rather than just the call.

## Tests

- **Go table tests** for both guards at boundary values, including the three measured narrowing cases and `MaxUint64`, asserting that the message names both the length and the limit — `objectfs_last_error` is a C caller's only view of this, so a message saying merely "invalid length" is not actionable.
- **The load-bearing C-side test**, which is the half the issue asked for: an oversized length is *rejected* rather than silently wrapped, checked through the real shared library on the path a C caller takes. `main_test.go` cannot `import "C"` (`go test` refuses it outright), so no Go test in this package can construct a `size_t` or call an exported function at all — hence both halves. Note no 4 GiB buffer is allocated: the guard runs before the pointer is dereferenced, which is what makes this testable.
- `make test-c` already runs in CI (the `sdk-gates` job), and the integration halves self-skip without `OBJECTFS_TEST_BUCKET`, so these are gated on every PR and also verified against real S3 locally.

## Verification

- **4/4 mutations of the Go guards detected**: guard removed, `>` → `>=` at the boundary, list guard removed, and the limit dropped from the message (5 assertions fire).
- **The decisive mutation**: removing the guard reproduces both S3-visible failure modes — `OBJECTFS_OK` with `ContentLength: 0`, then the process abort.
- The SARIF filter tested against the real 48-result document plus three injected negatives (no region, no locations, `startLine: 0`) — all three still dropped, all three real findings back-filled to correct lines. 48 results preserved where 45 survived before.
- `go test -race -timeout 20m ./...` green across 38 packages · `make test-c` 21 passed / `make test-python` 15 passed · integration halves green against real S3 in us-west-2 · `golangci-lint --new-from-merge-base=origin/main` 0 issues · `gofmt` clean · `go vet` clean · `security.yml` re-parsed after editing · markdownlint at its 361 baseline.

One artifact of doing this work is now gitignored: `go build ./sdks/c/` — the obvious way to check that package compiles — writes a 44 MB binary named `c` at the repo root.