### PR TITLE
build: stop passing three linker flags that set nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`make build` no longer passes three linker flags that do nothing** ([#353]).
+
+  `Makefile`'s `LDFLAGS` injected `-X main.Version`, `-X main.Commit` and `-X main.BuildTime`, and none
+  of those symbols exist. `cmd/objectfs/main.go` declares the version as an untyped *constant*, which
+  the linker cannot rewrite, so all three were accepted and silently ignored:
+
+  ```text
+  $ go build -ldflags="-s -w -X main.Version=FAKE-VERSION" -o /tmp/probe ./cmd/objectfs
+  $ /tmp/probe --version
+  objectfs version 0.11.0
+  ```
+
+  Every target sharing that variable — `build`, `build-all`, `build-linux`, `build-darwin`, `install`
+  and `package` — passed the dead flags. `OBJECTFS.md`'s build-configuration example showed the same
+  injection, and its three `go build` lines targeted `.` rather than `./cmd/objectfs`, which is not a
+  main package; both are corrected.
+
+  Dropped rather than made real, which is the choice `.github/workflows/release.yml` already made and
+  explains at its build step: the constant is the documented single authority for the version, so the
+  release asserts that it and the git tag agree instead of overwriting it at link time and leaving the
+  source disagreeing with the shipped artifact. `VERSION`, `COMMIT` and `BUILD_TIME` are still real
+  Makefile variables — `make version` prints them and the packaging targets name archives with them.
+  They simply do not reach the binary, and nothing now claims they do.
+
+  Whether the binary should report its commit and build time at all is a separate question: those two
+  have no constant to disagree with, so there is a real argument for injecting them — but `--version`
+  does not print them today, so injecting them would produce values nothing displays.
+
 - **`internal/fuse` compiles for 32-bit targets again, and `linux/armv7` is back in the release
   matrix** ([#198]).
 
@@ -401,8 +429,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `platform_unsupported.go` fails deliberately. It now lists what `release.yml` publishes, notes the
   386 canary, and says why Windows is absent. Its local-build snippet also passed
   `-ldflags "-X main.Version=$VERSION"`, which does nothing: `version` is a `const` and the linker
-  cannot rewrite a constant. Two other copies of that dead injection survive, in `Makefile:11` and
-  `OBJECTFS.md:613`, and are filed rather than fixed here ([#353]).
+  cannot rewrite a constant. Two other copies of that dead injection were in `Makefile` and
+  `OBJECTFS.md`; they were filed rather than fixed here, and are fixed above in the same release
+  ([#353]).
 
 [#198]: https://github.com/scttfrdmn/objectfs/issues/198
 [#200]: https://github.com/scttfrdmn/objectfs/issues/200

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,18 @@ BUILD_TIME := $(shell date -u '+%Y-%m-%d_%I:%M:%S%p')
 GO_VERSION := $(shell go version | cut -d ' ' -f 3)
 
 # Build flags
-LDFLAGS := -ldflags="-s -w -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildTime=$(BUILD_TIME)"
+#
+# No -X: main.Version, main.Commit and main.BuildTime do not exist. cmd/objectfs/main.go declares an
+# untyped `version` *constant*, which the linker cannot rewrite, so all three flags were accepted and
+# silently ignored — `-X main.Version=FAKE` builds a binary that still reports the constant. Every
+# target below shares this variable, so that was six targets passing three dead symbols.
+#
+# The constant stays the single authority, which is what CLAUDE.md asks for and what
+# .github/workflows/release.yml already does: it asserts the tag and the constant agree rather than
+# injecting a version the source then disagrees with. VERSION, COMMIT and BUILD_TIME above are still
+# real — `make version` prints them and the packaging targets name archives with them; they just do
+# not reach the binary.
+LDFLAGS := -ldflags="-s -w"
 TAGS := release,netgo
 DEBUG_TAGS := debug
 RACE_FLAGS := -race

--- a/OBJECTFS.md
+++ b/OBJECTFS.md
@@ -610,18 +610,24 @@ make build-all-platforms
 ```makefile
 # Makefile configuration
 VERSION := $(shell git describe --tags --always)
-LDFLAGS := -ldflags="-s -w -X main.Version=$(VERSION)"
+LDFLAGS := -ldflags="-s -w"
 TAGS := release,netgo
 
 build-production:
-	CGO_ENABLED=0 GOOS=linux go build $(LDFLAGS) -tags $(TAGS) -o objectfs .
+	CGO_ENABLED=0 GOOS=linux go build $(LDFLAGS) -tags $(TAGS) -o objectfs ./cmd/objectfs
 
 build-debug:
-	go build -race -tags debug -o objectfs-debug .
+	go build -race -tags debug -o objectfs-debug ./cmd/objectfs
 
 build-profile:
-	go build -tags profile -o objectfs-profile .
+	go build -tags profile -o objectfs-profile ./cmd/objectfs
 ```
+
+`LDFLAGS` carries no `-X`. This example used to inject `main.Version`, and there is no such symbol:
+`cmd/objectfs/main.go` declares the version as an untyped constant, which the linker cannot rewrite,
+so the flag was accepted and ignored. The constant is the single authority for the version — the
+release workflow asserts that it and the git tag agree rather than injecting a value the source would
+then disagree with. `VERSION` remains useful for naming artifacts.
 
 ### Environment Setup
 


### PR DESCRIPTION
Closes #353.

`Makefile`'s `LDFLAGS` injected `-X main.Version`, `-X main.Commit` and `-X main.BuildTime`. None of those symbols exist — `cmd/objectfs/main.go` declares the version as an untyped **constant**, which the linker cannot rewrite, so all three were accepted and silently ignored:

```console
$ go build -ldflags="-s -w -X main.Version=FAKE-VERSION" -o /tmp/probe ./cmd/objectfs
$ /tmp/probe --version
objectfs version 0.11.0
```

Six targets share that variable — `build`, `build-all`, `build-linux`, `build-darwin`, `install`, `package` — so each passed three dead symbols. `OBJECTFS.md`'s build-configuration example showed the same injection, and its three `go build` lines targeted `.` rather than `./cmd/objectfs`, which is not a main package and would not have built as written; both are corrected.

## Why dropped rather than made real

This is the choice `.github/workflows/release.yml` already made, and explains at its build step: the constant is the documented single authority for the version (`CLAUDE.md`), so a release asserts that it and the git tag agree rather than overwriting it at link time and leaving the source disagreeing with the shipped artifact. Making the flags work would mean moving the version to a `var`, which contradicts that authority.

`VERSION`, `COMMIT` and `BUILD_TIME` remain real Makefile variables — `make version` prints all three and the packaging targets name archives with them. They just do not reach the binary, and no comment now claims they do.

Whether the binary should report its commit and build time at all is left open as a separate question. Neither has a constant to disagree with, so there is a genuine argument for injecting those two — but `--version` does not print them, so today it would produce values nothing displays.

## One correction to this release's own changelog

The `[#198]` entry already in `Unreleased` said these two copies *"survive"* and were filed rather than fixed. This PR makes that false, so it now points at the new entry instead of contradicting it in the same section.

## Verification

```console
$ make build && ./bin/objectfs --version
objectfs version 0.11.0
$ make version
Version: v0.11.0-55-g90e951a-dirty
Commit: 90e951a
Build Time: 2026-08-05_03:41:01AM
```

`grep -rn "main\.Version\|main\.Commit\|main\.BuildTime"` across `*.go`, `*.md`, `Makefile`, `*.yml` and `Dockerfile` now returns only prose that explains why the symbols do not exist — no live `-X` flag anywhere. `markdownlint` unchanged on both edited files (`CHANGELOG.md` 361, `OBJECTFS.md` 72).
