### PR TITLE
feat(types)!: cache coordination on DistributedCoordinator, with stubs that refuse (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`types.DistributedCoordinator` can say where bytes are cached, and `types.KeyAnnouncement` is what
+  it says it with** ([#129]). Three methods — `AnnounceKey`, `QueryKeyOwnership`, and
+  `InvalidateKey(ctx, key, etag)` — beside the two the interface already had. This is the surface the
+  whole v0.13.0 cache-warming chain ([#140], [#141], [#142], [#143]) was blocked on, none of which
+  could begin while a coordinator had no way to express "this node holds these bytes at this version".
+
+  **The two unimplemented methods return `types.ErrNotSupported`, not `nil`.** The issue as filed said
+  stubs returning nil were acceptable; that was revised, because the failure it invites is one this
+  release just deleted. [#284]'s `CacheReplicator` added bytes to a `BytesReplicated` counter when
+  gossip was not running and it had sent nothing, and it survived four releases because the only test
+  covering it asserted that its field was non-nil. `QueryKeyOwnership` in particular must not return an
+  empty slice with a nil error, which is the *correct* answer for a key no peer has cached: returning it
+  from a method that cannot query is indistinguishable from a working query against a cold cluster, so
+  an operator watching peer-fetch hit rates would read a flat zero as "warming does not help" rather
+  than "warming is not built".
+
+  `InvalidateKey` is real, since [#284] built the message, the sender, and the receiver's
+  replay-suppressing ledger. Its ETag parameter is the reason the signature is not
+  `InvalidateKey(ctx, key)` as filed: gossip retransmits and reorders, so a bare key leaves a receiver
+  unable to tell an invalidation it has already applied from one it has not (requirement R4 of
+  `docs/design/conditional-writes-vs-raft.md` §1). Empty stays legal and means the caller cannot name a
+  version — a delete, or an unconditional put — and is then applied every time, which costs a redundant
+  eviction and can never serve stale bytes.
+
+  `KeyAnnouncement` carries the full object size alongside the announced range, because a peer weighing
+  a fetch needs both: the range says what it can get from that node, the size says what fraction of the
+  object that is. Its ETag is required rather than optional, which is the one place it differs from an
+  invalidation — an unversioned invalidation is still safe, since "evict whatever you hold" cannot serve
+  wrong bytes, but an unversioned *announcement* invites a peer to fetch bytes it cannot place relative
+  to the object in the bucket and hand them to a reading process as file content. Its JSON tags are
+  pinned by a test for the reason `types.Precondition`'s were added in [#284]: that type shipped
+  untagged and put `Absent` beside `created_at`, which was free to fix only because it had not been
+  released.
+
+  The `Offset`/`Length` pair is deliberately *not* `omitempty`, unlike `Precondition`'s fields. Offset 0
+  with Length 0 means "the whole object from the start" and is the commonest announcement there is, so
+  omitting the pair would make it indistinguishable on the wire from a malformed message carrying no
+  range at all.
+
+  Mutation-verified in both directions: returning nil from either stub, dropping the ETag from the
+  broadcast, having the wrapper's `InvalidateKey` silently succeed, adding `omitempty` to the range
+  fields, and renaming a wire field each fail a named assertion. Dropping the ETag is the interesting
+  one — the invalidation still *arrives*, and three of them then apply where two should, which is
+  exactly the R4 defect rather than a delivery failure.
+
 - **`internal/coord` — a lease over `PutObjectIf` where every guarded action re-asserts the CAS**
   ([#283]). Mutual exclusion between nodes with the object store as the arbiter, replacing the
   direction the consensus code was heading in.
@@ -2587,8 +2632,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#131]: https://github.com/scttfrdmn/objectfs/issues/131
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#133]: https://github.com/scttfrdmn/objectfs/issues/133
+[#129]: https://github.com/scttfrdmn/objectfs/issues/129
 [#139]: https://github.com/scttfrdmn/objectfs/issues/139
+[#140]: https://github.com/scttfrdmn/objectfs/issues/140
 [#141]: https://github.com/scttfrdmn/objectfs/issues/141
+[#142]: https://github.com/scttfrdmn/objectfs/issues/142
+[#143]: https://github.com/scttfrdmn/objectfs/issues/143
 [#150]: https://github.com/scttfrdmn/objectfs/issues/150
 [#151]: https://github.com/scttfrdmn/objectfs/issues/151
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
@@ -2612,6 +2661,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [scttfrdmn/substrate#540]: https://github.com/scttfrdmn/substrate/issues/540
 
 ### Changed
+
+- **BREAKING: broadcasting an invalidation reports whether it was sent** ([#129]).
+  `ClusterManager.InvalidateCacheKey` and `InvalidateDeletedCacheKey` return `error` where they
+  returned nothing, and `GossipProtocol.broadcastMessage` refuses with `types.ErrNotSupported` when
+  gossip is not listening instead of returning nil having sent nothing.
+
+  This was found by a test written for [#129] and is a real defect, not a tidying. `NewClusterManager`
+  builds a `GossipProtocol`; only `Start` opens its socket. Every send dials its own UDP socket, so
+  broadcasting from a constructed-but-unstarted cluster dialed out from an unbound port, reached nobody,
+  and reported success — and `broadcastMessage` returned nil unconditionally in any case, fanning out
+  into goroutines that discarded every send error. A node that had just replaced an object's bytes could
+  not distinguish "every peer was told to evict the version before" from "nothing was sent", and the
+  difference is whether peers keep serving stale content.
+
+  What the error means is bounded on purpose. A nil means the message was handed to the network for each
+  peer, never that any peer received it: gossip is unreliable datagrams with no acknowledgement, so
+  convergence rests on retransmission rather than on this return value. A running cluster with no peers
+  is a nil error and no sends, because there is nobody to tell and nothing went wrong. Per-peer send
+  failures stay counted in `NetworkErrors` and `MessagesOversize` rather than returned, since one
+  unreachable peer is the normal state of a gossip cluster.
+
+  The test this replaced asserted only that invalidating with gossip down did not panic, which passed
+  identically whether the message was broadcast or dropped on the floor — the weakest property that
+  could have been checked at that call site.
 
 - **BREAKING: `ClusterManager.InvalidateCacheKey` takes the ETag of the write that caused the
   invalidation, and a peer applies each version once** ([#284]). The gossip payload was `{Key, From}`

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -830,34 +830,47 @@ func (cm *ClusterManager) SetCache(c types.Cache) {
 // Empty is allowed and means the caller cannot name a version — an unconditional put whose ETag was
 // not read back. Such a message is applied by every receiver every time, which is safe but wasteful,
 // so prefer a conditional write's reported ETag where there is one.
-func (cm *ClusterManager) InvalidateCacheKey(key, etag string) {
-	cm.invalidateCacheKey(CacheInvalidateMessage{Key: key, ETag: etag})
+//
+// An error means the invalidation was not broadcast, so peers may still serve the version it was meant
+// to evict. It is not an acknowledgement that any of them acted on it: gossip has none to give.
+func (cm *ClusterManager) InvalidateCacheKey(key, etag string) error {
+	return cm.invalidateCacheKey(CacheInvalidateMessage{Key: key, ETag: etag})
 }
 
 // InvalidateDeletedCacheKey is InvalidateCacheKey for a key that was removed rather than replaced.
 //
 // It exists because a receiver cannot tell the two apart from the ETag: a delete has no version to
 // name, and neither does an unconditional put, so an empty ETag alone is ambiguous.
-func (cm *ClusterManager) InvalidateDeletedCacheKey(key string) {
-	cm.invalidateCacheKey(CacheInvalidateMessage{Key: key, Deleted: true})
+func (cm *ClusterManager) InvalidateDeletedCacheKey(key string) error {
+	return cm.invalidateCacheKey(CacheInvalidateMessage{Key: key, Deleted: true})
 }
 
-func (cm *ClusterManager) invalidateCacheKey(m CacheInvalidateMessage) {
+// invalidateCacheKey broadcasts m, filling in the sending node.
+//
+// It reports an error when it could not send rather than returning silently, which is what it used to
+// do when gossip was not running. That silence is the shape of defect #284 deleted: a caller invalidating
+// before Start got the same answer as one whose peers were all reached, and the difference is whether
+// other nodes are still serving bytes this key just replaced.
+//
+// A running cluster with no peers is a nil error, since there is nobody to tell and nothing went wrong.
+func (cm *ClusterManager) invalidateCacheKey(m CacheInvalidateMessage) error {
 	cm.mu.RLock()
 	gossip := cm.gossip
 	nodeID := cm.nodeID
 	cm.mu.RUnlock()
 
 	if gossip == nil {
-		return
+		return fmt.Errorf("cannot invalidate %q on peers: this cluster has no gossip protocol, so it has "+
+			"no way to reach them: %w", m.Key, types.ErrNotSupported)
 	}
 
 	m.From = nodeID
 	payload, err := json.Marshal(m)
 	if err != nil {
-		return
+		return fmt.Errorf("marshaling the invalidation for %q: %w", m.Key, err)
 	}
-	_ = gossip.broadcastMessage(&GossipMessage{
+
+	return gossip.broadcastMessage(&GossipMessage{
 		Type:      MessageTypeCacheInvalidate,
 		From:      nodeID,
 		Timestamp: time.Now(),
@@ -876,9 +889,52 @@ type coordinatorWrapper struct {
 	*Coordinator
 }
 
+// coordinatorWrapper must satisfy the whole interface, checked here rather than only at the one
+// GetCoordinator return that happens to exercise it today.
+var _ types.DistributedCoordinator = (*coordinatorWrapper)(nil)
+
 func (cw *coordinatorWrapper) ExecuteOperation(ctx context.Context, op any) (any, error) {
 	if distOp, ok := op.(*DistributedOperation); ok {
 		return cw.Coordinator.ExecuteOperation(ctx, distOp)
 	}
 	return nil, fmt.Errorf("invalid operation type: %T", op)
+}
+
+// AnnounceKey is not implemented yet and says so.
+//
+// The gossip message type it needs does not exist — [MessageTypeCacheInvalidate] is the only
+// cache-related one — so there is nothing to send and no receiver to send it to. #140 builds both.
+//
+// It returns an error rather than nil because a nil here would mean "announced" to every caller, and
+// #284 deleted a CacheReplicator that did exactly that: it added bytes to BytesReplicated when gossip
+// was not running and it had sent nothing, and it survived four releases because the only test covering
+// it asserted that its field was non-nil. A caller told [types.ErrNotSupported] falls back to reading
+// from the object store, which is correct and merely slower.
+func (cw *coordinatorWrapper) AnnounceKey(_ context.Context, ann types.KeyAnnouncement) error {
+	return fmt.Errorf("announcing %q to peers is not implemented (#140): %w", ann.Key, types.ErrNotSupported)
+}
+
+// QueryKeyOwnership is not implemented yet and says so, for the reason on [coordinatorWrapper.AnnounceKey]:
+// nothing announces, so no node has ownership information to report.
+//
+// Specifically it does not return an empty slice with a nil error. That is the documented answer for a
+// key no peer has cached, so returning it here would be indistinguishable from a working query against
+// a cold cluster — and a caller measuring peer-fetch hit rates would read a flat zero as "warming does
+// not help" rather than "warming is not built".
+func (cw *coordinatorWrapper) QueryKeyOwnership(_ context.Context, key string) ([]types.KeyAnnouncement, error) {
+	return nil, fmt.Errorf("querying which peers hold %q is not implemented (#140): %w", key,
+		types.ErrNotSupported)
+}
+
+// InvalidateKey broadcasts a cache invalidation for key at etag. This one is real: the message type,
+// the sender, and the receiver's replay-suppressing ledger all landed in #284.
+func (cw *coordinatorWrapper) InvalidateKey(_ context.Context, key, etag string) error {
+	// The embedded pointer is checked by name because the selector below reads through it; || short-circuits,
+	// so cw.cluster is only evaluated once there is a Coordinator to read it from.
+	if cw.Coordinator == nil || cw.cluster == nil {
+		return fmt.Errorf("cannot invalidate %q: this coordinator has no cluster: %w", key,
+			types.ErrNotSupported)
+	}
+
+	return cw.cluster.InvalidateCacheKey(key, etag)
 }

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -1202,15 +1202,152 @@ func (mc *mockCache) Stats() types.CacheStats {
 	return mc.stats
 }
 
-// TestClusterManager_InvalidateCacheKey_NoGossip verifies that
-// InvalidateCacheKey is a no-op (does not panic) when gossip is not running.
+// TestClusterManager_InvalidateCacheKey_NoGossip verifies that InvalidateCacheKey reports that it could
+// not reach peers when gossip is not running, rather than returning as though it had.
+//
+// This used to assert only that it did not panic, which is the weakest thing that could be checked
+// here: it passed identically whether the invalidation was broadcast or dropped on the floor. The
+// distinction matters because the caller is a node that just replaced an object's bytes, and a peer
+// that never hears about it keeps serving the version before.
 func TestClusterManager_InvalidateCacheKey_NoGossip(t *testing.T) {
 	t.Parallel()
 	cm := makeClusterWithNode(t, "inval-no-gossip")
 	mc := &mockCache{}
 	cm.SetCache(mc)
-	// gossip.conn is nil (Start not called) — should not panic
-	cm.InvalidateCacheKey("foo", `"etag-1"`)
+
+	// gossip.conn is nil: NewClusterManager builds a GossipProtocol, but only Start opens its socket. So
+	// the object exists and every send would dial out from an unbound port and reach nobody, which is the
+	// case this asserts on — not a nil gossip, which no constructed cluster has.
+	err := cm.InvalidateCacheKey("foo", `"etag-1"`)
+	if !errors.Is(err, types.ErrNotSupported) {
+		t.Errorf("InvalidateCacheKey with gossip not listening = %v, want ErrNotSupported: a nil here "+
+			"would tell a caller its peers had been told to evict a version they are still serving", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), string(MessageTypeCacheInvalidate)) {
+		t.Errorf("error %q does not name the message that was not sent: an operator reading this needs to "+
+			"know what was lost", err)
+	}
+
+	// And it must not have evicted locally. InvalidateCacheKey tells *peers*; the local cache belongs to
+	// whoever performed the write, and evicting here would hide the failure it just reported.
+	mc.mu.Lock()
+	deleted := mc.deleted
+	mc.mu.Unlock()
+	if len(deleted) != 0 {
+		t.Errorf("local cache deletions = %v, want none: InvalidateCacheKey is a message to peers", deleted)
+	}
+}
+
+// TestCoordinatorWrapper_UnimplementedMethodsRefuse pins that the two cache-coordination methods with no
+// implementation say so, rather than reporting success.
+//
+// The assertion is errors.Is against types.ErrNotSupported and not merely "err != nil", because the
+// caller of AnnounceKey is a cache write path that has to distinguish "this cluster cannot announce" —
+// fall back to the object store, permanently — from a transient send failure worth retrying.
+//
+// #284 deleted a CacheReplicator that returned nil having sent nothing, counted the bytes as replicated,
+// and survived four releases because the only test covering it asserted that its field was non-nil.
+// These are the assertions that would have caught it.
+func TestCoordinatorWrapper_UnimplementedMethodsRefuse(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "wrapper-refuse")
+	coord := cm.GetCoordinator()
+	ctx := t.Context()
+
+	t.Run("AnnounceKey", func(t *testing.T) {
+		t.Parallel()
+		err := coord.AnnounceKey(ctx, types.KeyAnnouncement{
+			Key: "some/key", NodeID: "wrapper-refuse", ETag: `"v1"`, Size: 10,
+		})
+		if !errors.Is(err, types.ErrNotSupported) {
+			t.Errorf("AnnounceKey = %v, want ErrNotSupported", err)
+		}
+		if err != nil && !strings.Contains(err.Error(), "some/key") {
+			t.Errorf("error %q does not name the key it failed to announce", err)
+		}
+	})
+
+	t.Run("QueryKeyOwnership", func(t *testing.T) {
+		t.Parallel()
+		holders, err := coord.QueryKeyOwnership(ctx, "some/key")
+		if !errors.Is(err, types.ErrNotSupported) {
+			t.Errorf("QueryKeyOwnership = %v, want ErrNotSupported", err)
+		}
+		// An empty slice with a nil error is the documented answer for "no peer holds this", so returning
+		// it here would be indistinguishable from a working query against a cold cluster.
+		if holders != nil {
+			t.Errorf("QueryKeyOwnership returned %d holders alongside its error; a caller that reads the "+
+				"slice before the error must find nothing", len(holders))
+		}
+	})
+}
+
+// TestCoordinatorWrapper_InvalidateKey_BroadcastsTheETag verifies the one cache-coordination method that
+// is implemented actually reaches a peer, carrying the version it was given.
+//
+// It asserts by receiving the message on a second node rather than by inspecting the call, because the
+// bug this guards against is a broadcast that is assembled correctly and never sent — which is what
+// InvalidateCacheKey did on a cluster with gossip down, silently, before this change.
+func TestCoordinatorWrapper_InvalidateKey_BroadcastsTheETag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	cm1, cm2 := startGossipPair(t, "wrapper-inval-a", "wrapper-inval-b")
+
+	// cm2's receive path records the invalidations it applies. A recording cache is what lets this
+	// distinguish "arrived" from "arrived naming the right version": the ledger in handleCacheInvalidate
+	// keys on (key, ETag), so a message carrying the wrong ETag still evicts and would pass a test that
+	// only watched for the eviction.
+	mc2 := &mockCache{}
+	cm2.SetCache(mc2)
+
+	if err := cm1.GetCoordinator().InvalidateKey(ctx, "warm/key", `"v7"`); err != nil {
+		t.Fatalf("InvalidateKey: %v", err)
+	}
+
+	waitForDeletion(t, mc2, "warm/key")
+
+	// Now prove the ETag crossed the wire and was recorded, not merely that an eviction happened: a
+	// second invalidation naming the same version must be discarded by the receiver's ledger, while one
+	// naming a different version must be applied.
+	if err := cm1.GetCoordinator().InvalidateKey(ctx, "warm/key", `"v7"`); err != nil {
+		t.Fatalf("InvalidateKey replay: %v", err)
+	}
+	if err := cm1.GetCoordinator().InvalidateKey(ctx, "warm/key", `"v8"`); err != nil {
+		t.Fatalf("InvalidateKey new version: %v", err)
+	}
+
+	// Wait for the "v8" eviction, then count. Ordering over loopback UDP from one sender is reliable
+	// enough in practice, but the count is what the assertion rests on, and it is only meaningful once
+	// the last message has landed.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mc2.mu.Lock()
+		n := len(mc2.deleted)
+		mc2.mu.Unlock()
+		if n >= 2 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Settle briefly so a wrongly-applied replay has time to show up rather than being missed by a
+	// racing count. Without this, a broken ledger could pass by arriving late.
+	time.Sleep(100 * time.Millisecond)
+
+	mc2.mu.Lock()
+	deleted := mc2.deleted
+	mc2.mu.Unlock()
+
+	if len(deleted) != 2 {
+		t.Errorf("cm2 applied %d invalidations (%v), want 2: one for \"v7\" and one for \"v8\", with the "+
+			"replay of \"v7\" discarded by the receiver's ledger", len(deleted), deleted)
+	}
+	for _, k := range deleted {
+		if k != "warm/key" {
+			t.Errorf("cm2 evicted %q, want only \"warm/key\"", k)
+		}
+	}
 }
 
 // TestGossip_CacheInvalidate_AppliesEachVersionOnce is requirement R4: an invalidation naming a
@@ -1319,72 +1456,92 @@ func TestGossip_MarkInvalidationApplied_LedgerIsBounded(t *testing.T) {
 	}
 }
 
-// TestClusterManager_CacheInvalidation_TwoNodes verifies that
-// InvalidateCacheKey on cm1 causes cm2's cache to have Delete called for the
-// same key over loopback UDP.
-func TestClusterManager_CacheInvalidation_TwoNodes(t *testing.T) {
-	t.Parallel()
+// startGossipPair starts two clusters on loopback and registers the second in the first's gossip
+// memberlist, so a broadcast from cm1 reaches cm2. Both are stopped by t.Cleanup.
+//
+// Registration is one-directional because that is what a broadcast test needs and adding the reverse
+// would start membership traffic between them, which changes what a message-count assertion is counting.
+func startGossipPair(t *testing.T, id1, id2 string) (cm1, cm2 *ClusterManager) {
+	t.Helper()
 	ctx := t.Context()
 
-	cfg1 := testConfig(t, "inval-node-a")
-	cfg2 := testConfig(t, "inval-node-b")
-
-	cm1, err := NewClusterManager(cfg1)
+	cm1, err := NewClusterManager(testConfig(t, id1))
 	if err != nil {
-		t.Fatalf("NewClusterManager cm1: %v", err)
+		t.Fatalf("NewClusterManager %s: %v", id1, err)
 	}
-	cm2, err := NewClusterManager(cfg2)
+	cm2, err = NewClusterManager(testConfig(t, id2))
 	if err != nil {
-		t.Fatalf("NewClusterManager cm2: %v", err)
+		t.Fatalf("NewClusterManager %s: %v", id2, err)
 	}
-
-	mc2 := &mockCache{}
-	cm2.SetCache(mc2)
 
 	if err := cm1.Start(ctx); err != nil {
-		t.Fatalf("cm1.Start: %v", err)
+		t.Fatalf("%s.Start: %v", id1, err)
 	}
-	defer func() { _ = cm1.Stop() }()
+	t.Cleanup(func() { _ = cm1.Stop() })
 
 	if err := cm2.Start(ctx); err != nil {
-		t.Fatalf("cm2.Start: %v", err)
+		t.Fatalf("%s.Start: %v", id2, err)
 	}
-	defer func() { _ = cm2.Stop() }()
+	t.Cleanup(func() { _ = cm2.Stop() })
 
-	addr1 := cm1.gossip.LocalAddr()
 	addr2 := cm2.gossip.LocalAddr()
-	if addr1 == "" || addr2 == "" {
+	if addr1 := cm1.gossip.LocalAddr(); addr1 == "" || addr2 == "" {
 		t.Fatalf("could not get local addresses: %q %q", addr1, addr2)
 	}
 
-	// Cross-register so cm1 knows about cm2's address.
-	cm1.UpdateNodeInfo("inval-node-b", &NodeInfo{
-		ID: "inval-node-b", Address: addr2, Status: NodeStatusAlive, Metadata: map[string]string{},
+	cm1.UpdateNodeInfo(id2, &NodeInfo{
+		ID: id2, Address: addr2, Status: NodeStatusAlive, Metadata: map[string]string{},
 	})
-	// Also register cm2's gossip memberlist entry so broadcastMessage sees it.
+	// The gossip memberlist is separate from the cluster's node map, and broadcastMessage reads this one.
 	cm1.gossip.mu.Lock()
-	cm1.gossip.memberlist["inval-node-b"] = &GossipNode{
-		Info:  &NodeInfo{ID: "inval-node-b", Address: addr2},
+	cm1.gossip.memberlist[id2] = &GossipNode{
+		Info:  &NodeInfo{ID: id2, Address: addr2},
 		State: StateAlive,
 	}
 	cm1.gossip.mu.Unlock()
 
-	cm1.InvalidateCacheKey("foo", `"etag-1"`)
+	return cm1, cm2
+}
 
-	// Wait up to 200ms for the message to arrive and be processed.
-	deadline := time.Now().Add(200 * time.Millisecond)
+// waitForDeletion blocks until mc records an eviction of key, or fails the test.
+//
+// The timeout is generous rather than tight — this waits on loopback UDP plus a receive goroutine, and
+// the failure it exists to catch is a message that is never sent, which no amount of waiting fixes. A
+// short deadline here buys nothing and flakes on a loaded CI runner.
+func waitForDeletion(t *testing.T, mc *mockCache, key string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		mc2.mu.Lock()
-		found := len(mc2.deleted) > 0 && mc2.deleted[len(mc2.deleted)-1] == "foo"
-		mc2.mu.Unlock()
+		mc.mu.Lock()
+		found := slices.Contains(mc.deleted, key)
+		mc.mu.Unlock()
 		if found {
 			return
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	mc2.mu.Lock()
-	deleted := mc2.deleted
-	mc2.mu.Unlock()
-	t.Errorf("cache.Delete(%q) was not called on cm2 within 200ms; deleted keys: %v", "foo", deleted)
+	mc.mu.Lock()
+	deleted := mc.deleted
+	mc.mu.Unlock()
+	t.Fatalf("cache.Delete(%q) was not called within 2s; deleted keys: %v", key, deleted)
+}
+
+// TestClusterManager_CacheInvalidation_TwoNodes verifies that
+// InvalidateCacheKey on cm1 causes cm2's cache to have Delete called for the
+// same key over loopback UDP.
+func TestClusterManager_CacheInvalidation_TwoNodes(t *testing.T) {
+	t.Parallel()
+
+	cm1, cm2 := startGossipPair(t, "inval-node-a", "inval-node-b")
+
+	mc2 := &mockCache{}
+	cm2.SetCache(mc2)
+
+	if err := cm1.InvalidateCacheKey("foo", `"etag-1"`); err != nil {
+		t.Fatalf("InvalidateCacheKey: %v", err)
+	}
+
+	waitForDeletion(t, mc2, "foo")
 }

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -246,6 +246,43 @@ sent nothing at all and added the byte count to BytesReplicated anyway, so the t
 was of work that had not happened. Warming a peer's *local* cache is a different thing and is real
 work; it is filed as #141.
 
+# Cache Coordination
+
+What nodes do share is *where bytes are cached*, not the bytes themselves. Three methods on
+[github.com/scttfrdmn/objectfs/pkg/types.DistributedCoordinator] cover it, and only one of them is
+implemented:
+
+	coord := cluster.GetCoordinator()
+
+	// Implemented. Tells peers to evict a key, naming the version that replaced what they hold.
+	if err := coord.InvalidateKey(ctx, key, res.ETag); err != nil {
+		// Peers may still be serving the version this write replaced. Not fatal to the write, which
+		// already succeeded at the store — but worth logging, because it is a staleness window.
+		slog.Warn("could not invalidate peers", "key", key, "error", err)
+	}
+
+	// Not implemented: both return types.ErrNotSupported until #140.
+	_ = coord.AnnounceKey(ctx, ann)
+	_, _ = coord.QueryKeyOwnership(ctx, key)
+
+The two unimplemented ones return an error rather than a nil or an empty slice, and that is deliberate
+rather than lazy. An empty slice with a nil error is the *correct* answer for a key no peer has cached,
+so returning it from a method that cannot query would be indistinguishable from a working query against
+a cold cluster — a caller measuring peer-fetch hit rates would read a flat zero as "warming does not
+help" instead of "warming is not built". This is the same shape as the CacheReplicator above, whose only
+test asserted that its field was non-nil.
+
+The ETag on an invalidation is load-bearing, not informational. Gossip retransmits and reorders, so a
+receiver handed a bare key cannot distinguish an invalidation it has already acted on from a new one;
+[GossipProtocol.markInvalidationApplied] keeps a bounded set of applied (key, ETag) pairs to make each
+exactly-once. An empty ETag stays legal and means the sender could not name a version — a delete, or an
+unconditional put — and is applied every time, which costs a redundant eviction and can never serve
+stale bytes.
+
+What this cannot yet do is suppress an invalidation *older* than what a peer holds. [types.Cache] stores
+bytes at offsets with no version beside them, so a receiver has nothing to compare an incoming ETag
+against; that needs a per-key version in the cache, which is #141's work.
+
 # Cluster Health Monitoring
 
 Check cluster health and node status:

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"sync"
 	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
 )
 
 // GossipProtocol implements a gossip-based cluster membership protocol
@@ -1278,6 +1280,17 @@ func (gp *GossipProtocol) sendMessage(addr string, msg *GossipMessage) error {
 	return nil
 }
 
+// broadcastMessage sends msg to every alive peer, reporting whether it was able to start sending.
+//
+// What the error does and does not mean. It is refused up front when this protocol is not listening —
+// there is no socket, so nothing can be sent and the caller's message is lost, which used to be
+// indistinguishable from a fanout to every peer. It says nothing about delivery: sends run concurrently
+// and gossip is an unreliable datagram protocol with no acknowledgement, so a nil means "handed to the
+// network for each peer", never "received". Callers needing convergence rely on retransmission, not on
+// this return value.
+//
+// A cluster with no peers is a nil error and no sends. That is not a failure — a single-node cluster
+// broadcasting has nobody to tell, and the operation it is reporting on succeeded locally.
 func (gp *GossipProtocol) broadcastMessage(msg *GossipMessage) error {
 	// Addresses rather than *NodeInfo, for the reason performGossip resolves them under the lock too:
 	// a pointer taken out of the memberlist aliases a struct the receive goroutine owns. This one
@@ -1285,6 +1298,7 @@ func (gp *GossipProtocol) broadcastMessage(msg *GossipMessage) error {
 	// and the ID filter below excludes it — but that is a property of a filter two lines away, not of
 	// the code doing the read, and it is the same reasoning that made three other sites wrong (#278).
 	gp.mu.RLock()
+	listening := gp.conn != nil
 	localID := gp.localNode.ID
 	targets := make([]string, 0, len(gp.memberlist))
 	for _, gossipNode := range gp.memberlist {
@@ -1295,8 +1309,22 @@ func (gp *GossipProtocol) broadcastMessage(msg *GossipMessage) error {
 	}
 	gp.mu.RUnlock()
 
+	// Checked against the socket rather than against gp being non-nil, because a GossipProtocol exists
+	// from NewGossipProtocol onward and only acquires a socket in Start. A cluster constructed and not
+	// started has a whole gossip object whose every send would dial out from an unbound port and go
+	// nowhere in particular — reporting success for that is how a caller comes to believe peers were
+	// told something they were not.
+	if !listening {
+		return fmt.Errorf("cannot broadcast %s: gossip is not listening, so this node has no way to "+
+			"reach its peers: %w", msg.Type, types.ErrNotSupported)
+	}
+
 	for _, addr := range targets {
 		go func(addr string) {
+			// Errors are counted rather than returned: this runs after the caller has its answer, and one
+			// unreachable peer is the normal state of a gossip cluster rather than a failure of the
+			// broadcast. sendMessage already increments NetworkErrors and MessagesOversize, which is where
+			// an operator sees it.
 			_ = gp.sendMessage(addr, msg)
 		}(addr)
 	}

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -111,13 +111,54 @@ type Backend interface {
 	HealthCheck(ctx context.Context) error
 }
 
-// DistributedCoordinator manages distributed operations across cluster nodes
+// DistributedCoordinator runs an operation on a cluster node and lets nodes tell each other what they
+// have cached.
+//
+// The two halves are separate on purpose. ExecuteOperation is about a single operation against the
+// object store, where correctness comes from the store evaluating a precondition — see
+// [Backend.PutObjectIf]. The cache-coordination methods are about which node holds which bytes, which
+// is an optimization: every one of them may fail, and a caller that treats a failure as fatal has
+// turned a slower read into no read. What they must never do is succeed without doing the work, which
+// is why implementations that cannot perform one return [ErrNotSupported] rather than nil.
 type DistributedCoordinator interface {
 	// Execute a distributed operation
 	ExecuteOperation(ctx context.Context, op any) (any, error)
 
 	// Get coordinator statistics
 	GetStats() map[string]any
+
+	// AnnounceKey tells peers this node has ann's bytes cached, so a peer can fetch from here instead of
+	// from the object store.
+	//
+	// Best-effort by nature: it is one message on an unreliable transport, and a peer that never hears
+	// it reads from S3, which is correct and merely slower. A returned error means the announcement was
+	// not sent, not that peers rejected it — there is no acknowledgement to wait for.
+	AnnounceKey(ctx context.Context, ann KeyAnnouncement) error
+
+	// QueryKeyOwnership reports the peers claiming to hold key, freshest information first where the
+	// implementation can order it.
+	//
+	// An empty slice and a nil error is the ordinary answer for a key nobody has cached, and callers
+	// must treat it as "read from the store" rather than as "the key does not exist" — this reports what
+	// is cached, and says nothing about what the bucket contains.
+	//
+	// Every returned [KeyAnnouncement] is a claim by another node, not a verified fact. A caller that
+	// fetches from a claimed holder must check what it receives against the ETag it wanted, because a
+	// holder can have evicted, replaced, or never held the bytes it announced.
+	QueryKeyOwnership(ctx context.Context, key string) ([]KeyAnnouncement, error)
+
+	// InvalidateKey tells peers to evict key, because the version named by etag replaced what they hold.
+	//
+	// etag is the version the caller wrote — the ETag reported by the write itself, not one from a
+	// later HeadObject, which could name a third node's subsequent write. It is what lets a receiver
+	// apply an invalidation exactly once: gossip retransmits and reorders, so a bare key leaves a
+	// receiver unable to distinguish an invalidation it has already acted on from one it has not.
+	//
+	// An empty etag is legal and means the caller cannot name a version — a delete, or an unconditional
+	// write whose ETag was not read back. Every receiver then applies the invalidation every time, which
+	// costs a redundant eviction and can never serve stale bytes. Prefer a real ETag where there is one;
+	// never invent one to fill the field.
+	InvalidateKey(ctx context.Context, key, etag string) error
 }
 
 // Cache defines the caching interface for byte ranges of objects.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,6 +48,53 @@ type Range struct {
 	Size   int64 `json:"size"`
 }
 
+// KeyAnnouncement says that one node holds one version of some bytes of one key in its local cache.
+//
+// It is what a peer needs in order to decide whether fetching from that node is worth doing instead of
+// reading from S3, so every field it carries is a field that decision depends on — see
+// [DistributedCoordinator.AnnounceKey] and [DistributedCoordinator.QueryKeyOwnership].
+//
+// The JSON tags are not decorative. This crosses the gossip wire, where every neighboring field is
+// snake_case; [Precondition] shipped untagged and put `Absent` beside `created_at` until it was fixed
+// before release.
+type KeyAnnouncement struct {
+	Key string `json:"key"`
+
+	// NodeID is the node holding the bytes, and is what a recipient dials. It is required: an
+	// announcement whose holder cannot be identified is not actionable, only misleading.
+	NodeID string `json:"node_id"`
+
+	// ETag is the object version these bytes were read from.
+	//
+	// Required rather than optional, which is the difference between this and an invalidation. An
+	// invalidation with no version is still safe — "evict whatever you hold" cannot serve wrong bytes.
+	// An announcement with no version is not: a peer that fetches from the holder gets bytes it cannot
+	// place relative to the object in the bucket, and hands them to a reading process as file content.
+	// A holder that does not know its own version has nothing to announce.
+	ETag string `json:"etag"`
+
+	// Size is the full object's size, not the length of the announced range. A peer weighing a fetch
+	// needs both: the range tells it what it can get here, the size tells it what fraction of the
+	// object that is.
+	Size int64 `json:"size"`
+
+	// CachedAt is when the holder cached these bytes. It exists so a recipient can prefer the freshest
+	// of several announcements for the same key, and it is advisory only: clocks across nodes are not
+	// synchronized, so it must never be compared against a local deadline to decide validity. ETag is
+	// what decides whether the bytes are the version wanted.
+	CachedAt time.Time `json:"cached_at"`
+
+	// Offset and Length are the byte range held, since a cache holds ranges rather than objects — a node
+	// that read the first 64 KiB of a 10 GiB object can serve that and nothing else, and an announcement
+	// that omitted the range would invite a peer to request bytes the holder has to fetch from S3
+	// itself, which is slower than the peer reading S3 directly.
+	//
+	// A Length of 0 means the full object from Offset, matching [Cache.Get]'s convention for a
+	// non-positive size.
+	Offset int64 `json:"offset"`
+	Length int64 `json:"length"`
+}
+
 // PrefetchCandidate represents a file/range to prefetch
 type PrefetchCandidate struct {
 	Path     string    `json:"path"`

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,99 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestKeyAnnouncementJSON pins the wire form.
+//
+// A KeyAnnouncement exists to travel: it is one node telling others what it has cached, and both halves
+// of that exchange are remote. So the field names are a wire contract, and the reason to pin them is
+// specific rather than general — Precondition shipped in this package with no tags at all and put
+// `Absent` and `ETag` beside `key` and `created_at` in the same message. That was free to fix only
+// because it had not been released yet.
+//
+// Every field is asserted present even when zero, which is deliberate and the opposite of Precondition's
+// omitzero treatment. An announcement's zero values carry meaning: Offset 0 with Length 0 is "the whole
+// object from the start", which is the commonest announcement there is, and omitting the pair would make
+// it indistinguishable on the wire from a malformed message with no range at all.
+func TestKeyAnnouncementJSON(t *testing.T) {
+	t.Parallel()
+
+	cachedAt := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+
+	got, err := json.Marshal(KeyAnnouncement{
+		Key:      "datasets/reads.bam",
+		NodeID:   "node-a",
+		ETag:     `"abc123"`,
+		Size:     4096,
+		CachedAt: cachedAt,
+		Offset:   0,
+		Length:   0,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	const want = `{"key":"datasets/reads.bam","node_id":"node-a","etag":"\"abc123\"","size":4096,` +
+		`"cached_at":"2026-08-08T12:00:00Z","offset":0,"length":0}`
+	if string(got) != want {
+		t.Errorf("marshaled to\n  %s\nwant\n  %s", got, want)
+	}
+
+	// And it round-trips. A peer acts on what it decodes, so a field that marshals under the right name
+	// but does not survive the return trip is the same defect one step later.
+	var back KeyAnnouncement
+	if err := json.Unmarshal(got, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.CachedAt.Equal(cachedAt) {
+		t.Errorf("CachedAt round-tripped to %v, want %v", back.CachedAt, cachedAt)
+	}
+	back.CachedAt = cachedAt // time.Time compares unequal across locations even when it is the same instant
+	if want := (KeyAnnouncement{
+		Key: "datasets/reads.bam", NodeID: "node-a", ETag: `"abc123"`, Size: 4096, CachedAt: cachedAt,
+	}); back != want {
+		t.Errorf("round-tripped to %+v, want %+v", back, want)
+	}
+}
+
+// TestKeyAnnouncementJSON_RangeSurvives is the case the zero-value test cannot cover: a partial range
+// must arrive as the range it was, not collapsed to the whole object.
+//
+// Length 0 means "to the end", so a marshaler that dropped a nonzero Length would turn "I hold the first
+// 64 KiB of this 10 GiB object" into "I hold all of it". A peer acting on that fetches bytes the holder
+// does not have, and the holder either reads them from S3 itself — slower than the peer would have been
+// — or answers short.
+func TestKeyAnnouncementJSON_RangeSurvives(t *testing.T) {
+	t.Parallel()
+
+	ann := KeyAnnouncement{
+		Key:    "big/object",
+		NodeID: "node-b",
+		ETag:   `"v2"`,
+		Size:   10 << 30,
+		Offset: 1 << 20,
+		Length: 64 << 10,
+	}
+
+	data, err := json.Marshal(ann)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var back KeyAnnouncement
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if back.Offset != ann.Offset || back.Length != ann.Length {
+		t.Errorf("range round-tripped to [%d,+%d), want [%d,+%d)", back.Offset, back.Length,
+			ann.Offset, ann.Length)
+	}
+	if back.Size != ann.Size {
+		t.Errorf("Size round-tripped to %d, want %d: the full object size is what tells a peer what "+
+			"fraction of the object the announced range is", back.Size, ann.Size)
+	}
+}


### PR DESCRIPTION
Closes #129. **The issue body was revised before implementing** — two of its items no longer held after #284, and the two comments on it are the record of why. What is built here is the revised version.

## Breaking, and found by a test rather than by inspection

`GossipProtocol.broadcastMessage` returned `nil` unconditionally. It fanned out into goroutines that discarded every send error, and `NewClusterManager` builds a `GossipProtocol` while only `Start` opens its socket — and every send dials its *own* UDP socket. So broadcasting from a constructed-but-unstarted cluster dialed from an unbound port, reached nobody, and reported success.

A node that had just replaced an object's bytes could not distinguish **"every peer was told to evict the version before"** from **"nothing was sent"**, and the difference is whether peers keep serving stale content. It now refuses with `types.ErrNotSupported` when not listening, and `ClusterManager.InvalidateCacheKey` / `InvalidateDeletedCacheKey` return `error` where they returned nothing.

**What a nil does and does not mean**, stated in the doc comment rather than left to inference: the message was handed to the network for each peer, never that any peer received it. Gossip is unreliable datagrams with no acknowledgement, so convergence rests on retransmission, not on this return value. A running cluster with no peers is a nil error and no sends — nobody to tell, nothing wrong. Per-peer failures stay counted in `NetworkErrors`/`MessagesOversize`, since one unreachable peer is the normal state of a gossip cluster.

`LeaveCluster` is the only other caller whose error reaches outward, and it has no callers, so nothing else changes behaviour.

## The interface

```go
type DistributedCoordinator interface {
    ExecuteOperation(ctx context.Context, op any) (any, error)
    GetStats() map[string]any

    AnnounceKey(ctx context.Context, ann KeyAnnouncement) error
    QueryKeyOwnership(ctx context.Context, key string) ([]KeyAnnouncement, error)
    InvalidateKey(ctx context.Context, key, etag string) error
}
```

This is what the whole v0.13.0 warming chain (#140, #141, #142, #143) was blocked on. None of it could begin while a coordinator had no way to say "this node holds these bytes at this version."

### Stubs return `ErrNotSupported`, not `nil`

The issue as filed said nil stubs were acceptable. Revised, because that is the defect #284 deleted: its `CacheReplicator` added bytes to `BytesReplicated` when gossip was not running and it had sent nothing, and it survived four releases because the only test covering it asserted its field was non-nil.

`QueryKeyOwnership` in particular must **not** return an empty slice with a nil error. That is the *correct* answer for a key no peer has cached, so returning it from a method that cannot query is indistinguishable from a working query against a cold cluster — an operator watching peer-fetch hit rates would read a flat zero as "warming does not help" rather than "warming is not built."

### `InvalidateKey` takes the ETag

Not `InvalidateKey(ctx, key)` as filed. Gossip retransmits and reorders, so a bare key leaves a receiver unable to tell an invalidation it has already applied from one it has not — requirement R4 of `docs/design/conditional-writes-vs-raft.md` §1. #284 built the receiving half (`markInvalidationApplied`, a bounded set of applied `(key, ETag)` pairs); this is the interface those messages travel under, so the signature has to admit the version or the plumbing stops at the boundary.

Empty stays legal, means the caller cannot name a version — a delete, or an unconditional put — and is applied every time. A redundant eviction, never a stale read.

### `KeyAnnouncement`

Its `ETag` is **required** rather than optional, which is the one place it differs from an invalidation. An unversioned invalidation is safe, since "evict whatever you hold" cannot serve wrong bytes. An unversioned *announcement* is not: it invites a peer to fetch bytes it cannot place relative to the object in the bucket, and hand them to a reading process as file content.

`Offset`/`Length` are deliberately **not** `omitempty`, unlike `Precondition`'s fields. Offset 0 with Length 0 means "the whole object from the start" and is the commonest announcement there is, so omitting the pair would be indistinguishable on the wire from a message carrying no range at all. `Size` is the full object's size rather than the range's, because a peer weighing a fetch needs both — the range says what it can get here, the size says what fraction of the object that is.

JSON tags are pinned by a test for the reason `Precondition`'s were added in #284: that type shipped untagged and put `Absent` beside `created_at`, and it was free to fix only because it had not been released.

## Mutation verification

Eight mutations, each killing the assertion that names it.

| mutation | assertion that died |
|---|---|
| `AnnounceKey` returns nil | `AnnounceKey = <nil>, want ErrNotSupported` |
| `QueryKeyOwnership` returns `[]KeyAnnouncement{}, nil` | both the error and the "returned 0 holders alongside its error" check |
| remove the not-listening guard | `InvalidateCacheKey with gossip not listening = <nil>` |
| drop the ETag from the broadcast | `cm2 applied 3 invalidations, want 2` |
| wrapper `InvalidateKey` returns nil silently | `cache.Delete("warm/key") was not called within 2s` |
| `omitempty` on `Offset`/`Length` | exact-JSON comparison |
| rename `node_id` → `NodeID` | exact-JSON comparison |
| remove an interface method | the compile-time assertion, at build |

Dropping the ETag is the interesting one: the invalidation still **arrives**, and three of them then apply where two should. That is the R4 defect itself rather than a delivery failure, which is what makes it worth asserting on the count rather than on the eviction.

The two-node test asserts by **receiving** on a second node rather than by inspecting the call, because the bug it guards against is a broadcast assembled correctly and never sent — which is exactly what `InvalidateCacheKey` did before this change. Its predecessor asserted only that invalidating with gossip down did not panic, which passed identically whether the message was broadcast or dropped on the floor.

Also extracted `startGossipPair` and `waitForDeletion` from the existing two-node test rather than copying its 40 lines of setup, and raised its 200ms deadline to 2s — the failure it catches is a message that is never sent, which no amount of waiting fixes, so a tight deadline buys nothing and flakes on a loaded runner.

## Verification

```
go build ./...                            ok
go vet ./...                              ok
gofmt -l .                                clean
make lint                                 0 issues
go test -race ./internal/... ./pkg/...    all pass
go test -race -tags=distributed ./tests/  green (x3, incl. -count=2)
```

Coverage: `internal/distributed` 80.6% → **81.2%**, `pkg/types` **100%**.

## Not in scope

`AnnounceKey` and `QueryKeyOwnership` have no implementation — that is #140, and they say so by returning `ErrNotSupported` with the issue number in the message. The `internal/distributed` package doc gains a "Cache Coordination" section stating which of the three works and what the invalidation ledger deliberately cannot do: suppress an invalidation *older* than what a peer holds, since `types.Cache` stores bytes at offsets with no version beside them. That needs a per-key version in the cache, which is #141's work, and is documented rather than guessed at.
