### PR TITLE
refactor(fuse): delete ReadAheadManager.Stop and its channel (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2394,6 +2394,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`ReadAheadManager.Stop` and its stop channel are deleted; the mount context is the only shutdown
+  signal** ([#376]). The production fix landed in [#179] — cancel the mount context and the prefetch
+  workers and the cleanup ticker return, which the adapter's existing `cancelMount()` on the unmount
+  path already does. What was left over was an exported lifecycle method nothing outside tests called,
+  which is the worst of the available states: a reader finds it, reasonably assumes `Unmount` calls it,
+  and is wrong.
+
+  Calling it from `Unmount` was the other option and was rejected, because it reintroduces exactly the
+  "someone must remember this on every mount path" obligation whose being missed *was* the leak — five
+  goroutines per mount, for the life of the process, each keeping its `FileSystem`, backend and cache
+  reachable.
+
+  **The issue proposed unexporting it and keeping it for tests, and a mutation refuted that premise.**
+  The stated justification was that `stopCh` expresses the one thing cancellation cannot: stopping a
+  manager whose context the caller does not own. Plausible, and false — neutering the channel's select
+  arm broke no test, so no test needed it either. A second shutdown path with no caller on *either*
+  side is not a seam worth preserving; two ways to stop the same goroutines is how they came to be
+  stopped by neither. The tests that wanted the workers out of the way now cancel a mount context of
+  their own, so the test shutdown and the real one are the same code path, which the deleted `Stop`
+  never was.
+
+  Not a behaviour change: `internal/fuse` has no importer outside this repository and the method had no
+  caller inside it. `sync.Once` and a `chan struct{}` leave the struct with it.
+
 - **substrate v0.87.0 → v0.93.0.** Test-only dependency, so nothing user-facing changes; `go.mod` and
   `go.sum` are the whole diff.
 

--- a/internal/fuse/optimizations.go
+++ b/internal/fuse/optimizations.go
@@ -8,15 +8,16 @@ import (
 	"time"
 )
 
-// ReadAheadManager implements intelligent read-ahead strategies
+// ReadAheadManager implements intelligent read-ahead strategies.
+//
+// There is no Stop, and no stop channel. The mount context is the one shutdown signal — see
+// [NewReadAheadManager] for why, and #376 for why the second one is gone.
 type ReadAheadManager struct {
 	mu            sync.RWMutex
 	activeReads   map[string]*ReadPattern
 	fs            *FileSystem
 	config        *ReadAheadConfig
 	prefetchQueue chan *PrefetchRequest
-	stopCh        chan struct{}
-	stopOnce      sync.Once
 }
 
 // ReadAheadConfig configures read-ahead behavior.
@@ -87,14 +88,24 @@ func DefaultReadAheadConfig() ReadAheadConfig {
 // build its own context from context.Background(), which is the one context nothing can carry anything
 // into and nothing can cancel.
 //
-// And it is a second stop signal, which is the one that matters in production. [ReadAheadManager.Stop]
-// exists, is safe to call twice, and **is called by nothing outside tests** — not by
-// [MountManager.Unmount], not by Adapter.Stop, not by anything on the unmount path. Measured: five
-// goroutines per filesystem, `ConcurrentReads` prefetch workers plus the cleanup ticker, surviving
-// every unmount for the life of the process. A long-running host that mounts and unmounts — which is
-// what the mount watcher's remount does — accumulates them, each still holding its FileSystem, its
-// backend and its cache reachable. Canceling ctx now stops them, so the adapter's existing
-// cancelMount() on the unmount path is the fix without a new call anyone has to remember to make.
+// And it is the shutdown signal — the only one there is. Cancel it and the prefetch workers and the
+// cleanup ticker return; there is nothing else to call, which is the point.
+//
+// That is the resolution of #376, and it is a deletion rather than a wiring-up. There was a `Stop`,
+// exported, `sync.Once`-guarded, closing a channel both workers selected on — and called by nothing
+// outside tests: not [MountManager.Unmount], not Adapter.Stop, not anything on the unmount path.
+// Measured: five goroutines per filesystem, `ConcurrentReads` prefetch workers plus the cleanup ticker,
+// surviving every unmount for the life of the process, each holding its FileSystem and through it the
+// backend and the cache. A long-running host that remounts, which is what the mount watcher does,
+// accumulated them.
+//
+// The mount context fixed that. What was left was an exported lifecycle method production never called,
+// and calling it from Unmount was rejected because it reintroduces the "someone must remember this on
+// every mount path" obligation whose being missed was the leak. The remaining case for keeping it was
+// that a test might need to stop a manager whose context it does not own — but neutering the channel's
+// select arm broke no test, so no test needed it either. A second shutdown path with no caller on either
+// side is not a seam worth preserving: two ways to stop the same goroutines is how they came to be
+// stopped by neither.
 func NewReadAheadManager(ctx context.Context, fs *FileSystem, config *ReadAheadConfig) *ReadAheadManager {
 	if config == nil {
 		defaults := DefaultReadAheadConfig()
@@ -106,7 +117,6 @@ func NewReadAheadManager(ctx context.Context, fs *FileSystem, config *ReadAheadC
 		fs:            fs,
 		config:        config,
 		prefetchQueue: make(chan *PrefetchRequest, 100),
-		stopCh:        make(chan struct{}),
 	}
 
 	// Start prefetch workers
@@ -216,17 +226,14 @@ func (ram *ReadAheadManager) schedulePrefetch(path string, offset, size int64) {
 	}
 }
 
-// prefetchWorker handles prefetch requests until Stop closes stopCh or the mount's context ends.
+// prefetchWorker handles prefetch requests until the mount's context ends.
 //
-// Both, not either: Stop is what the tests call, and canceling the mount context is what actually
-// happens on the unmount path, since nothing in the tree calls Stop. See [NewReadAheadManager].
+// One shutdown signal, not two. See [NewReadAheadManager].
 func (ram *ReadAheadManager) prefetchWorker(mount context.Context) {
 	for {
 		select {
 		case req := <-ram.prefetchQueue:
 			ram.performPrefetch(mount, req)
-		case <-ram.stopCh:
-			return
 		case <-mount.Done():
 			return
 		}
@@ -323,7 +330,7 @@ func (ram *ReadAheadManager) performPrefetch(mount context.Context, req *Prefetc
 	}
 }
 
-// cleanupWorker removes expired patterns until Stop closes stopCh or the mount's context ends.
+// cleanupWorker removes expired patterns until the mount's context ends.
 func (ram *ReadAheadManager) cleanupWorker(mount context.Context) {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
@@ -332,8 +339,6 @@ func (ram *ReadAheadManager) cleanupWorker(mount context.Context) {
 		select {
 		case <-ticker.C:
 			ram.cleanup()
-		case <-ram.stopCh:
-			return
 		case <-mount.Done():
 			return
 		}
@@ -351,11 +356,4 @@ func (ram *ReadAheadManager) cleanup() {
 			delete(ram.activeReads, path)
 		}
 	}
-}
-
-// Stop stops the read-ahead manager. Safe to call multiple times (#104).
-func (ram *ReadAheadManager) Stop() {
-	ram.stopOnce.Do(func() {
-		close(ram.stopCh)
-	})
 }

--- a/internal/fuse/optimizations_test.go
+++ b/internal/fuse/optimizations_test.go
@@ -39,7 +39,6 @@ func TestReadAheadManager_DefaultConfig(t *testing.T) {
 		TTL:             5 * time.Minute,
 	}
 	ram := NewReadAheadManager(t.Context(), nil, cfg)
-	defer ram.Stop()
 
 	if !ram.config.Enabled {
 		t.Error("expected Enabled=true")
@@ -56,7 +55,6 @@ func TestReadAheadManager_FirstRead_CreatesPattern(t *testing.T) {
 	t.Parallel()
 
 	ram := newTestRAM(t, 3, 5*time.Minute)
-	defer ram.Stop()
 
 	ram.OnRead("data.bin", 0, 1024)
 
@@ -82,7 +80,6 @@ func TestReadAheadManager_SequentialIncrementsHits(t *testing.T) {
 	t.Parallel()
 
 	ram := newTestRAM(t, 3, 5*time.Minute)
-	defer ram.Stop()
 
 	// 4 sequential reads: offsets 0, 1024, 2048, 3072
 	for i := range 4 {
@@ -104,7 +101,6 @@ func TestReadAheadManager_NonSequential_ResetsPattern(t *testing.T) {
 	t.Parallel()
 
 	ram := newTestRAM(t, 3, 5*time.Minute)
-	defer ram.Stop()
 
 	// Build up some sequential hits.
 	for i := range 4 {
@@ -133,7 +129,6 @@ func TestReadAheadManager_Disabled_NoPatterns(t *testing.T) {
 		TTL:             5 * time.Minute,
 	}
 	ram := NewReadAheadManager(t.Context(), nil, cfg)
-	defer ram.Stop()
 
 	ram.OnRead("disabled.bin", 0, 1024)
 
@@ -172,7 +167,6 @@ func TestReadAheadManager_PrefetchScheduled_AfterEnoughHits(t *testing.T) {
 	)
 
 	ram := newTestRAM(t, minSeq, 5*time.Minute)
-	defer ram.Stop()
 
 	// Reads up to but not including the one that reaches the threshold.
 	for i := range hitRead - 1 {
@@ -208,7 +202,6 @@ func TestReadAheadManager_PatternTTL_Cleanup(t *testing.T) {
 	t.Parallel()
 
 	ram := newTestRAM(t, 3, 10*time.Millisecond) // very short TTL
-	defer ram.Stop()
 
 	ram.OnRead("short.bin", 0, 1024)
 
@@ -332,7 +325,6 @@ func TestReadAheadConfig_DefaultValues(t *testing.T) {
 
 	// NewReadAheadManager fills in nil config with the canonical defaults.
 	ram := NewReadAheadManager(t.Context(), nil, nil)
-	defer ram.Stop()
 
 	want := ReadAheadConfig{
 		Enabled:         true,
@@ -381,7 +373,6 @@ func TestNewFileSystemPassesTheConfiguredReadAhead(t *testing.T) {
 		MountPoint: t.TempDir(),
 		ReadAhead:  &want,
 	})
-	t.Cleanup(fs.readAhead.Stop)
 
 	if fs.readAhead == nil {
 		t.Fatal("no read-ahead manager was constructed")
@@ -407,7 +398,6 @@ func TestNewFileSystemFallsBackWhenReadAheadIsUnset(t *testing.T) {
 	t.Parallel()
 
 	fs := NewFileSystem(t.Context(), nil, nil, nil, nil, &Config{MountPoint: t.TempDir()})
-	t.Cleanup(fs.readAhead.Stop)
 
 	if fs.readAhead == nil || fs.readAhead.config == nil {
 		t.Fatal("a Config with no ReadAhead left the filesystem with no read-ahead manager")

--- a/internal/fuse/read_path_test.go
+++ b/internal/fuse/read_path_test.go
@@ -34,6 +34,32 @@ type readPathFixture struct {
 	fs    *FileSystem
 	srv   *testaws.TestServer
 	cache *cache.LRUCache
+
+	// cancelMount is the fixture's own mount context, and it is how a test stops the read-ahead
+	// manager the fixture built. See [readPathFixture.stopReadAhead].
+	cancelMount context.CancelFunc
+}
+
+// stopReadAhead retires the prefetch workers the fixture started, by canceling its mount context —
+// which is the mechanism the unmount path uses, and since #376 the only one there is.
+//
+// Three tests take read-ahead out of the way before reading, because a prefetch worker issues its own
+// asynchronous GETs and one landing after the count has been taken makes the assertion depend on
+// goroutine scheduling; that is how the first version of TestSequentialReadIsCachedWholesale failed
+// intermittently while the cache was working correctly. Each of them then sets `readAhead` to nil or
+// replaces it with a worker-less manager, and **that** assignment is what does the work: it is what
+// stops new prefetches from being scheduled at all.
+//
+// So be clear about what this call is worth, because a mutation says it is not much — removing all
+// three of them leaves the suite green over twelve runs. Every caller invokes it during setup, before
+// any read has established a sequential pattern, so there is nothing queued for the workers to act on
+// and nothing for cancellation to prevent. It is kept for what it does rather than what it prevents:
+// a test that replaces the manager would otherwise leave the previous one's four goroutines running on
+// the fixture until the test ended, and stopping what you replace is the honest shape even when
+// nothing currently observes the difference. It earns its keep as documentation of intent, and it
+// exercises the production shutdown path from a test, which the deleted `Stop` never did.
+func (f *readPathFixture) stopReadAhead() {
+	f.cancelMount()
 }
 
 func newReadPathFixture(t *testing.T) *readPathFixture {
@@ -62,13 +88,19 @@ func newReadPathFixture(t *testing.T) *readPathFixture {
 	})
 	t.Cleanup(func() { _ = byteCache.Close() })
 
-	fs := NewFileSystem(t.Context(), backend, byteCache, writer, nil, &Config{
+	// A mount context of the fixture's own, derived from t.Context() so it is canceled at test end
+	// either way. Having one is what lets a test retire the read-ahead workers the way an unmount does;
+	// see [readPathFixture.stopReadAhead].
+	mount, cancelMount := context.WithCancel(t.Context())
+	t.Cleanup(cancelMount)
+
+	fs := NewFileSystem(mount, backend, byteCache, writer, nil, &Config{
 		DefaultMode: 0o644,
 		DefaultUID:  1000,
 		DefaultGID:  1000,
 	})
 
-	return &readPathFixture{fs: fs, srv: srv, cache: byteCache}
+	return &readPathFixture{fs: fs, srv: srv, cache: byteCache, cancelMount: cancelMount}
 }
 
 // open returns a handle for an object that already exists in the bucket, as Open would build one.
@@ -216,7 +248,7 @@ func TestSequentialReadIsCachedWholesale(t *testing.T) {
 	// asynchronous GETs, and a GET that lands after the warm pass has been counted makes the assertion
 	// depend on goroutine timing — which is how the first version of this test failed intermittently
 	// while the cache was working correctly. Prefetch has its own tests below.
-	f.fs.readAhead.Stop()
+	f.stopReadAhead()
 	f.fs.readAhead = nil
 
 	const (
@@ -326,7 +358,7 @@ func TestConcurrentIdenticalReadsShareOneGET(t *testing.T) {
 
 	// Read-ahead off: the point is what concurrent *readers* cost, and a prefetch worker issuing its
 	// own GETs is the variable this test exists to remove.
-	f.fs.readAhead.Stop()
+	f.stopReadAhead()
 	f.fs.readAhead = nil
 
 	const (
@@ -515,7 +547,7 @@ func TestCacheHitsAreReportedToTheDetector(t *testing.T) {
 	// Serve every read from cache, deterministically: fill it before reading a byte, and take the
 	// prefetch workers out of the picture entirely so nothing else can populate or race it. What remains
 	// is exactly the question under test — does a hit reach the detector.
-	f.fs.readAhead.Stop()
+	f.stopReadAhead()
 	f.fs.readAhead = NewReadAheadManager(t.Context(), f.fs, &ReadAheadConfig{
 		Enabled:         true,
 		WindowSize:      64 * 1024,
@@ -523,7 +555,6 @@ func TestCacheHitsAreReportedToTheDetector(t *testing.T) {
 		ConcurrentReads: 0, // no workers: schedulePrefetch fills the queue and nothing drains it
 		TTL:             time.Minute,
 	})
-	t.Cleanup(f.fs.readAhead.Stop)
 
 	f.cache.Put("detect.dat", 0, f.srv.GetObject("detect.dat"))
 

--- a/internal/fuse/readahead_lifetime_test.go
+++ b/internal/fuse/readahead_lifetime_test.go
@@ -13,14 +13,16 @@ import (
 // TestReadAhead_MountCancellationStopsTheWorkers is the defect behind this package's contextcheck
 // finding, which was not about the context.
 //
-// [ReadAheadManager.Stop] exists, is documented as safe to call twice, and is called by nothing outside
-// tests: not [MountManager.Unmount], not Adapter.Stop, not anything on the unmount path. So every mount
-// left ConcurrentReads prefetch workers plus a cleanup ticker running for the life of the process, each
-// holding its FileSystem — and through it the backend and the cache — reachable. Measured before the
-// fix: five goroutines per NewFileSystem, surviving every unmount.
+// The manager had a `Stop`, exported and documented as safe to call twice, and called by nothing
+// outside tests: not [MountManager.Unmount], not Adapter.Stop, not anything on the unmount path. So
+// every mount left ConcurrentReads prefetch workers plus a cleanup ticker running for the life of the
+// process, each holding its FileSystem — and through it the backend and the cache — reachable. Measured
+// before the fix: five goroutines per NewFileSystem, surviving every unmount.
 //
-// The fix is not a new Stop call someone has to remember to make on each path. The mount context is now
-// a second stop signal, so the cancelMount() the adapter already performs on unmount stops them.
+// The fix is not a new stop call someone has to remember to make on each path. The mount context is the
+// stop signal, so the cancelMount() the adapter already performs on unmount stops them — and `Stop` and
+// its channel are gone (#376), so this is now the only shutdown mechanism there is and the assertion
+// below is a test of the real one.
 //
 // Deliberately serial, and it is the only test in this package that has to be. Counting goroutines by
 // frame name (see [readAheadGoroutines]) makes this immune to the substrate servers and S3 clients the
@@ -62,7 +64,7 @@ func TestReadAhead_MountCancellationStopsTheWorkers(t *testing.T) {
 			"least %d; this is not measuring what it thinks it is", running, mounts, workers, want)
 	}
 
-	// What the unmount path does. Nothing calls Stop.
+	// What the unmount path does, and now the only thing that stops these at all.
 	for _, cancel := range mountCtxs {
 		cancel()
 	}
@@ -70,10 +72,9 @@ func TestReadAhead_MountCancellationStopsTheWorkers(t *testing.T) {
 	after := settledReadAheadGoroutines(func(n int) bool { return n <= before })
 	if after > before {
 		t.Errorf("%d read-ahead goroutines still running after every mount context was canceled "+
-			"(%d → %d → %d across %d managers of %d workers each). Nothing in the tree calls "+
-			"ReadAheadManager.Stop, so cancellation is the only thing that ends these — a "+
-			"mount/unmount cycle that leaves them behind holds its FileSystem, backend and cache "+
-			"reachable for the life of the process.",
+			"(%d → %d → %d across %d managers of %d workers each). Cancellation is the only thing that "+
+			"ends these — a mount/unmount cycle that leaves them behind holds its FileSystem, backend "+
+			"and cache reachable for the life of the process.",
 			after-before, before, running, after, mounts, workers)
 	}
 }
@@ -93,7 +94,7 @@ func TestPerformPrefetch_UsesTheMountsContext(t *testing.T) {
 	f.srv.SeedRandom(path, 8192)
 
 	// No workers: this test calls performPrefetch directly, so a queue nothing drains is what it wants.
-	f.fs.readAhead.Stop()
+	f.stopReadAhead()
 	f.fs.readAhead = NewReadAheadManager(t.Context(), f.fs, &ReadAheadConfig{
 		Enabled:         true,
 		WindowSize:      64 << 10,
@@ -101,7 +102,6 @@ func TestPerformPrefetch_UsesTheMountsContext(t *testing.T) {
 		ConcurrentReads: 0,
 		TTL:             time.Minute,
 	})
-	t.Cleanup(f.fs.readAhead.Stop)
 
 	mount, cancel := context.WithCancel(t.Context())
 	cancel()


### PR DESCRIPTION
Closes #376.

The mount context is the only shutdown signal now. `ReadAheadManager.Stop`, its `stopCh`, and its
`sync.Once` are deleted.

## What #376 asked

#179 fixed the real leak — five goroutines per mount surviving every unmount, each keeping its
`FileSystem` and through it the backend and the cache reachable — by making the mount context a stop
signal, so the `cancelMount()` the adapter already performs is what ends them. What was left over was
an exported lifecycle method that nothing outside tests called. #376 named two defensible resolutions
and asked for one to be picked:

1. Call it from `Unmount`, keeping cancellation as a backstop.
2. Unexport it or document it as test-only.

(1) is rejected for the reason the issue gives: it reintroduces exactly the "someone must remember to
call this on every mount path" obligation whose being missed *was* the leak.

## Why (2) became a deletion

The issue's case for keeping it was that `stopCh` expresses the one thing cancellation cannot —
stopping a manager whose context the caller does not own, "which is a test's situation and nothing
else's."

Plausible, and false. Neutering the channel's select arm broke no test:

```
$ # stopCh arm replaced with a nil channel receive
$ go test -race -count=1 ./internal/fuse/
ok  github.com/scttfrdmn/objectfs/internal/fuse  2.973s
```

So no test needed it either. A second shutdown path with no caller on *either* side is not a seam
worth preserving — two ways to stop the same goroutines is how they came to be stopped by neither.

The tests that wanted the workers out of the way now cancel a mount context of their own, through
`readPathFixture.stopReadAhead`, so the test shutdown and the production one are the same code path.
The deleted `Stop` never was. The ten `defer ram.stop()` calls in `optimizations_test.go` were pure
redundancy against `t.Context()` and are gone.

## The helper's comment says what a mutation showed it is worth

Removing all three `stopReadAhead()` calls leaves the suite green over twelve runs, and the comment
says so. Each caller invokes it during setup, before any read has established a sequential pattern,
and then nils or replaces the manager — and *that* assignment is what stops new prefetches from being
scheduled. It is kept for stopping what it replaces and for exercising the real shutdown path, not
for preventing a race it does not currently prevent. Claiming otherwise is how a comment becomes the
next reader's wrong premise, which is the shape of the defect this PR is closing.

## Verification

- `go build ./...`, `go vet ./...`, `make lint` — 0 issues
- full `go test -race -count=1 ./...` — pass; `./internal/fuse/ -count=3` — pass
- coverage gate: 36 packages at or above floor, `internal/fuse 68.5%` against a floor of 67
- **mutation:** removing the `mount.Done()` arm from both workers fails
  `TestReadAhead_MountCancellationStopsTheWorkers` with *"25 read-ahead goroutines still running after
  every mount context was canceled"*

Not a behaviour change. `internal/fuse` has no importer outside this repository and the method had no
caller inside it.
