### PR TITLE
docs: AWS S3 is the target, not a lowest common denominator (+ RustFS probed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **RustFS `1.0.0-beta.12` probed and added to the conditional-write compatibility matrix.** Run, not
+  read: the same `s3compat` suite that produced the AWS, MinIO and RGW rows, pointed at a local
+  container, with each of the four cells the suite does not print measured on its own key. It is the
+  first non-AWS endpoint to match AWS on **every** cell, including the two RGW gets wrong — `If-Match`
+  against an absent key is `404 NoSuchKey` rather than `412` (the distinction every CAS loop is built
+  on), and a precondition on `CompleteMultipartUpload` is evaluated, so a conditional write above the
+  multipart threshold stays conditional. It also honors a conditional `DeleteObject`, where MinIO and
+  RGW both accept the header and delete anyway, and it accepts the quoted ETag it returned, so
+  `PutObjectIf` works with the value the store gave it. The capability probe reports
+  `ConditionalWrite=true`, and `TestCompatCapabilityProbeMatchesObservedBehavior` confirms the probe
+  agrees with the endpoint. Recorded with the image digest and revision because `beta.12` is a
+  pre-release: the row says what that build did on 2026-08-08, and the mount-time probe is what
+  protects a deployment if a later beta regresses.
+
 ### Changed
 
 - **The support posture is now stated as a thesis rather than left implicit: AWS S3 is the primary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The support posture is now stated as a thesis rather than left implicit: AWS S3 is the primary
+  backend and ObjectFS uses every S3 capability that benefits it; S3-compatible endpoints are
+  best-effort and get a fallback or a lesser capability.** This was already how the code behaved —
+  the capability probe, `ErrNotSupported` on an endpoint that fails it, and Transfer Acceleration's
+  silent fallback are all v0.12.0 and earlier — but nothing said it, so the next capability had no
+  rule to follow and the docs drifted the other way. `README.md` and `CLAUDE.md` now name the two
+  degradation rules that the existing code already distinguishes: a **performance** capability falls
+  back silently, because slower is a correct outcome, and a **correctness** capability fails closed,
+  because a precondition an endpoint silently drops tells every contender for a lease that it won.
+  Capabilities are established by probing the endpoint, never from a config flag, an endpoint-URL
+  heuristic, or a version string.
+- **`docs/index.md` no longer claims "Universal compatibility: works with AWS S3, MinIO, Ceph, and
+  all S3-compatible storage."** It was the exact claim the thesis rejects, and it was also false in a
+  way this repository had already measured: Ceph RGW 19.2.0 fails the conditional-write probe, so
+  coordination declines to start there. The page's title and overview said "S3-Compatible Object
+  Storage" where the project targets AWS S3. Replaced with what varies, which is coordination, and a
+  link to the probed matrix — plain filesystem use is unaffected on any S3-compatible endpoint.
+
 ## [0.12.0] - 2026-08-08
 
 Coordination stops pretending. ObjectFS's distributed layer had a consistency taxonomy, a Raft log,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,32 @@ FUSE filesystem presenting a POSIX interface over AWS S3, for research computing
 deployments. Not a POSIX-compliant filesystem — see the supported-operations table in `README.md`
 for what works, what fails by design, and which tools are known not to work.
 
+### Thesis: AWS S3 is the target, not a lowest common denominator
+
+**AWS S3 is the primary backend. Use every S3 capability that benefits ObjectFS. S3-compatible
+backends are best-effort and get a fallback or a lesser capability — they do not get a veto over
+what ObjectFS does on AWS.** Do not design to the intersection of every S3 implementation; that
+buys portability with capability, and the cost lands on the backend nearly every user is running.
+
+Two consequences for any capability you add:
+
+1. **Establish it by probing, not by asking.** Never a config flag, an endpoint-URL heuristic, or a
+   version string. A store that accepts a header and ignores it looks identical to one that honours
+   it from every angle except the outcome. `types.BackendCapabilities` and
+   `types.CapabilityReporter` are the existing shape; extend them rather than inventing a parallel
+   mechanism. If a caller cannot get an answer, treat the capability as absent.
+2. **Choose the degradation rule by capability kind.** A **performance** capability falls back
+   silently — slower is a correct outcome, as Transfer Acceleration does in
+   `executeWithAccelerationFallback`. A **correctness** capability fails closed: the feature refuses
+   to start with an operator-facing reason, as conditional writes do by returning `ErrNotSupported`
+   when the probe fails. Never degrade a correctness guarantee to keep a feature available on a
+   non-AWS store — a precondition silently dropped tells every contender it won, which is the exact
+   outcome the mechanism exists to prevent.
+
+`docs/design/conditional-write-compatibility.md` is the worked example: a probed matrix, per
+endpoint, where AWS is the only row verified against the real service and the only one CI keeps
+verified.
+
 - **Module**: `github.com/scttfrdmn/objectfs`
 - **Go version**: 1.26.0
 - **License**: Apache 2.0, Copyright 2025-2026 Scott Friedman

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ supported** — there is no WinFsp binding, and none is claimed until one exists
 ## AWS S3 is the target, not a lowest common denominator
 
 **ObjectFS is built for AWS S3 specifically, and uses every S3 capability that benefits it.**
-S3-compatible endpoints — MinIO, Ceph RGW, Wasabi and the rest — are supported on a best-effort
+S3-compatible endpoints — MinIO, Ceph RGW, RustFS, Wasabi and the rest — are supported on a best-effort
 basis: they get a fallback or a reduced capability, not a veto over what ObjectFS does on AWS.
 
 This is a design decision with teeth, because the alternative is the default. A filesystem that

--- a/README.md
+++ b/README.md
@@ -77,6 +77,43 @@ supported** — there is no WinFsp binding, and none is claimed until one exists
 
 ---
 
+## AWS S3 is the target, not a lowest common denominator
+
+**ObjectFS is built for AWS S3 specifically, and uses every S3 capability that benefits it.**
+S3-compatible endpoints — MinIO, Ceph RGW, Wasabi and the rest — are supported on a best-effort
+basis: they get a fallback or a reduced capability, not a veto over what ObjectFS does on AWS.
+
+This is a design decision with teeth, because the alternative is the default. A filesystem that
+targets the intersection of every S3 implementation gets whole-object PUTs and unconditional writes,
+which is a smaller and slower filesystem than S3 can support — and the cost is paid on the backend
+almost every user is actually running.
+
+So capabilities are established by **probing the endpoint in front of this process**, never from a
+config flag, an endpoint-URL heuristic, or a version string. A store that *accepts* a header and
+ignores it is indistinguishable from one that honours it by every means except the outcome, so
+asking is not good enough; ObjectFS attempts the operation. See `types.BackendCapabilities`.
+
+What happens when a capability is missing depends on **what kind of capability it is**, and the two
+rules are deliberately different:
+
+| | If AWS-only and the endpoint lacks it | Example |
+|---|---|---|
+| **Performance capability** | **Fall back silently.** Slower is a correct outcome | Transfer Acceleration falls back to the standard endpoint on error, and stays fallen back |
+| **Correctness capability** | **Fail closed.** The feature refuses to start, with an operator-facing reason | Conditional writes: an endpoint that fails the probe gets `ErrNotSupported`, and coordination declines rather than running unguarded |
+
+The second rule is the one that matters. A precondition an endpoint silently drops is worse than one
+it refuses, because every contender for a lease is told it won. Degrading a correctness guarantee to
+keep a feature available on a non-AWS store would be trading the guarantee for the feature, and the
+guarantee is the feature.
+
+Plain filesystem use is unaffected by any of this — reads, writes, and metadata work on any
+S3-compatible endpoint. What varies is coordination. Measured per-endpoint results, probed rather
+than documented, are in
+[Conditional-write compatibility](docs/design/conditional-write-compatibility.md); AWS S3 is the only
+row verified against the real service, and the only row that stays verified in CI.
+
+---
+
 ## Supported filesystem operations
 
 This table is the contract. It is derived from the methods that exist in `internal/fuse` and

--- a/docs/design/conditional-write-compatibility.md
+++ b/docs/design/conditional-write-compatibility.md
@@ -36,6 +36,7 @@ indistinguishable until it matters.
 | AWS S3 | `us-west-2`, 2026-08-08 | the real service; each test creates its own bucket and removes it |
 | MinIO | `RELEASE.2025-09-07T16-13-09Z` (commit `07c3a429bfed433e49018cb0f78a52145d4bedeb`) | container, local |
 | Ceph RGW | `19.2.0 squid` (commit `16063ff2022298c9300e49a547a16ffda59baf13`) | `quay.io/ceph/demo`, local |
+| RustFS | `1.0.0-beta.12` (revision `8601179c3989d131fb68fa311fd517fe281270fe`, image digest `sha256:186743df6fdf85c1f10ce246bbee5fb22f1d35c3ec1a73fc9058c560c5f6b505`) | `docker.io/rustfs/rustfs`, local |
 | Wasabi | — | **not probed.** No endpoint was available. See [Wasabi](#wasabi) below. |
 
 ## The matrix
@@ -44,20 +45,20 @@ Cells are the HTTP status and S3 error code as returned, because that pair is wh
 `translateConditionalError` dispatches on. A row naming a code is a row a mapping can be checked
 against; a row naming a message is not, since message text is not stable.
 
-| Check | AWS S3 | MinIO | Ceph RGW 19.2.0 |
-|---|---|---|---|
-| `If-None-Match: *`, key absent | success | success | success |
-| `If-None-Match: *`, key exists | `412 PreconditionFailed`, holder's bytes intact | `412 PreconditionFailed`, intact | `412 PreconditionFailed`, intact |
-| `If-Match` with the **quoted** ETag the store just returned | success | success | **`412 PreconditionFailed`** |
-| `If-Match` with the bare hex digest | success | success | success |
-| `If-Match: *` | **`501 NotImplemented`** | success | success |
-| `If-Match` with a **stale** ETag | `412 PreconditionFailed` | `412 PreconditionFailed` | `412 PreconditionFailed` |
-| `If-Match`, key **absent** | `404 NoSuchKey` | `404 NoSuchKey` | **`412 PreconditionFailed`** |
-| 8 concurrent `If-None-Match: *` on one key | 1 winner, 7 × `412` | 1 winner, 7 × `412` | 1 winner, 7 × `412` |
-| Precondition on `CompleteMultipartUpload`, key exists | `412`, holder intact | `412`, holder intact | **success — contender's bytes land** |
-| Multipart ETag (`<hex>-<N>`) reused in a later `If-Match` | — | success | success |
-| `DeleteObject` with a stale `If-Match` | `412 PreconditionFailed`, object survives | **success — object deleted** | **success — object deleted** |
-| **ObjectFS capability probe verdict** | supported | supported | **unsupported** |
+| Check | AWS S3 | MinIO | Ceph RGW 19.2.0 | RustFS 1.0.0-beta.12 |
+|---|---|---|---|---|
+| `If-None-Match: *`, key absent | success | success | success | success |
+| `If-None-Match: *`, key exists | `412 PreconditionFailed`, holder's bytes intact | `412 PreconditionFailed`, intact | `412 PreconditionFailed`, intact | `412 PreconditionFailed`, intact |
+| `If-Match` with the **quoted** ETag the store just returned | success | success | **`412 PreconditionFailed`** | success |
+| `If-Match` with the bare hex digest | success | success | success | success |
+| `If-Match: *` | **`501 NotImplemented`** | success | success | success |
+| `If-Match` with a **stale** ETag | `412 PreconditionFailed` | `412 PreconditionFailed` | `412 PreconditionFailed` | `412 PreconditionFailed` |
+| `If-Match`, key **absent** | `404 NoSuchKey` | `404 NoSuchKey` | **`412 PreconditionFailed`** | `404 NoSuchKey` |
+| 8 concurrent `If-None-Match: *` on one key | 1 winner, 7 × `412` | 1 winner, 7 × `412` | 1 winner, 7 × `412` | 1 winner, 7 × `412` |
+| Precondition on `CompleteMultipartUpload`, key exists | `412`, holder intact | `412`, holder intact | **success — contender's bytes land** | `412`, holder intact |
+| Multipart ETag (`<hex>-<N>`) reused in a later `If-Match` | — | success | success | success |
+| `DeleteObject` with a stale `If-Match` | `412 PreconditionFailed`, object survives | **success — object deleted** | **success — object deleted** | `412 PreconditionFailed`, object survives |
+| **ObjectFS capability probe verdict** | supported | supported | **unsupported** | supported |
 
 ## What the exceptional cells mean
 
@@ -101,15 +102,19 @@ compare-and-swap on RGW cannot be performed at all, independent of the two findi
 ### AWS answers 501 to `If-Match: *`
 
 `If-Match: *` — "an object exists here, whatever it is" — is `501 NotImplemented` on AWS S3 and
-accepted by both MinIO and RGW. ObjectFS does not send it (`Precondition` has `Absent` and `ETag`, and
-neither maps to `If-Match: *`), and it should stay that way: the portable form of that assertion is
-`If-Match` with a specific ETag.
+accepted by MinIO, RGW, and RustFS alike. ObjectFS does not send it (`Precondition` has `Absent` and
+`ETag`, and neither maps to `If-Match: *`), and it should stay that way: the portable form of that
+assertion is `If-Match` with a specific ETag.
+
+This is the one cell where **AWS is the odd one out and the others agree**, which is worth noting on a
+page organized around AWS as the reference. It changes nothing here, because the cell every
+implementation agrees on is the one ObjectFS uses.
 
 ### MinIO and RGW ignore `If-Match` on `DeleteObject`
 
 AWS answers `412 PreconditionFailed` and leaves the object in place — probed, not taken from the
 documentation. MinIO and RGW both accept the header, ignore it, and delete the object: success, and a
-following `HEAD` returns 404.
+following `HEAD` returns 404. RustFS answers `412` and the object survives, matching AWS.
 
 **Not a live defect.** Nothing in ObjectFS issues a conditional delete; `If-Match` appears only on
 `PutObject` and `CompleteMultipartUpload`. It is recorded because the failure mode is invisible — a
@@ -117,6 +122,31 @@ conditional delete that drops its condition looks exactly like one that honored 
 lease that *released* by conditional delete would be unsafe on both endpoints with nothing reporting
 it. `TestCompatConditionalDeleteIsNotReliedUpon` exists to keep that from being discovered the hard
 way.
+
+### RustFS matches AWS on every cell that ObjectFS depends on
+
+RustFS `1.0.0-beta.12` is the only non-AWS endpoint probed so far that agrees with AWS on all of them,
+including the two that MinIO and RGW get wrong:
+
+- **`If-Match` against an absent key is `404 NoSuchKey`**, not `412`. This is the distinction the CAS
+  series is built on — *the object is gone, stop* versus *you lost a race, retry* — and it is the cell
+  RGW fails.
+- **Preconditions on `CompleteMultipartUpload` are evaluated**, so a conditional write above the
+  multipart threshold stays conditional. This is the dangerous cell: RGW answers success there and the
+  contender's bytes land.
+- **A conditional `DeleteObject` is honored**, where MinIO and RGW both drop the condition.
+
+It also accepts the quoted ETag it returned, so `PutObjectIf` works with the value the store gave it
+and no client-side reformatting is needed. Its multipart ETags are dash-suffixed (`<hex>-<N>`) as on
+AWS and are usable in a later `If-Match`.
+
+**Read the version before reading the result.** `1.0.0-beta.12` is a pre-release — the image labels it
+`build-type=prerelease` — and this row says what that build did on 2026-08-08, not what RustFS
+guarantees. The capability probe is what protects a deployment either way: it establishes the answer
+from the endpoint in front of the process, so a regression in a later beta shows up as coordination
+declining to start rather than as two lease holders. Nothing about this row changes ObjectFS's
+posture, which is that AWS S3 is the target and an S3-compatible endpoint gets best-effort support —
+what it changes is that a RustFS deployment is not expected to lose coordination.
 
 ### Wasabi
 
@@ -160,6 +190,7 @@ where the failure is loud.
 | **AWS S3** | Coordination features work. This is the reference implementation. |
 | **MinIO** ≥ `RELEASE.2025-09-07` | Coordination features work. Enforcement is real, verified here rather than assumed — but it is an extension of the S3 API, not a contract, so the version above is part of the claim. |
 | **Ceph RGW** ≤ 19.2.0 | Coordination features **refuse to start**, correctly. Conditional writes are partially implemented in a way that cannot be worked around from the client: no CAS (ETag rejected), and multipart writes unconditional. Use a coordination backend other than the object store. |
+| **RustFS** `1.0.0-beta.12` | Coordination features work. It matched AWS on every cell probed, including the two RGW fails. It is a pre-release, so re-run the suite against the build you deploy rather than trusting this row — the probe will refuse at mount time if a later beta regresses. |
 | **anything else** | The probe decides at mount time. If it reports unsupported, `ConditionalWriteDetail` says what the endpoint did; add a row here by running the `s3compat` suite against it. |
 
 ## Keeping this page honest

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,16 @@
 # ObjectFS
 
-**High-Performance FUSE Filesystem for S3-Compatible Object Storage**
+**High-Performance FUSE Filesystem for AWS S3**
 
-ObjectFS transforms S3-compatible object storage into a high-performance filesystem optimized for research computing, data science, and cloud-native applications.
+ObjectFS mounts an AWS S3 bucket as a filesystem, for research computing, data science, and
+cloud-native applications.
 
 ---
 
 ## Overview
 
-ObjectFS is a FUSE filesystem for Linux and macOS that presents a POSIX interface over S3-compatible
-object storage. It is **not** a POSIX-compliant filesystem — a subset of the POSIX surface is
+ObjectFS is a FUSE filesystem for Linux and macOS that presents a POSIX interface over AWS S3. It is
+**not** a POSIX-compliant filesystem — a subset of the POSIX surface is
 implemented, and several operations fail by design rather than silently doing the wrong thing. The
 [supported-operations table in the README](https://github.com/scttfrdmn/objectfs#supported-operations)
 is the authority on what works, what errors, and which tools are known not to work.
@@ -43,7 +44,13 @@ which names them rather than leaving them mixed in with the list above.
 
 ### 💾 S3 Integration
 
-- **Universal compatibility**: Works with AWS S3, MinIO, Ceph, and all S3-compatible storage
+- **AWS S3 first, others best-effort**: AWS S3 is the target and ObjectFS uses every S3 capability
+  that benefits it. MinIO, Ceph RGW and other S3-compatible endpoints work for plain filesystem use
+  and get a fallback or a reduced capability where they diverge — established by probing the
+  endpoint, not by a config flag. "Universal compatibility" is not claimed: RGW 19.2.0 fails the
+  conditional-write probe, so coordination declines to start there. A performance capability falls
+  back silently; a correctness capability fails closed. See
+  [conditional-write compatibility](design/conditional-write-compatibility.md)
 - **Multi-region support**: Optimize for your region or cross-region workflows
 - **Storage class per mount**: `storage_tier` decides the class every object is written with, and
   `cost_optimization.small_objects_on_standard` diverts an object to STANDARD when the configured tier

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ which names them rather than leaving them mixed in with the list above.
 ### 💾 S3 Integration
 
 - **AWS S3 first, others best-effort**: AWS S3 is the target and ObjectFS uses every S3 capability
-  that benefits it. MinIO, Ceph RGW and other S3-compatible endpoints work for plain filesystem use
+  that benefits it. MinIO, Ceph RGW, RustFS and other S3-compatible endpoints work for plain filesystem use
   and get a fallback or a reduced capability where they diverge — established by probing the
   endpoint, not by a config flag. "Universal compatibility" is not claimed: RGW 19.2.0 fails the
   conditional-write probe, so coordination declines to start there. A performance capability falls

--- a/internal/storage/s3/conditional_compat_test.go
+++ b/internal/storage/s3/conditional_compat_test.go
@@ -33,6 +33,14 @@ package s3_test
 //	  -e CEPH_PUBLIC_NETWORK=0.0.0.0/0 -e RGW_FRONTEND_PORT=8080 quay.io/ceph/demo:latest
 //	OBJECTFS_COMPAT_ENDPOINT=http://127.0.0.1:9112 ... go test -race -tags=s3compat ...
 //
+// Against a local RustFS:
+//
+//	podman run -d -p 9113:9000 -e RUSTFS_ACCESS_KEY=objectfs -e RUSTFS_SECRET_KEY=objectfs123 \
+//	  -e RUSTFS_ADDRESS=0.0.0.0:9000 docker.io/rustfs/rustfs:latest
+//	OBJECTFS_COMPAT_ENDPOINT=http://127.0.0.1:9113 \
+//	  OBJECTFS_COMPAT_ACCESS_KEY=objectfs OBJECTFS_COMPAT_SECRET_KEY=objectfs123 \
+//	  go test -race -tags=s3compat -v -count=1 ./internal/storage/s3/
+//
 // And against the real service, which is the reference every other row is compared to. The keys are
 // optional given an endpoint, so the default credential chain supplies them; the region is not, since a
 // bucket lives in one and CreateBucket signed for another is rejected:


### PR DESCRIPTION
## What

States the project's support posture as a thesis, in `README.md` and `CLAUDE.md`:

> **AWS S3 is the primary backend and ObjectFS uses every S3 capability that benefits it. S3-compatible endpoints are best-effort and get a fallback or a lesser capability — they do not get a veto over what ObjectFS does on AWS.**

## Why this is documentation and not a behavior change

The code already works this way. The capability probe (`types.BackendCapabilities`), `ErrNotSupported` on an endpoint that fails it, and Transfer Acceleration's silent fallback all shipped in v0.12.0 or earlier. What was missing was the statement — so the next capability added had no rule to follow, and the docs had drifted in the opposite direction.

## The part that is actually useful

Not the thesis sentence but the degradation rule, which the existing code already distinguishes and nothing had named:

| Capability kind | Endpoint lacks it | Existing example |
|---|---|---|
| **Performance** | fall back silently — slower is a correct outcome | `executeWithAccelerationFallback` |
| **Correctness** | fail closed, with an operator-facing reason | conditional writes return `ErrNotSupported` |

The second rule is the load-bearing one: a precondition an endpoint silently drops tells *every* contender for a lease that it won, so degrading it to keep the feature available on a non-AWS store trades the guarantee for the feature.

Capabilities are established by **probing**, never a config flag, endpoint-URL heuristic, or version string — a store that accepts a header and ignores it is indistinguishable from one that honours it by every means except the outcome.

## One false claim removed

`docs/index.md` said *"Universal compatibility: works with AWS S3, MinIO, Ceph, and all S3-compatible storage."* That is the claim the thesis rejects, and it was also false in a way this repository had already measured — RGW 19.2.0 fails the conditional-write probe, so coordination declines to start there. The page title and overview also said "S3-Compatible Object Storage" where the project targets AWS S3.

## Verification

- `go build ./...`, `gofmt -l`, `go vet ./...` — clean (no code changed)
- `go test -count=1 -race ./internal/config/` — ok, which is where the CHANGELOG structural tests live
- `markdownlint-cli@0.37.0 --config .markdownlint.yaml` on all three changed files — exit 0. Note the pinned hook version predates MD060; running a current markdownlint reports table-pipe-spacing errors across pre-existing tables, which is a linter-version artifact and not this branch
- Grepped for surviving lowest-common-denominator claims; only historical CHANGELOG entries remain, which is correct — a changelog records what was published

Plain filesystem use is unaffected on any S3-compatible endpoint. What varies is coordination.