### PR TITLE
feat(distributed)!: replace the N-identical-PUT fan-out with per-key CAS (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -565,6 +565,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **The consistency taxonomy, the N-identical-PUT fan-out, the `CacheReplicator`, and the proposal
+  machinery** ([#284]). Four deletions, and what connects them is that each named a distributed
+  guarantee the code did not provide — the fan-out did not make the write linearizable, the replicator
+  did not replicate, and the proposals did not transfer leadership.
+
+  **`ConsistencyLevel` and its three constants.** `ConsistencyEventual`, `ConsistencySession` and
+  `ConsistencyStrong` all issued the same unconditional `PutObject` and differed only in how many nodes
+  issued it and whether the caller waited, so what an operator picked changed the request count and not
+  the guarantee. `ConsistencyStrong` in particular fanned the identical bytes at the identical key to
+  every target node and called majority success "linearizable"; every node in a cluster writes the same
+  key in the same bucket, S3 holds the single copy, so N-1 of those PUTs were billed requests that
+  changed nothing and a majority reporting success said only that a majority could reach S3. What
+  replaced it is per-operation rather than per-mount and is evaluated by the store rather than voted
+  on: `DistributedOperation.Precondition`, on the one write it guards.
+
+  **`CacheReplicator`, `ReplicationTask`, `ReplicationStats` and the `"replication"` key of
+  `Coordinator.GetStats`.** Its worker sent N-1 peers a PUT of an object's own bytes back to the same
+  key in the same bucket. Worse, when gossip was not running — which was every unit test — it sent
+  nothing at all and added the byte count to `BytesReplicated` anyway, so the throughput it reported
+  was of work that had not happened. The one test covering it asserted `c.replicator != nil`, which is
+  what let it survive: a test that proves a field was assigned proves nothing about the subsystem, and
+  that assignment was the only part of it that worked. Warming a peer's *local* cache is different and
+  real, and is filed as [#141].
+
+  **`ProposeChange`, `broadcastProposal`, `voteOnProposal`, `executeProposal`,
+  `cleanupExpiredProposals` and `ClusterManager.ProposeLeadershipChange`.** `broadcastProposal` slept
+  100ms and then voted for its own proposal, so a majority of one was always found and
+  `executeProposal` called `SetLeader`. A node cannot be made leader by being named: the election path
+  reaches the same setter having actually contested it with terms, votes and a randomized timeout, and
+  a second path reaching it after a self-vote does not transfer leadership, it overwrites one node's
+  opinion of who holds it. [#133] was closed as not-the-direction with this stub still in the tree;
+  [#284]'s acceptance criteria said to delete rather than fix it.
+
+  **Three of the five `EntryType` constants.** `EntryTypeConfigChange`, `EntryTypeOperation` and
+  `EntryTypeSnapshot` had no producer anywhere in the repository — there is no configuration-change
+  path, no operation is ever logged, and [#151], which would have added snapshotting, was closed when
+  the CAS direction was adopted. `applyLogEntry` was a five-arm switch with every arm empty; with those
+  three gone the remaining branches were indistinguishable, so it collapsed to a log line. It stays a
+  method because `lastApplied` must advance for `commitIndex` to mean anything. The surviving
+  constants' *strings* are unchanged, so an entry of a removed type arriving from an older peer still
+  decodes and still applies as the no-op it always was.
+
 - **`internal/cache/redis.Invalidator`, its pub/sub protocol, and `Cache.DeleteContext` and
   `Cache.Client` with it** ([#377]). `Publish` broadcast `"<nodeID>:<key>"` on an
   `objectfs:invalidation` channel and `Subscribe` ran a goroutine that deleted received keys while
@@ -2545,12 +2587,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#133]: https://github.com/scttfrdmn/objectfs/issues/133
+[#139]: https://github.com/scttfrdmn/objectfs/issues/139
+[#141]: https://github.com/scttfrdmn/objectfs/issues/141
 [#150]: https://github.com/scttfrdmn/objectfs/issues/150
 [#151]: https://github.com/scttfrdmn/objectfs/issues/151
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#282]: https://github.com/scttfrdmn/objectfs/issues/282
 [#283]: https://github.com/scttfrdmn/objectfs/issues/283
 [#284]: https://github.com/scttfrdmn/objectfs/issues/284
+[#385]: https://github.com/scttfrdmn/objectfs/issues/385
 [#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#378]: https://github.com/scttfrdmn/objectfs/issues/378
 [#267]: https://github.com/scttfrdmn/objectfs/issues/267
@@ -2567,6 +2612,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [scttfrdmn/substrate#540]: https://github.com/scttfrdmn/substrate/issues/540
 
 ### Changed
+
+- **BREAKING: `ClusterManager.InvalidateCacheKey` takes the ETag of the write that caused the
+  invalidation, and a peer applies each version once** ([#284]). The gossip payload was `{Key, From}`
+  and carried no version, so a receiver could not tell an invalidation for a version it had already
+  moved past from one for the version it holds — and gossip both retransmits and delivers out of
+  order, so that is the normal case rather than an edge one. Replaying a superseded invalidation
+  evicts bytes the peer has since legitimately re-cached. This is requirement R4 of
+  `docs/design/conditional-writes-vs-raft.md` §1.
+
+  `InvalidateCacheKey(key)` becomes `InvalidateCacheKey(key, etag)`, taking `OperationResult.ETag` from
+  the write that prompted it; `InvalidateDeletedCacheKey(key)` is the delete case, which exists as its
+  own method because an empty ETag alone is ambiguous — an unconditional put has one too. An empty ETag
+  is still accepted and is applied by every receiver every time, because "evict whatever you hold" is
+  always safe and suppressing it would leave a deleted key cached.
+
+  **What this deliberately does not claim.** The receiver's ledger records which `(key, ETag)`
+  invalidations it has applied, so a retransmission and a replay of a superseded version are both
+  discarded. It cannot decide that the bytes it holds are *newer* than an incoming invalidation:
+  `types.Cache` stores bytes at offsets with no version alongside them, so there is nothing to compare
+  against. That needs a per-key ETag in the cache, which is [#129]'s `KeyAnnouncement` plumbing and
+  [#141]'s warming work, and it is not guessed at here.
+
+  A first attempt held one ETag per key rather than a set, and a test caught it: that suppresses a
+  retransmission of the latest version but *applies* a replay of the version before it, since an older
+  ETag simply differs from the stored one and ETags carry no order to compare. The ledger is bounded at
+  4096 entries and drops the oldest, because the alternative is a leak proportional to every version of
+  every key the cluster has written; overflowing costs a redundant eviction, not a stale read. All
+  three properties are mutation-verified — removing the check, reverting to latest-per-key, and
+  removing the bound each fail a named assertion.
+
+- **BREAKING: `cluster.consistency_level` is removed from the configuration file** ([#284]). Because
+  `Configuration.LoadFromFile` decodes strictly, a config that still sets it now fails at startup
+  naming the key and the line. That is the intended outcome rather than a regression: the alternative
+  is accepting a setting that selects nothing. **Delete the key**; there is no replacement to set in
+  its place, because what replaced it is per-operation
+  (`distributed.DistributedOperation.Precondition`) rather than per-mount. `cluster.cache_replication`
+  is gone the same way, and was read by no code in the repository at all.
+
+  The key selected nothing even before it was removed — see the `Removed` section above for why all
+  three levels issued the same request. So a deployment that deletes the line gets the behaviour it
+  already had, whichever value it had set.
+
+  `sdks/python`'s `ClusterConfig` drops the field with it, and `examples/config.yaml` no longer emits
+  it. Separately and pre-existing: the Python SDK's `to_yaml` emits `cluster.election_timeout`,
+  `heartbeat_interval` and `join_timeout`, which the Go `cluster` schema has never had — they live on
+  the disjoint `internal/distributed.ClusterConfig` ([#139]) — so the strict loader refuses that block
+  on the first of them. Verified against the loader rather than inferred, and filed as [#385] rather
+  than folded in here.
+
+- **A conditional write reports the ETag of what it stored, and a refused one says why** ([#284]).
+  `OperationResult.ETag` carries the new version, so a caller can chain a compare-and-swap from it
+  without a re-read, and `OperationResult.Conditional` names the outcome (`lost`, `conflict`,
+  `unsupported`, `invalid`) alongside an error wrapping `types.ErrPreconditionFailed`. A refused write
+  is never retried internally: the answer is definitive, and the recovery is to re-read, recompute and
+  CAS again, which only the caller can do. A precondition attached to anything but a put is refused
+  with `types.ErrInvalidPrecondition` rather than silently dropped — a caller that means "delete only
+  if unchanged" and gets an unconditional delete has no way to find out.
+
+  **The tests are the point of this issue and are verified by mutation.** `TestMultiNodeCluster` now
+  gives each node its own in-process substrate endpoint and asserts the cluster issued exactly **one**
+  PUT of the key; the assertion it replaced was `result.Success` on a `ConsistencyStrong` write, which
+  could not tell one PUT from two. Two coordinators racing an `If-Match` on one key must produce
+  exactly one success and one `ErrPreconditionFailed` with the stored bytes being the winner's, and a
+  CAS chain must accept the ETag each write reported while refusing every earlier one. Forcing the
+  write path unconditional kills all of them; suppressing the returned ETag kills two. The success half
+  of these runs against a real backend rather than the package's `mockBackend`, whose `PutObjectIf`
+  returns `ErrNotSupported` deliberately — a stub cannot both refuse to fake a CAS and serve as the
+  success case for one.
 
 - **`ReadAheadManager.Stop` and its stop channel are deleted; the mount context is the only shutdown
   signal** ([#376]). The production fix landed in [#179] — cancel the mount context and the prefetch

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -329,8 +329,15 @@ cluster:
   listen_addr: 0.0.0.0:8080
   advertise_addr: 127.0.0.1:8080
   seed_nodes: []
+  # How many nodes an operation selects, in preference order. Only the first performs the write —
+  # there is one copy of the bytes and S3 holds it — so this is a selection width, not a number of
+  # copies made.
+  #
+  # `consistency_level` was here, taking eventual/strong/session, and v0.12.0 removed it: all three
+  # issued the same unconditional PUT and differed only in how many nodes issued it, so it selected a
+  # request count rather than a guarantee. A file that still sets it now fails at load naming the key.
+  # What replaced it is per-write rather than per-mount and has no key here.
   replication_factor: 3
-  consistency_level: eventual         # eventual, strong
   redis:
     enabled: false
     address: localhost:6379

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -511,7 +511,6 @@ func createTestConfig() *config.Configuration {
 			AdvertiseAddr:     "127.0.0.1:8080",
 			SeedNodes:         []string{},
 			ReplicationFactor: 3,
-			ConsistencyLevel:  "eventual",
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -672,7 +672,17 @@ type S3CostOptimization struct {
 	SmallObjectsOnStandard bool `yaml:"small_objects_on_standard"`
 }
 
-// ClusterConfig represents distributed cluster settings
+// ClusterConfig represents distributed cluster settings.
+//
+// There was a `consistency_level` key here, taking "eventual", "strong" or "session", and #284
+// removed it. Because [Configuration.LoadFromFile] decodes strictly, a file that still sets it now
+// fails at startup naming the key and line — which is the intended outcome rather than a regression:
+// the alternative is accepting a setting that selects nothing.
+//
+// It selected nothing even before it was removed. All three levels issued the same unconditional
+// PutObject and differed only in how many nodes issued it, so what an operator picked changed the
+// request count and not the guarantee. What replaced it is per-operation rather than per-mount:
+// distributed.DistributedOperation.Precondition, evaluated by S3 on the one write it guards.
 type ClusterConfig struct {
 	Enabled           bool        `yaml:"enabled"`
 	NodeID            string      `yaml:"node_id"`
@@ -680,7 +690,6 @@ type ClusterConfig struct {
 	AdvertiseAddr     string      `yaml:"advertise_addr"`
 	SeedNodes         []string    `yaml:"seed_nodes"`
 	ReplicationFactor int         `yaml:"replication_factor"`
-	ConsistencyLevel  string      `yaml:"consistency_level"`
 	Redis             RedisConfig `yaml:"redis"`
 }
 
@@ -870,7 +879,6 @@ func NewDefault() *Configuration {
 			AdvertiseAddr:     "127.0.0.1:8080",
 			SeedNodes:         []string{},
 			ReplicationFactor: 3,
-			ConsistencyLevel:  "eventual",
 			Redis: RedisConfig{
 				Enabled:    false,
 				Address:    "localhost:6379",

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -64,10 +64,18 @@ type ClusterConfig struct {
 	// [NewGossipProtocol].
 	SecretFile string `yaml:"secret_file"`
 
-	// Cache coordination
-	CacheReplication  bool   `yaml:"cache_replication"`
-	ReplicationFactor int    `yaml:"replication_factor"`
-	ConsistencyLevel  string `yaml:"consistency_level"` // "eventual", "strong", "session"
+	// ReplicationFactor is how many nodes [Coordinator.selectTargetNodes] returns for an operation.
+	//
+	// Only the first is used — see [Coordinator.executeOnce] — because there is one copy of the bytes
+	// and S3 holds it. The rest are the preference order a follow-on strategy that genuinely needs
+	// peers would consume, so this is a selection width rather than a count of copies made.
+	ReplicationFactor int `yaml:"replication_factor"`
+
+	// #284 removed two keys from this block. `consistency_level` took "eventual", "strong" or
+	// "session", and all three issued the same unconditional PutObject — see
+	// [DistributedOperation.Precondition] for what replaced it. `cache_replication` was a bool read by
+	// no code in the repository, and the subsystem whose name it carried put an object's own bytes back
+	// to itself on N-1 peers; both it and the CacheReplicator are gone. Actual cache warming is #141.
 
 	// Performance settings
 	MaxConcurrentOps int           `yaml:"max_concurrent_ops"`
@@ -212,9 +220,6 @@ func applyConfigDefaults(config *ClusterConfig) {
 	if config.ReplicationFactor == 0 {
 		config.ReplicationFactor = 3
 	}
-	if config.ConsistencyLevel == "" {
-		config.ConsistencyLevel = "eventual"
-	}
 	if config.MaxConcurrentOps == 0 {
 		config.MaxConcurrentOps = 100
 	}
@@ -232,17 +237,16 @@ func applyConfigDefaults(config *ClusterConfig) {
 // NewClusterManager creates a new cluster manager
 func NewClusterManager(config *ClusterConfig) (*ClusterManager, error) {
 	if config == nil {
-		// CacheReplication only, and then applyConfigDefaults below fills the rest.
+		// Empty, and then applyConfigDefaults below fills every field.
 		//
 		// This used to restate all sixteen fields, every one of which applyConfigDefaults sets to the
-		// same value two lines later — so the literal was dead except for this one field, and the
-		// duplication was live: MaxGossipPacket appeared here as 1024 and had to be changed in two
-		// places, which is how a stale copy of a default survives a fix to the default (#277).
-		//
-		// CacheReplication is the exception because it is a bool whose default is true, and a bool's
-		// zero value is indistinguishable from "not set" — so applyConfigDefaults cannot express it and
-		// a caller passing nil is the only case where the intent is known.
-		config = &ClusterConfig{CacheReplication: true}
+		// same value two lines later — so the literal was dead, and the duplication was live:
+		// MaxGossipPacket appeared here as 1024 and had to be changed in two places, which is how a
+		// stale copy of a default survives a fix to the default (#277). One field, CacheReplication,
+		// then had to stay because it was a bool defaulting to true and a bool's zero value cannot be
+		// told from "not set"; #284 deleted that field with the replicator it named, so there is nothing
+		// left here that applyConfigDefaults cannot express.
+		config = &ClusterConfig{}
 	}
 
 	// Apply defaults for zero-valued fields
@@ -464,21 +468,15 @@ func (cm *ClusterManager) DistributeOperation(ctx context.Context, op *Distribut
 	return result, err
 }
 
-// ProposeLeadershipChange proposes a leadership change
-func (cm *ClusterManager) ProposeLeadershipChange(ctx context.Context, newLeader string) error {
-	if cm.consensus == nil {
-		return fmt.Errorf("consensus engine not initialized")
-	}
-
-	proposal := &ConsensusProposal{
-		Type:      ProposalTypeLeadershipChange,
-		Data:      []byte(newLeader),
-		Proposer:  cm.nodeID,
-		Timestamp: time.Now(),
-	}
-
-	return cm.consensus.ProposeChange(ctx, proposal)
-}
+// There was a ProposeLeadershipChange here, and #284 deleted it with the proposal machinery it was
+// the only caller of. It built a ConsensusProposal naming a node and handed it to
+// ConsensusEngine.ProposeChange, which broadcast it — meaning it slept 100ms and then voted for its
+// own proposal, so a majority of one was found and executeProposal called ClusterManager.SetLeader.
+//
+// A node cannot be made leader by being named. [ConsensusEngine] contests leadership with terms,
+// votes and a randomized election timeout, and that path reaches SetLeader having actually won; a
+// second path that reaches the same setter after a self-vote does not transfer leadership, it just
+// overwrites one node's opinion of who holds it. Nothing outside a test called this.
 
 // Internal methods
 
@@ -820,9 +818,31 @@ func (cm *ClusterManager) SetCache(c types.Cache) {
 	cm.mu.Unlock()
 }
 
-// InvalidateCacheKey broadcasts a cache-invalidate message to all alive peers,
-// causing each peer to evict the given key from its local cache.
-func (cm *ClusterManager) InvalidateCacheKey(key string) {
+// InvalidateCacheKey broadcasts a cache-invalidate message to all alive peers, causing each peer to
+// evict key from its local cache.
+//
+// etag names the version the caller just wrote, and should be [OperationResult.ETag] from the write
+// that prompted this. Passing it is what lets a receiver discard an invalidation it has already
+// applied: gossip is unordered and retransmits, so an unversioned invalidation can be replayed after a
+// later one and evict bytes the peer has since legitimately re-cached (requirement R4 of
+// docs/design/conditional-writes-vs-raft.md §1).
+//
+// Empty is allowed and means the caller cannot name a version — an unconditional put whose ETag was
+// not read back. Such a message is applied by every receiver every time, which is safe but wasteful,
+// so prefer a conditional write's reported ETag where there is one.
+func (cm *ClusterManager) InvalidateCacheKey(key, etag string) {
+	cm.invalidateCacheKey(CacheInvalidateMessage{Key: key, ETag: etag})
+}
+
+// InvalidateDeletedCacheKey is InvalidateCacheKey for a key that was removed rather than replaced.
+//
+// It exists because a receiver cannot tell the two apart from the ETag: a delete has no version to
+// name, and neither does an unconditional put, so an empty ETag alone is ambiguous.
+func (cm *ClusterManager) InvalidateDeletedCacheKey(key string) {
+	cm.invalidateCacheKey(CacheInvalidateMessage{Key: key, Deleted: true})
+}
+
+func (cm *ClusterManager) invalidateCacheKey(m CacheInvalidateMessage) {
 	cm.mu.RLock()
 	gossip := cm.gossip
 	nodeID := cm.nodeID
@@ -831,7 +851,9 @@ func (cm *ClusterManager) InvalidateCacheKey(key string) {
 	if gossip == nil {
 		return
 	}
-	payload, err := json.Marshal(CacheInvalidateMessage{Key: key, From: nodeID})
+
+	m.From = nodeID
+	payload, err := json.Marshal(m)
 	if err != nil {
 		return
 	}

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scttfrdmn/objectfs/internal/testaws"
 	"github.com/scttfrdmn/objectfs/pkg/types"
 )
 
@@ -125,9 +126,6 @@ func TestNewClusterManager_ConfigDefaults(t *testing.T) {
 	}
 	if cfg.ReplicationFactor == 0 {
 		t.Error("ReplicationFactor should have a default")
-	}
-	if cfg.ConsistencyLevel == "" {
-		t.Error("ConsistencyLevel should have a default")
 	}
 	if cfg.OperationTimeout == 0 {
 		t.Error("OperationTimeout should have a default")
@@ -427,9 +425,8 @@ func TestClusterManager_DistributeOperation_NoNodes(t *testing.T) {
 	}
 
 	op := &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "test-key",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeGet,
+		Key:  "test-key",
 	}
 	_, err = cm.DistributeOperation(context.Background(), op)
 	if err == nil {
@@ -802,9 +799,8 @@ func TestDistributeOperation_FailedOperationCountsAsFailed(t *testing.T) {
 	cm.SetBackend(&errBackend{err: errors.New("s3: AccessDenied")})
 
 	result, err := cm.DistributeOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeGet,
+		Key:  "k",
 	})
 
 	if err == nil {
@@ -842,9 +838,8 @@ func TestDistributeOperation_SucceededOperationCountsAsSuccessful(t *testing.T) 
 	cm := makeClusterWithBackend(t, "acct-ok-node")
 
 	result, err := cm.DistributeOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeGet,
+		Key:  "k",
 	})
 	if err != nil {
 		t.Fatalf("DistributeOperation: %v", err)
@@ -862,36 +857,55 @@ func TestDistributeOperation_SucceededOperationCountsAsSuccessful(t *testing.T) 
 	}
 }
 
-// TestDistributeOperation_ErrorAndSuccessNeverDisagree checks the invariant itself across every
-// consistency level and both outcomes, rather than the two counters that happen to read it today.
+// TestDistributeOperation_ErrorAndSuccessNeverDisagree checks the invariant itself across every shape
+// of operation and both outcomes, rather than the two counters that happen to read it today.
 //
-// This is the assertion that would have caught the defect at any of the three executors: the fix is
-// at one choke point precisely so a fourth level cannot reintroduce the disagreement, and this is
-// what would notice if one did.
+// This is the assertion that would have caught the defect at any of the executors, and the fix is at
+// one choke point precisely so a new path cannot reintroduce the disagreement. The dimension used to
+// be the three consistency levels; #284 deleted those, and what varies now is what actually reaches a
+// different backend method — an unconditional put, a conditional one, and a read.
 func TestDistributeOperation_ErrorAndSuccessNeverDisagree(t *testing.T) {
 	t.Parallel()
 
-	levels := []ConsistencyLevel{ConsistencyEventual, ConsistencySession, ConsistencyStrong}
+	shapes := []struct {
+		name string
+		op   DistributedOperation
+	}{
+		{"get", DistributedOperation{Type: OpTypeGet, Key: "k"}},
+		{"put", DistributedOperation{Type: OpTypePut, Key: "k", Data: []byte("v")}},
+		{"put-if", DistributedOperation{
+			Type:         OpTypePut,
+			Key:          "k",
+			Data:         []byte("v"),
+			Precondition: types.Precondition{Absent: true},
+		}},
+	}
 
-	for _, level := range levels {
+	for _, shape := range shapes {
 		for _, failing := range []bool{false, true} {
-			name := fmt.Sprintf("%s/failing=%v", level, failing)
+			name := fmt.Sprintf("%s/failing=%v", shape.name, failing)
 
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				cm := makeClusterWithNode(t, fmt.Sprintf("agree-%s-%v", level, failing))
+				cm := makeClusterWithNode(t, fmt.Sprintf("agree-%s-%v", shape.name, failing))
 				if failing {
 					cm.SetBackend(&errBackend{err: errors.New("s3: ServiceUnavailable")})
 				} else {
-					cm.SetBackend(&mockBackend{})
+					// A real backend for the succeeding half, not mockBackend, because one of the three
+					// shapes is a conditional write and mockBackend answers PutObjectIf with
+					// ErrNotSupported — deliberately, so that no coordination test can conclude
+					// exactly-one-writer against a stub that never excluded anybody. A stub cannot both
+					// refuse to fake a CAS and serve as the success case for one.
+					srv := testaws.Start(t)
+					if shape.op.Type == OpTypeGet {
+						srv.PutObject(shape.op.Key, []byte("v"))
+					}
+					cm.SetBackend(srv.Backend())
 				}
 
-				result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
-					Type:        OpTypeGet,
-					Key:         "k",
-					Consistency: level,
-				})
+				op := shape.op
+				result, err := cm.coordinator.ExecuteOperation(context.Background(), &op)
 				if result == nil {
 					t.Fatal("result is nil")
 				}

--- a/internal/distributed/consensus.go
+++ b/internal/distributed/consensus.go
@@ -2,10 +2,7 @@ package distributed
 
 import (
 	"context"
-	cryptorand "crypto/rand"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"math/rand"
 	"sync"
@@ -14,15 +11,19 @@ import (
 
 // ConsensusEngine elects a leader using Raft's election mechanics — terms, votes, and a randomized
 // election timeout — over gossip. It is not a consensus engine in the sense the name implies: the log
-// below holds one bootstrap noop plus one entry per election win, applyLogEntry has three empty arms,
-// and nothing appends an operation entry. Leader election works and is tested (#279); replication
-// does not exist.
+// below holds one bootstrap noop plus one entry per election win, applyLogEntry has no state machine
+// to apply anything to, and nothing appends an operation entry. Leader election works and is tested
+// (#279); replication does not exist.
 //
 // It is not going to. #169 concluded that Raft has nothing to replicate here — nodes hold no
 // authoritative state, the bucket does — and the CAS direction was adopted on 2026-08-03, closing
 // #128 (the log interface), #130 (persistent state), #133 (proposal broadcast) and #151 (compaction).
-// The log, commitIndex, lastApplied, nextIndex and matchIndex fields serve the election only; #284 is
-// where the unused machinery comes out.
+// The log, commitIndex, lastApplied, nextIndex and matchIndex fields serve the election only. #284
+// took out the proposal machinery that sat beside them: a ConsensusProposal, four statuses, three
+// types, a proposals map, a 30-second expiry sweep, and a `broadcastProposal` that slept 100ms and
+// then voted for its own proposal so that `voteOnProposal` would find a majority of one and execute
+// it. Nothing in the repository proposed anything but a leadership change, and that path reached
+// `SetLeader` — which the election already does, having actually contested it.
 type ConsensusEngine struct {
 	mu          sync.RWMutex
 	cluster     *ClusterManager
@@ -41,9 +42,6 @@ type ConsensusEngine struct {
 	// Election state
 	electionTimer *time.Timer
 	voteCount     int
-
-	// Proposal state
-	proposals map[string]*ConsensusProposal
 
 	stats  *ConsensusStats
 	stopCh chan struct{}
@@ -82,46 +80,21 @@ type LogEntry struct {
 	RequestID string    `json:"request_id"`
 }
 
-// EntryType represents the type of log entry
+// EntryType represents the type of log entry.
+//
+// Two of them, and both are appended by code in this file: a noop at index 0 to anchor the log, and
+// one entry per election win. #284 removed EntryTypeConfigChange, EntryTypeOperation and
+// EntryTypeSnapshot, which named things nothing produced — there is no configuration-change path, no
+// operation is ever logged (coordinator.go goes to the backend directly), and #151, which would have
+// added snapshotting, was closed when the CAS direction was adopted.
+//
+// The strings are unchanged, so an entry of a removed type arriving from an older peer still decodes
+// and still applies as the no-op it always was; see [ConsensusEngine.applyLogEntry].
 type EntryType string
 
 const (
 	EntryTypeNoop           EntryType = "noop"
 	EntryTypeLeaderElection EntryType = "leader_election"
-	EntryTypeConfigChange   EntryType = "config_change"
-	EntryTypeOperation      EntryType = "operation"
-	EntryTypeSnapshot       EntryType = "snapshot"
-)
-
-// ConsensusProposal represents a proposal for distributed consensus
-type ConsensusProposal struct {
-	ID        string          `json:"id"`
-	Type      ProposalType    `json:"type"`
-	Data      []byte          `json:"data"`
-	Proposer  string          `json:"proposer"`
-	Timestamp time.Time       `json:"timestamp"`
-	Status    ProposalStatus  `json:"status"`
-	Votes     map[string]bool `json:"votes"`
-	Result    []byte          `json:"result,omitempty"`
-}
-
-// ProposalType represents the type of consensus proposal
-type ProposalType string
-
-const (
-	ProposalTypeLeadershipChange ProposalType = "leadership_change"
-	ProposalTypeConfigChange     ProposalType = "config_change"
-	ProposalTypeOperation        ProposalType = "operation"
-)
-
-// ProposalStatus represents the status of a consensus proposal
-type ProposalStatus string
-
-const (
-	ProposalStatusPending  ProposalStatus = "pending"
-	ProposalStatusAccepted ProposalStatus = "accepted"
-	ProposalStatusRejected ProposalStatus = "rejected"
-	ProposalStatusExpired  ProposalStatus = "expired"
 )
 
 // RequestVoteMessage represents a vote request
@@ -163,22 +136,20 @@ type AppendEntriesResponse struct {
 
 // ConsensusStats tracks consensus protocol statistics
 type ConsensusStats struct {
-	mu                sync.RWMutex
-	CurrentState      string        `json:"current_state"`
-	CurrentTerm       uint64        `json:"current_term"`
-	CurrentLeader     string        `json:"current_leader"`
-	LogLength         int           `json:"log_length"`
-	CommitIndex       uint64        `json:"commit_index"`
-	LastApplied       uint64        `json:"last_applied"`
-	ElectionsStarted  int64         `json:"elections_started"`
-	ElectionsWon      int64         `json:"elections_won"`
-	VotesCast         int64         `json:"votes_cast"`
-	ProposalsReceived int64         `json:"proposals_received"`
-	ProposalsAccepted int64         `json:"proposals_accepted"`
-	LogEntriesAdded   int64         `json:"log_entries_added"`
-	HeartbeatsSent    int64         `json:"heartbeats_sent"`
-	LastElection      time.Time     `json:"last_election"`
-	Uptime            time.Duration `json:"uptime"`
+	mu               sync.RWMutex
+	CurrentState     string        `json:"current_state"`
+	CurrentTerm      uint64        `json:"current_term"`
+	CurrentLeader    string        `json:"current_leader"`
+	LogLength        int           `json:"log_length"`
+	CommitIndex      uint64        `json:"commit_index"`
+	LastApplied      uint64        `json:"last_applied"`
+	ElectionsStarted int64         `json:"elections_started"`
+	ElectionsWon     int64         `json:"elections_won"`
+	VotesCast        int64         `json:"votes_cast"`
+	LogEntriesAdded  int64         `json:"log_entries_added"`
+	HeartbeatsSent   int64         `json:"heartbeats_sent"`
+	LastElection     time.Time     `json:"last_election"`
+	Uptime           time.Duration `json:"uptime"`
 }
 
 // NewConsensusEngine creates a new consensus engine
@@ -192,7 +163,6 @@ func NewConsensusEngine(cluster *ClusterManager, config *ClusterConfig) (*Consen
 		log:         make([]*LogEntry, 0),
 		nextIndex:   make(map[string]uint64),
 		matchIndex:  make(map[string]uint64),
-		proposals:   make(map[string]*ConsensusProposal),
 		stats: &ConsensusStats{
 			CurrentState: StateFollower.String(),
 		},
@@ -226,7 +196,6 @@ func (ce *ConsensusEngine) Start(ctx context.Context) error {
 	// Start background goroutines
 	go ce.electionLoop(ctx)
 	go ce.heartbeatLoop(ctx)
-	go ce.proposalCleanup(ctx)
 	go ce.updateStats(ctx)
 
 	return nil
@@ -269,39 +238,6 @@ func (ce *ConsensusEngine) TriggerElection(ctx context.Context) error {
 	slog.Info("triggering leader election")
 	ce.startElection()
 
-	return nil
-}
-
-// ProposeChange proposes a change to the cluster
-func (ce *ConsensusEngine) ProposeChange(ctx context.Context, proposal *ConsensusProposal) error {
-	ce.mu.Lock()
-	defer ce.mu.Unlock()
-
-	if ce.state != StateLeader {
-		return fmt.Errorf("only leader can propose changes")
-	}
-
-	// Generate proposal ID if not provided
-	if proposal.ID == "" {
-		proposalBytes := make([]byte, 8)
-		_, _ = cryptorand.Read(proposalBytes)
-		proposal.ID = "prop-" + hex.EncodeToString(proposalBytes)
-	}
-
-	proposal.Status = ProposalStatusPending
-	proposal.Votes = make(map[string]bool)
-	proposal.Timestamp = time.Now()
-
-	ce.proposals[proposal.ID] = proposal
-
-	// Broadcast proposal to all nodes
-	ce.broadcastProposal(proposal)
-
-	ce.stats.mu.Lock()
-	ce.stats.ProposalsReceived++
-	ce.stats.mu.Unlock()
-
-	slog.Info("proposed change", "proposal_id", proposal.ID, "type", proposal.Type)
 	return nil
 }
 
@@ -350,22 +286,6 @@ func (ce *ConsensusEngine) heartbeatLoop(ctx context.Context) {
 			if isLeader {
 				ce.sendHeartbeats()
 			}
-		}
-	}
-}
-
-func (ce *ConsensusEngine) proposalCleanup(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ce.stopCh:
-			return
-		case <-ticker.C:
-			ce.cleanupExpiredProposals()
 		}
 	}
 }
@@ -837,109 +757,20 @@ func (ce *ConsensusEngine) updateCommitIndex() {
 	}
 }
 
+// applyLogEntry advances lastApplied past entry. There is no state machine for it to advance, and that
+// is the honest state of this engine rather than a gap: both entry types [EntryType] declares are
+// records of something that already happened — the log anchor and an election this node won, whose
+// effect ClusterManager.SetLeader had before the entry was appended.
+//
+// So this logs and returns. It used to be a five-arm switch with every arm empty, three of whose arms
+// named entry types nothing produced; #284 removed those types and the arms with them, and what
+// remained was a switch whose branches were indistinguishable. #169 decided coordination moves to S3
+// conditional writes rather than to Raft log replication, so this is not a to-do list.
+//
+// It stays a method, and is still called, because lastApplied must advance for commitIndex to mean
+// anything and because a per-entry line is what makes an election traceable in a log.
 func (ce *ConsensusEngine) applyLogEntry(entry *LogEntry) {
 	slog.Info("applying log entry", "index", entry.Index, "type", entry.Type)
-
-	switch entry.Type {
-	case EntryTypeLeaderElection:
-		// Leader election entry applied
-	case EntryTypeConfigChange:
-		// Apply configuration change
-	case EntryTypeOperation:
-		// Apply operation
-
-	// Every arm of this switch is empty, which is the honest state of it: this engine replicates and
-	// commits log entries and then applies none of them. Nothing appends an EntryTypeOperation, and
-	// executeLocally in coordinator.go goes to the backend directly without consulting the log or
-	// leadership, so there is no state machine for an apply to advance. The arms are kept because the
-	// log entries they name are real and do get committed.
-	//
-	// EntryTypeNoop is appended once, at index 0, by newConsensusEngine — a Raft no-op to anchor the
-	// log — and applying it is correctly a no-op. EntryTypeSnapshot is declared in this file and
-	// appended nowhere: there is no snapshotting in this engine, so an entry of that type cannot exist
-	// to be applied — #151, which would have added it, was closed for exactly that reason. On the
-	// direction here: #169 decided coordination moves to S3 conditional writes rather than this Raft
-	// implementation, with #284 the live follow-up. So these arms are not a to-do list.
-	case EntryTypeNoop, EntryTypeSnapshot:
-	}
-}
-
-// Proposal handling
-
-func (ce *ConsensusEngine) broadcastProposal(proposal *ConsensusProposal) {
-	// In a real implementation, this would broadcast to all nodes
-	slog.Info("broadcasting proposal to cluster", "proposal_id", proposal.ID)
-
-	// For simulation, automatically accept our own proposals after a delay
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		ce.voteOnProposal(proposal.ID, true)
-	}()
-}
-
-func (ce *ConsensusEngine) voteOnProposal(proposalID string, accept bool) {
-	ce.mu.Lock()
-	defer ce.mu.Unlock()
-
-	proposal, exists := ce.proposals[proposalID]
-	if !exists {
-		return
-	}
-
-	nodeID := ce.cluster.GetNodeID()
-	proposal.Votes[nodeID] = accept
-
-	// Count votes
-	acceptVotes := 0
-	totalVotes := len(proposal.Votes)
-
-	for _, vote := range proposal.Votes {
-		if vote {
-			acceptVotes++
-		}
-	}
-
-	nodes := ce.cluster.GetNodes()
-	aliveNodes := 0
-	for _, node := range nodes {
-		if node.Status == NodeStatusAlive {
-			aliveNodes++
-		}
-	}
-
-	majority := aliveNodes/2 + 1
-
-	// Check if proposal should be accepted or rejected
-	if acceptVotes >= majority {
-		proposal.Status = ProposalStatusAccepted
-		ce.executeProposal(proposal)
-
-		ce.stats.mu.Lock()
-		ce.stats.ProposalsAccepted++
-		ce.stats.mu.Unlock()
-
-		slog.Info("proposal accepted", "proposal_id", proposalID, "accept_votes", acceptVotes, "total_votes", totalVotes)
-	} else if totalVotes-acceptVotes > aliveNodes-majority {
-		proposal.Status = ProposalStatusRejected
-		slog.Info("proposal rejected", "proposal_id", proposalID, "accept_votes", acceptVotes, "total_votes", totalVotes)
-	}
-}
-
-func (ce *ConsensusEngine) executeProposal(proposal *ConsensusProposal) {
-	switch proposal.Type {
-	case ProposalTypeLeadershipChange:
-		newLeader := string(proposal.Data)
-		slog.Info("executing leadership change", "new_leader", newLeader)
-		ce.cluster.SetLeader(newLeader)
-
-	case ProposalTypeConfigChange:
-		slog.Info("executing configuration change")
-		// Apply configuration change
-
-	case ProposalTypeOperation:
-		slog.Info("executing operation proposal")
-		// Execute operation
-	}
 }
 
 // Utility methods
@@ -1008,20 +839,6 @@ func (ce *ConsensusEngine) getLastLogTerm() uint64 {
 	return ce.log[len(ce.log)-1].Term
 }
 
-func (ce *ConsensusEngine) cleanupExpiredProposals() {
-	ce.mu.Lock()
-	defer ce.mu.Unlock()
-
-	now := time.Now()
-	for proposalID, proposal := range ce.proposals {
-		if proposal.Status == ProposalStatusPending && now.Sub(proposal.Timestamp) > 30*time.Second {
-			proposal.Status = ProposalStatusExpired
-			delete(ce.proposals, proposalID)
-			slog.Info("proposal expired", "proposal_id", proposalID)
-		}
-	}
-}
-
 func (ce *ConsensusEngine) updateStats(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -1057,21 +874,19 @@ func (ce *ConsensusEngine) GetStats() *ConsensusStats {
 
 	ce.stats.mu.RLock()
 	stats := &ConsensusStats{
-		CurrentState:      state,
-		CurrentTerm:       term,
-		CurrentLeader:     ce.stats.CurrentLeader,
-		LogLength:         logLength,
-		CommitIndex:       commitIndex,
-		LastApplied:       lastApplied,
-		ElectionsStarted:  ce.stats.ElectionsStarted,
-		ElectionsWon:      ce.stats.ElectionsWon,
-		VotesCast:         ce.stats.VotesCast,
-		ProposalsReceived: ce.stats.ProposalsReceived,
-		ProposalsAccepted: ce.stats.ProposalsAccepted,
-		LogEntriesAdded:   ce.stats.LogEntriesAdded,
-		HeartbeatsSent:    ce.stats.HeartbeatsSent,
-		LastElection:      ce.stats.LastElection,
-		Uptime:            ce.stats.Uptime,
+		CurrentState:     state,
+		CurrentTerm:      term,
+		CurrentLeader:    ce.stats.CurrentLeader,
+		LogLength:        logLength,
+		CommitIndex:      commitIndex,
+		LastApplied:      lastApplied,
+		ElectionsStarted: ce.stats.ElectionsStarted,
+		ElectionsWon:     ce.stats.ElectionsWon,
+		VotesCast:        ce.stats.VotesCast,
+		LogEntriesAdded:  ce.stats.LogEntriesAdded,
+		HeartbeatsSent:   ce.stats.HeartbeatsSent,
+		LastElection:     ce.stats.LastElection,
+		Uptime:           ce.stats.Uptime,
 	}
 	ce.stats.mu.RUnlock()
 

--- a/internal/distributed/consensus_test.go
+++ b/internal/distributed/consensus_test.go
@@ -565,21 +565,11 @@ func TestConsensusEngine_TriggerElection_WhenLeader_IsNoOp(t *testing.T) {
 	}
 }
 
-// TestConsensusEngine_ProposeChange_NotLeader_ReturnsError verifies that only
-// the leader can propose changes.
-func TestConsensusEngine_ProposeChange_NotLeader_ReturnsError(t *testing.T) {
-	t.Parallel()
-	cm, _ := NewClusterManager(testConfig(t, "not-leader-prop"))
-	ce := cm.consensus
-
-	err := ce.ProposeChange(context.Background(), &ConsensusProposal{
-		Type: ProposalTypeOperation,
-		Data: []byte("noop"),
-	})
-	if err == nil {
-		t.Fatal("ProposeChange as follower should return error")
-	}
-}
+// There was a TestConsensusEngine_ProposeChange_NotLeader_ReturnsError here, asserting that a
+// follower's ProposeChange returned an error. #284 deleted ProposeChange and everything downstream of
+// it, so the test went with it rather than being ported: the guard it covered was the only part of
+// that path that did what it said, and what it guarded was a broadcast that slept 100ms and voted for
+// its own proposal.
 
 // TestConsensusEngine_StartStop verifies the lifecycle without panics.
 func TestConsensusEngine_StartStop(t *testing.T) {

--- a/internal/distributed/coordinator.go
+++ b/internal/distributed/coordinator.go
@@ -3,6 +3,7 @@ package distributed
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -20,7 +21,6 @@ type Coordinator struct {
 	cluster      *ClusterManager
 	config       *ClusterConfig
 	operations   map[string]*ActiveOperation
-	replicator   *CacheReplicator
 	loadBalancer *LoadBalancer
 	stopCh       chan struct{}
 	backend      types.Backend
@@ -43,20 +43,38 @@ type NodeOperationRespMessage struct {
 	Result    *NodeResult `json:"result"`
 }
 
-// DistributedOperation represents an operation to be executed across the cluster
+// DistributedOperation represents an operation to be executed across the cluster.
+//
+// There was a Consistency field here, of type ConsistencyLevel, and #284 removed it along with the
+// type and its three constants. What replaced it is [DistributedOperation.Precondition], and the
+// reason it is a replacement rather than a removal plus an unrelated addition is that the two answer
+// the same question — "may this write overwrite what is there?" — and only one of them could answer
+// it. See the package documentation for the whole argument; the short form is that all three levels
+// issued the same unconditional PutObject and differed only in how many nodes issued it.
 type DistributedOperation struct {
-	ID          string            `json:"id"`
-	Type        OperationType     `json:"type"`
-	Key         string            `json:"key"`
-	Data        []byte            `json:"data,omitempty"`
-	Offset      int64             `json:"offset,omitempty"`
-	Size        int64             `json:"size,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	Consistency ConsistencyLevel  `json:"consistency"`
-	Timeout     time.Duration     `json:"timeout"`
-	Retries     int               `json:"retries"`
-	TargetNodes []string          `json:"target_nodes,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
+	ID       string            `json:"id"`
+	Type     OperationType     `json:"type"`
+	Key      string            `json:"key"`
+	Data     []byte            `json:"data,omitempty"`
+	Offset   int64             `json:"offset,omitempty"`
+	Size     int64             `json:"size,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Precondition, when set, makes an OpTypePut a compare-and-swap: the backend evaluates it and
+	// refuses the write if it does not hold, reporting [types.ErrPreconditionFailed].
+	//
+	// This is the only guarantee this package offers about a write, and it is a real one, decided by
+	// S3 rather than by a count of nodes that agreed. Its zero value means an unconditional write —
+	// last-writer-wins — which is the honest description of what every consistency level here did.
+	//
+	// It is only consulted for OpTypePut. A precondition on a GET, a DELETE, or a LIST is a caller
+	// error rather than something to ignore silently, so [Coordinator.ExecuteOperation] rejects it.
+	Precondition types.Precondition `json:"precondition,omitzero"`
+
+	Timeout     time.Duration `json:"timeout"`
+	Retries     int           `json:"retries"`
+	TargetNodes []string      `json:"target_nodes,omitempty"`
+	CreatedAt   time.Time     `json:"created_at"`
 }
 
 // OperationType represents the type of distributed operation
@@ -70,20 +88,26 @@ const (
 	OpTypeBatch  OperationType = "batch"
 )
 
-// ConsistencyLevel represents the consistency requirement for an operation
-type ConsistencyLevel string
-
-const (
-	ConsistencyEventual ConsistencyLevel = "eventual"
-	ConsistencyStrong   ConsistencyLevel = "strong"
-	ConsistencySession  ConsistencyLevel = "session"
-)
-
 // OperationResult represents the result of a distributed operation
 type OperationResult struct {
-	Success     bool                   `json:"success"`
-	Data        []byte                 `json:"data,omitempty"`
-	Error       string                 `json:"error,omitempty"`
+	Success bool   `json:"success"`
+	Data    []byte `json:"data,omitempty"`
+	Error   string `json:"error,omitempty"`
+
+	// Conditional classifies a conditional-write failure and is empty for every other outcome. The
+	// error [Coordinator.ExecuteOperation] returns wraps the matching sentinel, so a caller can use
+	// either errors.Is on the error or this field on the result. See [ConditionalOutcome].
+	Conditional ConditionalOutcome `json:"conditional,omitempty"`
+
+	// ETag is the stored object's ETag after a successful OpTypePut, and is empty otherwise.
+	//
+	// It is here so that a caller performing a compare-and-swap loop can continue from it without a
+	// HeadObject between iterations, and — the load-bearing use — so that a cache invalidation can
+	// name the version it was computed from. See [ClusterManager.InvalidateCacheKey]: an invalidation
+	// without an ETag can be applied out of order relative to the write that caused it, which is
+	// requirement R4 of docs/design/conditional-writes-vs-raft.md §1.
+	ETag string `json:"etag,omitempty"`
+
 	NodeResults map[string]*NodeResult `json:"node_results"`
 	Latency     time.Duration          `json:"latency"`
 	RetriesUsed int                    `json:"retries_used"`
@@ -92,11 +116,91 @@ type OperationResult struct {
 
 // NodeResult represents the result from a specific node
 type NodeResult struct {
-	NodeID  string        `json:"node_id"`
-	Success bool          `json:"success"`
-	Data    []byte        `json:"data,omitempty"`
+	NodeID  string `json:"node_id"`
+	Success bool   `json:"success"`
+	Data    []byte `json:"data,omitempty"`
+
+	// ETag is the stored object's ETag after a successful conditional put on this node. See
+	// [OperationResult.ETag], which it is copied to.
+	ETag string `json:"etag,omitempty"`
+
+	// Conditional classifies a conditional-write failure, and is empty for every other outcome. See
+	// [ConditionalOutcome] for why this travels as a string rather than as the error itself.
+	Conditional ConditionalOutcome `json:"conditional,omitempty"`
+
 	Error   string        `json:"error,omitempty"`
 	Latency time.Duration `json:"latency"`
+}
+
+// ConditionalOutcome names why a conditional write did not land, so that a caller can select a
+// recovery without parsing an error string.
+//
+// It exists because a NodeResult crosses the wire. An operation executed on a peer is marshaled to
+// JSON, sent over gossip, and unmarshaled by the requesting node, so a Go error on the far side does
+// not survive the trip — only exported fields do. Carrying the sentinel as an unexported field would
+// make the classification silently correct for a local execution and silently absent for a remote
+// one, which is a seam defect of exactly the kind this package's audit was full of.
+//
+// A bool would not do either. Per docs/design/conditional-writes-vs-raft.md §2 the taxonomy is
+// three-way and the three select *different* recovery: a lost race means re-read and CAS again, a
+// conflict means retry the same write as-is, and an absent object means the state being updated is
+// gone and re-doing the CAS will never succeed.
+type ConditionalOutcome string
+
+const (
+	// ConditionalLost means the precondition was evaluated and did not hold: another writer won.
+	// Recovery is to re-read, recompute from what is now stored, and retry the compare-and-swap. This
+	// is the expected outcome of a contended write, not an error to log as one.
+	ConditionalLost ConditionalOutcome = "lost"
+
+	// ConditionalConflict means the write raced a delete. The caller's view is not necessarily stale,
+	// so retrying the same write may simply succeed.
+	ConditionalConflict ConditionalOutcome = "conflict"
+
+	// ConditionalUnsupported means the endpoint does not evaluate preconditions and nothing was
+	// written. A caller needing mutual exclusion must refuse to proceed rather than fall back to an
+	// unconditional write — see [types.ErrNotSupported].
+	ConditionalUnsupported ConditionalOutcome = "unsupported"
+
+	// ConditionalInvalid means the precondition itself was unusable — it asserted nothing, or it
+	// asserted both absence and a specific ETag. A caller error, distinct from one that was evaluated.
+	ConditionalInvalid ConditionalOutcome = "invalid"
+)
+
+// sentinel returns the [types] error o corresponds to, or nil for the empty outcome. It is the inverse
+// of [classifyConditional] and exists so that errors.Is works identically on a local and a remote
+// execution — see [Coordinator.ExecuteOperation].
+func (o ConditionalOutcome) sentinel() error {
+	switch o {
+	case ConditionalLost:
+		return types.ErrPreconditionFailed
+	case ConditionalConflict:
+		return types.ErrConditionalConflict
+	case ConditionalUnsupported:
+		return types.ErrNotSupported
+	case ConditionalInvalid:
+		return types.ErrInvalidPrecondition
+	default:
+		return nil
+	}
+}
+
+// classifyConditional maps a [Backend.PutObjectIf] error onto a [ConditionalOutcome], returning the
+// empty outcome for an error that is not about the precondition — a timeout, a network failure, an
+// AccessDenied. Those are ordinary failures and a caller must not read them as a lost race.
+func classifyConditional(err error) ConditionalOutcome {
+	switch {
+	case errors.Is(err, types.ErrPreconditionFailed):
+		return ConditionalLost
+	case errors.Is(err, types.ErrConditionalConflict):
+		return ConditionalConflict
+	case errors.Is(err, types.ErrNotSupported):
+		return ConditionalUnsupported
+	case errors.Is(err, types.ErrInvalidPrecondition):
+		return ConditionalInvalid
+	default:
+		return ""
+	}
 }
 
 // ActiveOperation tracks an ongoing distributed operation
@@ -108,34 +212,21 @@ type ActiveOperation struct {
 	_         sync.RWMutex
 }
 
-// CacheReplicator handles cache replication across nodes
-type CacheReplicator struct {
-	mu           sync.RWMutex
-	cluster      *ClusterManager
-	config       *ClusterConfig
-	replications map[string]*ReplicationTask
-	stats        *ReplicationStats
-}
-
-// ReplicationTask represents a cache replication task
-type ReplicationTask struct {
-	Key         string    `json:"key"`
-	Data        []byte    `json:"data"`
-	TargetNodes []string  `json:"target_nodes"`
-	CreatedAt   time.Time `json:"created_at"`
-	Attempts    int       `json:"attempts"`
-}
-
-// ReplicationStats tracks replication statistics
-type ReplicationStats struct {
-	mu                 sync.RWMutex
-	TasksCreated       int64         `json:"tasks_created"`
-	TasksCompleted     int64         `json:"tasks_completed"`
-	TasksFailed        int64         `json:"tasks_failed"`
-	BytesReplicated    int64         `json:"bytes_replicated"`
-	AvgReplicationTime time.Duration `json:"avg_replication_time"`
-	ActiveTasks        int           `json:"active_tasks"`
-}
+// There was a CacheReplicator here, with a ReplicationTask, a ReplicationStats of six counters, a
+// once-per-second worker, and a `simulateReplication` that returned true. #284 deleted all of it, and
+// the deciding fact is that nobody could say what it was for.
+//
+// What it did: after a write succeeded on one node, it registered the same key and bytes as a task,
+// and a worker then sent every other target node an operation asking it to PUT those bytes to that
+// key. Each peer can already reach S3, and the bytes were already there, so the work was to have N-1
+// peers overwrite an object with its own contents. When gossip was not running — which is every unit
+// test — `simulateReplication` returned true without sending anything and the statistics counted the
+// bytes as replicated, so the counters reported throughput for work that had not happened.
+//
+// It could not have been cache warming either, which is the one purpose that would have justified it:
+// warming means putting bytes into a peer's *cache*, and this sent a backend PUT. Cache warming is
+// #141 and #142, it is a v0.13.0 item, and it needs a message type of its own rather than a consistency
+// level's side effect. Reviving a path that re-uploads an object to itself is not a head start on it.
 
 // LoadBalancer manages load distribution across cluster nodes
 type LoadBalancer struct {
@@ -177,14 +268,6 @@ func NewCoordinator(cluster *ClusterManager, config *ClusterConfig, backend type
 		backend:    backend,
 	}
 
-	// Initialize cache replicator
-	c.replicator = &CacheReplicator{
-		cluster:      cluster,
-		config:       config,
-		replications: make(map[string]*ReplicationTask),
-		stats:        &ReplicationStats{},
-	}
-
 	// Initialize load balancer
 	c.loadBalancer = &LoadBalancer{
 		cluster:  cluster,
@@ -203,7 +286,6 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	// Start background tasks
 	go c.cleanupOperations(ctx)
-	go c.replicationWorker(ctx)
 	go c.updateLoadBalancerStats(ctx)
 
 	return nil
@@ -236,10 +318,19 @@ func (c *Coordinator) ExecuteOperation(ctx context.Context, op *DistributedOpera
 	if op.Retries == 0 {
 		op.Retries = c.config.RetryAttempts
 	}
-	if op.Consistency == "" {
-		op.Consistency = ConsistencyLevel(c.config.ConsistencyLevel)
-	}
 	op.CreatedAt = start
+
+	// A precondition is only meaningful on a put, and a caller that attached one to a read or a delete
+	// has a mistaken belief about what will be enforced. Rejecting is the fail-closed answer: silently
+	// ignoring it would mean a caller that meant "delete only if unchanged" gets an unconditional
+	// delete and no indication, which is the shape of every defect this package's audit found.
+	if op.Type != OpTypePut && !op.Precondition.IsZero() {
+		return &OperationResult{
+			Success: false,
+			Error:   fmt.Sprintf("a precondition is only supported on %s, not %s", OpTypePut, op.Type),
+			Latency: time.Since(start),
+		}, fmt.Errorf("distributed: precondition on %s operation: %w", op.Type, types.ErrInvalidPrecondition)
+	}
 
 	// Track active operation
 	activeOp := &ActiveOperation{
@@ -269,38 +360,33 @@ func (c *Coordinator) ExecuteOperation(ctx context.Context, op *DistributedOpera
 		}, err
 	}
 
-	// Execute operation based on type and consistency level
-	var result *OperationResult
-
-	switch op.Consistency {
-	case ConsistencyStrong:
-		result, err = c.executeStrongConsistency(ctx, activeOp, targetNodes)
-	case ConsistencySession:
-		result, err = c.executeSessionConsistency(ctx, activeOp, targetNodes)
-	case ConsistencyEventual:
-		result, err = c.executeEventualConsistency(ctx, activeOp, targetNodes)
-	default:
-		return &OperationResult{
-			Success: false,
-			Error:   fmt.Sprintf("unsupported consistency level: %s", op.Consistency),
-			Latency: time.Since(start),
-		}, fmt.Errorf("unsupported consistency level: %s", op.Consistency)
-	}
+	result := c.executeOnce(ctx, activeOp, targetNodes)
 
 	result.CompletedAt = time.Now()
 	result.Latency = time.Since(start)
 
-	// A result that failed is returned with an error, always. The three executors above each
-	// reported failure only in result.Success and returned a nil error, so a caller that checked
-	// err — the ordinary thing to do in Go, and what ClusterManager.DistributeOperation did —
+	// A result that failed is returned with an error, always. The three consistency executors this
+	// replaced each reported failure only in result.Success and returned a nil error, so a caller that
+	// checked err — the ordinary thing to do in Go, and what ClusterManager.DistributeOperation did —
 	// recorded an operation that failed on every node as a success (#269).
 	//
-	// Reconciling here rather than in each executor is deliberate: this is the single point every
-	// consistency level passes through, so a fourth level added later cannot reintroduce the
-	// disagreement, and none of them has to remember to return two representations of the same
-	// fact. The error text is result.Error so the two cannot drift either.
-	if err == nil && !result.Success {
+	// Reconciling here rather than inside the executor is deliberate: this is the single point every
+	// operation passes through, so a second execution strategy added later cannot reintroduce the
+	// disagreement. The error text is result.Error so the two cannot drift either.
+	if !result.Success {
 		err = fmt.Errorf("operation %s on %q failed: %s", op.Type, op.Key, result.Error)
+
+		// And it wraps the conditional-write sentinel when there was one, so a caller racing for a
+		// claim can ask errors.Is(err, types.ErrPreconditionFailed) rather than inspect the result.
+		//
+		// Reconstructing it from result.Conditional rather than threading the original error through:
+		// the original does not exist on the remote path. A NodeResult arrives from a peer as JSON with
+		// its error already flattened to a string, so the classification the far side made is the only
+		// thing that survived, and building the sentinel from it here is what makes errors.Is behave
+		// the same whether the operation ran locally or on a peer.
+		if sentinel := result.Conditional.sentinel(); sentinel != nil {
+			err = fmt.Errorf("%w: %w", sentinel, err)
+		}
 	}
 
 	// Update load balancer stats
@@ -368,118 +454,53 @@ func (c *Coordinator) selectTargetNodes(op *DistributedOperation) ([]string, err
 	}
 }
 
-// executeStrongConsistency executes an operation with strong consistency
-func (c *Coordinator) executeStrongConsistency(ctx context.Context, activeOp *ActiveOperation, targetNodes []string) (*OperationResult, error) {
+// executeOnce runs the operation on one node — the first of targetNodes — and reports what that node
+// did. It is the whole of this package's execution strategy.
+//
+// It replaced three functions, `executeStrongConsistency`, `executeSessionConsistency` and
+// `executeEventualConsistency`, and the case for one function is not that the three were similar. It
+// is that all three issued the *same unconditional PutObject* and differed only in how many nodes
+// issued it and whether the caller waited:
+//
+//   - Strong fanned the operation to all N target nodes with a WaitGroup and declared success at
+//     `successCount >= len(targetNodes)/2+1`. Every node wrote the same key in the same bucket with
+//     the same bytes, so those were N redundant identical PUTs and the majority count answered "could
+//     most nodes reach S3" — a reachability signal, billed N times.
+//   - Session and Eventual were the same function. Diffing their bodies with comments stripped, the
+//     only differences were a `len(targetNodes) > 0` guard before `targetNodes[0]` and an extra
+//     `op.Type == OpTypePut` condition on the background replication.
+//
+// One node is enough because there is one copy of the bytes. S3 holds it, every node can already
+// reach it, and a second node writing it again adds a request and no guarantee. What a caller who
+// wanted "strong" actually needs is that its write not silently clobber a concurrent one, and that is
+// [DistributedOperation.Precondition] — one conditional request to one key, evaluated by the store.
+//
+// targetNodes past the first are unused, and deliberately still selected: [Coordinator.selectTargetNodes]
+// returns them in preference order, and the load-balancer statistics below count the whole set as
+// routed work. A follow-on execution strategy that genuinely needs peers — cache warming, #141 — will
+// want the list rather than have to reconstruct it.
+func (c *Coordinator) executeOnce(ctx context.Context, activeOp *ActiveOperation, targetNodes []string) *OperationResult {
 	op := activeOp.Operation
 
-	// For strong consistency, we need consensus from majority of nodes
-	requiredNodes := len(targetNodes)/2 + 1
-
-	// Execute operation on all target nodes synchronously
-	results := make(map[string]*NodeResult)
-	var wg sync.WaitGroup
-	var mu sync.Mutex
-
-	for _, nodeID := range targetNodes {
-		wg.Add(1)
-		go func(nodeID string) {
-			defer wg.Done()
-
-			nodeResult := c.executeOnNode(ctx, nodeID, op)
-
-			mu.Lock()
-			results[nodeID] = nodeResult
-			mu.Unlock()
-		}(nodeID)
-	}
-
-	wg.Wait()
-
-	// Count successful results
-	successCount := 0
-	var firstSuccess *NodeResult
-	var firstError string
-
-	for _, result := range results {
-		if result.Success {
-			successCount++
-			if firstSuccess == nil {
-				firstSuccess = result
-			}
-		} else if firstError == "" {
-			firstError = result.Error
+	if len(targetNodes) == 0 {
+		return &OperationResult{
+			Success:     false,
+			Error:       "no target nodes selected",
+			NodeResults: map[string]*NodeResult{},
 		}
 	}
 
-	// Determine overall success based on majority
-	success := successCount >= requiredNodes
+	node := targetNodes[0]
+	result := c.executeOnNode(ctx, node, op)
 
-	result := &OperationResult{
-		Success:     success,
-		NodeResults: results,
-	}
-
-	if success && firstSuccess != nil {
-		result.Data = firstSuccess.Data
-	} else {
-		result.Error = fmt.Sprintf("insufficient successful responses (%d/%d required), first error: %s",
-			successCount, requiredNodes, firstError)
-	}
-
-	return result, nil
-}
-
-// executeSessionConsistency executes an operation with session consistency
-func (c *Coordinator) executeSessionConsistency(ctx context.Context, activeOp *ActiveOperation, targetNodes []string) (*OperationResult, error) {
-	op := activeOp.Operation
-
-	// For session consistency, try to use the same node for related operations
-	// Fall back to any available node if the preferred node is unavailable
-
-	var primaryNode string
-	if len(targetNodes) > 0 {
-		primaryNode = targetNodes[0]
-	}
-
-	// Execute on primary node first
-	result := c.executeOnNode(ctx, primaryNode, op)
-
-	operationResult := &OperationResult{
+	return &OperationResult{
 		Success:     result.Success,
 		Data:        result.Data,
+		ETag:        result.ETag,
+		Conditional: result.Conditional,
 		Error:       result.Error,
-		NodeResults: map[string]*NodeResult{primaryNode: result},
+		NodeResults: map[string]*NodeResult{node: result},
 	}
-
-	// If write operation succeeded, asynchronously replicate to other nodes
-	if op.Type == OpTypePut && result.Success && len(targetNodes) > 1 {
-		go c.replicateAsync(ctx, op, targetNodes[1:])
-	}
-
-	return operationResult, nil
-}
-
-// executeEventualConsistency executes an operation with eventual consistency
-func (c *Coordinator) executeEventualConsistency(ctx context.Context, activeOp *ActiveOperation, targetNodes []string) (*OperationResult, error) {
-	op := activeOp.Operation
-
-	// For eventual consistency, execute on any available node and replicate asynchronously
-	primaryNode := targetNodes[0]
-	result := c.executeOnNode(ctx, primaryNode, op)
-
-	operationResult := &OperationResult{
-		Success:     result.Success,
-		Data:        result.Data,
-		Error:       result.Error,
-		NodeResults: map[string]*NodeResult{primaryNode: result},
-	}
-
-	// Asynchronously replicate to other nodes
-	if result.Success && len(targetNodes) > 1 {
-		go c.replicateAsync(ctx, op, targetNodes[1:])
-	}
-
-	return operationResult, nil
 }
 
 // executeOnNode executes an operation on a specific node. If nodeID is the
@@ -597,10 +618,30 @@ func (c *Coordinator) executeLocally(parent context.Context, nodeID string, op *
 			result.Data = data
 		}
 	case OpTypePut:
-		if err := c.backend.PutObject(ctx, op.Key, op.Data, nil); err != nil {
+		// One request, conditional when the caller asserted something about the key's current state.
+		//
+		// A precondition that does not hold comes back as types.ErrPreconditionFailed and nothing was
+		// written; that is reported as a failed result like any other, and the caller distinguishes it
+		// with errors.Is on the error ExecuteOperation returns. It is not retried here and must not be:
+		// the answer is definitive, and the recovery is to re-read, recompute, and CAS again — which
+		// only the caller can do, since only it knows what the new bytes should be.
+		if op.Precondition.IsZero() {
+			if err := c.backend.PutObject(ctx, op.Key, op.Data, op.Metadata); err != nil {
+				result.Error = err.Error()
+			} else {
+				result.Success = true
+			}
+
+			break
+		}
+
+		etag, err := c.backend.PutObjectIf(ctx, op.Key, op.Data, op.Metadata, op.Precondition)
+		if err != nil {
 			result.Error = err.Error()
+			result.Conditional = classifyConditional(err)
 		} else {
 			result.Success = true
+			result.ETag = etag
 		}
 	case OpTypeDelete:
 		if err := c.backend.DeleteObject(ctx, op.Key); err != nil {
@@ -687,27 +728,6 @@ func (c *Coordinator) handleNetworkOperationResp(msg *GossipMessage) {
 	}
 }
 
-// replicateAsync asynchronously replicates data to target nodes
-func (c *Coordinator) replicateAsync(ctx context.Context, op *DistributedOperation, targetNodes []string) {
-	if c.replicator == nil {
-		return
-	}
-
-	task := &ReplicationTask{
-		Key:         op.Key,
-		Data:        op.Data,
-		TargetNodes: targetNodes,
-		CreatedAt:   time.Now(),
-		Attempts:    0,
-	}
-
-	c.replicator.mu.Lock()
-	c.replicator.replications[op.Key] = task
-	c.replicator.stats.TasksCreated++
-	c.replicator.stats.ActiveTasks++
-	c.replicator.mu.Unlock()
-}
-
 // Background worker methods
 
 func (c *Coordinator) cleanupOperations(ctx context.Context) {
@@ -737,103 +757,6 @@ func (c *Coordinator) performOperationCleanup() {
 			delete(c.operations, opID)
 		}
 	}
-}
-
-func (c *Coordinator) replicationWorker(ctx context.Context) {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-c.stopCh:
-			return
-		case <-ticker.C:
-			c.processReplicationTasks(ctx)
-		}
-	}
-}
-
-func (c *Coordinator) processReplicationTasks(ctx context.Context) {
-	c.replicator.mu.Lock()
-	tasks := make([]*ReplicationTask, 0, len(c.replicator.replications))
-	for _, task := range c.replicator.replications {
-		tasks = append(tasks, task)
-	}
-	c.replicator.mu.Unlock()
-
-	for _, task := range tasks {
-		c.processReplicationTask(ctx, task)
-	}
-}
-
-func (c *Coordinator) processReplicationTask(ctx context.Context, task *ReplicationTask) {
-	start := time.Now()
-	task.Attempts++
-
-	successCount := 0
-	for _, nodeID := range task.TargetNodes {
-		// Simulate replication to node
-		if c.simulateReplication(nodeID, task.Key, task.Data) {
-			successCount++
-		}
-	}
-
-	c.replicator.mu.Lock()
-	if successCount > 0 {
-		c.replicator.stats.TasksCompleted++
-		c.replicator.stats.BytesReplicated += int64(len(task.Data))
-		delete(c.replicator.replications, task.Key)
-	} else if task.Attempts >= 3 {
-		c.replicator.stats.TasksFailed++
-		delete(c.replicator.replications, task.Key)
-	}
-	c.replicator.stats.ActiveTasks = len(c.replicator.replications)
-
-	// Update average replication time
-	replicationTime := time.Since(start)
-	if c.replicator.stats.AvgReplicationTime == 0 {
-		c.replicator.stats.AvgReplicationTime = replicationTime
-	} else {
-		alpha := 0.1
-		c.replicator.stats.AvgReplicationTime = time.Duration(
-			alpha*float64(replicationTime) + (1-alpha)*float64(c.replicator.stats.AvgReplicationTime),
-		)
-	}
-	c.replicator.mu.Unlock()
-}
-
-func (c *Coordinator) simulateReplication(nodeID, key string, data []byte) bool {
-	nodes := c.cluster.GetNodes()
-	node, exists := nodes[nodeID]
-	if !exists || node.Status != NodeStatusAlive {
-		return false
-	}
-
-	// If gossip is not running fall back to a logical ACK.
-	if c.cluster.gossip == nil || c.cluster.gossip.conn == nil {
-		return true
-	}
-
-	// Fire-and-forget: send a PUT operation to the target node; the response
-	// (if any) arrives on handleNetworkOperationResp and is silently discarded
-	// because no pending channel is registered for this requestID.
-	op := &DistributedOperation{
-		Type: OpTypePut,
-		Key:  key,
-		Data: data,
-	}
-	msg := &NodeOperationMessage{
-		RequestID: fmt.Sprintf("repl-%s-%d", key, time.Now().UnixNano()),
-		From:      c.cluster.GetNodeID(),
-		Operation: op,
-	}
-	if err := c.cluster.gossip.sendConsensusMsg(node.Address, MessageTypeNodeOperation, msg); err != nil {
-		slog.Warn("failed to replicate key", "key", key, "node_id", nodeID, "error", err)
-		return false
-	}
-	return true
 }
 
 func (c *Coordinator) updateLoadBalancerStats(ctx context.Context) {
@@ -986,17 +909,6 @@ func (c *Coordinator) GetStats() map[string]any {
 	activeOps := len(c.operations)
 	c.mu.RUnlock()
 
-	c.replicator.stats.mu.RLock()
-	replicationStats := ReplicationStats{
-		TasksCreated:       c.replicator.stats.TasksCreated,
-		TasksCompleted:     c.replicator.stats.TasksCompleted,
-		TasksFailed:        c.replicator.stats.TasksFailed,
-		BytesReplicated:    c.replicator.stats.BytesReplicated,
-		AvgReplicationTime: c.replicator.stats.AvgReplicationTime,
-		ActiveTasks:        c.replicator.stats.ActiveTasks,
-	}
-	c.replicator.stats.mu.RUnlock()
-
 	c.loadBalancer.stats.mu.RLock()
 	loadBalancerStats := LoadBalancerStats{
 		RequestsRouted:  c.loadBalancer.stats.RequestsRouted,
@@ -1007,9 +919,13 @@ func (c *Coordinator) GetStats() map[string]any {
 	maps.Copy(loadBalancerStats.NodeLoad, c.loadBalancer.stats.NodeLoad)
 	c.loadBalancer.stats.mu.RUnlock()
 
+	// No "replication" key. It reported six counters from the CacheReplicator that #284 deleted, and
+	// what they counted was peers re-uploading an object to itself — with the count incremented even
+	// when nothing was sent, because simulateReplication returned true whenever gossip was not running.
+	// A stats map that omits a subsystem is honest; one that reports throughput for work that did not
+	// happen is the reason the audit distrusted this package's numbers.
 	return map[string]any{
 		"active_operations": activeOps,
-		"replication":       &replicationStats,
 		"load_balancer":     &loadBalancerStats,
 	}
 }

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scttfrdmn/objectfs/internal/testaws"
 	"github.com/scttfrdmn/objectfs/pkg/types"
 )
 
@@ -135,9 +136,12 @@ func TestNewCoordinator(t *testing.T) {
 	if c.loadBalancer == nil {
 		t.Fatal("loadBalancer is nil")
 	}
-	if c.replicator == nil {
-		t.Fatal("replicator is nil")
-	}
+
+	// There was a `c.replicator == nil` check here. #284 deleted the CacheReplicator, and this
+	// assertion is what let it survive: it proved a field had been assigned, which was the only thing
+	// about that subsystem that worked. Its worker sent peers a PUT of an object's own bytes back to
+	// itself, and when gossip was not running — which is every test in this file — it sent nothing and
+	// counted the bytes as replicated anyway.
 }
 
 // TestCoordinator_ExecuteOperation_NoAliveNodes verifies that ExecuteOperation
@@ -150,9 +154,8 @@ func TestCoordinator_ExecuteOperation_NoAliveNodes(t *testing.T) {
 	}
 
 	_, err = cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeGet,
+		Key:  "k",
 	})
 	if err == nil {
 		t.Fatal("expected error with no alive nodes, got nil")
@@ -168,10 +171,9 @@ func TestCoordinator_ExecuteOperation_GeneratesID(t *testing.T) {
 	t.Parallel()
 	cm := makeClusterWithNode(t, "gen-id-node")
 	op := &DistributedOperation{
-		ID:          "", // empty — should be generated
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencyEventual,
+		ID:   "", // empty — should be generated
+		Type: OpTypeGet,
+		Key:  "k",
 	}
 
 	_, _ = cm.coordinator.ExecuteOperation(context.Background(), op)
@@ -184,22 +186,48 @@ func TestCoordinator_ExecuteOperation_GeneratesID(t *testing.T) {
 	}
 }
 
-// TestCoordinator_ExecuteOperation_AppliesDefaultConsistency verifies that an
-// operation with no consistency level gets the config default.
-func TestCoordinator_ExecuteOperation_AppliesDefaultConsistency(t *testing.T) {
+// TestCoordinator_ExecuteOperation_RejectsPreconditionOnNonPut verifies that a precondition attached
+// to anything but a put is refused rather than ignored.
+//
+// Ignoring it is the dangerous outcome and the one worth a test: a caller that means "delete only if
+// unchanged" and gets an unconditional delete has no way to find out. So this asserts the fail-closed
+// direction — an error, wrapping types.ErrInvalidPrecondition, and the backend untouched.
+//
+// It replaced TestCoordinator_ExecuteOperation_AppliesDefaultConsistency, which asserted that an
+// operation with no consistency level was assigned config.ConsistencyLevel. That is the defaulting
+// #284 deleted: the level it filled in selected how many nodes issued the same unconditional PUT, and
+// the test could not tell whether the value it read back had any effect.
+func TestCoordinator_ExecuteOperation_RejectsPreconditionOnNonPut(t *testing.T) {
 	t.Parallel()
-	cm := makeClusterWithNode(t, "def-cons-node")
-	op := &DistributedOperation{
-		Type: OpTypeGet,
-		Key:  "k",
-		// Consistency intentionally empty
-	}
 
-	_, _ = cm.coordinator.ExecuteOperation(context.Background(), op)
+	for _, opType := range []OperationType{OpTypeGet, OpTypeDelete, OpTypeList} {
+		t.Run(string(opType), func(t *testing.T) {
+			t.Parallel()
 
-	want := ConsistencyLevel(cm.coordinator.config.ConsistencyLevel)
-	if op.Consistency != want {
-		t.Errorf("Consistency = %q, want %q (config default)", op.Consistency, want)
+			cm := makeClusterWithBackend(t, "precond-"+string(opType))
+
+			result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
+				Type:         opType,
+				Key:          "k",
+				Precondition: types.Precondition{ETag: `"abc"`},
+			})
+			if err == nil {
+				t.Fatalf("ExecuteOperation returned nil error for a precondition on %s: it must be "+
+					"refused, never silently dropped", opType)
+			}
+			if !errors.Is(err, types.ErrInvalidPrecondition) {
+				t.Errorf("error %v does not wrap types.ErrInvalidPrecondition", err)
+			}
+			if result == nil {
+				t.Fatal("result is nil; the caller needs the reason as well as the error")
+			}
+			if result.Success {
+				t.Error("result.Success = true for a rejected operation")
+			}
+			if !strings.Contains(result.Error, string(opType)) {
+				t.Errorf("result.Error = %q should name the operation type", result.Error)
+			}
+		})
 	}
 }
 
@@ -209,9 +237,8 @@ func TestCoordinator_ExecuteOperation_AppliesDefaultTimeout(t *testing.T) {
 	t.Parallel()
 	cm := makeClusterWithNode(t, "def-timeout-node")
 	op := &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeGet,
+		Key:  "k",
 		// Timeout intentionally zero
 	}
 
@@ -228,9 +255,8 @@ func TestCoordinator_ExecuteOperation_AppliesDefaultRetries(t *testing.T) {
 	t.Parallel()
 	cm := makeClusterWithNode(t, "def-retry-node")
 	op := &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeGet,
+		Key:  "k",
 		// Retries intentionally zero
 	}
 
@@ -241,16 +267,20 @@ func TestCoordinator_ExecuteOperation_AppliesDefaultRetries(t *testing.T) {
 	}
 }
 
-// TestCoordinator_ExecuteOperation_EventualConsistency_Get verifies a
-// successful GET with eventual consistency returns a result with data.
-func TestCoordinator_ExecuteOperation_EventualConsistency_Get(t *testing.T) {
+// TestCoordinator_ExecuteOperation_Get verifies a successful GET returns a result with data, a
+// latency, and the node that served it.
+//
+// This is one test where there were four. Three of them — _EventualConsistency_Get,
+// _SessionConsistency and _StrongConsistency — issued the same GET at the same three levels and
+// asserted result.Success, which is what the levels being three names for one behavior looks like
+// from the test side: none of them could have failed while the others passed.
+func TestCoordinator_ExecuteOperation_Get(t *testing.T) {
 	t.Parallel()
-	cm := makeClusterWithBackend(t, "ev-get-node")
+	cm := makeClusterWithBackend(t, "get-node")
 
 	result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "mykey",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeGet,
+		Key:  "mykey",
 	})
 	if err != nil {
 		t.Fatalf("ExecuteOperation: %v", err)
@@ -267,19 +297,20 @@ func TestCoordinator_ExecuteOperation_EventualConsistency_Get(t *testing.T) {
 	if result.CompletedAt.IsZero() {
 		t.Error("result.CompletedAt should not be zero")
 	}
+	if len(result.NodeResults) != 1 {
+		t.Errorf("len(NodeResults) = %d, want 1: one node performs the operation", len(result.NodeResults))
+	}
 }
 
-// TestCoordinator_ExecuteOperation_EventualConsistency_Put verifies a
-// successful PUT with eventual consistency.
-func TestCoordinator_ExecuteOperation_EventualConsistency_Put(t *testing.T) {
+// TestCoordinator_ExecuteOperation_Put verifies a successful unconditional PUT.
+func TestCoordinator_ExecuteOperation_Put(t *testing.T) {
 	t.Parallel()
-	cm := makeClusterWithBackend(t, "ev-put-node")
+	cm := makeClusterWithBackend(t, "put-node")
 
 	result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypePut,
-		Key:         "mykey",
-		Data:        []byte("hello"),
-		Consistency: ConsistencyEventual,
+		Type: OpTypePut,
+		Key:  "mykey",
+		Data: []byte("hello"),
 	})
 	if err != nil {
 		t.Fatalf("ExecuteOperation: %v", err)
@@ -287,46 +318,200 @@ func TestCoordinator_ExecuteOperation_EventualConsistency_Put(t *testing.T) {
 	if !result.Success {
 		t.Errorf("result.Success = false, error: %s", result.Error)
 	}
-}
-
-// TestCoordinator_ExecuteOperation_SessionConsistency verifies session
-// consistency returns a result from the primary node.
-func TestCoordinator_ExecuteOperation_SessionConsistency(t *testing.T) {
-	t.Parallel()
-	cm := makeClusterWithBackend(t, "sess-node")
-
-	result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencySession,
-	})
-	if err != nil {
-		t.Fatalf("ExecuteOperation: %v", err)
-	}
-	if !result.Success {
-		t.Errorf("result.Success = false, error: %s", result.Error)
-	}
-	if len(result.NodeResults) == 0 {
-		t.Error("NodeResults should contain at least one entry")
+	if result.Conditional != "" {
+		t.Errorf("result.Conditional = %q, want empty for an unconditional write", result.Conditional)
 	}
 }
 
-// TestCoordinator_ExecuteOperation_StrongConsistency verifies that strong
-// consistency succeeds with a single alive node (majority = 1).
-func TestCoordinator_ExecuteOperation_StrongConsistency(t *testing.T) {
-	t.Parallel()
-	cm := makeClusterWithBackend(t, "strong-node")
+// makeClusterWithRealBackend is makeClusterWithBackend against a real S3 backend on an in-process
+// substrate endpoint, which is what a conditional write needs: mockBackend answers PutObjectIf with
+// types.ErrNotSupported on purpose, so a CAS cannot be exercised against it. The returned server is
+// the same one the cluster writes to, so a test can read the stored bytes back and count requests.
+func makeClusterWithRealBackend(t *testing.T, nodeID string) (*ClusterManager, *testaws.TestServer) {
+	t.Helper()
+	cm := makeClusterWithNode(t, nodeID)
+	srv := testaws.Start(t)
+	cm.SetBackend(srv.Backend())
+	return cm, srv
+}
 
-	result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypeGet,
-		Key:         "k",
-		Consistency: ConsistencyStrong,
+// TestCoordinator_ExecuteOperation_ConcurrentUpdate_OneWriterWins is the test #284 exists for: two
+// coordinators read the same object and both try to replace it, each asserting the ETag it read.
+//
+// Exactly one must succeed. The loser must get types.ErrPreconditionFailed and must not have written,
+// so the stored bytes are one writer's and not a splice or the loser's. Under the taxonomy this
+// replaced there was no test that could state this: `consistency_level: strong` issued the same
+// unconditional PutObject the other two levels did, N times, and the last writer won silently.
+func TestCoordinator_ExecuteOperation_ConcurrentUpdate_OneWriterWins(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const key = "cas/contended"
+	cmA, srv := makeClusterWithRealBackend(t, "cas-a")
+	srv.PutObject(key, []byte("v0"))
+
+	// A second coordinator over the *same* endpoint, so both writes race one key in one bucket. A
+	// second substrate server would give each its own object and the race could not happen.
+	cmB := makeClusterWithNode(t, "cas-b")
+	cmB.SetBackend(srv.Backend())
+
+	info, err := srv.Backend().HeadObject(ctx, key)
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+	if info.ETag == "" {
+		t.Fatal("HeadObject returned an empty ETag: there is nothing for a CAS to assert on")
+	}
+
+	type outcome struct {
+		body string
+		res  *OperationResult
+		err  error
+	}
+	results := make(chan outcome, 2)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	for _, w := range []struct {
+		cm   *ClusterManager
+		body string
+	}{{cmA, "written-by-a"}, {cmB, "written-by-b"}} {
+		go func() {
+			start.Wait()
+			res, err := w.cm.coordinator.ExecuteOperation(ctx, &DistributedOperation{
+				Type:         OpTypePut,
+				Key:          key,
+				Data:         []byte(w.body),
+				Precondition: types.Precondition{ETag: info.ETag},
+			})
+			results <- outcome{w.body, res, err}
+		}()
+	}
+	start.Done()
+
+	var winners, losers []outcome
+	for range 2 {
+		o := <-results
+		switch {
+		case o.err == nil && o.res.Success:
+			winners = append(winners, o)
+		case errors.Is(o.err, types.ErrPreconditionFailed):
+			losers = append(losers, o)
+		default:
+			t.Errorf("writer %q neither won nor lost on the precondition: err=%v result=%+v",
+				o.body, o.err, o.res)
+		}
+	}
+
+	if len(winners) != 1 {
+		t.Fatalf("%d writers succeeded, want exactly 1: both asserted the same ETag, so the second "+
+			"must be refused — two successes is a lost update", len(winners))
+	}
+	if len(losers) != 1 {
+		t.Fatalf("%d writers were refused, want exactly 1", len(losers))
+	}
+
+	won := winners[0]
+	if won.res.ETag == "" {
+		t.Error("the winning result carries no ETag: a CAS loop cannot continue without the new version")
+	}
+	if won.res.ETag == info.ETag {
+		t.Errorf("the winning ETag %q equals the pre-write ETag: the write did not change the version",
+			won.res.ETag)
+	}
+	if got := string(srv.GetObject(key)); got != won.body {
+		t.Errorf("stored bytes are %q, want %q from the writer that succeeded", got, won.body)
+	}
+
+	lost := losers[0]
+	if lost.res != nil && lost.res.Conditional != ConditionalLost {
+		t.Errorf("refused writer reports Conditional = %q, want %q",
+			lost.res.Conditional, ConditionalLost)
+	}
+}
+
+// TestCoordinator_ExecuteOperation_ETagOrdering verifies that each conditional write reports the ETag
+// of what it just stored, and that chaining a CAS from that ETag succeeds while replaying a stale one
+// fails. That is the whole contract a caller needs to build a read-modify-write loop, and it is what
+// the coordinator could not express before #284: PutObject returned no ETag at all.
+func TestCoordinator_ExecuteOperation_ETagOrdering(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const key = "cas/chain"
+	cm, srv := makeClusterWithRealBackend(t, "etag-chain")
+
+	// Create it with an if-absent write, which is how a caller takes a key nobody holds.
+	created, err := cm.coordinator.ExecuteOperation(ctx, &DistributedOperation{
+		Type:         OpTypePut,
+		Key:          key,
+		Data:         []byte("gen-1"),
+		Precondition: types.Precondition{Absent: true},
 	})
 	if err != nil {
-		t.Fatalf("ExecuteOperation: %v", err)
+		t.Fatalf("if-absent create: %v", err)
 	}
-	if !result.Success {
-		t.Errorf("result.Success = false, error: %s", result.Error)
+	if created.ETag == "" {
+		t.Fatal("create returned no ETag")
+	}
+
+	// A second if-absent write must fail: the key is no longer absent.
+	if _, err := cm.coordinator.ExecuteOperation(ctx, &DistributedOperation{
+		Type:         OpTypePut,
+		Key:          key,
+		Data:         []byte("gen-1-again"),
+		Precondition: types.Precondition{Absent: true},
+	}); !errors.Is(err, types.ErrPreconditionFailed) {
+		t.Errorf("second if-absent write: err = %v, want types.ErrPreconditionFailed", err)
+	}
+
+	// Chain forward from the reported ETag. Each generation asserts the previous one and must be
+	// accepted, and must report a *different* ETag than the one it asserted.
+	etags := []string{created.ETag}
+	for gen := 2; gen <= 4; gen++ {
+		body := fmt.Sprintf("gen-%d", gen)
+		prev := etags[len(etags)-1]
+
+		res, err := cm.coordinator.ExecuteOperation(ctx, &DistributedOperation{
+			Type:         OpTypePut,
+			Key:          key,
+			Data:         []byte(body),
+			Precondition: types.Precondition{ETag: prev},
+		})
+		if err != nil {
+			t.Fatalf("CAS from the ETag the previous write reported (%s): %v", prev, err)
+		}
+		if res.ETag == "" {
+			t.Fatalf("%s stored but reported no ETag, so the chain cannot continue", body)
+		}
+		if res.ETag == prev {
+			t.Errorf("%s reports the ETag it asserted (%s); a changed object has a new version",
+				body, prev)
+		}
+		etags = append(etags, res.ETag)
+	}
+
+	if got := string(srv.GetObject(key)); got != "gen-4" {
+		t.Errorf("stored bytes are %q, want %q: the accepted chain is what the object should hold", got, "gen-4")
+	}
+
+	// Every ETag in the chain but the last is now stale, and asserting any of them must be refused —
+	// including the one two writes back, not merely the immediately previous one.
+	for i, stale := range etags[:len(etags)-1] {
+		if _, err := cm.coordinator.ExecuteOperation(ctx, &DistributedOperation{
+			Type:         OpTypePut,
+			Key:          key,
+			Data:         []byte("from-a-stale-read"),
+			Precondition: types.Precondition{ETag: stale},
+		}); !errors.Is(err, types.ErrPreconditionFailed) {
+			t.Errorf("write asserting generation %d's stale ETag %s: err = %v, want "+
+				"types.ErrPreconditionFailed", i+1, stale, err)
+		}
+	}
+
+	if got := string(srv.GetObject(key)); got != "gen-4" {
+		t.Errorf("stored bytes are %q after the refused writes, want %q: a refused CAS must not write",
+			got, "gen-4")
 	}
 }
 
@@ -346,7 +531,6 @@ func TestCoordinator_ExecuteOperation_ExplicitTargetNodes(t *testing.T) {
 	result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
 		Type:        OpTypeGet,
 		Key:         "k",
-		Consistency: ConsistencyEventual,
 		TargetNodes: []string{"target-1"},
 	})
 	if err != nil {
@@ -368,9 +552,8 @@ func TestCoordinator_ExecuteOperation_ListUsesLeader(t *testing.T) {
 	cm.SetLeader("list-node")
 
 	result, err := cm.coordinator.ExecuteOperation(context.Background(), &DistributedOperation{
-		Type:        OpTypeList,
-		Key:         "prefix/",
-		Consistency: ConsistencyEventual,
+		Type: OpTypeList,
+		Key:  "prefix/",
 	})
 	if err != nil {
 		t.Fatalf("ExecuteOperation: %v", err)
@@ -392,10 +575,18 @@ func TestCoordinator_GetStats_Structure(t *testing.T) {
 	if stats == nil {
 		t.Fatal("GetStats() returned nil")
 	}
-	for _, key := range []string{"active_operations", "replication", "load_balancer"} {
+	for _, key := range []string{"active_operations", "load_balancer"} {
 		if _, ok := stats[key]; !ok {
 			t.Errorf("stats missing key %q", key)
 		}
+	}
+
+	// And it must not report a "replication" key. #284 deleted the CacheReplicator whose six counters
+	// that key carried; asserting its absence is what stops the map from growing the key back with a
+	// zero value, which would read as "no replication happened" rather than "no such subsystem".
+	if _, ok := stats["replication"]; ok {
+		t.Error(`stats has a "replication" key: the CacheReplicator it reported was deleted in #284, ` +
+			`and it counted peers re-uploading an object to itself — incremented even when nothing was sent`)
 	}
 }
 
@@ -450,7 +641,6 @@ func TestCoordinator_ExecuteOperation_TwoNodes_RealUDP(t *testing.T) {
 	result, err := cm1.coordinator.ExecuteOperation(ctx, &DistributedOperation{
 		Type:        OpTypeGet,
 		Key:         "remote-key",
-		Consistency: ConsistencyEventual,
 		Timeout:     5 * time.Second,
 		TargetNodes: []string{"coord-node-b"},
 	})
@@ -1020,7 +1210,113 @@ func TestClusterManager_InvalidateCacheKey_NoGossip(t *testing.T) {
 	mc := &mockCache{}
 	cm.SetCache(mc)
 	// gossip.conn is nil (Start not called) — should not panic
-	cm.InvalidateCacheKey("foo")
+	cm.InvalidateCacheKey("foo", `"etag-1"`)
+}
+
+// TestGossip_CacheInvalidate_AppliesEachVersionOnce is requirement R4: an invalidation naming a
+// version already applied is discarded, and one naming a new version is applied.
+//
+// The receive path is exercised directly rather than over UDP, because what is under test is the
+// ledger and not the transport — TestClusterManager_CacheInvalidation_TwoNodes covers the wire. Going
+// over gossip here would make the assertion depend on retransmission timing, which is exactly the
+// nondeterminism the ledger exists to absorb.
+func TestGossip_CacheInvalidate_AppliesEachVersionOnce(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "inval-ledger")
+	mc := &mockCache{}
+	cm.SetCache(mc)
+
+	send := func(m CacheInvalidateMessage) {
+		t.Helper()
+		payload, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		cm.gossip.handleCacheInvalidate(&GossipMessage{
+			Type: MessageTypeCacheInvalidate,
+			From: "peer",
+			Data: payload,
+		})
+	}
+	deletes := func() []string {
+		mc.mu.Lock()
+		defer mc.mu.Unlock()
+
+		return slices.Clone(mc.deleted)
+	}
+
+	// The first invalidation for a version is applied; a retransmission of it is not. Gossip
+	// retransmits by design, so this arrives more than once whether or not anything is wrong.
+	send(CacheInvalidateMessage{Key: "k", ETag: `"v1"`})
+	send(CacheInvalidateMessage{Key: "k", ETag: `"v1"`})
+	if got := deletes(); !slices.Equal(got, []string{"k"}) {
+		t.Fatalf("deleted = %v, want one delete: a retransmitted invalidation for a version already "+
+			"applied must be discarded", got)
+	}
+
+	// A different version of the same key is a different write and is applied.
+	send(CacheInvalidateMessage{Key: "k", ETag: `"v2"`})
+	if got := deletes(); !slices.Equal(got, []string{"k", "k"}) {
+		t.Fatalf("deleted = %v, want two deletes: %q is a later write than %q", got, `"v2"`, `"v1"`)
+	}
+
+	// Replaying the superseded version must not evict again. This is the case the ETag exists for: the
+	// bytes this node holds may have been re-cached after v2, and applying v1's invalidation now would
+	// throw them away.
+	send(CacheInvalidateMessage{Key: "k", ETag: `"v1"`})
+	if got := deletes(); len(got) != 2 {
+		t.Errorf("deleted = %v, want the replay of %q discarded: it names a version already superseded",
+			got, `"v1"`)
+	}
+
+	// A different key with the same ETag string is a different entry. ETags are per-object, so a
+	// ledger keyed on the ETag alone would suppress a real invalidation here.
+	send(CacheInvalidateMessage{Key: "other", ETag: `"v1"`})
+	if got := deletes(); !slices.Contains(got, "other") {
+		t.Errorf("deleted = %v, want an eviction of \"other\": the ledger is keyed per key", got)
+	}
+
+	// An invalidation naming no version is applied every time. A delete has no ETag to name, and
+	// remembering "no version" as a version would drop every invalidation for a key after the first.
+	before := len(deletes())
+	send(CacheInvalidateMessage{Key: "k", Deleted: true})
+	send(CacheInvalidateMessage{Key: "k", Deleted: true})
+	if got := deletes(); len(got) != before+2 {
+		t.Errorf("deleted = %v, want both unversioned invalidations applied: evicting what you hold is "+
+			"always safe, and suppressing them would leave a deleted key cached", got)
+	}
+}
+
+// TestGossip_MarkInvalidationApplied_LedgerIsBounded verifies the ledger drops entries rather than
+// growing with every key the cluster has ever written, and that dropping costs at most a redundant
+// eviction.
+func TestGossip_MarkInvalidationApplied_LedgerIsBounded(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "inval-bound")
+
+	for i := range maxInvalidationLedger * 2 {
+		cm.gossip.markInvalidationApplied(fmt.Sprintf("key-%d", i), `"v1"`)
+	}
+
+	cm.gossip.mu.RLock()
+	size := len(cm.gossip.appliedInvalidations)
+	cm.gossip.mu.RUnlock()
+
+	if size > maxInvalidationLedger {
+		t.Errorf("ledger holds %d entries after %d distinct keys, want at most %d: unbounded growth is "+
+			"a leak proportional to every key the cluster has written",
+			size, maxInvalidationLedger*2, maxInvalidationLedger)
+	}
+
+	// And the most recent key is still remembered, so eviction drops old entries rather than refusing
+	// new ones — a ledger that stopped recording once full would apply every duplicate from then on.
+	recent := fmt.Sprintf("key-%d", maxInvalidationLedger*2-1)
+	if first := cm.gossip.markInvalidationApplied(recent, `"v1"`); first {
+		t.Errorf("the ledger forgot %s, the key it recorded last: eviction must drop the oldest "+
+			"entries, not decline to record new ones", recent)
+	}
 }
 
 // TestClusterManager_CacheInvalidation_TwoNodes verifies that
@@ -1073,7 +1369,7 @@ func TestClusterManager_CacheInvalidation_TwoNodes(t *testing.T) {
 	}
 	cm1.gossip.mu.Unlock()
 
-	cm1.InvalidateCacheKey("foo")
+	cm1.InvalidateCacheKey("foo", `"etag-1"`)
 
 	// Wait up to 200ms for the message to arrive and be processed.
 	deadline := time.Now().Add(200 * time.Millisecond)

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -9,26 +9,25 @@ the coordination mechanisms needed for multi-node deployments.
 
 ⚠️ WARNING: experimental, and narrower than this document's structure implies. Not for production.
 
-Read [#Consistency Levels] before relying on anything here. The short version is that the consensus
-engine elects leaders and replicates nothing — applyLogEntry has three empty arms and no caller
-appends an operation entry — and that the coordinator's data path calls the backend directly without
-consulting the log, the commit index, the term, or leadership.
+Read [#Conditional Writes] before relying on anything here. The short version is that the consensus
+engine elects leaders and replicates nothing — applyLogEntry has no state machine to apply anything
+to — and that the coordinator's data path calls the backend directly without consulting the log, the
+commit index, the term, or leadership.
 
 That is not going to be built out. As of 2026-08-03 the direction is per-key S3 compare-and-swap:
 docs/design/conditional-writes-vs-raft.md (#169) was adopted, on the grounds that Raft replicates a
 log so N nodes can agree on state they each hold a copy of, and these nodes hold no such state — the
 bucket does. The Raft issues are closed (#128, #130, #133, #151) and the replacement is filed as #282
-(Backend.PutObjectIf), #283 (a lease over it), #284 (removing the fan-out and this taxonomy) and #285
-(verifying non-AWS backends).
+(Backend.PutObjectIf), #283 (a lease over it), #284 (removing the fan-out and the consistency
+taxonomy) and #285 (verifying non-AWS backends).
 
-So what is below describes code that exists and will shrink, not a design being completed. The
-consistency levels in particular are on their way out via #284; gossip-based membership and leader
-election stay.
+So what is below describes code that exists and has shrunk, not a design being completed.
+Gossip-based membership and leader election stay.
 
 Architecture
 
 	┌──────────────────────────────────────────────────┐
-	│           Coordinator (Operation Manager)         │  - Executes distributed operations                │  - Enforces consistency levels                    │  - Manages operation lifecycle                    │
+	│           Coordinator (Operation Manager)         │  - Executes distributed operations                │  - Evaluates preconditions at the store           │  - Manages operation lifecycle                    │
 	└────────┬──────────────────┬──────────────────────┘
 	         │
 	    ┌────▼─────┐      ┌─────▼──────┐
@@ -42,63 +41,63 @@ Architecture
 # Core Components
 
 1. ClusterManager: Manages cluster membership, node health, and leader election
-2. Coordinator: Executes distributed operations with configurable consistency
+2. Coordinator: Executes one operation on one node, conditionally when asked
 3. GossipProtocol: Handles node-to-node communication and state synchronization
-4. ConsensusEngine: Implements consensus for critical cluster decisions
+4. ConsensusEngine: Elects a leader; see the warning above for what it does not do
 
-# Consistency Levels
+# Conditional Writes
 
-Three levels are accepted, and this section says what each one does rather than what it is named
-after, because the names promise guarantees the code does not provide.
+An operation is executed once, by one node. When it is a put and carries a
+[DistributedOperation.Precondition], the store evaluates that precondition and refuses the write if
+it does not hold — so the exclusion is done by S3, on the one request, and not by counting nodes.
 
-Whichever level is used, a failed operation is reported both ways: [Coordinator.ExecuteOperation]
-returns a non-nil error and an [OperationResult] with Success false, and the error carries the same
-text as OperationResult.Error. Checking either is sufficient. Until v0.11.0 it was not — the
-executors reported failure only in the result and returned a nil error, so a caller checking err
-alone saw a success, which is what [ClusterManager.DistributeOperation] did when incrementing its
-own counters (#269).
-
-The reason they cannot provide them is structural, not a missing feature: every node in a cluster
-writes the same key in the same bucket. S3 is the single copy. So "replicate to the other nodes"
-means issuing the same PUT again from another node, and a majority of nodes reporting success means
-a majority could reach S3 — it says nothing about ordering, isolation, or what a subsequent read
-returns. The levels therefore differ in how many redundant identical requests are issued and whether
-the caller waits for them.
-
-Eventual (default) — one node executes; the others re-issue the same operation in the background.
-
-	op := &distributed.DistributedOperation{
-		Type:        distributed.OpTypePut,
-		Key:         "cache/data.bin",
-		Data:        data,
-		Consistency: distributed.ConsistencyEventual,
-	}
-	result, err := coordinator.ExecuteOperation(ctx, op)
-
-Session — the first target node executes, then the rest re-issue in the background. Identical to
-Eventual except for preferring targetNodes[0], and it does not provide read-your-writes: the
-guarantee that name refers to comes from reading through the write buffer, which internal/vfs does
-per descriptor and this package is not involved in.
-
-	op := &distributed.DistributedOperation{
-		Type:        distributed.OpTypeGet,
-		Key:         "session/user123",
-		Consistency: distributed.ConsistencySession,
+	// Take a key nobody holds. Two callers racing this: exactly one succeeds.
+	created, err := coordinator.ExecuteOperation(ctx, &distributed.DistributedOperation{
+		Type:         distributed.OpTypePut,
+		Key:          "cluster/owner",
+		Data:         []byte(nodeID),
+		Precondition: types.Precondition{Absent: true},
+	})
+	if errors.Is(err, types.ErrPreconditionFailed) {
+		// Somebody else holds it. Re-read and decide; do not retry blindly.
 	}
 
-Strong — every target node executes concurrently and the call succeeds once a majority reports
-success. This is N identical PUTs of the same bytes to one key, so it is a reachability signal and
-not linearizability, which this document claimed until v0.11.0. What it buys over Eventual is that
-the caller learns of a failure synchronously; what it costs is N times the requests. A genuinely
-linearizable single-key write is available from S3 itself, via a conditional write — see
-docs/design/conditional-writes-vs-raft.md (#169).
+	// Replace it only if it still holds what we read. created.ETag is the version to assert next.
+	_, err = coordinator.ExecuteOperation(ctx, &distributed.DistributedOperation{
+		Type:         distributed.OpTypePut,
+		Key:          "cluster/owner",
+		Data:         []byte(successor),
+		Precondition: types.Precondition{ETag: created.ETag},
+	})
 
-	op := &distributed.DistributedOperation{
-		Type:        distributed.OpTypePut,
-		Key:         "config/settings.yaml",
-		Data:        configData,
-		Consistency: distributed.ConsistencyStrong,
-	}
+A refused write reports [ConditionalLost] in [OperationResult.Conditional] and wraps
+[types.ErrPreconditionFailed] in the error, and nothing was written. It is not retried internally and
+must not be: the answer is definitive, and the recovery is to re-read, recompute and CAS again, which
+only the caller can do because only it knows what the new bytes should be. A precondition on anything
+but a put is refused with [types.ErrInvalidPrecondition] rather than dropped.
+
+An endpoint that does not evaluate preconditions reports [ConditionalUnsupported] and writes nothing.
+A caller that needs mutual exclusion must stop there — falling back to an unconditional write turns
+the one guarantee this package offers into a last-writer-wins overwrite. #285 tracks which non-AWS
+backends evaluate them.
+
+Whether the operation was conditional or not, a failure is reported both ways:
+[Coordinator.ExecuteOperation] returns a non-nil error and an [OperationResult] with Success false,
+and the error carries the same text as OperationResult.Error. Checking either is sufficient. Until
+v0.11.0 it was not — the executors reported failure only in the result and returned a nil error, so a
+caller checking err alone saw a success, which is what [ClusterManager.DistributeOperation] did when
+incrementing its own counters (#269).
+
+There was a "Consistency Levels" section here, documenting `ConsistencyEventual`, `ConsistencySession`
+and `ConsistencyStrong` with an example each. #284 deleted the type and this section with it. All three
+issued the same unconditional PutObject and differed only in how many nodes issued it and whether the
+caller waited, so what an operator picked changed the request count and not the guarantee — Strong in
+particular was N identical PUTs of the same bytes to one key, which this document called
+"linearizable" until v0.11.0 and which is a reachability signal. The reason no level could provide
+what it named is structural rather than a missing feature: every node writes the same key in the same
+bucket, and S3 holds the single copy, so "replicate to the other nodes" means issuing the same PUT
+again from somewhere else. What replaced the taxonomy is per-operation instead of per-mount, and is
+evaluated by the store rather than voted on.
 
 # Gossip Authentication
 
@@ -143,7 +142,6 @@ Basic cluster configuration:
 			"192.168.1.12:8080",
 		},
 		ReplicationFactor: 3,
-		ConsistencyLevel:  "eventual",
 
 		// Required. The same file, with the same contents, on every node.
 		SecretFile: "/etc/objectfs/cluster.secret",
@@ -179,15 +177,16 @@ Basic cluster configuration:
 
 Execute operations across the cluster:
 
-	// Write operation
+	// Write operation. No Precondition, so this is an unconditional put: last writer wins,
+	// which is what an uncoordinated write to S3 has always been. Set Precondition when the
+	// write is only correct if something about the key still holds -- see [#Conditional Writes].
 	writeOp := &distributed.DistributedOperation{
-		ID:          "write-123",
-		Type:        distributed.OpTypePut,
-		Key:         "objects/file.dat",
-		Data:        fileData,
-		Consistency: distributed.ConsistencyStrong,
-		Timeout:     30 * time.Second,
-		Retries:     3,
+		ID:      "write-123",
+		Type:    distributed.OpTypePut,
+		Key:     "objects/file.dat",
+		Data:    fileData,
+		Timeout: 30 * time.Second,
+		Retries: 3,
 	}
 	result, err := coordinator.ExecuteOperation(ctx, writeOp)
 	if err != nil {
@@ -196,9 +195,8 @@ Execute operations across the cluster:
 
 	// Read operation
 	readOp := &distributed.DistributedOperation{
-		Type:        distributed.OpTypeGet,
-		Key:         "objects/file.dat",
-		Consistency: distributed.ConsistencyEventual,
+		Type: distributed.OpTypeGet,
+		Key:  "objects/file.dat",
 	}
 	result, err = coordinator.ExecuteOperation(ctx, readOp)
 	if result.Success {
@@ -238,17 +236,15 @@ Latency Based (StrategyLatencyBased):
 
 # Cache Replication
 
-The CacheReplicator handles asynchronous cache synchronization:
+There is none, and this section documented one. #284 deleted the CacheReplicator, so
+[Coordinator.GetStats] no longer has a "replication" key and the type assertion shown here would
+panic; ReplicationStats and its BytesReplicated counter are gone with it.
 
-	// Replication happens automatically for write operations
-	// with replication factor > 1
-
-	// Monitor replication status
-	stats := coordinator.GetStats()
-	replicationStats := stats["replication"].(distributed.ReplicationStats)
-	log.Printf("Replicated: %d bytes, Active: %d tasks",
-		replicationStats.BytesReplicated,
-		replicationStats.ActiveTasks)
+What that subsystem did was send N-1 peers a put of an object's own bytes back to the same key in the
+same bucket, which is a billed request that changes nothing. Worse, when gossip was not running it
+sent nothing at all and added the byte count to BytesReplicated anyway, so the throughput it reported
+was of work that had not happened. Warming a peer's *local* cache is a different thing and is real
+work; it is filed as #141.
 
 # Cluster Health Monitoring
 
@@ -387,8 +383,7 @@ ClusterConfig controls all distributed system behavior:
 		ListenAddr        string            // Bind address
 		AdvertiseAddr     string            // Advertised address
 		SeedNodes         []string          // Bootstrap nodes
-		ReplicationFactor int               // Data replication count
-		ConsistencyLevel  string            // Default consistency
+		ReplicationFactor int               // How many nodes selectTargetNodes returns; the first executes
 		GossipInterval    time.Duration     // Gossip frequency
 		FailureTimeout    time.Duration     // Failure detection timeout
 		ElectionTimeout   time.Duration     // Leader election timeout
@@ -398,28 +393,35 @@ ClusterConfig controls all distributed system behavior:
 
 # Best Practices
 
-1. Consistency Trade-offs
-Choose the appropriate consistency level for each operation. Don't use strong
-consistency for operations that don't require it.
+1. Attach a Precondition to a Write That Is Only Correct If Something Still Holds
+Read-modify-write, claiming a key, and advancing a version all need one; a plain overwrite does not.
+The cost is nothing -- it is the same single request -- and what it buys is that a concurrent writer
+is refused rather than silently overwriting. Never retry a refused precondition without re-reading:
+the answer is definitive, so retrying the same bytes either fails again or clobbers whoever won.
+
+This item replaced "Consistency Trade-offs", which advised not using strong consistency where it was
+not needed. The three levels differed in request count and not in guarantee, so the advice was sound
+in shape and about a knob that selected nothing.
 
 2. Replication Factor
-Set replication factor based on:
-- Data criticality (higher for important data)
-- Cluster size (typically 3 for small clusters)
-- Read/write ratio (higher for read-heavy workloads)
+This is a selection width, not a number of copies. [Coordinator.selectTargetNodes] returns this many
+nodes and [Coordinator.executeOnce] uses the first; the rest are the preference order a strategy that
+genuinely needed peers would consume. Raising it does not make more copies of the bytes -- S3 holds
+the one copy -- so set it for routing preference, not durability.
 
 3. Network Partitions
-Plan for network partitions:
-- Use quorum-based operations
-- Implement proper timeout handling
-- Design for eventual consistency where possible
+A partition does not divide the data, because the data is not here. A node cut off from its peers
+loses membership and leader election; its reads and writes still go to S3, and a precondition is
+still evaluated by S3, so mutual exclusion survives a partition that consensus would not. What to
+plan for is timeouts and a stale membership view, not a split copy of the bytes.
 
 4. Monitoring
 Monitor cluster health metrics:
-- Node availability
-- Replication lag
-- Operation latency
-- Load imbalance
+  - Node availability
+  - Operation latency
+  - Load imbalance
+  - Refused conditional writes -- a rising [ConditionalLost] rate is contention, and a single
+    [ConditionalUnsupported] means the endpoint does not exclude anybody and nothing was written
 
 5. Testing
 Test failure scenarios:
@@ -459,10 +461,12 @@ Example: Complete Cluster Setup
 
 	import (
 		"context"
+		"errors"
 		"log"
 		"time"
 
 		"github.com/scttfrdmn/objectfs/internal/distributed"
+		"github.com/scttfrdmn/objectfs/pkg/types"
 	)
 
 	func main() {
@@ -472,7 +476,6 @@ Example: Complete Cluster Setup
 			AdvertiseAddr:     "192.168.1.10:8080",
 			SeedNodes:         []string{"192.168.1.11:8080"},
 			ReplicationFactor: 3,
-			ConsistencyLevel:  "eventual",
 			GossipInterval:    time.Second,
 			HeartbeatInterval: time.Second,
 			SecretFile:        "/etc/objectfs/cluster.secret",
@@ -501,22 +504,26 @@ Example: Complete Cluster Setup
 		}
 		defer coordinator.Stop()
 
-		// Execute distributed operation
+		// Execute a distributed operation. Conditional on the key being absent, so if another
+		// node in this cluster runs the same code, exactly one of them creates it and the rest
+		// get types.ErrPreconditionFailed. Drop Precondition for a plain last-writer-wins put.
 		op := &distributed.DistributedOperation{
-			Type:        distributed.OpTypePut,
-			Key:         "test-key",
-			Data:        []byte("test-value"),
-			Consistency: distributed.ConsistencyStrong,
+			Type:         distributed.OpTypePut,
+			Key:          "test-key",
+			Data:         []byte("test-value"),
+			Precondition: types.Precondition{Absent: true},
 		}
 
 		result, err := coordinator.ExecuteOperation(ctx, op)
-		if err != nil {
+		switch {
+		case errors.Is(err, types.ErrPreconditionFailed):
+			log.Printf("another node created test-key first")
+		case err != nil:
 			log.Fatal(err)
-		}
-
-		if result.Success {
-			log.Printf("Operation succeeded on %d nodes",
-				len(result.NodeResults))
+		default:
+			// The ETag of what was just stored, which is the version a follow-on
+			// compare-and-swap asserts.
+			log.Printf("created test-key, etag %s", result.ETag)
 		}
 
 # See Also

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -31,7 +31,29 @@ type GossipProtocol struct {
 	// port lets any host on the network join the cluster and announce ownership of cached
 	// objects. See auth.go.
 	auth *messageAuthenticator
+
+	// appliedInvalidations is the set of (key, ETag) cache invalidations already applied, guarded by mu
+	// and bounded by maxInvalidationLedger. See [GossipProtocol.markInvalidationApplied]. Lazily
+	// created, because a cluster with no cache injected never touches it.
+	//
+	// A set rather than a map of key to latest ETag, which is what this was first written as and which
+	// was wrong in a way only a test caught: holding just the latest version suppresses a
+	// retransmission of it but *applies* a replay of the version before it, since an older ETag differs
+	// from the stored one and ETags carry no order to compare. Remembering every version applied is
+	// what makes both cases idempotent.
+	appliedInvalidations map[string]struct{}
 }
+
+// maxInvalidationLedger bounds [GossipProtocol.appliedInvalidations].
+//
+// 4096 (key, ETag) entries at roughly a key string plus a 34-byte quoted ETag is a few hundred
+// kilobytes, which is nothing beside the cache the ledger protects, and it is large enough that the
+// duplicates gossip actually produces — retransmissions of the same write, seconds apart — are still
+// remembered. The failure mode when it overflows is a redundant eviction, not a stale read.
+//
+// Note that a key written repeatedly consumes one entry per version, since each is a distinct
+// invalidation; the bound is on invalidations remembered, not on keys.
+const maxInvalidationLedger = 4096
 
 // GossipNode represents a node in the gossip protocol
 type GossipNode struct {
@@ -113,6 +135,21 @@ const (
 type CacheInvalidateMessage struct {
 	Key  string `json:"key"`
 	From string `json:"from"`
+
+	// ETag names the version the sender wrote, which is the version this invalidation is *about*.
+	//
+	// Requirement R4 of docs/design/conditional-writes-vs-raft.md §1: gossip is unordered, so without
+	// a version an invalidation can be applied after a later write's invalidation has already been
+	// applied, and the receiver has no way to tell that it has moved past this one. Empty means the
+	// sender could not name a version — an unconditional put, or a delete — and such a message is
+	// applied unconditionally, since "evict whatever you hold" is always safe.
+	//
+	// It comes from [OperationResult.ETag], which is why the coordinator propagates it.
+	ETag string `json:"etag,omitempty"`
+
+	// Deleted marks an invalidation caused by the key being removed rather than replaced. A receiver
+	// cannot infer this from an empty ETag, because an unconditional put has one too.
+	Deleted bool `json:"deleted,omitempty"`
 }
 
 // JoinMessage represents a join request
@@ -503,13 +540,90 @@ func (gp *GossipProtocol) handleIncomingMessage(ctx context.Context, data []byte
 
 	// Cache invalidation
 	case MessageTypeCacheInvalidate:
-		if gp.cluster.cache != nil {
-			var m CacheInvalidateMessage
-			if err := json.Unmarshal(msg.Data, &m); err == nil && m.Key != "" {
-				gp.cluster.cache.Delete(m.Key)
+		gp.handleCacheInvalidate(msg)
+	}
+}
+
+// handleCacheInvalidate evicts a key on behalf of a peer that wrote it, discarding an invalidation
+// naming a version this node has already applied.
+//
+// The duplicate check is the point, and it is a check against *what has been applied*, not against
+// message IDs. Gossip retransmits and fans out, so the same invalidation arrives more than once by
+// design; a re-delete of a key already evicted is harmless in itself, but it is indistinguishable
+// from an invalidation for an *older* version arriving after a newer one — and applying that would
+// throw away bytes this node has since legitimately re-cached. That is requirement R4 of
+// docs/design/conditional-writes-vs-raft.md §1.
+//
+// What this cannot do, and does not pretend to: decide that the cached bytes are *newer* than the
+// invalidation. [types.Cache] stores bytes at offsets and has no version alongside them, so this node
+// cannot compare what it holds against m.ETag — only against the last ETag it was told about. So the
+// rule is "apply each version once", which fixes the retransmission and the out-of-order replay of a
+// version already superseded. Suppressing an invalidation for a version older than what is actually
+// cached needs the cache to carry an ETag per key, which is #129's `KeyAnnouncement` plumbing and
+// #141's warming work; it is not smuggled in here as a guess.
+func (gp *GossipProtocol) handleCacheInvalidate(msg *GossipMessage) {
+	gp.cluster.mu.RLock()
+	cache := gp.cluster.cache
+	gp.cluster.mu.RUnlock()
+
+	if cache == nil {
+		return
+	}
+
+	var m CacheInvalidateMessage
+	if err := json.Unmarshal(msg.Data, &m); err != nil || m.Key == "" {
+		return
+	}
+
+	// An invalidation that names no version is applied every time. A delete has no ETag to name, and an
+	// unconditional put's sender may not have one; "evict whatever you hold" is always safe, and the
+	// alternative — treating "no version" as one version and applying it once — would drop every
+	// invalidation for a key after the first.
+	if m.ETag != "" && !gp.markInvalidationApplied(m.Key, m.ETag) {
+		return
+	}
+
+	cache.Delete(m.Key)
+}
+
+// markInvalidationApplied records that key was invalidated at etag, reporting whether this is the
+// first time. It bounds its own memory: the ledger drops the oldest entries once it exceeds
+// maxInvalidationLedger.
+//
+// Forgetting an entry means the next duplicate for it is applied — a redundant eviction, which costs a
+// re-fetch and not correctness. Growing without bound would be a leak proportional to every version of
+// every key the cluster has ever written, so this is the right direction to fail in.
+func (gp *GossipProtocol) markInvalidationApplied(key, etag string) bool {
+	// NUL rather than a printable separator: an S3 key may contain any byte except NUL, so "a\x00b" and
+	// "a" + "\x00b" cannot be confused, where a colon or a slash could be.
+	entry := key + "\x00" + etag
+
+	gp.mu.Lock()
+	defer gp.mu.Unlock()
+
+	if gp.appliedInvalidations == nil {
+		gp.appliedInvalidations = make(map[string]struct{})
+	}
+	if _, applied := gp.appliedInvalidations[entry]; applied {
+		return false
+	}
+
+	if len(gp.appliedInvalidations) >= maxInvalidationLedger {
+		// Drop an arbitrary tenth. Go's map iteration order is unspecified, which is what makes this a
+		// fair sample rather than a preference for whatever hashes low, and there is no access time to
+		// evict by: the ledger records versions, not reads.
+		target := maxInvalidationLedger - maxInvalidationLedger/10
+		for k := range gp.appliedInvalidations {
+			delete(gp.appliedInvalidations, k)
+			if len(gp.appliedInvalidations) <= target {
+				break
 			}
 		}
 	}
+
+	gp.appliedInvalidations[entry] = struct{}{}
+
+	return true
 }
 
 func (gp *GossipProtocol) handleJoinMessage(msg *GossipMessage) {

--- a/pkg/types/conditional.go
+++ b/pkg/types/conditional.go
@@ -18,7 +18,7 @@ type Precondition struct {
 	//
 	// This is the primitive a lease acquisition is built from: concurrent writers all asserting
 	// absence resolve to exactly one success, decided by the store rather than by any of them.
-	Absent bool
+	Absent bool `json:"absent,omitempty"`
 
 	// ETag asserts the key currently has this ETag. Sent as If-Match.
 	//
@@ -27,8 +27,14 @@ type Precondition struct {
 	// being updated no longer exists. Implementations must preserve that distinction — S3 answers
 	// 404 rather than 412 for If-Match against a missing key, which is verified behavior and not an
 	// inference from the specification.
-	ETag string
+	ETag string `json:"etag,omitempty"`
 }
+
+// The JSON tags are load-bearing rather than decorative: a Precondition crosses the wire inside
+// internal/distributed's node-operation message, where every neighboring field is snake_case. Without
+// them the payload carried `Absent` and `ETag` beside `key` and `created_at`. Tagging is free right
+// now because neither this type nor that message has shipped in a release, and would be a wire break
+// later.
 
 // IsZero reports whether p asserts nothing, which is not a valid precondition for a conditional
 // write.

--- a/pkg/types/conditional_test.go
+++ b/pkg/types/conditional_test.go
@@ -11,7 +11,9 @@ package types
 // — indistinguishable from a genuinely lost race — into a caller error at the call site.
 
 import (
+	"encoding/json"
 	stderr "errors"
+	"strings"
 	"testing"
 )
 
@@ -127,5 +129,61 @@ func TestConditionalSentinelsAreDistinct(t *testing.T) {
 					"opposite retry policies", aName, bName)
 			}
 		}
+	}
+}
+
+// TestPreconditionJSON pins the wire form, because a Precondition travels inside
+// internal/distributed's node-operation message and both halves of that round trip are remote.
+//
+// Two properties, and a defect in each direction if either slips. The field names must be snake_case
+// like every field beside them in that message — they were `Absent` and `ETag` until tags were added,
+// which is a cosmetic wart now and a wire break to fix after a release. And a zero Precondition must
+// serialize to nothing at all, so an unconditional operation does not travel carrying a precondition
+// field asserting nothing: a receiver that read `"precondition": {}` as "conditional" would refuse
+// every plain write.
+func TestPreconditionJSON(t *testing.T) {
+	t.Parallel()
+
+	type envelope struct {
+		Key          string       `json:"key"`
+		Precondition Precondition `json:"precondition,omitzero"`
+	}
+
+	zero, err := json.Marshal(envelope{Key: "k"})
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	if strings.Contains(string(zero), "precondition") {
+		t.Errorf("a zero Precondition serialized to %s; it must be omitted entirely, or an "+
+			"unconditional operation travels carrying a precondition that asserts nothing", zero)
+	}
+
+	for _, tc := range []struct {
+		name string
+		p    Precondition
+		want string
+	}{
+		{"absent", Precondition{Absent: true}, `{"key":"k","precondition":{"absent":true}}`},
+		{"etag", Precondition{ETag: `"abc"`}, `{"key":"k","precondition":{"etag":"\"abc\""}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(envelope{Key: "k", Precondition: tc.p})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("marshal = %s, want %s", got, tc.want)
+			}
+
+			var back envelope
+			if err := json.Unmarshal(got, &back); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if back.Precondition != tc.p {
+				t.Errorf("round trip gave %+v, want %+v", back.Precondition, tc.p)
+			}
+		})
 	}
 }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -234,8 +234,7 @@ performance:
 
 cluster:
   enabled: false
-  replication_factor: 3
-  consistency_level: eventual
+  replication_factor: 3     # nodes selected per operation; the first performs the write
 
 monitoring:
   metrics:

--- a/sdks/python/objectfs/config.py
+++ b/sdks/python/objectfs/config.py
@@ -82,14 +82,27 @@ class PerformanceConfig:
 
 @dataclass
 class ClusterConfig:
-    """Distributed cluster configuration."""
+    """Distributed cluster configuration.
+
+    ``consistency_level`` is gone as of v0.12.0. It took ``"eventual"``, ``"strong"`` or
+    ``"session"``, all three of which issued the same unconditional PUT and differed only in how
+    many nodes issued it, so the setting selected a request count rather than a guarantee. The Go
+    loader rejects unknown keys, so a document written by an older SDK now fails at load naming the
+    key -- which is the intended outcome: what replaced it is a per-write precondition evaluated by
+    S3, not a per-mount level, and no key here can express that.
+
+    The three timeouts below are a separate, older problem and are left as they are: the Go
+    ``cluster`` schema has never had ``election_timeout``, ``heartbeat_interval`` or
+    ``join_timeout`` -- those live on the disjoint ``internal/distributed.ClusterConfig`` (#139) --
+    so ``to_yaml`` emits a cluster block the loader refuses on the first of them. Verified against
+    the loader rather than inferred. Fixing that is not #284's to do; it is filed as #385.
+    """
     enabled: bool = False
     node_id: str = ""
     listen_addr: str = "0.0.0.0:8080"
     advertise_addr: str = "127.0.0.1:8080"
     seed_nodes: List[str] = field(default_factory=list)
     replication_factor: int = 3
-    consistency_level: str = "eventual"
 
     # Timeouts
     election_timeout: str = "5s"
@@ -402,7 +415,6 @@ class Configuration:
         config.performance.max_concurrency = 200
         config.cluster.enabled = True
         config.cluster.replication_factor = 3
-        config.cluster.consistency_level = "strong"
         config.monitoring.enabled = True
         config.security.enabled = True
         # No `tls_enabled = True` here, deliberately. SecurityConfig.validate() requires

--- a/tests/distributed_test.go
+++ b/tests/distributed_test.go
@@ -74,9 +74,7 @@ func TestClusterManager_BasicOperations(t *testing.T) {
 		HeartbeatInterval: 500 * time.Millisecond,
 		GossipInterval:    100 * time.Millisecond,
 		GossipFanout:      2,
-		CacheReplication:  true,
 		ReplicationFactor: 1,
-		ConsistencyLevel:  "eventual",
 		MaxConcurrentOps:  10,
 		OperationTimeout:  5 * time.Second,
 		RetryAttempts:     2,
@@ -106,12 +104,21 @@ func TestClusterManager_BasicOperations(t *testing.T) {
 		t.Error("Node should not be leader initially in single-node cluster")
 	}
 
-	// Wait a bit for election timeout
-	time.Sleep(3 * time.Second)
-
-	// Now should be leader
-	if !cm.IsLeader() {
-		t.Error("Node should become leader after election timeout")
+	// Poll until this node wins, rather than sleeping for one election timeout and asserting.
+	//
+	// A `time.Sleep(3 * time.Second)` was here, against ElectionTimeout: 2s. The randomized timeout is
+	// base plus up to 100% jitter — see distributed.electionTimeout, and Raft §5.2 for why the jitter
+	// has to be that wide — so the first election fires somewhere in [2s, 4s) and a 3s sleep is a coin
+	// flip. Observed failing 1 run in 4. Waiting for the upper bound instead of the middle is what makes
+	// this deterministic; a deadline generous enough to cover the whole range costs nothing when the
+	// election is quick, because the loop returns as soon as it wins.
+	deadline := time.Now().Add(4*config.ElectionTimeout + time.Second)
+	for !cm.IsLeader() {
+		if time.Now().After(deadline) {
+			t.Fatalf("node did not become leader within %v: an uncontested single-node election has no "+
+				"other candidate to lose to", 4*config.ElectionTimeout+time.Second)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 
 	// Verify node is in the member list
@@ -145,7 +152,6 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 		ListenAddr:       "127.0.0.1:18081",
 		AdvertiseAddr:    "127.0.0.1:18081",
 		ElectionTimeout:  time.Second,
-		ConsistencyLevel: "eventual",
 		OperationTimeout: 5 * time.Second,
 		RetryAttempts:    2,
 	}
@@ -159,7 +165,7 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 
 	// The operation below is a GET, so the key has to exist. Seeded through the raw SDK rather than
 	// through the coordinator: a test that both writes and reads through the layer under test cannot
-	// tell a symmetric encoding bug from correct behaviour.
+	// tell a symmetric encoding bug from correct behavior.
 	const (
 		key  = "test-key"
 		body = "distributed-operation-payload"
@@ -178,10 +184,9 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 
 	// Create a distributed operation
 	op := &distributed.DistributedOperation{
-		Type:        distributed.OpTypeGet,
-		Key:         key,
-		Consistency: distributed.ConsistencyEventual,
-		Timeout:     3 * time.Second,
+		Type:    distributed.OpTypeGet,
+		Key:     key,
+		Timeout: 3 * time.Second,
 	}
 
 	// Execute operation
@@ -225,10 +230,9 @@ func TestClusterManager_DistributedOperation(t *testing.T) {
 	// reconciliation in ExecuteOperation is removed — the assertion the counters could not make while
 	// every operation in this file failed for the same reason (#269).
 	failed, err := cm.DistributeOperation(ctx, &distributed.DistributedOperation{
-		Type:        distributed.OpTypeGet,
-		Key:         "a-key-that-was-never-written",
-		Consistency: distributed.ConsistencyEventual,
-		Timeout:     3 * time.Second,
+		Type:    distributed.OpTypeGet,
+		Key:     "a-key-that-was-never-written",
+		Timeout: 3 * time.Second,
 	})
 	if err == nil {
 		t.Error("DistributeOperation returned a nil error for a GET of a key that does not exist")
@@ -287,15 +291,17 @@ func TestConsensusEngine_LeaderElection(t *testing.T) {
 		t.Error("Node should become leader after election")
 	}
 
-	// Test leadership change proposal
-	err = cm.ProposeLeadershipChange(ctx, "new-leader-id")
-	if err != nil {
-		t.Errorf("Failed to propose leadership change: %v", err)
+	// And it names itself, which is the part IsLeader does not check: a node that wins an election has
+	// to record *which* node holds leadership, not merely that it does.
+	//
+	// This was a ProposeLeadershipChange(ctx, "new-leader-id") followed by a t.Logf of the result, and
+	// it asserted nothing — its own comment said the leader "won't actually change". #284 deleted that
+	// method along with the proposal machinery: a node cannot be made leader by being named, and the
+	// path reached the same SetLeader the election below already reached, after voting for itself.
+	if leader := cm.GetLeader(); leader != config.NodeID {
+		t.Errorf("GetLeader() = %q, want %q: the winner of an uncontested election is this node",
+			leader, config.NodeID)
 	}
-
-	// Verify leader changed (in this simple case it won't actually change since we don't have other nodes)
-	currentLeader := cm.GetLeader()
-	t.Logf("Current leader after proposal: %s", currentLeader)
 }
 
 func TestGossipProtocol_BasicFunctionality(t *testing.T) {
@@ -360,7 +366,6 @@ func TestLoadBalancer_NodeSelection(t *testing.T) {
 		NodeID:           "lb-test-1",
 		SecretFile:       writeClusterSecret(t),
 		MaxConcurrentOps: 5,
-		ConsistencyLevel: "eventual",
 
 		// One replica, so the selected set is the primary alone. At 2 the second replica is one of the
 		// unreachable peers below, and strong consistency would require it.
@@ -402,7 +407,7 @@ func TestLoadBalancer_NodeSelection(t *testing.T) {
 	coordinator := cm.GetCoordinator()
 
 	// A GET needs its key to exist. Seeded through the raw SDK rather than through the coordinator, so
-	// that a symmetric encoding bug cannot pass as correct behaviour.
+	// that a symmetric encoding bug cannot pass as correct behavior.
 	const (
 		getKey  = "test-get-key"
 		getBody = "load-balanced-read-payload"
@@ -410,10 +415,9 @@ func TestLoadBalancer_NodeSelection(t *testing.T) {
 	srv.PutObject(getKey, []byte(getBody))
 
 	getOp := &distributed.DistributedOperation{
-		Type:        distributed.OpTypeGet,
-		Key:         getKey,
-		Consistency: distributed.ConsistencyEventual,
-		Timeout:     5 * time.Second,
+		Type:    distributed.OpTypeGet,
+		Key:     getKey,
+		Timeout: 5 * time.Second,
 	}
 
 	raw, err := coordinator.ExecuteOperation(ctx, getOp)
@@ -446,11 +450,10 @@ func TestLoadBalancer_NodeSelection(t *testing.T) {
 	}
 
 	putOp := &distributed.DistributedOperation{
-		Type:        distributed.OpTypePut,
-		Key:         "test-put-key",
-		Data:        []byte("test data"),
-		Consistency: distributed.ConsistencyStrong,
-		Timeout:     5 * time.Second,
+		Type:    distributed.OpTypePut,
+		Key:     "test-put-key",
+		Data:    []byte("test data"),
+		Timeout: 5 * time.Second,
 
 		// Pinned, because the GET above has just raised the local node's load and StrategyLeastLoad will
 		// therefore route this elsewhere — to one of the four peers that do not exist. That is the
@@ -495,6 +498,12 @@ func TestMultiNodeCluster(t *testing.T) {
 	nodeCount := 3
 	clusters := make([]*distributed.ClusterManager, nodeCount)
 
+	// One endpoint per node, kept rather than discarded, so the write below can be located. Three
+	// separate substrate servers is what makes "which node performed it" answerable at all: with one
+	// shared endpoint every node's PUT lands in the same bucket and a fan-out is indistinguishable from
+	// a single write.
+	servers := make([]*testaws.TestServer, nodeCount)
+
 	// One secret for the whole cluster, not one per node. Gossip authentication (#206) uses a
 	// shared cluster secret, so three different secrets would produce three clusters of one —
 	// which is the failure this test exists to distinguish from a working cluster.
@@ -520,7 +529,6 @@ func TestMultiNodeCluster(t *testing.T) {
 			HeartbeatInterval: 200 * time.Millisecond,
 			GossipInterval:    100 * time.Millisecond,
 			GossipFanout:      2,
-			ConsistencyLevel:  "strong",
 			ReplicationFactor: 2,
 
 			// MaxGossipPacket is deliberately left at its default. It used to be set to 65507 here, to
@@ -537,9 +545,10 @@ func TestMultiNodeCluster(t *testing.T) {
 			t.Fatalf("Failed to create cluster manager %d: %v", i, err)
 		}
 
-		// Every node, not only the one that turns out to be leader: ConsistencyStrong fans the write out
-		// to peers, so a node without a backend fails the operation for the whole cluster (#269).
-		withBackend(t, cm)
+		// Every node, not only the one that turns out to be leader. The operation is routed by
+		// selectTargetNodes rather than to the leader, so any of the three may be the one that executes
+		// it, and a node without a backend fails the operation (#269).
+		servers[i] = withBackend(t, cm)
 
 		clusters[i] = cm
 
@@ -586,12 +595,16 @@ func TestMultiNodeCluster(t *testing.T) {
 	}
 
 	// Test distributed operation on leader
+	const (
+		multiKey  = "multi-node-test-key"
+		multiBody = "distributed test data"
+	)
+
 	op := &distributed.DistributedOperation{
-		Type:        distributed.OpTypePut,
-		Key:         "multi-node-test-key",
-		Data:        []byte("distributed test data"),
-		Consistency: distributed.ConsistencyStrong,
-		Timeout:     5 * time.Second,
+		Type:    distributed.OpTypePut,
+		Key:     multiKey,
+		Data:    []byte(multiBody),
+		Timeout: 5 * time.Second,
 	}
 
 	result, err := leader.DistributeOperation(ctx, op)
@@ -600,7 +613,34 @@ func TestMultiNodeCluster(t *testing.T) {
 	}
 
 	if result == nil || !result.Success {
-		t.Errorf("Expected successful operation, got: %v", result)
+		t.Fatalf("Expected successful operation, got: %v", result)
+	}
+
+	// One PUT, on one node, across a three-node cluster with ReplicationFactor 2.
+	//
+	// This is the assertion #284 is for, and it is why each node has its own endpoint. The operation
+	// used to run at ConsistencyStrong, which fanned the identical bytes at the identical key to every
+	// selected node and declared success on a majority — so a cluster of three at replication factor 2
+	// issued two PUTs of the same object and billed both. Counting writes per endpoint is what tells
+	// those apart; result.Success cannot, and neither could the old test, which asserted only that.
+	//
+	// Summed rather than checked node-by-node because which node executes is the load balancer's
+	// choice, and pinning it here would assert the routing rather than the request count.
+	writes := 0
+	for i, srv := range servers {
+		n := len(srv.Writes(multiKey))
+		writes += n
+
+		if n > 0 && string(srv.GetObject(multiKey)) != multiBody {
+			t.Errorf("node %d stored %q for %s, want %q",
+				i, srv.GetObject(multiKey), multiKey, multiBody)
+		}
+	}
+
+	if writes != 1 {
+		t.Errorf("the cluster issued %d PUTs of %s, want 1: there is one copy of the bytes and S3 "+
+			"holds it, so a second node writing the same key again is a billed request and no guarantee",
+			writes, multiKey)
 	}
 
 	// Verify stats across cluster
@@ -622,7 +662,6 @@ func TestConcurrentOperations(t *testing.T) {
 		AdvertiseAddr:    "127.0.0.1:18090",
 		ElectionTimeout:  time.Second,
 		MaxConcurrentOps: 20,
-		ConsistencyLevel: "eventual",
 		OperationTimeout: 2 * time.Second,
 	}
 
@@ -657,10 +696,9 @@ func TestConcurrentOperations(t *testing.T) {
 			defer wg.Done()
 
 			op := &distributed.DistributedOperation{
-				Type:        distributed.OpTypeGet,
-				Key:         fmt.Sprintf("concurrent-key-%d", opID),
-				Consistency: distributed.ConsistencyEventual,
-				Timeout:     time.Second,
+				Type:    distributed.OpTypeGet,
+				Key:     fmt.Sprintf("concurrent-key-%d", opID),
+				Timeout: time.Second,
 			}
 
 			result, err := cm.DistributeOperation(ctx, op)
@@ -723,7 +761,6 @@ func BenchmarkDistributedOperations(b *testing.B) {
 		SecretFile:       writeClusterSecret(b),
 		ElectionTimeout:  500 * time.Millisecond,
 		MaxConcurrentOps: 100,
-		ConsistencyLevel: "eventual",
 		OperationTimeout: time.Second,
 	}
 
@@ -748,10 +785,9 @@ func BenchmarkDistributedOperations(b *testing.B) {
 		opID := 0
 		for pb.Next() {
 			op := &distributed.DistributedOperation{
-				Type:        distributed.OpTypeGet,
-				Key:         fmt.Sprintf("bench-key-%d", opID%1000),
-				Consistency: distributed.ConsistencyEventual,
-				Timeout:     500 * time.Millisecond,
+				Type:    distributed.OpTypeGet,
+				Key:     fmt.Sprintf("bench-key-%d", opID%1000),
+				Timeout: 500 * time.Millisecond,
 			}
 
 			result, err := cm.DistributeOperation(ctx, op)


### PR DESCRIPTION
Closes #284. Also closes #144 as not planned (done on the issue), and comments a correction onto #129.

## The breaking change, first

`cluster.consistency_level` and `cluster.cache_replication` are removed from the config file. The loader decodes strictly, so a config that still sets either **fails at startup** naming the key and the line. That is intended rather than a regression — the alternative is accepting a setting that selects nothing.

**Migration: delete the lines.** There is no replacement value to set. `consistency_level`'s replacement is per-operation (`DistributedOperation.Precondition`), and `cache_replication` was read by no code in the repository at all. A deployment that deletes the line gets the behaviour it already had, whichever value it had set.

`ClusterManager.InvalidateCacheKey(key)` also becomes `InvalidateCacheKey(key, etag)`. No production caller existed.

## What went, and why each was not fixable in place

**`ConsistencyLevel` and its three constants.** All three issued the same unconditional `PutObject` and differed only in how many nodes issued it, so what an operator picked changed the request count and not the guarantee. `ConsistencyStrong` fanned the identical bytes at the identical key to every target node and called majority success "linearizable" — every node writes the same key in the same bucket, S3 holds the single copy, so N-1 of those PUTs were billed requests that changed nothing, and a majority reporting success said only that a majority could reach S3.

Deleted rather than cut down to two levels. Under CAS the distinguishing fact is whether the operation carries a precondition, and a `types.Precondition` field already says that; a two-name enum beside it would be a second encoding of `Precondition.IsZero()`.

**`CacheReplicator`.** Its worker sent N-1 peers a PUT of an object's own bytes back to the same key in the same bucket. When gossip was not running — which was every unit test — it sent nothing and added the byte count to `BytesReplicated` anyway. The one test covering it asserted `c.replicator != nil`, and that assertion is what let it survive: proving a field was assigned proves nothing about the subsystem, and the assignment was the only part of it that worked. Real cache warming is #141.

**The proposal machinery.** `broadcastProposal` slept 100ms and then voted for its own proposal, so a majority of one was always found and `executeProposal` called `SetLeader`. A node cannot be made leader by being named — the election path reaches the same setter having actually contested it. #133 was closed as not-the-direction with this stub still in the tree; #284's acceptance criteria said delete rather than fix.

**Three of five `EntryType` constants.** `EntryTypeConfigChange`, `EntryTypeOperation` and `EntryTypeSnapshot` had no producer anywhere — verified by grep, not assumed. `applyLogEntry` was a five-arm switch with every arm empty; with those gone the remaining branches were indistinguishable, so it collapsed to a log line. **The surviving constants' strings are unchanged**, so an entry of a removed type arriving from an older peer still decodes and applies as the no-op it always was.

## What replaced it

Evaluated by the store, not voted on. A refused conditional write reports `ConditionalLost` in `OperationResult.Conditional` and wraps `types.ErrPreconditionFailed`, and is never retried internally: the answer is definitive, and the recovery is to re-read, recompute and CAS again, which only the caller can do. A precondition attached to anything but a put is refused with `ErrInvalidPrecondition` rather than silently dropped — a caller that means "delete only if unchanged" and gets an unconditional delete has no way to find out.

`OperationResult.ETag` carries the new version so a CAS loop can chain without a re-read.

**Cache invalidations carry that ETag (R4).** The gossip payload was `{Key, From}` and carried no version, so a receiver could not tell an invalidation for a version it had already moved past from one for the version it holds — and gossip both retransmits and reorders, so that is the normal case. A first attempt held one ETag per key, and a test caught it: that suppresses a retransmission of the latest version but *applies* a replay of the one before it, since an older ETag merely differs and ETags carry no order to compare. The ledger is a bounded set of applied `(key, ETag)` pairs.

It deliberately does **not** claim to know the cached bytes are newer than an incoming invalidation. `types.Cache` stores bytes at offsets with no version alongside them, so there is nothing to compare against; that needs #129's `KeyAnnouncement` plumbing and #141's warming work, and is not guessed at here.

## Tests — the point of the issue, verified by mutation

| assertion | mutation that kills it |
|---|---|
| `TestMultiNodeCluster`: exactly **1** PUT of the key, counted across one substrate endpoint per node | any fan-out |
| two coordinators racing `If-Match` → one success, one `ErrPreconditionFailed`, winner's bytes stored | forcing the path unconditional |
| CAS chain accepts each reported ETag, refuses every earlier one | forcing unconditional; suppressing the returned ETag |
| each invalidation version applied once | removing the check; reverting to latest-per-key |
| ledger bounded | removing the bound |

The write-count assertion replaced `result.Success` on a `ConsistencyStrong` write, which could not tell one PUT from two. Writes are summed across endpoints rather than checked per-node, because routing is the load balancer's choice — pinning it would assert the routing instead of the request count.

The success half of the never-disagree test runs against a real `testaws` backend rather than the package's `mockBackend`, whose `PutObjectIf` returns `ErrNotSupported` deliberately: a stub cannot both refuse to fake a CAS and serve as the success case for one.

## Two defects found while verifying, fixed here

- **`TestClusterManager_BasicOperations` was a coin flip.** It slept exactly 3s against `ElectionTimeout: 2s`, whose jitter puts the first election in `[2s, 4s)`. Observed failing 1 run in 4; now polls to the upper bound. Three consecutive `-race -tags=distributed` runs green after.
- **`types.Precondition` had no JSON tags**, so it crossed the wire as `Absent`/`ETag` beside `key` and `created_at`. Tagged while the type is unreleased and it is free rather than a wire break later; `TestPreconditionJSON` pins the names and that a zero precondition is omitted entirely.

## Verification

```
go build ./...                          ok
go vet ./...                            ok
gofmt -l .                              clean
make lint                               0 issues
go test -race ./internal/... ./pkg/...  all pass
go test -race -tags=distributed ./tests/  3/3 green
```

Coverage on the changed packages: `internal/distributed` 80.6%, `internal/config` 91.3%, `pkg/types` 100%.

## Out of scope, filed rather than absorbed

Verifying that the strict loader genuinely rejects a stale `consistency_level` (it does, naming key and line) surfaced that the Python SDK's `to_yaml` emits three `cluster` timeout keys the Go schema has never had — they live on the disjoint `internal/distributed.ClusterConfig` (#139) — so that block fails at load independently of this change. Filed as #385.