### PR TITLE
test: t.Parallel across seventeen files, and one test that passed by luck (#179)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -204,6 +204,24 @@ linters:
         linters:
           - unused
 
+      # pkg/utils' debug-mode tests cannot run in parallel, and the obstacle is the design rather
+      # than the tests (#373).
+      #
+      # DebugManager is a package-level singleton behind a sync.Once with no exported constructor, so
+      # every test observes the same instance — but that alone would be workable, since each test
+      # already uses a distinct session ID. The blocker is DebugManager.RecordEvent: it fans every
+      # event out to *all* open sessions, so a session's event count is a function of what every
+      # other concurrently-open session recorded. Adding t.Parallel here produces exactly that,
+      # measured rather than predicted: "Expected 1 event, got 17", "Expected 2 storage events, got
+      # 6", and four other counts inflated by siblings' traffic.
+      #
+      # Suppressed rather than silenced with a false t.Parallel, which would leave the tests
+      # sequential in effect and the lint green — the worst of both. #373 tracks giving the manager a
+      # constructor so each test can own one, which is the fix that makes the exclusion removable.
+      - path: 'pkg/utils/debug_mode_test\.go'
+        linters:
+          - paralleltest
+
 issues:
   # Report everything. A cap that hides findings is how a lint gate becomes decorative.
   max-issues-per-linter: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **278 of the `paralleltest`/`tparallel` backlog cleared: the lint total is 570 → 299** ([#179]).
+  `t.Parallel()` on every test and subtest in seventeen files across `pkg/errors`, `pkg/status`,
+  `pkg/health`, `pkg/recovery`, `pkg/retry`, `pkg/api`, `pkg/utils`, `pkg/types`, `internal/cache` and
+  `internal/metrics`. CLAUDE.md already required this; the finding count was the gap between the
+  requirement and the tree. Each package was run under `-race -count=2` after the change and its
+  coverage checked against its floor, because parallelizing a test that shares state is a way to make
+  it pass less often rather than a way to make it faster.
+
+  **Two packages resisted, and both are the point of doing this rather than suppressing it.**
+  `pkg/health`'s `TestTracker_CanRead` had a genuine order dependency, described under Fixed below.
+  `pkg/utils/debug_mode_test.go`'s 19 findings cannot be fixed by a `t.Parallel()` at all —
+  `DebugManager` is a `sync.Once` singleton with no exported constructor, and `RecordEvent` fans every
+  event out to *all* open sessions, so a session's event count depends on what every concurrently-open
+  session recorded. Measured: `Expected 1 event, got 17`, and five other counts inflated by siblings'
+  traffic, with no data race — the locking is correct and the broadcast is doing what it is written to
+  do. Excluded in `.golangci.yml` with that reasoning recorded and filed as [#373], rather than
+  silenced with a `t.Parallel()` that would leave the tests sequential in effect and the lint green.
+
 - **A measured per-iteration allocation budget for the difftest fuzz target, and a bound on what the
   shared emulator retains** ([#193]). `TestPerIterationAllocationBudget` asserts that one worst-shaped
   iteration allocates under 16 MiB; it measures 6.3 MiB for a program of writes and reads and 7.1 MiB for
@@ -529,6 +547,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`TestTracker_CanRead` was passing on the order its subtests happened to run in** — found by
+  parallelizing it, and the more useful half of that change ([#179]).
+
+  The test wrote a component's `State` directly and asserted what `CanRead`/`CanWrite` answered. But
+  `State` alone does not decide that: `admissionState` admits one probe against a refusing component
+  once `nextProbe` has elapsed, and reports `StateDegraded` to get that probe past the gate. So
+  `State=StateUnavailable` with a **zero-value `nextProbe`**, which is always in the past, reads as
+  *readable* — a combination the tracker never produces, since `RecordError` sets both fields and the
+  test set one.
+
+  One tracker shared across the table concealed it. The first subtest to reach a refusing state took
+  the probe path, which pushed `nextProbe` `ProbeAfter` into the future, and every later subtest then
+  read raw state and agreed with the table. Giving each subtest its own tracker — the isolation
+  `t.Parallel()` requires — removed the accident and the unavailable case failed immediately with
+  `CanRead() = true, want false`. Fixed by setting `nextProbe` alongside `State`, in the shape
+  `RecordError` leaves it; verified by deleting that line and watching the case fail.
+
+  No production defect here: the tracker's own code path sets both fields together. What was broken is
+  a test that could not have caught it if they came apart.
+
 - **Error classification for Transfer Acceleration no longer disables the accelerated endpoint on
   unrelated failures** ([#187]).
 
@@ -898,11 +936,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OBJECTFS.md`; they were filed rather than fixed here, and are fixed above in the same release
   ([#353]).
 
+[#179]: https://github.com/scttfrdmn/objectfs/issues/179
 [#187]: https://github.com/scttfrdmn/objectfs/issues/187
 [#198]: https://github.com/scttfrdmn/objectfs/issues/198
 [#199]: https://github.com/scttfrdmn/objectfs/issues/199
 [#200]: https://github.com/scttfrdmn/objectfs/issues/200
 [#235]: https://github.com/scttfrdmn/objectfs/issues/235
+[#373]: https://github.com/scttfrdmn/objectfs/issues/373
 [#353]: https://github.com/scttfrdmn/objectfs/issues/353
 [#362]: https://github.com/scttfrdmn/objectfs/issues/362
 

--- a/internal/cache/lru_test.go
+++ b/internal/cache/lru_test.go
@@ -8,6 +8,8 @@ import (
 
 // TestNewLRUCache tests cache creation with various configurations
 func TestNewLRUCache(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		config *CacheConfig
@@ -52,6 +54,8 @@ func TestNewLRUCache(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cache := NewLRUCache(tt.config)
 			if cache == nil {
 				t.Fatal("NewLRUCache returned nil")
@@ -69,6 +73,8 @@ func TestNewLRUCache(t *testing.T) {
 
 // TestLRUCache_PutGet tests basic Put and Get operations
 func TestLRUCache_PutGet(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize:    1024 * 1024,
 		MaxEntries: 100,
@@ -102,6 +108,8 @@ func TestLRUCache_PutGet(t *testing.T) {
 
 // TestLRUCache_GetMiss tests cache miss behavior
 func TestLRUCache_GetMiss(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024 * 1024,
 		TTL:     time.Hour,
@@ -122,6 +130,8 @@ func TestLRUCache_GetMiss(t *testing.T) {
 
 // TestLRUCache_PutEmpty tests that empty data is ignored
 func TestLRUCache_PutEmpty(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024 * 1024,
 	})
@@ -136,6 +146,8 @@ func TestLRUCache_PutEmpty(t *testing.T) {
 
 // TestLRUCache_UpdateExisting tests updating an existing cache entry
 func TestLRUCache_UpdateExisting(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024 * 1024,
 		TTL:     time.Hour,
@@ -168,6 +180,8 @@ func TestLRUCache_UpdateExisting(t *testing.T) {
 
 // TestLRUCache_Eviction tests LRU eviction when cache is full
 func TestLRUCache_Eviction(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize:    100, // Small cache
 		MaxEntries: 3,   // Max 3 entries
@@ -209,6 +223,8 @@ func TestLRUCache_Eviction(t *testing.T) {
 
 // TestLRUCache_EvictionBySize tests eviction based on size limit
 func TestLRUCache_EvictionBySize(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize:    50, // 50 bytes
 		MaxEntries: 100,
@@ -244,6 +260,8 @@ func TestLRUCache_EvictionBySize(t *testing.T) {
 // of the bug is identical, and a test that only usually passes is worth the same as one that
 // usually fails.
 func TestLRUCache_TTLExpiration(t *testing.T) {
+	t.Parallel()
+
 	const ttl = 2 * time.Second
 
 	cache := NewLRUCache(&CacheConfig{
@@ -278,6 +296,8 @@ func TestLRUCache_TTLExpiration(t *testing.T) {
 
 // TestLRUCache_Delete tests Delete operation
 func TestLRUCache_Delete(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024 * 1024,
 		TTL:     time.Hour,
@@ -307,6 +327,8 @@ func TestLRUCache_Delete(t *testing.T) {
 
 // TestLRUCache_Clear tests Clear operation
 func TestLRUCache_Clear(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024 * 1024,
 		TTL:     time.Hour,
@@ -333,6 +355,8 @@ func TestLRUCache_Clear(t *testing.T) {
 
 // TestLRUCache_ConcurrentAccess tests thread-safety
 func TestLRUCache_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize:    10 * 1024 * 1024,
 		MaxEntries: 1000,
@@ -378,6 +402,8 @@ func TestLRUCache_ConcurrentAccess(t *testing.T) {
 
 // TestLRUCache_Stats tests statistics tracking
 func TestLRUCache_Stats(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize:    1024,
 		MaxEntries: 10,
@@ -422,6 +448,8 @@ func TestLRUCache_Stats(t *testing.T) {
 
 // TestLRUCache_Resize tests cache resize operation
 func TestLRUCache_Resize(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize:    1000,
 		MaxEntries: 100,
@@ -451,6 +479,8 @@ func TestLRUCache_Resize(t *testing.T) {
 
 // TestLRUCache_Evict tests manual eviction
 func TestLRUCache_Evict(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize:    1024,
 		MaxEntries: 100,
@@ -480,6 +510,8 @@ func TestLRUCache_Evict(t *testing.T) {
 
 // TestLRUCache_GetKeys tests GetKeys helper
 func TestLRUCache_GetKeys(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024,
 		TTL:     time.Hour,
@@ -518,6 +550,8 @@ func TestLRUCache_GetKeys(t *testing.T) {
 
 // TestWeightedLRUCache_Creation tests weighted LRU cache creation
 func TestWeightedLRUCache_Creation(t *testing.T) {
+	t.Parallel()
+
 	cache := NewWeightedLRUCache(&CacheConfig{
 		MaxSize: 1024 * 1024,
 	})
@@ -532,6 +566,8 @@ func TestWeightedLRUCache_Creation(t *testing.T) {
 
 // TestWeightedLRUCache_EvictByWeight tests weight-based eviction
 func TestWeightedLRUCache_EvictByWeight(t *testing.T) {
+	t.Parallel()
+
 	cache := NewWeightedLRUCache(&CacheConfig{
 		MaxSize:    1024,
 		MaxEntries: 100,
@@ -567,6 +603,8 @@ func TestWeightedLRUCache_EvictByWeight(t *testing.T) {
 
 // TestLRUCache_AccessTimeUpdate tests that access time is updated on Get
 func TestLRUCache_AccessTimeUpdate(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024,
 		TTL:     time.Hour,
@@ -599,6 +637,8 @@ func TestLRUCache_AccessTimeUpdate(t *testing.T) {
 
 // TestLRUCache_DataIsolation tests that returned data is a copy
 func TestLRUCache_DataIsolation(t *testing.T) {
+	t.Parallel()
+
 	cache := NewLRUCache(&CacheConfig{
 		MaxSize: 1024,
 		TTL:     time.Hour,

--- a/internal/cache/persistent_test.go
+++ b/internal/cache/persistent_test.go
@@ -12,6 +12,8 @@ import (
 
 // TestNewPersistentCache tests cache creation with various configurations
 func TestNewPersistentCache(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	tests := []struct {
@@ -88,6 +90,8 @@ func TestNewPersistentCache(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cache, err := NewPersistentCache(tt.config)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewPersistentCache() error = %v, wantErr %v", err, tt.wantErr)
@@ -108,6 +112,8 @@ func TestNewPersistentCache(t *testing.T) {
 
 // TestPersistentCache_PutGet tests basic Put and Get operations
 func TestPersistentCache_PutGet(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory:   tmpDir,
@@ -154,6 +160,8 @@ func TestPersistentCache_PutGet(t *testing.T) {
 
 // TestPersistentCache_GetMiss tests cache miss behavior
 func TestPersistentCache_GetMiss(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -179,6 +187,8 @@ func TestPersistentCache_GetMiss(t *testing.T) {
 
 // TestPersistentCache_Compression tests compression functionality
 func TestPersistentCache_Compression(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	tests := []struct {
@@ -200,6 +210,8 @@ func TestPersistentCache_Compression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cache, err := NewPersistentCache(&PersistentCacheConfig{
 				Directory:   filepath.Join(tmpDir, tt.name),
 				MaxSize:     10 * 1024 * 1024,
@@ -247,6 +259,8 @@ func TestPersistentCache_Compression(t *testing.T) {
 // Stamping the timestamp after the write would also fix the flake, but TTL-measured-from-write-start
 // is the defensible semantic — the entry is as old as its data — so the test is what changes.
 func TestPersistentCache_TTLExpiration(t *testing.T) {
+	t.Parallel()
+
 	const ttl = 2 * time.Second
 
 	tmpDir := t.TempDir()
@@ -286,6 +300,8 @@ func expiryWait(ttl time.Duration) {
 
 // TestPersistentCache_Delete tests Delete operation
 func TestPersistentCache_Delete(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -317,6 +333,8 @@ func TestPersistentCache_Delete(t *testing.T) {
 
 // TestPersistentCache_Eviction tests eviction when cache is full
 func TestPersistentCache_Eviction(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -346,6 +364,8 @@ func TestPersistentCache_Eviction(t *testing.T) {
 
 // TestPersistentCache_EvictManual tests manual Evict operation
 func TestPersistentCache_EvictManual(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -379,6 +399,8 @@ func TestPersistentCache_EvictManual(t *testing.T) {
 
 // TestPersistentCache_Clear tests Clear operation
 func TestPersistentCache_Clear(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -416,6 +438,8 @@ func TestPersistentCache_Clear(t *testing.T) {
 // against a 100ms budget is a coin flip on a loaded runner, and losing it looks like Optimize
 // evicting a fresh entry.
 func TestPersistentCache_Optimize(t *testing.T) {
+	t.Parallel()
+
 	const ttl = 2 * time.Second
 
 	tmpDir := t.TempDir()
@@ -455,6 +479,8 @@ func TestPersistentCache_Optimize(t *testing.T) {
 
 // TestPersistentCache_IndexPersistence tests that index is saved and loaded
 func TestPersistentCache_IndexPersistence(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	// Create cache and add data
@@ -500,6 +526,8 @@ func TestPersistentCache_IndexPersistence(t *testing.T) {
 
 // TestPersistentCache_ChecksumValidation tests checksum verification
 func TestPersistentCache_ChecksumValidation(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory:   tmpDir,
@@ -652,6 +680,8 @@ func TestPersistentCache_ChecksumIsWhatCatchesWrongBytes(t *testing.T) {
 
 // TestPersistentCache_ConcurrentAccess tests thread-safety
 func TestPersistentCache_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -701,6 +731,8 @@ func TestPersistentCache_ConcurrentAccess(t *testing.T) {
 
 // TestPersistentCache_Stats tests statistics tracking
 func TestPersistentCache_Stats(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -741,6 +773,8 @@ func TestPersistentCache_Stats(t *testing.T) {
 
 // TestPersistentCache_EmptyData tests that empty data is ignored
 func TestPersistentCache_EmptyData(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	cache, err := NewPersistentCache(&PersistentCacheConfig{
 		Directory: tmpDir,
@@ -761,6 +795,8 @@ func TestPersistentCache_EmptyData(t *testing.T) {
 
 // TestPersistentCache_PathValidation tests security of path validation
 func TestPersistentCache_PathValidation(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	// Test that config with suspicious index file is rejected during load

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -11,6 +11,8 @@ func TestNewCollector(t *testing.T) {
 	t.Parallel()
 
 	t.Run("with valid config", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -37,6 +39,8 @@ func TestNewCollector(t *testing.T) {
 	})
 
 	t.Run("with nil config uses defaults", func(t *testing.T) {
+		t.Parallel()
+
 		collector, err := NewCollector(nil)
 		if err != nil {
 			t.Fatalf("NewCollector(nil) error = %v, want nil", err)
@@ -61,6 +65,8 @@ func TestNewCollector(t *testing.T) {
 	})
 
 	t.Run("with disabled config", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled: false,
 		}
@@ -81,6 +87,8 @@ func TestRecordOperation(t *testing.T) {
 	t.Parallel()
 
 	t.Run("record successful operation", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -120,6 +128,8 @@ func TestRecordOperation(t *testing.T) {
 	})
 
 	t.Run("record failed operation", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -140,6 +150,8 @@ func TestRecordOperation(t *testing.T) {
 	})
 
 	t.Run("record multiple operations", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -173,6 +185,8 @@ func TestRecordOperation(t *testing.T) {
 	})
 
 	t.Run("disabled collector ignores operations", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled: false,
 		}
@@ -195,6 +209,8 @@ func TestRecordCacheOperations(t *testing.T) {
 	t.Parallel()
 
 	t.Run("record cache hit", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -210,6 +226,8 @@ func TestRecordCacheOperations(t *testing.T) {
 	})
 
 	t.Run("record cache miss", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -225,6 +243,8 @@ func TestRecordCacheOperations(t *testing.T) {
 	})
 
 	t.Run("disabled collector ignores cache operations", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled: false,
 		}
@@ -243,6 +263,8 @@ func TestRecordError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("record error", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -258,6 +280,8 @@ func TestRecordError(t *testing.T) {
 	})
 
 	t.Run("disabled collector ignores errors", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled: false,
 		}
@@ -323,6 +347,8 @@ func TestClassifyError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := collector.classifyError(tt.err)
 			if result != tt.expectedType {
 				t.Errorf("classifyError() = %q, want %q", result, tt.expectedType)
@@ -335,6 +361,8 @@ func TestUpdateCacheSize(t *testing.T) {
 	t.Parallel()
 
 	t.Run("update cache size", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -350,6 +378,8 @@ func TestUpdateCacheSize(t *testing.T) {
 	})
 
 	t.Run("disabled collector ignores cache size", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled: false,
 		}
@@ -366,6 +396,8 @@ func TestUpdateActiveConnections(t *testing.T) {
 	t.Parallel()
 
 	t.Run("update active connections", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled:   true,
 			Addr:      "127.0.0.1:0",
@@ -381,6 +413,8 @@ func TestUpdateActiveConnections(t *testing.T) {
 	})
 
 	t.Run("disabled collector ignores connections", func(t *testing.T) {
+		t.Parallel()
+
 		config := &Config{
 			Enabled: false,
 		}
@@ -564,6 +598,8 @@ func TestContainsHelper(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := contains(tt.s, tt.substr)
 			if result != tt.want {
 				t.Errorf("contains(%q, %q) = %v, want %v", tt.s, tt.substr, result, tt.want)
@@ -609,6 +645,8 @@ func TestIndexOfHelper(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := indexOf(tt.s, tt.substr)
 			if result != tt.want {
 				t.Errorf("indexOf(%q, %q) = %d, want %d", tt.s, tt.substr, result, tt.want)

--- a/internal/metrics/detailed_test.go
+++ b/internal/metrics/detailed_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestNewDetailedPerformanceMetrics(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(1000, true)
 
 	if dpm == nil {
@@ -27,6 +29,8 @@ func TestNewDetailedPerformanceMetrics(t *testing.T) {
 }
 
 func TestRecordOperation_BasicMetrics(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record a read operation
@@ -66,6 +70,8 @@ func TestRecordOperation_BasicMetrics(t *testing.T) {
 }
 
 func TestRecordOperation_MultipleOperations(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record multiple read operations
@@ -96,6 +102,8 @@ func TestRecordOperation_MultipleOperations(t *testing.T) {
 }
 
 func TestRecordOperation_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record operations with errors
@@ -118,6 +126,8 @@ func TestRecordOperation_ErrorHandling(t *testing.T) {
 }
 
 func TestRecordOperation_CacheSourceTracking(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record operations from different cache sources
@@ -143,6 +153,8 @@ func TestRecordOperation_CacheSourceTracking(t *testing.T) {
 }
 
 func TestRecordOperation_LatencyTracking(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	latencies := []time.Duration{
@@ -175,6 +187,8 @@ func TestRecordOperation_LatencyTracking(t *testing.T) {
 }
 
 func TestRecordOperation_FileMetrics(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, true) // Enable file tracking
 
 	// Record operations on multiple files
@@ -210,6 +224,8 @@ func TestRecordOperation_FileMetrics(t *testing.T) {
 }
 
 func TestRecordOperation_MaxTrackedFiles(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(2, true) // Only track 2 files
 
 	// Try to record operations on 3 different files
@@ -224,6 +240,8 @@ func TestRecordOperation_MaxTrackedFiles(t *testing.T) {
 }
 
 func TestRecordNetworkOperation(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record network operation
@@ -261,6 +279,8 @@ func TestRecordNetworkOperation(t *testing.T) {
 }
 
 func TestRecordNetworkOperation_PeakRates(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record multiple operations with different rates
@@ -282,6 +302,8 @@ func TestRecordNetworkOperation_PeakRates(t *testing.T) {
 }
 
 func TestRecordCost(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record cost for read operations
@@ -312,6 +334,8 @@ func TestRecordCost(t *testing.T) {
 }
 
 func TestCacheBreakdown(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record read operations from different cache sources
@@ -354,6 +378,8 @@ func TestCacheBreakdown(t *testing.T) {
 }
 
 func TestGetSummary(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, true)
 
 	// Record some operations
@@ -385,6 +411,8 @@ func TestGetSummary(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, true)
 
 	// Record some operations
@@ -423,6 +451,8 @@ func TestReset(t *testing.T) {
 }
 
 func TestMultipleOperationTypes(t *testing.T) {
+	t.Parallel()
+
 	dpm := NewDetailedPerformanceMetrics(100, false)
 
 	// Record different operation types

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultServerConfig()
 	statusTracker := status.NewTracker(status.DefaultTrackerConfig())
 	healthTracker := health.NewTracker(health.DefaultConfig())
@@ -42,6 +44,8 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestHandleHealth(t *testing.T) {
+	t.Parallel()
+
 	healthTracker := health.NewTracker(health.DefaultConfig())
 	healthTracker.RegisterComponent("test-service")
 
@@ -70,6 +74,8 @@ func TestHandleHealth(t *testing.T) {
 }
 
 func TestHandleHealthDegraded(t *testing.T) {
+	t.Parallel()
+
 	healthTracker := health.NewTracker(health.DefaultConfig())
 	healthTracker.RegisterComponent("test-service")
 
@@ -103,6 +109,8 @@ func TestHandleHealthDegraded(t *testing.T) {
 }
 
 func TestHandleHealthComponents(t *testing.T) {
+	t.Parallel()
+
 	healthTracker := health.NewTracker(health.DefaultConfig())
 	healthTracker.RegisterComponent("service-1")
 	healthTracker.RegisterComponent("service-2")
@@ -140,6 +148,8 @@ func TestHandleHealthComponents(t *testing.T) {
 }
 
 func TestHandleLiveness(t *testing.T) {
+	t.Parallel()
+
 	server := &Server{
 		config: DefaultServerConfig(),
 	}
@@ -164,6 +174,8 @@ func TestHandleLiveness(t *testing.T) {
 }
 
 func TestHandleReadiness(t *testing.T) {
+	t.Parallel()
+
 	healthTracker := health.NewTracker(health.DefaultConfig())
 	healthTracker.RegisterComponent("test-service")
 
@@ -192,6 +204,8 @@ func TestHandleReadiness(t *testing.T) {
 }
 
 func TestHandleReadinessUnavailable(t *testing.T) {
+	t.Parallel()
+
 	healthTracker := health.NewTracker(health.DefaultConfig())
 	healthTracker.RegisterComponent("test-service")
 
@@ -225,6 +239,8 @@ func TestHandleReadinessUnavailable(t *testing.T) {
 }
 
 func TestHandleSystemStatus(t *testing.T) {
+	t.Parallel()
+
 	statusTracker := status.NewTracker(status.DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -257,6 +273,8 @@ func TestHandleSystemStatus(t *testing.T) {
 }
 
 func TestHandleOperations(t *testing.T) {
+	t.Parallel()
+
 	statusTracker := status.NewTracker(status.DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -293,6 +311,8 @@ func TestHandleOperations(t *testing.T) {
 }
 
 func TestHandleOperation(t *testing.T) {
+	t.Parallel()
+
 	statusTracker := status.NewTracker(status.DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -323,6 +343,8 @@ func TestHandleOperation(t *testing.T) {
 }
 
 func TestHandleOperationNotFound(t *testing.T) {
+	t.Parallel()
+
 	statusTracker := status.NewTracker(status.DefaultTrackerConfig())
 
 	server := &Server{
@@ -341,6 +363,8 @@ func TestHandleOperationNotFound(t *testing.T) {
 }
 
 func TestHandleHistory(t *testing.T) {
+	t.Parallel()
+
 	statusTracker := status.NewTracker(status.DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -383,6 +407,8 @@ func TestHandleHistory(t *testing.T) {
 }
 
 func TestHandleInfo(t *testing.T) {
+	t.Parallel()
+
 	t.Run("version from config", func(t *testing.T) {
 		t.Parallel()
 		cfg := DefaultServerConfig()
@@ -428,6 +454,8 @@ func TestHandleInfo(t *testing.T) {
 }
 
 func TestMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
 	server := &Server{
 		config: DefaultServerConfig(),
 	}
@@ -444,6 +472,8 @@ func TestMethodNotAllowed(t *testing.T) {
 }
 
 func TestCORSMiddleware(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultServerConfig()
 	config.EnableCORS = true
 
@@ -464,6 +494,8 @@ func TestCORSMiddleware(t *testing.T) {
 }
 
 func TestServerShutdown(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultServerConfig()
 	config.Address = "localhost:0" // Use random available port
 
@@ -486,6 +518,8 @@ func TestServerShutdown(t *testing.T) {
 }
 
 func TestNilTrackers(t *testing.T) {
+	t.Parallel()
+
 	server := &Server{
 		config: DefaultServerConfig(),
 	}
@@ -503,6 +537,8 @@ func TestNilTrackers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			w := httptest.NewRecorder()
 
@@ -563,6 +599,8 @@ func BenchmarkHandleOperations(b *testing.B) {
 // Test with actual errors integration
 
 func TestHealthWithActualErrors(t *testing.T) {
+	t.Parallel()
+
 	healthTracker := health.NewTracker(health.DefaultConfig())
 	healthTracker.RegisterComponent("storage")
 
@@ -752,6 +790,8 @@ func TestHandleMounts_NoMountManager(t *testing.T) {
 
 	for _, method := range []string{http.MethodGet, http.MethodPost} {
 		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+
 			req := httptest.NewRequest(method, "/api/v1/mounts", strings.NewReader("{}"))
 			w := httptest.NewRecorder()
 			server.handleMounts(w, req)

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -11,6 +11,8 @@ func TestNewError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("creates error with all defaults", func(t *testing.T) {
+		t.Parallel()
+
 		err := NewError(ErrCodeInvalidConfig, "configuration is invalid")
 		if err == nil {
 			t.Fatal("NewError returned nil")
@@ -36,6 +38,8 @@ func TestNewError(t *testing.T) {
 	})
 
 	t.Run("sets correct retryable defaults", func(t *testing.T) {
+		t.Parallel()
+
 		retryableErr := NewError(ErrCodeConnectionTimeout, "connection timed out")
 		if !retryableErr.Retryable {
 			t.Error("ConnectionTimeout should be retryable by default")
@@ -48,6 +52,8 @@ func TestNewError(t *testing.T) {
 	})
 
 	t.Run("sets correct user-facing defaults", func(t *testing.T) {
+		t.Parallel()
+
 		userFacingErr := NewError(ErrCodeFileNotFound, "file not found")
 		if !userFacingErr.UserFacing {
 			t.Error("FileNotFound should be user-facing by default")
@@ -60,6 +66,8 @@ func TestNewError(t *testing.T) {
 	})
 
 	t.Run("sets correct HTTP status defaults", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []struct {
 			code       ErrorCode
 			wantStatus int
@@ -112,6 +120,8 @@ func TestGetCategory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.code), func(t *testing.T) {
+			t.Parallel()
+
 			result := GetCategory(tt.code)
 			if result != tt.expected {
 				t.Errorf("GetCategory(%v) = %v, want %v", tt.code, result, tt.expected)
@@ -142,6 +152,8 @@ func TestIsRetryableByDefault(t *testing.T) {
 
 	for _, code := range retryableCodes {
 		t.Run(string(code)+" should be retryable", func(t *testing.T) {
+			t.Parallel()
+
 			if !IsRetryableByDefault(code) {
 				t.Errorf("%v should be retryable by default", code)
 			}
@@ -150,6 +162,8 @@ func TestIsRetryableByDefault(t *testing.T) {
 
 	for _, code := range nonRetryableCodes {
 		t.Run(string(code)+" should not be retryable", func(t *testing.T) {
+			t.Parallel()
+
 			if IsRetryableByDefault(code) {
 				t.Errorf("%v should not be retryable by default", code)
 			}
@@ -178,6 +192,8 @@ func TestIsUserFacingByDefault(t *testing.T) {
 
 	for _, code := range userFacingCodes {
 		t.Run(string(code)+" should be user-facing", func(t *testing.T) {
+			t.Parallel()
+
 			if !IsUserFacingByDefault(code) {
 				t.Errorf("%v should be user-facing by default", code)
 			}
@@ -186,6 +202,8 @@ func TestIsUserFacingByDefault(t *testing.T) {
 
 	for _, code := range internalCodes {
 		t.Run(string(code)+" should not be user-facing", func(t *testing.T) {
+			t.Parallel()
+
 			if IsUserFacingByDefault(code) {
 				t.Errorf("%v should not be user-facing by default", code)
 			}
@@ -221,6 +239,8 @@ func TestGetDefaultHTTPStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.code), func(t *testing.T) {
+			t.Parallel()
+
 			result := GetDefaultHTTPStatus(tt.code)
 			if result != tt.wantStatus {
 				t.Errorf("GetDefaultHTTPStatus(%v) = %d, want %d", tt.code, result, tt.wantStatus)
@@ -268,6 +288,8 @@ func TestObjectFSError_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := tt.err.Error()
 			if result != tt.want {
 				t.Errorf("Error() = %q, want %q", result, tt.want)

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestTracker_RegisterComponent(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultConfig())
 
 	tracker.RegisterComponent("test-service")
@@ -22,6 +24,8 @@ func TestTracker_RegisterComponent(t *testing.T) {
 }
 
 func TestTracker_RecordSuccess(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultConfig())
 	tracker.RegisterComponent("test-service")
 
@@ -44,6 +48,8 @@ func TestTracker_RecordSuccess(t *testing.T) {
 }
 
 func TestTracker_RecordError_Degradation(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.ErrorThreshold = 3
 	tracker := NewTracker(config)
@@ -69,6 +75,8 @@ func TestTracker_RecordError_Degradation(t *testing.T) {
 }
 
 func TestTracker_RecordError_Unavailable(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.ErrorThreshold = 3
 	config.UnavailableThreshold = 10
@@ -87,6 +95,8 @@ func TestTracker_RecordError_Unavailable(t *testing.T) {
 }
 
 func TestTracker_RecordError_ReadOnly(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.ErrorThreshold = 3
 	tracker := NewTracker(config)
@@ -105,6 +115,8 @@ func TestTracker_RecordError_ReadOnly(t *testing.T) {
 }
 
 func TestTracker_GetOverallHealth(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultConfig())
 	tracker.RegisterComponent("service-1")
 	tracker.RegisterComponent("service-2")
@@ -138,8 +150,7 @@ func TestTracker_GetOverallHealth(t *testing.T) {
 }
 
 func TestTracker_CanRead(t *testing.T) {
-	tracker := NewTracker(DefaultConfig())
-	tracker.RegisterComponent("test-service")
+	t.Parallel()
 
 	tests := []struct {
 		state    HealthState
@@ -154,9 +165,29 @@ func TestTracker_CanRead(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.state.String(), func(t *testing.T) {
-			// Set state directly for testing
+			t.Parallel()
+
+			// A tracker per subtest, and nextProbe set alongside State rather than left at its zero
+			// value. Both are needed, and the first is what made the second visible.
+			//
+			// State alone does not decide what CanRead answers. admissionState admits one probe
+			// against a refusing component once nextProbe has elapsed, and reports StateDegraded to
+			// get that probe past the gate — so State=StateUnavailable with a zero-value nextProbe,
+			// which is always in the past, reads as *readable*. The tracker never produces that
+			// combination: RecordError sets both fields, and this test set one.
+			//
+			// A single shared tracker concealed it. The first subtest to reach a refusing state took
+			// the probe path, which pushed nextProbe ProbeAfter into the future, and every later
+			// subtest then read raw state and agreed with the table — so the assertion held on the
+			// order its siblings happened to run in. Verified by deleting the nextProbe line below:
+			// the unavailable case fails.
+			tracker := NewTracker(DefaultConfig())
+			tracker.RegisterComponent("test-service")
+
+			// Set state directly for testing, in the shape RecordError would leave it.
 			tracker.mu.Lock()
 			tracker.components["test-service"].State = tt.state
+			tracker.components["test-service"].nextProbe = time.Now().Add(DefaultConfig().ProbeAfter)
 			tracker.mu.Unlock()
 
 			canRead := tracker.CanRead("test-service")
@@ -173,6 +204,8 @@ func TestTracker_CanRead(t *testing.T) {
 }
 
 func TestTracker_StateChangeCallback(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.ErrorThreshold = 3
 	tracker := NewTracker(config)
@@ -247,6 +280,8 @@ func (l *testHealthListener) OnHealthCheck(component string, healthy bool, err e
 }
 
 func TestTracker_HealthListener(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.ErrorThreshold = 3
 	tracker := NewTracker(config)
@@ -284,6 +319,8 @@ func TestTracker_HealthListener(t *testing.T) {
 }
 
 func TestTracker_GetAllComponents(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultConfig())
 	tracker.RegisterComponent("service-1")
 	tracker.RegisterComponent("service-2")
@@ -303,6 +340,8 @@ func TestTracker_GetAllComponents(t *testing.T) {
 }
 
 func TestTracker_SetComponentMetadata(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultConfig())
 	tracker.RegisterComponent("test-service")
 
@@ -324,6 +363,8 @@ func TestTracker_SetComponentMetadata(t *testing.T) {
 }
 
 func TestTracker_IsHealthy(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultConfig())
 	tracker.RegisterComponent("test-service")
 
@@ -342,6 +383,8 @@ func TestTracker_IsHealthy(t *testing.T) {
 }
 
 func TestTracker_StartHealthChecks(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.HealthCheckInterval = 50 * time.Millisecond
 	tracker := NewTracker(config)
@@ -372,6 +415,8 @@ func TestTracker_StartHealthChecks(t *testing.T) {
 }
 
 func TestTracker_StartHealthChecks_WithErrors(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.HealthCheckInterval = 50 * time.Millisecond
 	config.ErrorThreshold = 2
@@ -400,6 +445,8 @@ func TestTracker_StartHealthChecks_WithErrors(t *testing.T) {
 }
 
 func TestHealthState_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		state    HealthState
 		expected string
@@ -413,6 +460,8 @@ func TestHealthState_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
+			t.Parallel()
+
 			result := tt.state.String()
 			if result != tt.expected {
 				t.Errorf("String() = %s, want %s", result, tt.expected)
@@ -422,6 +471,8 @@ func TestHealthState_String(t *testing.T) {
 }
 
 func TestTracker_GetComponentHealth_NotRegistered(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultConfig())
 
 	_, err := tracker.GetComponentHealth("non-existent")
@@ -431,6 +482,8 @@ func TestTracker_GetComponentHealth_NotRegistered(t *testing.T) {
 }
 
 func TestTracker_RecoveryFromDegradation(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.ErrorThreshold = 3
 	config.RecoveryThreshold = 5

--- a/pkg/recovery/connection_test.go
+++ b/pkg/recovery/connection_test.go
@@ -19,6 +19,8 @@ func (m *mockConnection) Close() error {
 }
 
 func TestConnectionState_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		state    ConnectionState
 		expected string
@@ -38,6 +40,8 @@ func TestConnectionState_String(t *testing.T) {
 }
 
 func TestDefaultConnectionConfig(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 
 	if config.ConnectionTimeout != 30*time.Second {
@@ -66,6 +70,8 @@ func TestDefaultConnectionConfig(t *testing.T) {
 }
 
 func TestNewConnectionManager(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -93,6 +99,8 @@ func TestNewConnectionManager(t *testing.T) {
 }
 
 func TestConnectionManager_Connect(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	config.ConnectionTimeout = 5 * time.Second
 
@@ -124,6 +132,8 @@ func TestConnectionManager_Connect(t *testing.T) {
 }
 
 func TestConnectionManager_ConnectTimeout(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	config.ConnectionTimeout = 100 * time.Millisecond
 	config.EnableAutoReconnect = false // Disable for this test
@@ -151,6 +161,8 @@ func TestConnectionManager_ConnectTimeout(t *testing.T) {
 }
 
 func TestConnectionManager_GetConnection(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -190,6 +202,8 @@ func TestConnectionManager_GetConnection(t *testing.T) {
 }
 
 func TestConnectionManager_Reconnect(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	config.EnableAutoReconnect = false
 
@@ -227,6 +241,8 @@ func TestConnectionManager_Reconnect(t *testing.T) {
 }
 
 func TestConnectionManager_HealthCheckFailure(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	config.HealthCheckInterval = 50 * time.Millisecond
 	config.HealthCheckTimeout = 10 * time.Millisecond
@@ -265,6 +281,8 @@ func TestConnectionManager_HealthCheckFailure(t *testing.T) {
 }
 
 func TestConnectionManager_GetStats(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -312,6 +330,8 @@ func TestConnectionManager_GetStats(t *testing.T) {
 }
 
 func TestConnectionManager_Close(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -354,6 +374,8 @@ func TestConnectionManager_Close(t *testing.T) {
 }
 
 func TestConnectionManager_AutoReconnect(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	config.ReconnectDelay = 50 * time.Millisecond
 	config.MaxReconnectDelay = 100 * time.Millisecond
@@ -392,6 +414,8 @@ func TestConnectionManager_AutoReconnect(t *testing.T) {
 }
 
 func TestConnectionManager_MaxReconnectAttempts(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	config.ReconnectDelay = 10 * time.Millisecond
 	config.MaxReconnectAttempts = 2
@@ -431,6 +455,8 @@ func TestConnectionManager_MaxReconnectAttempts(t *testing.T) {
 }
 
 func TestConnectionPool_New(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -451,6 +477,8 @@ func TestConnectionPool_New(t *testing.T) {
 }
 
 func TestConnectionPool_ConnectAll(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -477,6 +505,8 @@ func TestConnectionPool_ConnectAll(t *testing.T) {
 }
 
 func TestConnectionPool_GetConnection(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -506,6 +536,8 @@ func TestConnectionPool_GetConnection(t *testing.T) {
 }
 
 func TestConnectionPool_HealthyCount(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	config.EnableAutoReconnect = false
 
@@ -534,6 +566,8 @@ func TestConnectionPool_HealthyCount(t *testing.T) {
 }
 
 func TestConnectionPool_Close(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -559,6 +593,8 @@ func TestConnectionPool_Close(t *testing.T) {
 }
 
 func TestConnectionManager_Wait(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		return &mockConnection{healthy: true}, nil
@@ -590,6 +626,8 @@ func TestConnectionManager_Wait(t *testing.T) {
 }
 
 func TestConnectionManager_WaitTimeout(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConnectionConfig()
 	factory := func(ctx context.Context) (any, error) {
 		// Never connects

--- a/pkg/recovery/recovery_test.go
+++ b/pkg/recovery/recovery_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestNewRecoveryManager(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	rm := NewRecoveryManager(config)
 
@@ -33,6 +35,8 @@ func TestNewRecoveryManager(t *testing.T) {
 }
 
 func TestRecoveryManager_ExecuteSuccess(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.DefaultStrategy = StrategyRetry
 	rm := NewRecoveryManager(config)
@@ -55,6 +59,8 @@ func TestRecoveryManager_ExecuteSuccess(t *testing.T) {
 }
 
 func TestRecoveryManager_ExecuteWithRetry(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.DefaultStrategy = StrategyRetry
 	config.RetryConfig.MaxAttempts = 3
@@ -82,6 +88,8 @@ func TestRecoveryManager_ExecuteWithRetry(t *testing.T) {
 }
 
 func TestRecoveryManager_ExecuteWithCircuitBreaker(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.CircuitBreakerConfig = circuit.Config{
 		MaxRequests: 1,
@@ -117,6 +125,8 @@ func TestRecoveryManager_ExecuteWithCircuitBreaker(t *testing.T) {
 }
 
 func TestRecoveryManager_RegisterFallback(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	rm := NewRecoveryManager(config)
 
@@ -146,6 +156,8 @@ func TestRecoveryManager_RegisterFallback(t *testing.T) {
 }
 
 func TestRecoveryManager_GracefulDegradation(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.DefaultStrategy = StrategyGracefulDegradation
 	rm := NewRecoveryManager(config)
@@ -186,6 +198,8 @@ func TestRecoveryManager_GracefulDegradation(t *testing.T) {
 }
 
 func TestRecoveryManager_RecoverComponent(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.EnableAutoRecovery = false // Disable auto recovery for this test
 	rm := NewRecoveryManager(config)
@@ -213,6 +227,8 @@ func TestRecoveryManager_RecoverComponent(t *testing.T) {
 }
 
 func TestRecoveryManager_GetRecoveryStats(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	rm := NewRecoveryManager(config)
 
@@ -232,6 +248,8 @@ func TestRecoveryManager_GetRecoveryStats(t *testing.T) {
 }
 
 func TestRecoveryManager_FailFastStrategy(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.DefaultStrategy = StrategyFailFast
 	rm := NewRecoveryManager(config)
@@ -254,6 +272,8 @@ func TestRecoveryManager_FailFastStrategy(t *testing.T) {
 }
 
 func TestRecoveryManager_DetermineStrategy(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.DefaultStrategy = StrategyRetry
 	rm := NewRecoveryManager(config)
@@ -282,6 +302,8 @@ func TestRecoveryManager_DetermineStrategy(t *testing.T) {
 }
 
 func TestRecoveryStrategy_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		strategy RecoveryStrategy
 		expected string
@@ -301,6 +323,8 @@ func TestRecoveryStrategy_String(t *testing.T) {
 }
 
 func TestRecoveryManager_EnhanceError(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	rm := NewRecoveryManager(config)
 
@@ -330,6 +354,8 @@ func TestRecoveryManager_EnhanceError(t *testing.T) {
 }
 
 func TestRecoveryManager_ExecuteWithResult(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	rm := NewRecoveryManager(config)
 
@@ -350,6 +376,8 @@ func TestRecoveryManager_ExecuteWithResult(t *testing.T) {
 }
 
 func TestRecoveryManager_HandleSuccessAndFailure(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	rm := NewRecoveryManager(config)
 
@@ -380,6 +408,8 @@ func TestRecoveryManager_HandleSuccessAndFailure(t *testing.T) {
 }
 
 func TestRecoveryManager_AutoRecoveryDisabled(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.EnableAutoRecovery = false
 	rm := NewRecoveryManager(config)
@@ -404,6 +434,8 @@ func TestRecoveryManager_AutoRecoveryDisabled(t *testing.T) {
 }
 
 func TestRecoveryManager_Shutdown(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	rm := NewRecoveryManager(config)
 
@@ -416,6 +448,8 @@ func TestRecoveryManager_Shutdown(t *testing.T) {
 }
 
 func TestDegradedState(t *testing.T) {
+	t.Parallel()
+
 	state := &DegradedState{
 		Component:    "test",
 		Reason:       "test reason",
@@ -433,6 +467,8 @@ func TestDegradedState(t *testing.T) {
 }
 
 func TestRecoveryManager_ConcurrentExecution(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 	config.RetryConfig.MaxAttempts = 2
 	config.RetryConfig.InitialDelay = 5 * time.Millisecond
@@ -468,6 +504,8 @@ func TestRecoveryManager_ConcurrentExecution(t *testing.T) {
 }
 
 func TestDefaultRecoveryConfig(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultRecoveryConfig()
 
 	if config.DefaultStrategy != StrategyRetry {

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestRetryer_Success(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 3
 	retryer := New(config)
@@ -30,6 +32,8 @@ func TestRetryer_Success(t *testing.T) {
 }
 
 func TestRetryer_RetryableError(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 3
 	config.InitialDelay = 10 * time.Millisecond
@@ -56,6 +60,8 @@ func TestRetryer_RetryableError(t *testing.T) {
 }
 
 func TestRetryer_NonRetryableError(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 3
 	retryer := New(config)
@@ -79,6 +85,8 @@ func TestRetryer_NonRetryableError(t *testing.T) {
 }
 
 func TestRetryer_MaxAttemptsExceeded(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 3
 	config.InitialDelay = 10 * time.Millisecond
@@ -109,6 +117,8 @@ func TestRetryer_MaxAttemptsExceeded(t *testing.T) {
 }
 
 func TestRetryer_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 10
 	config.InitialDelay = 100 * time.Millisecond
@@ -139,6 +149,8 @@ func TestRetryer_ContextCancellation(t *testing.T) {
 }
 
 func TestRetryer_ExponentialBackoff(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 4
 	config.InitialDelay = 100 * time.Millisecond
@@ -183,6 +195,8 @@ func TestRetryer_ExponentialBackoff(t *testing.T) {
 }
 
 func TestRetryer_MaxDelayCap(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 10
 	config.InitialDelay = 1 * time.Second
@@ -210,6 +224,8 @@ func TestRetryer_MaxDelayCap(t *testing.T) {
 }
 
 func TestRetryer_OnRetryCallback(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 3
 	config.InitialDelay = 10 * time.Millisecond
@@ -251,6 +267,8 @@ func TestRetryer_OnRetryCallback(t *testing.T) {
 }
 
 func TestRetryer_WithMethods(t *testing.T) {
+	t.Parallel()
+
 	original := New(DefaultConfig())
 
 	// Test WithMaxAttempts
@@ -291,6 +309,8 @@ func TestRetryer_WithMethods(t *testing.T) {
 }
 
 func TestRetryWithBackoff_Convenience(t *testing.T) {
+	t.Parallel()
+
 	attempts := 0
 	err := RetryWithBackoff(context.Background(), 3, func() error {
 		attempts++
@@ -310,6 +330,8 @@ func TestRetryWithBackoff_Convenience(t *testing.T) {
 }
 
 func TestRetryableFunc(t *testing.T) {
+	t.Parallel()
+
 	attempts := 0
 	fn := RetryableFunc(func() error {
 		attempts++
@@ -331,6 +353,8 @@ func TestRetryableFunc(t *testing.T) {
 }
 
 func TestStatsCollector(t *testing.T) {
+	t.Parallel()
+
 	collector := NewStatsCollector()
 
 	// Record some attempts
@@ -371,6 +395,8 @@ func TestStatsCollector(t *testing.T) {
 }
 
 func TestRetryer_JitterVariance(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultConfig()
 	config.MaxAttempts = 3
 	config.InitialDelay = 100 * time.Millisecond

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestOperationStatus_String(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		status   OperationStatus
 		expected string
@@ -25,6 +27,8 @@ func TestOperationStatus_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
+			t.Parallel()
+
 			result := tt.status.String()
 			if result != tt.expected {
 				t.Errorf("String() = %s, want %s", result, tt.expected)
@@ -34,6 +38,8 @@ func TestOperationStatus_String(t *testing.T) {
 }
 
 func TestTracker_StartOperation(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -70,6 +76,8 @@ func TestTracker_StartOperation(t *testing.T) {
 }
 
 func TestTracker_UpdateProgress(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -107,6 +115,8 @@ func TestTracker_UpdateProgress(t *testing.T) {
 }
 
 func TestTracker_UpdateProgress_NotFound(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 
 	err := tracker.UpdateProgress("non-existent", 50, 100, "bytes")
@@ -116,6 +126,8 @@ func TestTracker_UpdateProgress_NotFound(t *testing.T) {
 }
 
 func TestTracker_SetPhase(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -137,6 +149,8 @@ func TestTracker_SetPhase(t *testing.T) {
 }
 
 func TestTracker_SetMessage(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -158,6 +172,8 @@ func TestTracker_SetMessage(t *testing.T) {
 }
 
 func TestTracker_CompleteOperation(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -190,6 +206,8 @@ func TestTracker_CompleteOperation(t *testing.T) {
 }
 
 func TestTracker_FailOperation(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -221,6 +239,8 @@ func TestTracker_FailOperation(t *testing.T) {
 }
 
 func TestTracker_CancelOperation(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -251,6 +271,8 @@ func TestTracker_CancelOperation(t *testing.T) {
 }
 
 func TestTracker_GetAllOperations(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -282,6 +304,8 @@ func TestTracker_GetAllOperations(t *testing.T) {
 }
 
 func TestTracker_GetHistory(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -307,6 +331,8 @@ func TestTracker_GetHistory(t *testing.T) {
 }
 
 func TestTracker_Subscribe(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx := context.Background()
 
@@ -339,6 +365,8 @@ func TestTracker_Subscribe(t *testing.T) {
 }
 
 func TestTracker_Subscribe_NotFound(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 
 	_, err := tracker.Subscribe("non-existent")
@@ -348,6 +376,8 @@ func TestTracker_Subscribe_NotFound(t *testing.T) {
 }
 
 func TestTracker_GetSystemStatus(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultTrackerConfig()
 	healthTracker := health.NewTracker(health.DefaultConfig())
 	config.HealthTracker = healthTracker
@@ -384,6 +414,8 @@ func TestTracker_GetSystemStatus(t *testing.T) {
 }
 
 func TestProgress_Update(t *testing.T) {
+	t.Parallel()
+
 	progress := &Progress{
 		Unit: "bytes",
 	}
@@ -417,6 +449,8 @@ func TestProgress_Update(t *testing.T) {
 }
 
 func TestProgress_Copy(t *testing.T) {
+	t.Parallel()
+
 	original := &Progress{
 		Current:    50,
 		Total:      100,
@@ -452,6 +486,8 @@ func TestProgress_Copy(t *testing.T) {
 }
 
 func TestOperation_Copy(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 	original := &Operation{
 		ID:        "test-123",
@@ -495,6 +531,8 @@ func TestOperation_Copy(t *testing.T) {
 }
 
 func TestTracker_MaxHistory(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultTrackerConfig()
 	config.MaxHistorySize = 3
 	tracker := NewTracker(config)
@@ -515,6 +553,8 @@ func TestTracker_MaxHistory(t *testing.T) {
 }
 
 func TestTracker_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
 	tracker := NewTracker(DefaultTrackerConfig())
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -540,6 +580,8 @@ func TestTracker_ContextCancellation(t *testing.T) {
 }
 
 func TestGenerateOperationID(t *testing.T) {
+	t.Parallel()
+
 	id1 := generateOperationID()
 	time.Sleep(1 * time.Millisecond)
 	id2 := generateOperationID()

--- a/pkg/types/interfaces_test.go
+++ b/pkg/types/interfaces_test.go
@@ -8,6 +8,8 @@ import (
 
 // TestInterfaces verifies that our interfaces are properly structured
 func TestInterfaces(t *testing.T) {
+	t.Parallel()
+
 	// Test that we can define variables of interface types
 	var (
 		_ Backend           = (*mockBackend)(nil)

--- a/pkg/utils/log_rotation_test.go
+++ b/pkg/utils/log_rotation_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNewLogRotator(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -33,6 +35,8 @@ func TestNewLogRotator(t *testing.T) {
 }
 
 func TestLogRotator_Write(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -78,6 +82,8 @@ func TestLogRotator_Write(t *testing.T) {
 }
 
 func TestLogRotator_SizeBasedRotation(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -127,6 +133,8 @@ func TestLogRotator_SizeBasedRotation(t *testing.T) {
 }
 
 func TestLogRotator_ForceRotate(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -191,6 +199,8 @@ func TestLogRotator_ForceRotate(t *testing.T) {
 }
 
 func TestLogRotator_Compression(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -243,6 +253,8 @@ func TestLogRotator_Compression(t *testing.T) {
 }
 
 func TestLogRotator_MaxBackups(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -292,6 +304,8 @@ func TestLogRotator_MaxBackups(t *testing.T) {
 }
 
 func TestLogRotator_DirectoryCreation(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logDir := filepath.Join(tmpDir, "logs", "app")
 	logFile := filepath.Join(logDir, "test.log")
@@ -322,6 +336,8 @@ func TestLogRotator_DirectoryCreation(t *testing.T) {
 }
 
 func TestLogRotator_Close(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -354,6 +370,8 @@ func TestLogRotator_Close(t *testing.T) {
 }
 
 func TestRotationConfig_Validation(t *testing.T) {
+	t.Parallel()
+
 	// Test with nil config
 	_, err := NewLogRotator(nil)
 	if err == nil {
@@ -371,6 +389,8 @@ func TestRotationConfig_Validation(t *testing.T) {
 }
 
 func TestLogRotator_Sync(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 
@@ -408,6 +428,8 @@ func TestLogRotator_Sync(t *testing.T) {
 }
 
 func TestBackupFilename(t *testing.T) {
+	t.Parallel()
+
 	config := &RotationConfig{
 		Filename:  "/var/log/app/test.log",
 		LocalTime: false,
@@ -427,6 +449,8 @@ func TestBackupFilename(t *testing.T) {
 }
 
 func TestGetBackupFiles(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "test.log")
 

--- a/pkg/utils/logging_test.go
+++ b/pkg/utils/logging_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestParseLogLevel(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -59,6 +61,8 @@ func TestParseLogLevel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := ParseLogLevel(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseLogLevel() error = %v, wantErr %v", err, tt.wantErr)
@@ -72,6 +76,8 @@ func TestParseLogLevel(t *testing.T) {
 }
 
 func TestLogLevelString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		level    LogLevel
 		expected string
@@ -85,6 +91,8 @@ func TestLogLevelString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
+			t.Parallel()
+
 			result := tt.level.String()
 			if result != tt.expected {
 				t.Errorf("LogLevel.String() = %v, want %v", result, tt.expected)
@@ -94,6 +102,8 @@ func TestLogLevelString(t *testing.T) {
 }
 
 func TestLogger(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	logger := NewLogger(DEBUG, &buf)
 
@@ -125,6 +135,8 @@ func TestLogger(t *testing.T) {
 }
 
 func TestLoggerLevelFiltering(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	logger := NewLogger(WARN, &buf)
 
@@ -158,6 +170,8 @@ func TestLoggerLevelFiltering(t *testing.T) {
 }
 
 func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		bytes    int64
@@ -202,6 +216,8 @@ func TestFormatBytes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := FormatBytes(tt.bytes)
 			if result != tt.expected {
 				t.Errorf("FormatBytes() = %v, want %v", result, tt.expected)
@@ -211,6 +227,8 @@ func TestFormatBytes(t *testing.T) {
 }
 
 func TestParseBytes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -420,6 +438,8 @@ func TestParseBytes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := ParseBytes(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseBytes() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/utils/path_test.go
+++ b/pkg/utils/path_test.go
@@ -73,6 +73,8 @@ func TestValidatePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := ValidatePath(tt.path, tt.allowAbsolute)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidatePath() error = %v, wantErr %v", err, tt.wantErr)
@@ -160,6 +162,8 @@ func TestValidatePathWithinBase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Skip tests with hardcoded Unix paths on Windows
 			if runtime.GOOS == "windows" && strings.HasPrefix(tt.base, "/") {
 				t.Skip("Skipping Unix path test on Windows")
@@ -243,6 +247,8 @@ func TestSecureJoin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			// Skip tests with hardcoded Unix paths on Windows
 			if runtime.GOOS == "windows" && strings.HasPrefix(tt.base, "/") {
 				t.Skip("Skipping Unix path test on Windows")

--- a/pkg/utils/structured_logger_test.go
+++ b/pkg/utils/structured_logger_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestNewStructuredLogger(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -29,6 +31,8 @@ func TestNewStructuredLogger(t *testing.T) {
 }
 
 func TestLogLevels(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -81,6 +85,8 @@ func TestLogLevels(t *testing.T) {
 }
 
 func TestStructuredFields(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -116,6 +122,8 @@ func TestStructuredFields(t *testing.T) {
 }
 
 func TestWithField(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -146,6 +154,8 @@ func TestWithField(t *testing.T) {
 }
 
 func TestWithFields(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -178,6 +188,8 @@ func TestWithFields(t *testing.T) {
 }
 
 func TestWithComponent(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -202,6 +214,8 @@ func TestWithComponent(t *testing.T) {
 }
 
 func TestJSONFormat(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -247,6 +261,8 @@ func TestJSONFormat(t *testing.T) {
 }
 
 func TestComponentLevels(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -296,6 +312,8 @@ func TestComponentLevels(t *testing.T) {
 }
 
 func TestFormatfMethods(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -340,6 +358,8 @@ func TestFormatfMethods(t *testing.T) {
 }
 
 func TestCaller(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -364,6 +384,8 @@ func TestCaller(t *testing.T) {
 }
 
 func TestStructuredParseLogLevel(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input    string
 		expected LogLevel
@@ -392,6 +414,8 @@ func TestStructuredParseLogLevel(t *testing.T) {
 }
 
 func TestStructuredLogLevelString(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		level    LogLevel
 		expected string
@@ -413,6 +437,8 @@ func TestStructuredLogLevelString(t *testing.T) {
 }
 
 func TestSetLevel(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -453,6 +479,8 @@ func TestSetLevel(t *testing.T) {
 }
 
 func TestTrace(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 
 	config := &StructuredLoggerConfig{
@@ -479,6 +507,8 @@ func TestTrace(t *testing.T) {
 }
 
 func TestDefaultConfig(t *testing.T) {
+	t.Parallel()
+
 	config := DefaultStructuredLoggerConfig()
 
 	if config.Level != INFO {


### PR DESCRIPTION
Part of #179. Does not close it — the remaining 299 findings are other linters plus 141 `paralleltest`/`tparallel` in packages not touched here.

## The number

| | before | after |
|---|---|---|
| **total** | **570** | **299** |
| `paralleltest` | 385 | 134 |
| `tparallel` | 27 | 7 |
| everything else | 158 | 158 |

`t.Parallel()` on every test and subtest in seventeen files across `pkg/errors`, `pkg/status`, `pkg/health`, `pkg/recovery`, `pkg/retry`, `pkg/api`, `pkg/utils`, `pkg/types`, `internal/cache` and `internal/metrics`. CLAUDE.md already requires this; the finding count was the gap between the requirement and the tree.

Every package was run under `-race -count=2` after the change and its coverage checked against its floor. That matters more than it sounds: parallelizing a test that shares state is a way to make it pass *less often*, not a way to make it faster, so a green single run proves nothing.

## Two packages resisted, and that is the point

### `pkg/health` — a test that was passing on subtest ordering

`TestTracker_CanRead` wrote a component's `State` directly and asserted what `CanRead`/`CanWrite` answered. But `State` alone does not decide that. `admissionState` admits one probe against a refusing component once `nextProbe` has elapsed, and reports `StateDegraded` to get that probe past the gate:

```go
state, due := health.State, health.nextProbe
t.mu.RUnlock()

if t.config.ProbeAfter <= 0 || state == StateHealthy || state == StateDegraded {
	return state
}
if time.Now().Before(due) {
	return state
}

return t.probe(component)   // returns StateDegraded
```

So `State=StateUnavailable` with a **zero-value `nextProbe`** — always in the past — reads as *readable*. That is not a combination the tracker ever produces: `RecordError` sets both fields, and the test set one.

One tracker shared across the table concealed it. The first subtest to reach a refusing state took the probe path, which pushed `nextProbe` `ProbeAfter` into the future, and every later subtest then read raw state and agreed with the table. **The assertion held on the order its siblings happened to run in.**

Giving each subtest its own tracker — the isolation `t.Parallel()` requires anyway — removed the accident, and the unavailable case failed immediately:

```
--- FAIL: TestTracker_CanRead/unavailable
    health_test.go:180: CanRead() = true, want false for state unavailable
```

Fixed by setting `nextProbe` alongside `State`, in the shape `RecordError` leaves it. Verified by deleting that line: the unavailable case fails. `-race -count=5` green after.

**No production defect** — the tracker's own code path sets both fields together. What was broken is a test that could not have caught it if they came apart.

### `pkg/utils/debug_mode_test.go` — 19 findings a `t.Parallel()` cannot fix

Filed as #373 and excluded in `.golangci.yml` with the reasoning recorded.

`DebugManager` is a `sync.Once` singleton with no exported constructor, so every test observes the same instance. That alone would be workable — each test already uses a distinct session ID. The blocker is `DebugManager.RecordEvent`, which fans every event out to **all** open sessions:

```go
for _, session := range sessions {
	session.RecordEvent(component, operation, message, fields, goroutineID)
}
```

A session's event count is therefore a function of what every *other* concurrently-open session recorded. Adding `t.Parallel()` to all 19 and running `-race -count=4`:

```
TestRecordEvent            Expected 1 event, got 2
TestGetEventsByComponent   Expected 2 storage events, got 6
TestGetStats               Expected 3 events in stats, got 8
TestDebugTrace             Expected 1 event, got 17
TestDebugTrace_WithError   Expected 1 event, got 17
```

No data race — the locking is correct, and the broadcast is doing exactly what it is written to do. Suppressed rather than silenced with a false `t.Parallel()`, which would have left the tests sequential in effect and the lint green: the worst of both. #373 proposes an exported constructor so each test can own a manager, which is the fix that makes the exclusion removable.

## A note on the transform

The mechanical pass had a bug worth mentioning because it produced a *loud* failure rather than a quiet one. Its first version inserted `t.Parallel()` without checking whether the closure already called it further down, which yields `panic: testing: t.Parallel called multiple times` in `pkg/api`. Fixed to scan the closure body up to its first nested `t.Run`, reverted and reapplied — 2 insertions rather than 4 in that file. All seventeen files were then scanned for doubled calls; none.

## Verification

```
go build ./...                                    clean
go test -race -count=2 ./pkg/... ./internal/cache/... ./internal/metrics/...    all pass
golangci-lint run --enable-only=paralleltest,tparallel <touched packages>       0 issues
```

Coverage held at each package's floor: `pkg/status` 93.0%, `pkg/health` 93.5%, and the rest unchanged.