### PR TITLE
fix: classify acceleration errors by code and message, not by substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,6 +529,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Error classification for Transfer Acceleration no longer disables the accelerated endpoint on
+  unrelated failures** ([#187]).
+
+  `isAccelerationError` substring-matched six patterns against `err.Error()`, two of which are not
+  acceleration errors: `InvalidRequest`, which is S3's code for a large family of malformed requests,
+  and `BucketAlreadyExists`, which is `CreateBucket`'s name collision and was listed with the comment
+  "sometimes returned for acceleration errors". Because the match was against a *message* rather than
+  a code, both also fired on any wrapped error whose text happened to quote them, and `InvalidRequest`
+  matched inside `InvalidRequestException`.
+
+  A false positive here is not a wasted retry. `executeWithAccelerationFallback` calls
+  `DisableAcceleration` for the remaining life of the mount, so the first unrelated `InvalidRequest`
+  — a bad `Range`, a single-part `CopyObject` above 5 GiB — permanently dropped the mount back to the
+  standard endpoint, and logged a warning naming acceleration regardless of what had actually failed.
+
+  The obvious fix does not work, and the code now says why so it is not simplified back: **S3 has no
+  acceleration-specific error code.** Every acceleration failure arrives as `InvalidRequest`
+  distinguished only by its message — "not configured on this bucket", "disabled on this bucket",
+  "not supported for buckets with non-DNS compliant names". So matching the code against a closed set,
+  the way `isInvalidRange` does, would classify every one of those as unrelated and leave the fallback
+  as dead code. What replaces it is a conjunction: a structured `smithy.APIError` whose code is
+  *exactly* `InvalidRequest` **and** whose message names Transfer Acceleration. Both halves are
+  load-bearing, and each is pinned by a test that fails when the other is removed. The one
+  message-only arm left is for a DNS or TLS failure reaching `<bucket>.s3-accelerate.amazonaws.com`,
+  which carries the hostname and no error code at all; it matches the hostname rather than the word
+  "acceleration", so an unrelated error mentioning acceleration in prose cannot trigger it.
+
+- **Persistent cache filenames use the whole SHA-256 rather than its first 8 bytes** ([#187]).
+
+  Sixty-four bits reaches a one-in-a-million collision chance at around 6 million entries, which a
+  long-lived cache on a large bucket can pass.
+
+  What a collision would actually have cost was measured before changing anything, and it is not
+  corrupt data: the index is keyed on the full entry key and `readFromFile` verifies a full SHA-256 of
+  the content, so two keys landing on one filename produce a **miss** — the checksum fails, the entry
+  is dropped, and the shared file goes with it, costing the other key its entry too. Deleting that
+  checksum check and re-running the same probe *does* serve the wrong bytes under the wrong key, so
+  the content checksum is the guard and the filename width is hygiene. Both directions are now tests.
+
+  Existing cache directories are unaffected. `FilePath` is stored in the index and every read uses the
+  stored value, so the new width applies only to newly written entries; files with the old short names
+  stay readable until they expire or are evicted.
+
 - **Every package the coverage gate reports as unfloored now has a recorded reason, and a test keeps
   the two in agreement** ([#199]).
 
@@ -855,6 +898,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OBJECTFS.md`; they were filed rather than fixed here, and are fixed above in the same release
   ([#353]).
 
+[#187]: https://github.com/scttfrdmn/objectfs/issues/187
 [#198]: https://github.com/scttfrdmn/objectfs/issues/198
 [#199]: https://github.com/scttfrdmn/objectfs/issues/199
 [#200]: https://github.com/scttfrdmn/objectfs/issues/200

--- a/internal/cache/persistent.go
+++ b/internal/cache/persistent.go
@@ -576,10 +576,25 @@ func (c *PersistentCache) isExpired(item *persistentItem) bool {
 	return time.Since(item.Timestamp) > c.config.TTL
 }
 
+// generateFilePath names the on-disk file for a cache key.
+//
+// The full SHA-256 rather than its first 8 bytes (audit finding L25). Sixty-four bits gives a 50%
+// chance of some collision at ~5 billion entries and a one-in-a-million chance at ~6 million, which a
+// long-lived cache on a large bucket can reach; 256 bits cannot be reached.
+//
+// What a collision actually cost was worth measuring before changing this, and it is not corruption:
+// the index is keyed on the full entryKey string and readFromFile verifies a full SHA-256 of the
+// content, so two keys landing on one filename produce a *miss* — the checksum fails, dropEntry runs,
+// and the shared file goes with it, costing the other key its entry too. Removing that checksum check
+// and re-running the same probe does serve the wrong bytes, so the checksum is the guard and this
+// width is hygiene. Both were verified by mutation.
+//
+// Widening is backward compatible with a cache directory written by an older build: FilePath is stored
+// in the index and every read uses the stored value, so this function is only consulted for new
+// entries. Old files keep their short names until they expire or are evicted.
 func (c *PersistentCache) generateFilePath(key string) string {
 	hash := sha256.Sum256([]byte(key))
-	filename := fmt.Sprintf("%x", hash[:8]) // Use first 8 bytes of hash
-	return filepath.Join(c.directory, filename+".cache")
+	return filepath.Join(c.directory, fmt.Sprintf("%x.cache", hash))
 }
 
 func (c *PersistentCache) calculateChecksum(data []byte) string {

--- a/internal/cache/persistent_test.go
+++ b/internal/cache/persistent_test.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -527,6 +529,124 @@ func TestPersistentCache_ChecksumValidation(t *testing.T) {
 	retrieved := cache.Get(key, 0, int64(len(data)))
 	if retrieved != nil {
 		t.Error("should return nil for corrupted data")
+	}
+}
+
+// TestPersistentCache_FilenameUsesFullHash pins the on-disk filename width (audit finding L25).
+//
+// The cache used to name files after the first 8 bytes of the key's SHA-256. Sixty-four bits is
+// reachable by a long-lived cache on a large bucket, and this test asserts the full digest is used so
+// a later "shorter names are tidier" change has to argue with a failing test.
+func TestPersistentCache_FilenameUsesFullHash(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cache, err := NewPersistentCache(&PersistentCacheConfig{
+		Directory: tmpDir,
+		MaxSize:   10 * 1024 * 1024,
+		TTL:       time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewPersistentCache failed: %v", err)
+	}
+	defer func() { _ = cache.Close() }()
+
+	key := entryKey("some/object", 0)
+	got := filepath.Base(cache.generateFilePath(key))
+
+	want := fmt.Sprintf("%x.cache", sha256.Sum256([]byte(key)))
+	if got != want {
+		t.Errorf("generateFilePath basename = %q, want %q", got, want)
+	}
+
+	// 64 hex characters plus ".cache". Stated as a length too, because that is the property that
+	// matters and it fails loudly if the digest is ever truncated some other way.
+	if len(got) != sha256.Size*2+len(".cache") {
+		t.Errorf("filename %q is %d chars; a full SHA-256 digest plus .cache is %d",
+			got, len(got), sha256.Size*2+len(".cache"))
+	}
+}
+
+// TestPersistentCache_CollidingFilenameMisses records what a filename collision actually costs, which
+// is not corruption: the index is keyed on the full entry key and readFromFile verifies a full SHA-256
+// of the content, so a collision is a miss.
+//
+// The collision is simulated rather than found — with the full digest in use it is not reachable —
+// by pointing one entry's FilePath at another entry's file. That makes this a test of the checksum
+// guard, which is the thing standing between a collision and wrong bytes. Deleting the check in
+// readFromFile makes this test report served bytes.
+func TestPersistentCache_CollidingFilenameMisses(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cache, err := NewPersistentCache(&PersistentCacheConfig{
+		Directory:   tmpDir,
+		MaxSize:     10 * 1024 * 1024,
+		TTL:         time.Hour,
+		Compression: false,
+	})
+	if err != nil {
+		t.Fatalf("NewPersistentCache failed: %v", err)
+	}
+	defer func() { _ = cache.Close() }()
+
+	alpha, beta := []byte("AAAAAAAA"), []byte("BBBBBBBB")
+	cache.Put("alpha", 0, alpha)
+	cache.Put("beta", 0, beta)
+
+	alphaItem := cache.index[entryKey("alpha", 0)]
+	betaItem := cache.index[entryKey("beta", 0)]
+	if alphaItem == nil || betaItem == nil {
+		t.Fatal("both entries should be indexed after Put")
+	}
+
+	// Collide: alpha's own file goes away and its index entry points at beta's.
+	if err := os.Remove(alphaItem.FilePath); err != nil {
+		t.Fatalf("removing alpha's file: %v", err)
+	}
+	alphaItem.FilePath = betaItem.FilePath
+
+	if got := cache.Get("alpha", 0, int64(len(alpha))); got != nil {
+		t.Errorf("collision served %q under key alpha; the content checksum must turn this into a miss", got)
+	}
+}
+
+// TestPersistentCache_ChecksumIsWhatCatchesWrongBytes states the same guard directly, without the
+// collision framing: an entry whose stored checksum does not describe its file must not be served.
+func TestPersistentCache_ChecksumIsWhatCatchesWrongBytes(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cache, err := NewPersistentCache(&PersistentCacheConfig{
+		Directory:   tmpDir,
+		MaxSize:     10 * 1024 * 1024,
+		TTL:         time.Hour,
+		Compression: false,
+	})
+	if err != nil {
+		t.Fatalf("NewPersistentCache failed: %v", err)
+	}
+	defer func() { _ = cache.Close() }()
+
+	data := []byte("the bytes that were stored")
+	cache.Put("obj", 0, data)
+
+	item := cache.index[entryKey("obj", 0)]
+	if item == nil {
+		t.Fatal("entry should be indexed after Put")
+	}
+
+	// Same length, different content — so a length check alone would pass it.
+	wrong := []byte("the bytes that were WRONGED")[:len(data)]
+	if err := os.WriteFile(item.FilePath, wrong, 0600); err != nil {
+		t.Fatalf("rewriting the cache file: %v", err)
+	}
+
+	if got, err := cache.readFromFile(item); err == nil {
+		t.Errorf("readFromFile returned %q with no error; the checksum must reject it", got)
+	}
+	if got := cache.Get("obj", 0, int64(len(data))); got != nil {
+		t.Errorf("Get served %q from a file whose checksum does not match", got)
 	}
 }
 

--- a/internal/storage/s3/acceleration_bench_test.go
+++ b/internal/storage/s3/acceleration_bench_test.go
@@ -134,10 +134,17 @@ func BenchmarkFallback(b *testing.B) {
 func BenchmarkAccelerationOverhead(b *testing.B) {
 	backend := &Backend{}
 
+	// One error per path through the classifier: the InvalidRequest-plus-message conjunction that
+	// matches, an InvalidRequest that fails the message half (the most expensive path — it pays for
+	// the unwrap, the code comparison, and the ToLower), a different code that short-circuits after
+	// the unwrap, a code-less transport failure at the accelerate endpoint, and a plain error.
+	//
+	// SDK-shaped rather than fmt.Errorf strings, because errors.As unwrapping is part of the cost now.
 	testErrors := []error{
-		fmt.Errorf("InvalidRequest: Transfer acceleration not enabled"),
-		fmt.Errorf("s3-accelerate endpoint error"),
-		fmt.Errorf("AccelerateNotSupported"),
+		apiErr("InvalidRequest", "S3 Transfer Acceleration is not configured on this bucket"),
+		apiErr("InvalidRequest", "Invalid Range header"),
+		apiErr("NoSuchKey", "The specified key does not exist"),
+		fmt.Errorf("dial tcp: lookup b.s3-accelerate.amazonaws.com: no such host"),
 		fmt.Errorf("normal S3 error"),
 	}
 

--- a/internal/storage/s3/acceleration_test.go
+++ b/internal/storage/s3/acceleration_test.go
@@ -2,56 +2,136 @@ package s3
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 )
 
+// apiErr builds the shape the AWS SDK actually hands back for an S3 error response: a
+// smithy.GenericAPIError wrapped in the OperationError that names the call. Matching on the code has
+// to see through that wrapping, which is why the helper wraps rather than returning the bare error.
+func apiErr(code, message string) error {
+	return &smithy.OperationError{
+		ServiceID:     "S3",
+		OperationName: "GetObject",
+		Err: &smithy.GenericAPIError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
 func TestBackend_isAccelerationError(t *testing.T) {
+	t.Parallel()
+
 	b := &Backend{}
 
 	tests := []struct {
 		name     string
 		err      error
 		expected bool
+		why      string
 	}{
 		{
 			name:     "nil error",
 			err:      nil,
 			expected: false,
 		},
+
+		// True positives. S3 has no acceleration-specific error code — every one of these arrives as
+		// InvalidRequest, distinguished only by the message. That is why the classifier is a
+		// conjunction of code and message rather than a code lookup.
 		{
-			name:     "InvalidRequest error",
-			err:      errors.New("InvalidRequest: Transfer acceleration is not enabled on this bucket"),
+			name:     "acceleration not configured on the bucket",
+			err:      apiErr("InvalidRequest", "S3 Transfer Acceleration is not configured on this bucket"),
 			expected: true,
+			why:      "the common case: accelerate endpoint used against a bucket that never enabled it",
 		},
 		{
-			name:     "acceleration error",
-			err:      errors.New("acceleration endpoint not available"),
+			name:     "acceleration disabled on the bucket",
+			err:      apiErr("InvalidRequest", "S3 Transfer Acceleration is disabled on this bucket"),
 			expected: true,
+			why:      "enabled once, since suspended",
 		},
 		{
-			name:     "s3-accelerate error",
-			err:      errors.New("failed to connect to s3-accelerate endpoint"),
+			name:     "bucket name is not DNS-compliant",
+			err:      apiErr("InvalidRequest", "S3 Transfer Acceleration is not supported for buckets with non-DNS compliant names"),
 			expected: true,
+			why:      "a bucket name containing a period can never be accelerated; falling back is the only option",
 		},
 		{
-			name:     "transfer-acceleration error",
-			err:      errors.New("transfer-acceleration not supported"),
+			name:     "acceleration unsupported on this bucket",
+			err:      apiErr("InvalidRequest", "S3 Transfer Acceleration is not supported on this bucket. Contact AWS Support for more information."),
 			expected: true,
+			why:      "region or account restriction",
 		},
 		{
-			name:     "AccelerateNotSupported error",
-			err:      errors.New("AccelerateNotSupported: Bucket does not support acceleration"),
+			name:     "AWS says Accelerate rather than Acceleration",
+			err:      apiErr("InvalidRequest", "S3 Transfer Accelerate is not configured on this bucket"),
 			expected: true,
+			why:      "S3 uses both spellings; matching only one would silently stop classifying half the cases",
+		},
+		{
+			name:     "message case differs",
+			err:      apiErr("InvalidRequest", "s3 transfer acceleration is not configured on this bucket"),
+			expected: true,
+			why:      "the message is service prose, not a contract; AWS can reword its casing without notice",
+		},
+		{
+			name:     "transport failure naming the accelerate endpoint",
+			err:      errors.New(`dial tcp: lookup bucket.s3-accelerate.amazonaws.com: no such host`),
+			expected: true,
+			why:      "no API error to inspect, but the accelerate endpoint is unmistakably what failed",
+		},
+
+		// Audit finding L27. Each of these was classified as an acceleration error by the substring
+		// matcher this replaced, and each false positive disables acceleration for the remaining life
+		// of the mount.
+		{
+			name:     "InvalidRequest for an unrelated reason",
+			err:      apiErr("InvalidRequest", "Invalid Range header"),
+			expected: false,
+			why:      "InvalidRequest covers a large family of malformed requests; the code alone means nothing here",
+		},
+		{
+			name:     "InvalidRequest for an oversized single-part copy",
+			err:      apiErr("InvalidRequest", "The specified copy source is larger than the maximum allowable size for a copy source: 5368709120"),
+			expected: false,
+			why:      "a real InvalidRequest ObjectFS can hit, and it must reach the multipart-copy path rather than the fallback",
+		},
+		{
+			name:     "InvalidRequestException does not match as a substring",
+			err:      apiErr("InvalidRequestException", "S3 Transfer Acceleration is not configured on this bucket"),
+			expected: false,
+			why:      "the old matcher found InvalidRequest inside this longer code; the code must match exactly",
+		},
+		{
+			name:     "BucketAlreadyExists is never an acceleration error",
+			err:      apiErr("BucketAlreadyExists", "bucket name is taken"),
+			expected: false,
+			why:      "CreateBucket's name collision; ObjectFS does not create buckets",
+		},
+		{
+			name:     "an unrelated code whose message says acceleration",
+			err:      apiErr("AccessDenied", "user lacks s3:PutAccelerateConfiguration for Transfer Acceleration settings"),
+			expected: false,
+			why:      "the message half is not sufficient on its own; a permissions problem is not an endpoint problem",
+		},
+		{
+			name:     "a wrapped API error quoting transfer-acceleration",
+			err:      fmt.Errorf("upload part 3: %w", apiErr("RequestTimeout", "retry per Transfer Acceleration guidance")),
+			expected: false,
+			why:      "a retryable timeout must stay retryable, not permanently disable the endpoint",
 		},
 		{
 			name:     "generic S3 error",
-			err:      errors.New("NoSuchKey: The specified key does not exist"),
+			err:      apiErr("NoSuchKey", "The specified key does not exist"),
 			expected: false,
 		},
 		{
-			name:     "network error",
+			name:     "network error unrelated to the accelerate endpoint",
 			err:      errors.New("connection timeout"),
 			expected: false,
 		},
@@ -59,11 +139,31 @@ func TestBackend_isAccelerationError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := b.isAccelerationError(tt.err)
 			if result != tt.expected {
-				t.Errorf("isAccelerationError() = %v, want %v for error: %v", result, tt.expected, tt.err)
+				t.Errorf("isAccelerationError(%v) = %v, want %v\nwhy: %s", tt.err, result, tt.expected, tt.why)
 			}
 		})
+	}
+}
+
+// TestBackend_isAccelerationError_WrappedInvalidRequestStillMatches pins that the conjunction sees
+// through wrapping. Every caller of executeWithAccelerationFallback receives the SDK's error inside an
+// OperationError, and the retry and circuit-breaker wrappers may add more layers, so a classifier that
+// only inspected the outermost error would classify nothing at all and the fallback would be dead code.
+func TestBackend_isAccelerationError_WrappedInvalidRequestStillMatches(t *testing.T) {
+	t.Parallel()
+
+	b := &Backend{}
+	inner := apiErr("InvalidRequest", "S3 Transfer Acceleration is not configured on this bucket")
+
+	for depth, err := 0, inner; depth < 4; depth++ {
+		if !b.isAccelerationError(err) {
+			t.Errorf("wrapped %d deep: isAccelerationError = false, want true (%v)", depth, err)
+		}
+		err = fmt.Errorf("layer %d: %w", depth, err)
 	}
 }
 

--- a/internal/storage/s3/backend.go
+++ b/internal/storage/s3/backend.go
@@ -2617,31 +2617,73 @@ func (b *Backend) IsFullyHealthy() bool {
 	return b.healthTracker.GetOverallHealth() == health.StateHealthy
 }
 
-// isAccelerationError checks if an error is related to Transfer Acceleration
+// isAccelerationError reports whether err is the accelerate endpoint refusing the request *as* an
+// acceleration problem, rather than any other failure that happened to arrive over it.
+//
+// The distinction matters because a true answer is not a retry: the caller disables acceleration for
+// the remaining life of the mount. So every false positive costs the accelerated path permanently, on
+// the first unrelated error, and does it quietly — the fallback logs a warning naming an acceleration
+// problem regardless of what actually failed. A false *negative* costs one wasted round trip per
+// request forever, which is the milder of the two, so ambiguity resolves toward not matching.
+//
+// # Why this is not a pure error-code match
+//
+// The obvious fix for audit finding L27 — match smithy.APIError.ErrorCode() against a closed set, the
+// way isInvalidRange does — cannot work here, and the reason is worth writing down so it is not
+// "simplified" back. S3 has no acceleration-specific error code. It reports every acceleration
+// failure as InvalidRequest with an acceleration-specific *message*:
+//
+//	InvalidRequest / "S3 Transfer Acceleration is not configured on this bucket"
+//	InvalidRequest / "S3 Transfer Acceleration is disabled on this bucket"
+//	InvalidRequest / "S3 Transfer Acceleration is not supported for buckets with non-DNS compliant names"
+//	InvalidRequest / "S3 Transfer Acceleration is not supported on this bucket. Contact AWS Support for more information."
+//	InvalidRequest / "S3 Transfer Accelerate is not configured on this bucket"
+//
+// So the code alone is necessary and nowhere near sufficient: InvalidRequest is also a bad Range, a
+// single-part CopyObject above 5 GiB, a conflicting parameter combination. That is precisely the
+// defect L27 named — the old classifier matched the *bare string* "InvalidRequest" anywhere in
+// err.Error(), so all of those disabled acceleration, as did "InvalidRequestException" and any
+// wrapped message that quoted one.
+//
+// What replaces it is a conjunction. The error must be a structured API error whose code is exactly
+// InvalidRequest, *and* its message must name Transfer Acceleration. Both halves are load-bearing:
+// the code keeps an arbitrary error whose text mentions acceleration (an AccessDenied on
+// s3:PutAccelerateConfiguration, say) from matching, and the message keeps the large InvalidRequest
+// family from matching. Neither test alone is safe.
+//
+// "BucketAlreadyExists" is gone with no replacement. Its comment claimed it was "sometimes returned
+// for acceleration errors"; it is CreateBucket's name collision, and ObjectFS does not create buckets.
+//
+// The remaining message-only check is for a failure with no API error at all: reaching
+// <bucket>.s3-accelerate.amazonaws.com can fail in DNS or TLS before S3 answers. That is genuinely an
+// acceleration failure and genuinely needs the fallback. It matches the endpoint hostname label rather
+// than the word "acceleration", because a hostname cannot appear in a standard-endpoint error.
 func (b *Backend) isAccelerationError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	errMsg := err.Error()
+	var apiErr smithy.APIError
+	if stderr.As(err, &apiErr) {
+		// Exactly InvalidRequest, not a code containing it, and only when the message says what the
+		// code cannot. Case-insensitive on the message because it is prose from a service, not a
+		// contract: S3 uses both "Transfer Acceleration" and "Transfer Accelerate", and the message
+		// is the one part of this that AWS can reword without a deprecation notice.
+		if apiErr.ErrorCode() == "InvalidRequest" {
+			msg := strings.ToLower(apiErr.ErrorMessage())
 
-	// Common acceleration-specific errors
-	accelerationErrors := []string{
-		"InvalidRequest",         // Acceleration not enabled on bucket
-		"acceleration",           // Generic acceleration error
-		"s3-accelerate",          // Acceleration endpoint error
-		"transfer-acceleration",  // Explicit acceleration error
-		"AccelerateNotSupported", // Bucket doesn't support acceleration
-		"BucketAlreadyExists",    // Sometimes returned for acceleration errors
-	}
-
-	for _, errPattern := range accelerationErrors {
-		if strings.Contains(errMsg, errPattern) {
-			return true
+			return strings.Contains(msg, "transfer acceleration") ||
+				strings.Contains(msg, "transfer accelerate")
 		}
+
+		// Some other structured API error. Whatever it is, it is not about acceleration, and
+		// misreading it would disable the endpoint for the life of the mount.
+		return false
 	}
 
-	return false
+	// No API error: a transport failure reaching the accelerate endpoint itself, which carries the
+	// hostname and no code.
+	return strings.Contains(err.Error(), "s3-accelerate")
 }
 
 // executeWithAccelerationFallback executes an S3 operation with automatic fallback


### PR DESCRIPTION
Closes #187.

Two of the three findings needed a code change. The third, L26, is already fixed on `main` — `cost_optimizer.go:448` reads `CopySource: aws.String(co.backend.copySource(opt.ObjectKey))`, and the comment above it names the failure mode the issue described. A sweep of all four production `CopySource` construction sites confirms every one routes through `b.copySource`, which escapes the whole `bucket/key` string with one rule.

## L27 — the issue's suggested fix would have broken the fallback

The issue said to match `smithy.APIError.ErrorCode()` against a closed set and drop `InvalidRequest`. I built that first, then checked it against the AWS documentation, and the premise does not hold: **S3 has no acceleration-specific error code.** There is no `AccelerateNotSupported` and no `AccelerateConfigurationNotFound` in the API. Every acceleration failure arrives as `InvalidRequest`, distinguished only by the message:

```
InvalidRequest / "S3 Transfer Acceleration is not configured on this bucket"
InvalidRequest / "S3 Transfer Acceleration is disabled on this bucket"
InvalidRequest / "S3 Transfer Acceleration is not supported for buckets with non-DNS compliant names"
InvalidRequest / "S3 Transfer Acceleration is not supported on this bucket. Contact AWS Support..."
InvalidRequest / "S3 Transfer Accelerate is not configured on this bucket"
```

So a closed-set code match would have classified every real acceleration failure as unrelated and left `executeWithAccelerationFallback` as dead code — trading a false positive for a much worse false negative. `client.go:56` already records the behavior that makes this concrete: a bucket without the acceleration configuration returns `InvalidRequest` for *every* request.

What landed instead is a **conjunction**. The error must be a structured `smithy.APIError` whose code is *exactly* `InvalidRequest`, **and** whose message names Transfer Acceleration. Both halves are necessary and neither is sufficient:

- the code half stops an unrelated error whose prose mentions acceleration (an `AccessDenied` on `s3:PutAccelerateConfiguration`) from matching;
- the message half stops the large `InvalidRequest` family — a bad `Range`, a single-part `CopyObject` above 5 GiB — from matching.

`BucketAlreadyExists` is gone with no replacement. One message-only arm remains, for a DNS or TLS failure reaching `<bucket>.s3-accelerate.amazonaws.com`, which carries the hostname and no error code at all; it matches the hostname rather than the word "acceleration", so a hostname that cannot appear in a standard-endpoint error is the signal.

The rewritten doc comment states the no-such-code fact explicitly, because the natural instinct on reading this function is to simplify it into the code lookup that cannot work.

### Why the false positive was expensive

`executeWithAccelerationFallback` calls `b.clientManager.DisableAcceleration(...)`, and its own comment says that "is for the life of the mount — nothing re-enables acceleration afterwards." So the first unrelated `InvalidRequest` permanently dropped the mount to the standard endpoint, logging a warning that named acceleration regardless of what actually failed.

### Verified by mutation — seven, one per clause

Every clause is load-bearing; each mutation fails a test that names why:

| mutation | test that fails |
|---|---|
| restore the original substring matcher | 4 cases, incl. oversized-copy `InvalidRequest` |
| drop the message half (code only) | the two unrelated `InvalidRequest` cases |
| drop the code half (message only) | wrapped `RequestTimeout`, `InvalidRequestException`, `AccessDenied` |
| `strings.Contains` on the code instead of `==` | `InvalidRequestException` |
| match only "Acceleration", not "Accelerate" | the `Accelerate` spelling case |
| case-sensitive message match | all five true positives plus the wrapping test |
| drop the transport arm | the DNS-failure case |

A separate test walks a matching error through four layers of `fmt.Errorf` wrapping, since every caller receives the SDK error inside an `OperationError` and the retry/breaker wrappers add more — a classifier that only inspected the outermost error would match nothing in production while passing a naive unit test.

## L25 — the severity was lower than filed, and this is now proven both directions

The issue flagged that a collision means "one cached object's bytes served under another key" and asked whether `calculateChecksum` is verified on read. It is, and that changes the finding.

A throwaway probe simulated the collision by pointing one entry's `FilePath` at another's. Result on current code: **a miss, not corruption.** The index is keyed on the full `entryKey` string and only the *filename* was truncated, and `readFromFile` verifies a full SHA-256 of the content. Mutating out that checksum check makes the same probe report served bytes under the wrong key. So the content checksum is what stands between a collision and wrong bytes; the hash width is hygiene.

Both directions are now committed tests rather than a throwaway:

- `TestPersistentCache_FilenameUsesFullHash` — pins the width, so a later "shorter names are tidier" change argues with a failing test
- `TestPersistentCache_CollidingFilenameMisses` — a simulated collision must miss
- `TestPersistentCache_ChecksumIsWhatCatchesWrongBytes` — same guard without the collision framing, using a wrong payload of identical length so a length check alone would pass it

The width is now the full 32 bytes. **Existing cache directories are unaffected**: `FilePath` is stored in the index and every read uses the stored value, so `generateFilePath` is consulted only for new entries and old short-named files stay readable until they expire or are evicted.

## Also updated

`BenchmarkAccelerationOverhead` measured the old classifier with `fmt.Errorf` strings, which no longer exercises any interesting path. It now covers one error per branch — including the most expensive one, an `InvalidRequest` that fails the message half after paying for the unwrap and the `ToLower`. 1279 ns/op for five errors on an M4 Max; this is not on a hot path.

## Verification

```
go build ./...
go vet ./internal/storage/s3/ ./internal/cache/
go test -race -short ./internal/storage/s3/ ./internal/cache/   # both ok
go test -race ./internal/config/                                # prose gates ok
```

`markdownlint` on `CHANGELOG.md` reports 362 errors both before and after the edit — all pre-existing in old release sections, none added.