### PR TITLE
test: give pkg/archive tests of its own and sdks/c a floor (#360, #361)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -16,7 +16,9 @@
 # with `t.Log("No alerts generated (may be normal...)")`, so deleting the branch entirely left it
 # green. A gate with zero margin is what made that visible. Widen the test, not the margin.
 #
-# CLAUDE.md's target is 80%+ per package. Sixteen of the thirty below are there. Two of the four
+# CLAUDE.md's target is 80%+ per package. Twenty-three of the thirty-five below are there — counted
+# from the file rather than remembered, since this sentence said "sixteen of the thirty" for several
+# releases after both numbers moved. Two of the four
 # packages this file originally listed as furthest from it have since been rewritten, and both moved
 # for a structural reason rather than by anyone writing tests harder — which is the useful thing to
 # record, because it says where the remaining two are actually blocked:
@@ -29,13 +31,14 @@
 #   pkg/errors          48.3%          mostly classification tables; needs table tests, not design
 #                                      work
 #
-# Floors are deliberately absent for six packages, and the gate names all six in every run so the
+# Floors are deliberately absent for four packages, and the gate names all four in every run so the
 # omission stays visible instead of looking like a decision. TestUnfloorablePackagesAreExplained in
 # internal/config/coverage_floors_test.go asserts that the set the gate reports and the set this
 # block explains are the same set, in both directions, so this list cannot drift out of agreement
-# with the gate the way it had.
+# with the gate the way it had. It was six until #360 gave pkg/archive tests of its own and a floor
+# and #361 made the coverage job's cgo posture explicit enough to floor sdks/c.
 #
-# All six report 0.0% or near it, and for five of them that number is an artifact rather than a
+# All four report 0.0%, and in every case that number is an artifact rather than a
 # measurement — which is the thing to understand before reading a floor into it. `go test
 # -coverprofile` instruments only the package under test, so a package with no test files of its own
 # gets a profile full of count-0 lines even when every statement in it executes under a sibling
@@ -44,12 +47,18 @@
 #   internal/cache/cachetest        0.0% reported, 81.9% under internal/cache + internal/cache/redis
 #   internal/testhttp               0.0% reported, 75.6% under internal/adapter
 #   pkg/compression                 0.0% reported, 88.9% under internal/compression
-#   pkg/archive                     0.0% reported, 48.6% under internal/archive
 #   internal/awsrates/…/offertest   0.0% reported, 48.9% under internal/awsrates/...
 #
-# So a floor here would not be a weak gate, it would be a broken one: it would have to be 0 to pass,
-# and 0 is not a gate. The real check for each is that its consumers' suites fail when it changes,
+# So a floor for any of those four would not be a weak gate, it would be a broken one: it would have
+# to be 0 to pass, and 0 is not a gate. The real check for each is that its consumers' suites fail when it changes,
 # which is what their own floors above already enforce.
+#
+# Two more packages used to appear in the gate's unfloored list and no longer do: `flatted`, an npm
+# dependency of docs-platform and sdks/javascript, ships a Go port inside its package directory, so
+# `go list ./...` reports it twice once anything has run `npm install`. The gate now skips any profile
+# path under node_modules. They are gitignored and the coverage job never installs npm packages, so
+# they were visible only on a developer machine — noise in the one place a gate's output is read most
+# often, and not actionable by either a floor or a test, because the code is not this repository's.
 #
 # no-floor: internal/cache/cachetest
 #     no tests, deliberately: it is the shared conformance suite five cache implementations are
@@ -60,14 +69,6 @@
 #     that use it. A test for FreeAddr would assert that an address is free by binding it, which is
 #     what the function does — a tautology. Its real check is that deleting adapter.Start's metrics
 #     call fails the tests built on it, which it does, with the message it exists to print
-# no-floor: pkg/archive
-#     no tests of its own. It is *not* dead code — this line said "dead code pending a decision
-#     (Part 4)" and internal/archive imports it from five files, so the claim was wrong in the
-#     direction that matters: it read as a reason not to test a package that a floored package
-#     depends on. Its ArchiveFormat table and IsArchive run under internal/archive (floored at 90),
-#     reaching 48.6% of it. The uncovered half is metadata.go's index construction, which
-#     internal/archive does not exercise — worth its own tests, tracked rather than floored, because
-#     a floor set from the artifact number gates nothing
 # no-floor: pkg/compression
 #     no tests in this package; its constants and SupportedAlgorithms list are exercised from
 #     internal/compression, which is at 88.6%. SupportedAlgorithms is load-bearing there since #230
@@ -79,16 +80,6 @@
 #     its own would assert that a fixture it just built contains what it put in — the
 #     self-consistency failure the Glacier PUT defect had. Its real check is that the suites using
 #     it fail when a rule changes
-# no-floor: sdks/c
-#     11.0%, and unfloorable for a different reason than the five above: the number depends on
-#     CGO_ENABLED. main.go is a CgoFile, so `CGO_ENABLED=0 go test ./sdks/c/` does not fall back to
-#     a build-tag-excluded variant — it fails to compile, because main_test.go references
-#     codeFromErr and fillCStr and neither declaration is built. CI's Go jobs set CGO_ENABLED=0 for
-#     the cross-build matrix and the release build, so a floor here would be a claim about a file
-#     set part of CI does not compile — the mistake internal/network's note below records, arriving
-#     through cgo rather than through //go:build. The 11.0% is stable (three runs, and identical
-#     under the full-repo profile), so this is a floor worth setting once the coverage job's cgo
-#     posture is explicit rather than incidental
 #
 # Three packages are absent from the gate's report entirely, and that is correct rather than a gap.
 # They contain no statements at all, so they produce no profile lines for the gate to match, and
@@ -330,6 +321,26 @@ internal/fuse            67
 # which implementation a configuration selects rather than only that one was returned.
 internal/cache           85
 
+# 100, and the only floor in this file set at 100 on purpose rather than because a package happens to
+# be small. pkg/archive is 189 lines of declarations plus IsArchive and four index methods; there is
+# no error path, no I/O, and no concurrency in it, so every statement is reachable from a table entry
+# and a floor below 100 would permit a regression with nothing to justify it.
+#
+# It had no floor until #360. The note that used to stand here said its statements ran under
+# internal/archive, reaching 48.6% — true, and the weaker of the two available positions, because the
+# uncovered 51.4% was ListDirectory and its two helpers, which no consumer calls at all. Testing the
+# package directly rather than reaching it from internal/archive was the deliberate choice #360 asked
+# for: ArchiveIndex is exported, so its contract should not depend on which consumer happens to exist.
+#
+# Reaching 100 turned up the thing worth knowing. ListDirectory's second disjunct requires an entry
+# whose Path ends in '/', and internal/archive.BuildIndexFromBytes runs every tar name through
+# path.Clean, which strips exactly that — so that branch, and containsSlashExceptLast which only it
+# calls, are unreachable from the only producer in the repository. They are covered rather than
+# deleted because a caller outside this repository may build an index using tar's own convention,
+# where a directory name keeps its slash. The test says which convention each half serves, so
+# removing the branch stays a decision about the exported surface.
+pkg/archive              100
+
 pkg/api                  73
 pkg/errors               48
 pkg/health               93
@@ -337,6 +348,28 @@ pkg/recovery             86
 pkg/retry                87
 pkg/status               93
 pkg/utils                82
+
+# sdks/c measures 12.1%, and the floor is 12 rather than 11 for a reason worth recording: 11.0% was
+# what this file claimed while it argued the package was unfloorable, and that number was already
+# stale when it was written. #355 added the tests that took it from 11.0% to 12.1%; the note was
+# authored on a branch cut before #355 merged, so it recorded a measurement its own commit had
+# invalidated. Verified rather than reasoned — `sdks/c` has no commits touching it since, and the
+# package measures 11.0% at f6f2ae5^ and 12.1% at HEAD.
+#
+# The number depends on CGO_ENABLED, which is why this floor waited on #361. main.go is a CgoFile, so
+# `CGO_ENABLED=0 go test ./sdks/c/` does not fall back to a build-tag-excluded variant — it fails to
+# compile, because main_test.go references codeFromErr, fillCStr, maxPutLength and more, and none of
+# those declarations are built. Part of CI sets CGO_ENABLED=0 deliberately (the cross-build matrix
+# and the release build, where the point is a static binary), so a floor read off an inherited value
+# would have been a claim about a file set some jobs do not compile. The coverage job now states
+# CGO_ENABLED=1, so this floor is about a configuration a workflow declares.
+#
+# 12.1% is low and stays low by design: the covered part is the pure-Go logic reachable without a
+# live C caller (codeFromErr, fillCStr, bytesToCacheString, the length and limit error builders), and
+# the rest is //export cgo entry points whose parameters are C pointers. Exercising those needs the
+# C test suite in sdks/c/tests, which links the shared library and is not a `go test` target. The
+# floor is a ratchet on the Go-testable half, not a coverage target for the SDK.
+sdks/c                   12
 
 # sdks/go/objectfs measures 54.1% with AWS credentials present and 43.5% without, because several
 # of its tests call requireAWS and skip. CI has no credentials, so the floor is set for the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,22 @@ jobs:
           go-version-file: ${{ env.GO_VERSION_FILE }}
           cache: true
 
+      # CGO_ENABLED is stated rather than inherited (#361). It was neither set nor unset here, so the
+      # job took the runner's default of cgo *on*, and sdks/c — the one package whose coverage depends
+      # on it — appeared in the profile at 11.0% because of that default rather than because of a
+      # decision. A floor read off an inherited value is a claim about a configuration no workflow
+      # states.
+      #
+      # On, not off, and the direction matters. sdks/c/main.go carries `import "C"`, so with cgo off
+      # the package does not fall back to a build-tag-excluded variant — `go test` fails to compile,
+      # because main_test.go references codeFromErr and fillCStr and neither declaration is built.
+      # CGO_ENABLED=0 here would turn a coverage question into a compile failure in the job whose
+      # output is a coverage number, which is a much worse failure to read. The cross-build matrix and
+      # the release build set 0 deliberately, because there the point is a static binary; here the
+      # point is measuring every package, so the value that compiles every package is the right one.
       - name: Measure per-package coverage
+        env:
+          CGO_ENABLED: 1
         run: go test -covermode=atomic -coverprofile=coverage.out -timeout 20m ./...
 
       - name: Enforce per-package floors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`pkg/archive` has tests of its own and a 100% floor** ([#360]). The package had none: its
+  coverage was reported entirely through `internal/archive`, at 48.6%, which is a number about a
+  consumer rather than about this package. `metadata_test.go` takes it to 100.0% and the floor is set
+  there.
+
+  The issue offered a choice between testing the package directly and folding it into its consumer,
+  and the premise had shifted since it was filed — `internal/archive` now builds an index and reads it
+  back, so the genuinely unreached code was `ListDirectory` and its two helpers, which no consumer
+  calls at all. Testing directly was the only option that covers them.
+
+  Reaching 100% surfaced something worth recording rather than deleting: `ListDirectory`'s second
+  disjunct requires an entry whose `Path` ends in `/`, and `internal/archive.BuildIndexFromBytes` runs
+  every tar name through `path.Clean`, which strips exactly that. So that branch, and
+  `containsSlashExceptLast` which only it calls, are **unreachable from the only producer in this
+  repository**. They are covered rather than removed because `ArchiveIndex` is exported and an outside
+  caller may build an index by hand using tar's own convention, where a directory name keeps its
+  slash — the test names which convention each half serves, so dropping the branch stays a decision
+  about the exported surface instead of a coverage cleanup. Two other behaviors are now pinned rather
+  than assumed: `TotalFiles` counts directories while `TotalSize` does not, and a repeated path
+  replaces the entry without rolling either counter back.
+
+- **A coverage floor for `sdks/c`, and an explicit cgo posture in the job that measures it**
+  ([#361]). The coverage job set no `CGO_ENABLED`, so it took the runner's default; `sdks/c` is the one
+  package whose coverage depends on that, and its number came from an inherited value no workflow
+  stated. The job now sets `CGO_ENABLED: 1`, and the direction matters — `sdks/c/main.go` carries
+  `import "C"`, so with cgo off the package does not fall back to a tag-excluded variant, it **fails to
+  compile**, because `main_test.go` references `codeFromErr`, `fillCStr`, `maxPutLength` and more and
+  none of those declarations are built. `CGO_ENABLED=0` would have turned a coverage question into a
+  compile failure in the job whose output is a coverage number.
+
+  With that stated, the floor is set at 12. `.coverage-floors` claimed 11.0% while arguing the package
+  was unfloorable, and that number was already stale when written: #355 added the tests that took it to
+  12.1%, and the note was authored on a branch cut before #355 merged, so it recorded a measurement its
+  own commit had invalidated. Verified rather than reasoned — `sdks/c` has no commits touching it
+  since, and it measures 11.0% at `f6f2ae5^` and 12.1% at `HEAD`. The floor is a ratchet on the
+  Go-testable half of the SDK, not a coverage target for it: the rest is `//export` cgo entry points
+  whose parameters are C pointers, which the C suite under `sdks/c/tests` exercises and `go test`
+  cannot.
+
+- **The coverage gate no longer measures Go files vendored inside npm dependencies.** Two copies of
+  the `flatted` package ship a Go port under their package directory, so once anything has run `npm
+  install` in `docs-platform` or `sdks/javascript`, `go list ./...` reports two more packages and the
+  gate named them as unfloored at 0.0%. They are gitignored, absent from a fresh checkout, and never
+  installed by the coverage job — so they appeared only on a developer machine, which is the worst
+  place for a gate to grow noise, and neither a floor nor a test is the fix, because the code is not
+  this repository's. `TestUnfloorablePackagesAreExplained` previously filtered them out of its own
+  synthetic profile, which made the test pass while leaving the noise in the output a person reads;
+  that filter is gone, so the synthetic profile now names them and the assertion that the gate does not
+  report them is what tests the exclusion. Verified by mutation in both directions.
+
 - **A measured per-iteration allocation budget for the difftest fuzz target, and a bound on what the
   shared emulator retains** ([#193]). `TestPerIterationAllocationBudget` asserts that one worst-shaped
   iteration allocates under 16 MiB; it measures 6.3 MiB for a program of writes and reads and 7.1 MiB for
@@ -904,6 +954,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#200]: https://github.com/scttfrdmn/objectfs/issues/200
 [#235]: https://github.com/scttfrdmn/objectfs/issues/235
 [#353]: https://github.com/scttfrdmn/objectfs/issues/353
+[#360]: https://github.com/scttfrdmn/objectfs/issues/360
+[#361]: https://github.com/scttfrdmn/objectfs/issues/361
 [#362]: https://github.com/scttfrdmn/objectfs/issues/362
 
 - **Every build tag is compiled in CI, and the two tagged files that had stopped compiling now

--- a/internal/config/coverage_floors_test.go
+++ b/internal/config/coverage_floors_test.go
@@ -43,11 +43,13 @@ package config
 // was added, and `go list`'s trailing empty fields collapse under a plain separator, which made `tests`
 // — a package of only _test.go files, and one of the three the header has to classify — unparseable.
 //
-// The gate's report and this file's header can also disagree for a reason that is neither's fault: two
-// copies of the `flatted` npm package vendor a Go file, so on a machine that has run `npm ci` the gate
-// names eight packages rather than six. Those two are filtered here rather than floored or explained,
-// because they are not this repository's code. CI's coverage job installs no npm dependencies, so it
-// sees six either way.
+// The gate's report and this file's header used to disagree for a reason that was neither's fault: two
+// copies of the `flatted` npm package vendor a Go file, so on a machine that had run `npm ci` the gate
+// named two extra packages. This file filtered them out of the synthetic profile, which made the test
+// pass and left the noise in the gate's output — the wrong half to fix, since the gate's report is what
+// a person reads. coverage-gate.sh now skips profile paths under node_modules, and the filter here is
+// gone: the synthetic profile names those packages and the assertion that the gate does not report them
+// is the test that its exclusion works.
 
 import (
 	"bufio"
@@ -104,7 +106,7 @@ func moduleFromGoMod(t *testing.T) string {
 //
 // CgoFiles are parsed alongside GoFiles. sdks/c is the whole reason: its only non-test file is
 // main.go with an `import "C"`, so it lands in CgoFiles and a GoFiles-only walk would have called the
-// package empty and expected the gate not to report it. The gate does report it, at 11.0%.
+// package empty and expected the gate not to report it. The gate does report it, and it has a floor now.
 func packagesWithStatements(t *testing.T) (all, withStatements map[string]bool) {
 	t.Helper()
 
@@ -133,16 +135,12 @@ func packagesWithStatements(t *testing.T) (all, withStatements map[string]bool) 
 
 		importPath, dir := fields[0], fields[1]
 
-		// node_modules is skipped for the same reason .gitignore lists it: two copies of the
-		// `flatted` npm package vendor a Go file, so `go list ./...` reports them as packages of
-		// this module and the gate names them as unfloored on any machine that has run `npm ci`.
-		// They are not this repository's code and no floor should be set for them. CI's coverage job
-		// installs no npm dependencies, so its profile does not contain them — which is why the
-		// gate's output there is six packages and locally it is eight.
-		if strings.Contains(importPath, "/node_modules/") {
-			continue
-		}
-
+		// node_modules is deliberately *not* skipped here. Two copies of the `flatted` npm package
+		// vendor a Go file, so on a machine that has run `npm ci` they appear in `go list ./...` and
+		// land in the synthetic profile below — which is the point: coverage-gate.sh excludes them,
+		// and letting them into the profile is what tests that it does. Filtering them here instead
+		// is what this test used to do, and it made the gate's exclusion unfalsifiable while leaving
+		// the noise in the output a person actually reads.
 		var files []string
 
 		for _, group := range []string{fields[2], fields[3]} {

--- a/pkg/archive/metadata_test.go
+++ b/pkg/archive/metadata_test.go
@@ -1,0 +1,310 @@
+package archive
+
+import (
+	"testing"
+	"time"
+)
+
+// The index API in this file has one producer, internal/archive.BuildIndexFromBytes, and no consumer
+// at all: nothing reads an index back except that package's own tests. So these tests assert the
+// contract directly rather than through a caller (issue #360). The distinction matters for one of
+// them — see TestListDirectory_TrailingSlashEntriesAreNotProducedHere, which records that a whole
+// branch of ListDirectory is unreachable from the only producer.
+
+func TestIsArchive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		wantIs     bool
+		wantFormat ArchiveFormat
+	}{
+		{name: "tar.zst", path: "data/set.tar.zst", wantIs: true, wantFormat: FormatTarZstd},
+		{name: "tar.gz", path: "data/set.tar.gz", wantIs: true, wantFormat: FormatTarGzip},
+		{name: "tgz", path: "set.tgz", wantIs: true, wantFormat: FormatTarGzip},
+		{name: "tar.bz2", path: "set.tar.bz2", wantIs: true, wantFormat: FormatTarBzip2},
+
+		{name: "plain tar is not a supported format", path: "set.tar", wantIs: false},
+		{name: "bare zstd is not an archive", path: "set.zst", wantIs: false},
+		{name: "no extension", path: "README", wantIs: false},
+		{name: "empty", path: "", wantIs: false},
+
+		// The length guards are the interesting part of this function: it indexes from the end
+		// without checking that the prefix exists, so a name that is *only* the extension has to be
+		// handled. ".tgz" is 4 characters and the function's first guard rejects anything under 5.
+		{name: "extension with no basename, tgz", path: ".tgz", wantIs: false},
+		{name: "extension with no basename, tar.gz", path: ".tar.gz", wantIs: true, wantFormat: FormatTarGzip},
+		{name: "one character short of any match", path: "a.gz", wantIs: false},
+
+		// Case matters. S3 keys are case-sensitive and so is this.
+		{name: "uppercase extension does not match", path: "SET.TAR.GZ", wantIs: false},
+
+		// A directory-ish key that merely contains an archive extension mid-path.
+		{name: "extension in the middle of a key", path: "set.tar.gz/inner", wantIs: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotIs, gotFormat := IsArchive(tt.path)
+			if gotIs != tt.wantIs {
+				t.Errorf("IsArchive(%q) is-archive = %v, want %v", tt.path, gotIs, tt.wantIs)
+			}
+			if gotFormat != tt.wantFormat {
+				t.Errorf("IsArchive(%q) format = %q, want %q", tt.path, gotFormat, tt.wantFormat)
+			}
+		})
+	}
+}
+
+func TestArchiveIndex_AddAndGet(t *testing.T) {
+	t.Parallel()
+
+	idx := NewArchiveIndex()
+	if idx.Files == nil {
+		t.Fatal("NewArchiveIndex must return an index with a usable map, not a nil one")
+	}
+	if idx.TotalFiles != 0 || idx.TotalSize != 0 {
+		t.Errorf("new index has TotalFiles=%d TotalSize=%d, want 0/0", idx.TotalFiles, idx.TotalSize)
+	}
+
+	modTime := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	file := &ArchiveEntry{Name: "a.txt", Path: "d/a.txt", Size: 100, Mode: 0o644, ModTime: modTime}
+	dir := &ArchiveEntry{Name: "d", Path: "d", Size: 4096, IsDir: true}
+
+	idx.AddEntry(file)
+	idx.AddEntry(dir)
+
+	// TotalFiles counts every entry including directories; TotalSize counts only non-directories.
+	// That asymmetry is deliberate — a directory's tar-reported size is not content — and it is the
+	// kind of thing that gets "cleaned up" into one rule, so it is asserted rather than assumed.
+	if idx.TotalFiles != 2 {
+		t.Errorf("TotalFiles = %d after two entries, want 2", idx.TotalFiles)
+	}
+	if idx.TotalSize != 100 {
+		t.Errorf("TotalSize = %d, want 100: a directory's size must not be counted as content", idx.TotalSize)
+	}
+
+	got, ok := idx.GetEntry("d/a.txt")
+	if !ok {
+		t.Fatal("GetEntry(d/a.txt) reported absent")
+	}
+	if got != file {
+		t.Error("GetEntry returned a different entry than the one added")
+	}
+	if !got.ModTime.Equal(modTime) {
+		t.Errorf("ModTime = %v, want %v", got.ModTime, modTime)
+	}
+
+	if _, ok := idx.GetEntry("nope"); ok {
+		t.Error("GetEntry reported a key that was never added as present")
+	}
+}
+
+// TestArchiveIndex_AddEntryReplacesOnDuplicatePath pins what happens on a repeated path, because a
+// tar can legally contain the same name twice and the index is a map. The counters are *not* rolled
+// back for the replaced entry, so TotalFiles and TotalSize overcount. That is the current contract;
+// this test exists so a change to it is visible rather than incidental.
+func TestArchiveIndex_AddEntryReplacesOnDuplicatePath(t *testing.T) {
+	t.Parallel()
+
+	idx := NewArchiveIndex()
+	idx.AddEntry(&ArchiveEntry{Path: "dup", Size: 10})
+	idx.AddEntry(&ArchiveEntry{Path: "dup", Size: 20})
+
+	got, ok := idx.GetEntry("dup")
+	if !ok {
+		t.Fatal("GetEntry(dup) reported absent")
+	}
+	if got.Size != 20 {
+		t.Errorf("Size = %d, want 20: the later entry wins", got.Size)
+	}
+
+	if len(idx.Files) != 1 {
+		t.Errorf("len(Files) = %d, want 1", len(idx.Files))
+	}
+	if idx.TotalFiles != 2 {
+		t.Errorf("TotalFiles = %d; the counters do not roll back a replacement, so 2 is the "+
+			"current behavior. If this is now 1, the contract changed on purpose and this test "+
+			"should say so", idx.TotalFiles)
+	}
+	if idx.TotalSize != 30 {
+		t.Errorf("TotalSize = %d; a replacement adds without subtracting, so 30 is the current "+
+			"behavior", idx.TotalSize)
+	}
+}
+
+func TestArchiveIndex_ListDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Paths exactly as internal/archive.BuildIndexFromBytes writes them: path.Clean'd, so no entry
+	// carries a trailing slash and there is no synthetic "." root.
+	newIndex := func() *ArchiveIndex {
+		idx := NewArchiveIndex()
+		for _, e := range []*ArchiveEntry{
+			{Path: "top.txt", Size: 5},
+			{Path: "mydir", IsDir: true},
+			{Path: "mydir/a.txt", Size: 10},
+			{Path: "mydir/b.txt", Size: 20},
+			{Path: "mydir/sub", IsDir: true},
+			{Path: "mydir/sub/deep.txt", Size: 30},
+		} {
+			idx.AddEntry(e)
+		}
+
+		return idx
+	}
+
+	tests := []struct {
+		name string
+		dir  string
+		want []string
+		why  string
+	}{
+		{
+			name: "root lists only top-level entries",
+			dir:  "",
+			want: []string{"mydir", "top.txt"},
+			why:  "mydir/a.txt is two levels down and must not appear",
+		},
+		{
+			name: "a directory lists its direct children",
+			dir:  "mydir",
+			want: []string{"mydir/a.txt", "mydir/b.txt", "mydir/sub"},
+			why:  "mydir/sub/deep.txt is a grandchild and must not appear",
+		},
+		{
+			name: "a trailing slash on the query is equivalent",
+			dir:  "mydir/",
+			want: []string{"mydir/a.txt", "mydir/b.txt", "mydir/sub"},
+			why:  "the function appends the separator itself, so both spellings must agree",
+		},
+		{
+			name: "a nested directory",
+			dir:  "mydir/sub",
+			want: []string{"mydir/sub/deep.txt"},
+		},
+		{
+			name: "a directory that does not exist lists nothing",
+			dir:  "absent",
+			want: nil,
+		},
+		{
+			name: "a file queried as a directory lists nothing",
+			dir:  "top.txt",
+			want: nil,
+			why:  "top.txt/ is not a prefix of any path",
+		},
+		{
+			name: "a prefix that is not a path component boundary lists nothing",
+			dir:  "my",
+			want: nil,
+			why: "string-prefix matching would return mydir's children here; the separator the " +
+				"function appends is what prevents it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := newIndex().ListDirectory(tt.dir)
+			assertPathSet(t, got, tt.want, tt.dir, tt.why)
+		})
+	}
+}
+
+// TestListDirectory_TrailingSlashEntriesAreNotProducedHere covers ListDirectory's second disjunct
+// and records that it is unreachable from the only producer in the repository.
+//
+// The condition reads:
+//
+//	if !containsSlash(remaining) || (entry.IsDir && remaining[len(remaining)-1] == '/' && ...)
+//
+// The right-hand side needs an entry whose own Path ends in '/'. internal/archive.BuildIndexFromBytes
+// runs every tar name through path.Clean, which strips exactly that — so no index built in this
+// repository can reach it, and neither can containsSlashExceptLast, which only that branch calls.
+//
+// It is covered rather than deleted because ArchiveIndex is exported and a caller outside this
+// repository may build an index by hand with tar's own directory convention, where a directory name
+// does end in '/'. The test states which convention each half serves, so a future decision to drop
+// the branch is a decision about the exported surface rather than a coverage cleanup.
+func TestListDirectory_TrailingSlashEntriesAreNotProducedHere(t *testing.T) {
+	t.Parallel()
+
+	// tar's convention: directory entries keep their trailing slash.
+	idx := NewArchiveIndex()
+	for _, e := range []*ArchiveEntry{
+		{Path: "d/", IsDir: true},
+		{Path: "d/sub/", IsDir: true},
+		{Path: "d/x.txt", Size: 1},
+		{Path: "d/sub/deep.txt", Size: 2},
+	} {
+		idx.AddEntry(e)
+	}
+
+	// d/sub/ has a trailing slash and no other slash before it, so it is a direct child of d/ by
+	// the second disjunct — the first would reject it, since "sub/" contains a slash.
+	assertPathSet(t, idx.ListDirectory("d"), []string{"d/sub/", "d/x.txt"}, "d",
+		"a trailing-slash directory entry is a direct child, which is what the second disjunct is for")
+
+	// And the grandchildren are still excluded. Two shapes, because they fail the second disjunct at
+	// different points: "sub/deep.txt" fails on its last character, while a grandchild *directory*
+	// gets all the way to containsSlashExceptLast and is rejected there — the only thing that
+	// distinguishes it from a child directory.
+	idx.AddEntry(&ArchiveEntry{Path: "d/sub/deeper/", IsDir: true})
+	assertPathSet(t, idx.ListDirectory("d"), []string{"d/sub/", "d/x.txt"}, "d",
+		"d/sub/deeper/ is a grandchild directory; containsSlashExceptLast is what excludes it")
+	assertPathSet(t, idx.ListDirectory("d/sub"), []string{"d/sub/deep.txt", "d/sub/deeper/"}, "d/sub", "")
+
+	// A one-character remainder. containsSlashExceptLast has a len <= 1 guard, and this is the only
+	// input that reaches it: the remainder must contain a slash and end in one, so it must be exactly
+	// "/". Degenerate, but a tar can name an entry "/" and the guard is what keeps the loop bound
+	// (len(s) - 1) from being 0 with an off-by-one read behind it.
+	root := NewArchiveIndex()
+	root.AddEntry(&ArchiveEntry{Path: "/", IsDir: true})
+	assertPathSet(t, root.ListDirectory(""), []string{"/"}, "",
+		"an entry named \"/\" is a direct child of the root, and reaching that answer runs "+
+			"containsSlashExceptLast's length guard")
+}
+
+// assertPathSet compares an entry slice to an expected set of paths. ListDirectory iterates a map, so
+// its order is not defined and must not be asserted.
+func assertPathSet(t *testing.T, got []*ArchiveEntry, want []string, dir, why string) {
+	t.Helper()
+
+	gotPaths := make(map[string]bool, len(got))
+	for _, e := range got {
+		if e == nil {
+			t.Fatalf("ListDirectory(%q) returned a nil entry", dir)
+		}
+		gotPaths[e.Path] = true
+	}
+
+	if len(gotPaths) != len(got) {
+		t.Errorf("ListDirectory(%q) returned %d entries but only %d distinct paths",
+			dir, len(got), len(gotPaths))
+	}
+
+	wantPaths := make(map[string]bool, len(want))
+	for _, p := range want {
+		wantPaths[p] = true
+	}
+
+	for p := range wantPaths {
+		if !gotPaths[p] {
+			t.Errorf("ListDirectory(%q) is missing %q", dir, p)
+		}
+	}
+	for p := range gotPaths {
+		if !wantPaths[p] {
+			t.Errorf("ListDirectory(%q) unexpectedly returned %q", dir, p)
+		}
+	}
+
+	if t.Failed() && why != "" {
+		t.Logf("why: %s", why)
+	}
+}

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -64,6 +64,13 @@ trap 'rm -f "$measured"' EXIT
 
 awk -v module="$module" '
   NR == 1 && $0 ~ /^mode:/ { next }
+  # Go files vendored inside npm dependencies are not this repository. `flatted` ships a Go port
+  # under its package directory, so once anything runs `npm install` in docs-platform or
+  # sdks/javascript, `go list ./...` reports two more packages and the gate lists them as unfloored
+  # at 0.0%. They are gitignored, absent from a fresh checkout, and not installed by the coverage
+  # job — so they appear only on a developer machine, which is the worst place for a gate to grow
+  # noise nobody can act on: the fix is neither a floor nor a test, it is not measuring them.
+  $1 ~ /\/node_modules\// { next }
   {
     split($1, loc, ":")
     path = loc[1]


### PR DESCRIPTION
Closes #360. Closes #361.

## `pkg/archive` — 0 own-tests → 100.0%, with a floor (#360)

The package had no tests of its own. Its 48.6% was measured through `internal/archive` under `-coverpkg`, which is a number about a consumer rather than about this package — and the code no consumer touches was invisible inside it.

#360 offered two options, and the premise had moved since it was filed: `internal/archive` now builds an index and reads it back, so the genuinely unreached code was `ListDirectory` and its two helpers, which **no consumer calls at all**. Testing directly is the only option that covers them.

`pkg/archive/metadata_test.go` takes it to 100.0% in three measured steps (94.6% → 97.3% → 100.0%), and the floor is set there.

### The branch that is unreachable from the only producer

Reaching 100% surfaced this, and it is covered with the reason written down rather than deleted:

```go
if !containsSlash(remaining) || (entry.IsDir && remaining[len(remaining)-1] == '/' && ...)
```

The right-hand side needs an entry whose own `Path` ends in `/`. `internal/archive.BuildIndexFromBytes` runs every tar name through `path.Clean`, which strips exactly that — so no index built in this repository can reach it, and neither can `containsSlashExceptLast`, which only that branch calls.

Covered rather than removed because `ArchiveIndex` is **exported**, and a caller outside this repository may build an index by hand using tar's own convention, where a directory name does keep its slash. The test states which convention each half serves, so a future decision to drop the branch is a decision about the exported surface instead of a coverage cleanup.

Two behaviors are now pinned rather than assumed:

- `TotalFiles` counts directories; `TotalSize` does not. A directory's tar-reported size is not content, and that asymmetry is the kind of thing that gets "cleaned up" into one rule.
- A repeated path replaces the entry and **does not** roll either counter back — `TotalFiles=2`, `TotalSize=30` for one replaced path. That is the current contract; the test exists so a change to it is visible.

## `sdks/c` — an explicit cgo posture, then a floor (#361)

**Step 1.** The coverage job set no `CGO_ENABLED`, so it took the runner's default. `sdks/c` is the one package whose coverage depends on that, so its number came from an inherited value no workflow stated. The job now sets `CGO_ENABLED: 1`.

The direction matters. `sdks/c/main.go` carries `import "C"`, so with cgo off the package does not fall back to a build-tag-excluded variant — it **fails to compile**:

```
sdks/c/main_test.go:105:16: undefined: bytesToCacheString
sdks/c/main_test.go:156:18: undefined: codeFromErr
sdks/c/main_test.go:333:4:  undefined: fillCStr
sdks/c/main_test.go:411:42: undefined: maxPutLength
```

`CGO_ENABLED=0` here would turn a coverage question into a compile failure in the job whose output is a coverage number. The cross-build matrix and the release build set `0` deliberately, because there the point is a static binary; here the point is measuring every package.

**Step 2 — the floor is 12, and the stale number is the finding.** `.coverage-floors` claimed 11.0% while arguing the package was unfloorable, and that number was already stale when it was written: **#355 added the tests that took it from 11.0% to 12.1%**, and the note was authored on a branch cut before #355 merged, so it recorded a measurement its own commit had invalidated.

Verified rather than reasoned:

| | measured |
|---|---|
| `f6f2ae5^` (before #355) | 11.0% |
| `HEAD` | 12.1% |
| commits touching `sdks/c` since the note | none |

12.1% is stable across three runs and identical under `set`, `count` and `atomic`. The floor is a ratchet on the Go-testable half — `codeFromErr`, `fillCStr`, `bytesToCacheString`, the length and limit error builders — not a coverage target for the SDK. The rest is `//export` cgo entry points whose parameters are C pointers, which the C suite under `sdks/c/tests` exercises by linking the shared library and `go test` cannot reach.

## The gate stops measuring npm-vendored Go

Two copies of the `flatted` npm package ship a Go port under their package directory, so once anything has run `npm install` in `docs-platform` or `sdks/javascript`, `go list ./...` reports two more packages and the gate named them as unfloored at 0.0%. They are gitignored, absent from a fresh checkout, and never installed by the coverage job — so they appeared **only on a developer machine**, which is the worst place for a gate to grow noise, and neither a floor nor a test is the fix, because the code is not this repository's.

`TestUnfloorablePackagesAreExplained` previously filtered them out of its own synthetic profile. That passed the test and left the noise in the output a person actually reads — the wrong half to fix. The filter is gone: the synthetic profile now names those packages, and the assertion that the gate does not report them is what tests the exclusion.

## Verification

Both new gates verified by mutation, per the standing rule:

- **Drop the `node_modules` skip from `coverage-gate.sh`** → `TestUnfloorablePackagesAreExplained` fails, naming both `flatted` packages with the "add a `# no-floor:` entry" message.
- **Set the `sdks/c` floor to 13** → `FAIL  sdks/c — 12.1%, below its floor of 13%`.

Full-repo gate against a fresh `CGO_ENABLED=1` profile:

```
ok    pkg/archive                        100.0%  (floor 100%)
ok    sdks/c                              12.1%  (floor 12%)
...
no floor set (add to .coverage-floors to gate them):
  internal/awsrates/offerfile/offertest   0.0%
  internal/cache/cachetest             0.0%
  internal/testhttp                    0.0%
  pkg/compression                      0.0%

coverage-gate: 35 package(s) at or above their floor
```

Four unfloored packages, down from six — and all four are the "no tests, deliberately; every statement runs under a floored consumer" case, where a floor would have to be 0 to pass and 0 is not a gate. `.coverage-floors`' header count is updated from five to four, its 80%-target sentence recounted from the file (23 of 35), and the `no-floor: sdks/c` block replaced with a per-floor note.