### PR TITLE
deps(sdks/javascript): eventemitter3 4.0.7 → 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1633,6 +1633,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`eventemitter3` 4.0.7 → 5.0.4 in the JavaScript SDK.** A major bump, taken by hand rather than by
+  merging [#346], because that pull request carried four unrelated *downgrades* alongside it: `jest`
+  30 → 29, `typescript` 6 → 5, `typedoc` 0.28 → 0.24, and `@types/jest` 30 → 29. Dependabot had opened
+  it against a manifest that has since moved forward, and its lockfile regeneration reverted the newer
+  pins rather than preserving them. Merging it would have rolled the toolchain back to buy one
+  dependency bump — quietly, since a lockfile diff of 2,883 lines does not advertise which four of its
+  versions went the wrong way.
+
+  The bump itself is safe, and the two facts that make it safe are worth naming because the major
+  version number tells you neither. v5's breaking changes are the removal of the `EventEmitter2` and
+  `EventEmitter3` aliases and of the CommonJS default export; `sdks/javascript/src/client.ts:8` imports
+  `{ EventEmitter }` — the named export, unchanged across the major — and the SDK references neither
+  alias. Verified rather than reasoned: `tsc` compiles clean, all 65 tests across 4 suites pass,
+  `npm run lint` reports 0 errors, and `require('eventemitter3').EventEmitter` constructs and
+  round-trips an `emit` under 5.0.4.
+
+[#346]: https://github.com/scttfrdmn/objectfs/pull/346
+
 - **The JavaScript SDK's fabricated operations throw instead of returning invented data, and its
   README documents what the code does** ([#325]). Ten methods reported success for work they never
   performed. The worst wrote to disk: `S3StorageAdapter.downloadObject` did

--- a/sdks/javascript/package-lock.json
+++ b/sdks/javascript/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.4.0",
-        "eventemitter3": "^4.0.7",
+        "eventemitter3": "^5.0.4",
         "ws": "^8.13.0",
         "yaml": "^2.3.0"
       },
@@ -3324,9 +3324,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/execa": {

--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/scttfrdmn/objectfs/tree/main/sdks/javascript",
   "dependencies": {
     "axios": "^1.4.0",
-    "eventemitter3": "^4.0.7",
+    "eventemitter3": "^5.0.4",
     "ws": "^8.13.0",
     "yaml": "^2.3.0"
   },


### PR DESCRIPTION
Closes #346 — which should be closed rather than merged, and that is the point
of this PR.

## Why not just merge #346

Dependabot opened it against a manifest that has since moved forward. Its
lockfile regeneration did not preserve the newer pins; it reverted them. The
manifest diff:

```diff
-    "eventemitter3": "^4.0.7",
+    "eventemitter3": "^5.0.4",       <- the bump it is named for
-    "@types/jest": "^30.0.0",
+    "@types/jest": "^29.5.0",        <- downgrade
-    "jest": "^30.0.0",
+    "jest": "^29.5.0",               <- downgrade
-    "typedoc": "^0.28.20",
+    "typedoc": "^0.24.0",            <- downgrade
-    "typescript": "^6.0.0",
+    "typescript": "^5.0.0",          <- downgrade
```

Merging it buys one dependency bump and rolls the toolchain back four versions
to pay for it. A 2,883-line lockfile diff does not advertise which four of its
versions went the wrong way, which is why this was worth checking rather than
rubber-stamping.

This PR is the same bump with nothing else in it: two lines of manifest, eight
of lockfile.

## Why the major is safe

The version number does not tell you. v5's breaking changes are:

1. the `EventEmitter2` and `EventEmitter3` aliases are removed
2. the CommonJS default export is removed

`sdks/javascript/src/client.ts:8` does `import { EventEmitter } from 'eventemitter3'`
— the **named** export, unchanged across the major — and the SDK references
neither alias anywhere.

## Verified, not reasoned

A predicted-compatible import has been wrong on this repo before, so:

| check | result |
|---|---|
| `npm run build` (`tsc`) | compiles clean |
| `npm test` | 65 passed, 4 suites |
| `npm run lint` | **0 errors**, 19 `no-explicit-any` warnings (unchanged) |
| `require('eventemitter3').EventEmitter` | constructs; `emit` round-trips a value |
| resolved version | 5.0.4 |

All four are what CI runs on `sdks/javascript` — `npm ci`, `npm run build`,
`npm test`, `npm run lint` — so this is the same gate, run locally first.