### PR TITLE
test: close the ephemeral-port window that failed a CI run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scrape. `FreeAddr` survives for the one caller that needs an address in advance and never binds it
   — the test asserting a disabled endpoint listens nowhere, which a competing bind cannot make pass.
 
+  `internal/health` had the same reserve-then-release pattern in the #211 regression test, not yet
+  triggered, and no way to fix it: nothing reported where the health listener bound. So
+  `health.Checker.Addr()` now exists, matching `metrics.Collector.Addr()` — which also means an
+  operator running the health endpoint on port 0 can find out where it went.
+
 ## [0.12.0] - 2026-08-08
 
 Coordination stops pretending. ObjectFS's distributed layer had a consistency taxonomy, a Raft log,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A flaky test that failed a CI run, in a helper written to make tests reliable.**
+  `testhttp.FreeAddr` binds `127.0.0.1:0`, records the address and closes the listener — which
+  returns the port to the ephemeral pool, so the kernel is free to hand it to something else before
+  the caller binds it. In CI it did: `TestStartMetricsBindsTheEndpoint` failed with
+  `bind: address already in use` on a port the `miniredis` in `internal/adapter`'s own
+  `cache_selection_test.go` had been given in the interval. Nothing in the test was wrong; the
+  address was stale by the time it was used.
+
+  Every caller that binds now configures port 0 and reads back where the kernel put it, closing the
+  window rather than narrowing it. That means the bound port is not known in advance, so the
+  where-it-bound assertion is now `testhttp.SameHost` — which is the assertion [#211] always turned
+  on: `fmt.Sprintf(":%d", Port)` produced a *wildcard host*, publishing an unauthenticated
+  `/metrics` on every routable interface, and a wildcard bind reads back as `0.0.0.0` or `[::]`
+  rather than the loopback address configured. Verified by mutation: reintroducing the host-stripped
+  bind fails both wiring tests naming the wildcard, and deleting the `Serve` goroutine fails the
+  scrape. `FreeAddr` survives for the one caller that needs an address in advance and never binds it
+  — the test asserting a disabled endpoint listens nowhere, which a competing bind cannot make pass.
+
 ## [0.12.0] - 2026-08-08
 
 Coordination stops pretending. ObjectFS's distributed layer had a consistency taxonomy, a Raft log,

--- a/internal/adapter/metrics_wiring_test.go
+++ b/internal/adapter/metrics_wiring_test.go
@@ -28,14 +28,21 @@ import (
 //
 // The address is a non-default one, and that is deliberate. A fixture equal to the default passes
 // whether the mapping happened or not, since the field would hold that value anyway.
+//
+// Port 0, not testhttp.FreeAddr. FreeAddr closes its listener before returning the address, so the
+// port goes back to the ephemeral pool and anything else asking for one can be handed it before
+// startMetrics binds — which is what happened in CI, where this test failed with
+// "bind: address already in use" on a port the miniredis in cache_selection_test.go got in the
+// interval. Nothing in the test was wrong; the address was stale by the time it was used. Port 0
+// closes the window instead of narrowing it, because the kernel picks at the moment of the bind.
 func TestStartMetricsBindsTheEndpoint(t *testing.T) {
 	t.Parallel()
 
-	addr := testhttp.FreeAddr(t)
+	const configured = "127.0.0.1:0"
 
 	cfg := config.NewDefault()
 	cfg.Monitoring.Metrics.Enabled = true
-	cfg.Monitoring.Metrics.Addr = addr
+	cfg.Monitoring.Metrics.Addr = configured
 
 	a := &Adapter{config: cfg}
 
@@ -47,11 +54,14 @@ func TestStartMetricsBindsTheEndpoint(t *testing.T) {
 	// The address the listener reports, which is the value the consumer received — not a recomputation
 	// of the mapping. #211's whole point is that "something is listening" and "the listener is where
 	// the configuration said" are different assertions, and only the second one fails for a wildcard
-	// bind: a wildcard answers on loopback too.
-	if got := a.metrics.Addr(); got != addr {
-		t.Errorf("the collector bound %s; monitoring.metrics.addr was %s. A wildcard bind reports "+
-			"0.0.0.0 or [::] here and publishes an unauthenticated endpoint on every interface", got, addr)
+	// bind: a wildcard answers on loopback too. The host is the half that carries that, and the half
+	// port 0 leaves comparable.
+	addr := a.metrics.Addr()
+	if addr == "" {
+		t.Fatal("the collector reports no bound address after a successful startMetrics, so nothing " +
+			"bound a listener — the field is non-nil either way, which is how this shipped once already")
 	}
+	testhttp.SameHost(t, addr, configured, "the adapter's metrics endpoint")
 
 	body := testhttp.Get(t, addr, "/metrics", "the adapter bound no metrics listener")
 
@@ -75,6 +85,12 @@ func TestStartMetricsBindsTheEndpoint(t *testing.T) {
 // This is also the only way to turn the endpoint off now. `metrics_port: 0` used to look like a way,
 // and it was the worst of both: zero read as "unset" to the collector's defaulting, came back as 8080,
 // and got bound (#212). An address has no value that quietly means something else.
+//
+// FreeAddr is right here and wrong in the test above, for the same reason in both cases: it hands
+// back an address whose port has already been released. This test never binds it — the assertion is
+// that nothing does — so a competing ephemeral bind cannot make it wrong, since failing it requires
+// answering HTTP 200 on /metrics. And an address is needed before Start, which is what port 0
+// cannot give.
 func TestStartMetricsHonorsDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -110,7 +126,9 @@ func TestStartMetricsRejectsAnUnusableLabel(t *testing.T) {
 
 	cfg := config.NewDefault()
 	cfg.Monitoring.Metrics.Enabled = true
-	cfg.Monitoring.Metrics.Addr = testhttp.FreeAddr(t)
+	// Port 0 rather than an address from testhttp.FreeAddr: the registration this test is about fails
+	// in NewCollector, before anything binds, so the only requirement on this value is that it parses.
+	cfg.Monitoring.Metrics.Addr = "127.0.0.1:0"
 	// "operation" is a variable label on operations_total, errors_total and both histograms.
 	cfg.Monitoring.Metrics.CustomLabels = map[string]string{"operation": "read"}
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -22,6 +22,10 @@ type Checker struct {
 	stopCh     chan struct{}
 	started    bool
 	lastUpdate time.Time
+
+	// boundAddr is what the listener reports, which is not necessarily Config.HTTPAddr: a caller
+	// asking for port 0 gets whatever the kernel assigned, and [Checker.Addr] is how it finds out.
+	boundAddr string
 }
 
 // Config represents health checker configuration
@@ -561,7 +565,29 @@ func (c *Checker) listenHealth(ctx context.Context) (net.Listener, error) {
 		return nil, fmt.Errorf("binding the health endpoint on %s: %w", c.config.HTTPAddr, err)
 	}
 
+	// Recorded under the lock Start already holds when it calls this — see Addr.
+	c.boundAddr = ln.Addr().String()
+
 	return ln, nil
+}
+
+// Addr returns the address the health endpoint is bound to, or "" if nothing has bound one.
+//
+// It exists for the same reason [metrics.Collector.Addr] does, and it is the piece that was missing
+// on this side: a test asserting *where* this listener is had to reserve an ephemeral port, close it,
+// and hand the address to Start — which returns the port to the kernel's pool in between, so anything
+// else asking for an ephemeral port can be given it first. That window failed a CI run on the metrics
+// side. Configuring port 0 and reading back closes it, and needs somewhere to read back from.
+//
+// The address, not a port, and the host half is what matters: /health reports component names, error
+// strings and check timings with no authentication, so a wildcard bind publishes that to anything
+// that can route here (#211). A wildcard reads back as 0.0.0.0 or [::] rather than the configured
+// host, which a scrape of loopback cannot distinguish.
+func (c *Checker) Addr() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.boundAddr
 }
 
 // serveHealth serves the health endpoint on ln, returning when Stop closes stopCh.

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/testhttp"
 )
 
 // This file covers the HTTP health endpoint and the Checker accessors around it.
@@ -313,24 +315,19 @@ func TestStartFailsWhenTheHealthAddressCannotBeBound(t *testing.T) {
 func TestStartServesTheEndpointWhereConfigured(t *testing.T) {
 	t.Parallel()
 
-	// A reserved-then-released address, because the address has to be known before Start binds it.
-	var lc net.ListenConfig
-
-	probe, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Skipf("cannot listen on loopback in this environment: %v", err)
-	}
-	addr := probe.Addr().String()
-	if err := probe.Close(); err != nil {
-		t.Fatalf("releasing the reserved address: %v", err)
-	}
+	// Port 0, read back through Addr. This used to reserve an ephemeral port, close it, and hand the
+	// address to Start — which returns the port to the kernel's pool in between, so anything else
+	// asking for an ephemeral port could be given it first and Start would fail to bind. That is not
+	// hypothetical: the same pattern in internal/testhttp.FreeAddr failed a CI run on the metrics
+	// side. The kernel picks at the moment of the bind, so there is no interval to lose.
+	const configured = "127.0.0.1:0"
 
 	checker, err := NewChecker(&Config{
 		Enabled:       true,
 		CheckInterval: time.Hour,
 		Timeout:       5 * time.Second,
 		HTTPEnabled:   true,
-		HTTPAddr:      addr,
+		HTTPAddr:      configured,
 		HTTPPath:      "/health",
 	})
 	if err != nil {
@@ -341,6 +338,15 @@ func TestStartServesTheEndpointWhereConfigured(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 	t.Cleanup(func() { _ = checker.Stop() })
+
+	addr := checker.Addr()
+	if addr == "" {
+		t.Fatal("Start returned nil with http_enabled true, but Addr reports nothing bound")
+	}
+
+	// The host half is the assertion. A wildcard bind reports 0.0.0.0 or [::] here and never the
+	// configured loopback address, where a scrape of 127.0.0.1 passes against either.
+	testhttp.SameHost(t, addr, configured, "the health endpoint")
 
 	if code, _ := get(t, "http://"+addr+"/health"); code != http.StatusOK &&
 		code != http.StatusServiceUnavailable {

--- a/internal/metrics/wiring_test.go
+++ b/internal/metrics/wiring_test.go
@@ -31,8 +31,10 @@ func exactAdapterConfig(addr string) *Config {
 //
 // Port 0 rather than a fixed number, and rather than testhttp.FreeAddr: the kernel picks a port that
 // is free at the moment of the bind, where FreeAddr picks one that was free a moment earlier and
-// leaves a window. Collector.Addr reports what was chosen, so a scrape still knows where to go. Use
-// FreeAddr only where the address must be known before the server starts.
+// leaves a window — a window that has since failed a CI run, so it is a race and not a caveat.
+// Collector.Addr reports what was chosen, so a scrape still knows where to go, and testhttp.SameHost
+// is how the where-it-bound assertion survives not knowing the port. Use FreeAddr only where the
+// address must be known before the server starts *and* nothing is going to bind it.
 const anyLoopbackAddr = "127.0.0.1:0"
 
 // TestStartSurvivesTheConfigTheAdapterBuilds is the regression test for two panics on the live path.
@@ -352,8 +354,9 @@ func TestScrapeServesTheDocumentedPath(t *testing.T) {
 func TestStartBindsWhereConfiguredAndNowhereElse(t *testing.T) {
 	t.Parallel()
 
-	addr := testhttp.FreeAddr(t) // fixed port: the assertion is about the host half
-	c, err := NewCollector(exactAdapterConfig(addr))
+	// Port 0: the assertion is about the host half, and the port half is what testhttp.FreeAddr can
+	// only hand over stale. See anyLoopbackAddr, and the CI failure recorded on FreeAddr itself.
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
 	if err != nil {
 		t.Fatalf("NewCollector: %v", err)
 	}
@@ -363,10 +366,11 @@ func TestStartBindsWhereConfiguredAndNowhereElse(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = c.Stop(context.Background()) })
 
-	if got := c.Addr(); got != addr {
-		t.Errorf("bound %s, configured %s — a wildcard bind reports 0.0.0.0 or [::] here, and it "+
-			"publishes an unauthenticated endpoint on every interface", got, addr)
+	addr := c.Addr()
+	if addr == "" {
+		t.Fatal("Start returned nil and Addr reports nothing bound")
 	}
+	testhttp.SameHost(t, addr, anyLoopbackAddr, "the metrics endpoint")
 
 	// Confirm it over a socket too, from an address that is this host but is not loopback.
 	_, port, err := net.SplitHostPort(addr)

--- a/internal/testhttp/testhttp.go
+++ b/internal/testhttp/testhttp.go
@@ -44,11 +44,19 @@ const (
 // these servers default to are the popular ones: 8080 for ObjectFS's metrics endpoint, 9090 for the
 // Prometheus a developer may well have running. Asking the kernel is the only way to be sure.
 //
-// There is a window between the close here and the bind by the caller, which nothing can eliminate
-// without handing over the listener itself. Prefer configuring "127.0.0.1:0" and reading back where
-// the server bound — [metrics.Collector.Addr] reports it — and use this only where the address has
-// to be known before the server starts, which is every test that supplies it through a config file
-// or a Configuration.
+// **Only for an address nothing will bind.** The port is returned to the ephemeral pool by the
+// Close below, so between here and a bind by the caller the kernel is free to hand it to anything
+// else asking for an ephemeral port — including another test in the same binary, which is not a
+// hypothetical: this window failed TestStartMetricsBindsTheEndpoint in CI with "bind: address
+// already in use" on a port internal/adapter's own miniredis had been given in the interval. The
+// window cannot be closed without handing over the listener itself.
+//
+// So the caller that survives this is the one asserting nothing is listening, which needs an
+// address in advance and never binds it — a competing ephemeral bind cannot fail that assertion,
+// because the thing it would have to do to fail it is answer HTTP 200 on /metrics. A caller that
+// does bind should configure port 0 and read back where the kernel put it:
+// [metrics.Collector.Addr] reports it, and [SameHost] is how the where-it-bound assertion survives
+// not knowing the port up front.
 func FreeAddr(t *testing.T) string {
 	t.Helper()
 
@@ -65,6 +73,38 @@ func FreeAddr(t *testing.T) string {
 	}
 
 	return addr
+}
+
+// SameHost fails the test unless a server bound the host its configuration named.
+//
+// This is the assertion #211 turns on, in the form that works when the port is 0. A server handed
+// "127.0.0.1:0" binds a port only the kernel knows, so `bound == configured` cannot be the check —
+// but the port half was never what the issue was about. `fmt.Sprintf(":%d", Port)` was the defect,
+// and what it produced was a *wildcard host*: an unauthenticated /metrics and /debug/operations
+// published on every interface the machine can route. A wildcard bind reads back here as 0.0.0.0 or
+// [::], never as the loopback address that was asked for, so comparing hosts catches it — while a
+// scrape of 127.0.0.1 does not, since a wildcard answers on loopback too.
+//
+// whatBound names the thing whose address this is, so the failure says which listener is exposed
+// rather than only that some host comparison did not hold.
+func SameHost(t *testing.T, bound, configured, whatBound string) {
+	t.Helper()
+
+	boundHost, _, err := net.SplitHostPort(bound)
+	if err != nil {
+		t.Fatalf("%s reported %q, which is not a host:port: %v", whatBound, bound, err)
+	}
+
+	configuredHost, _, err := net.SplitHostPort(configured)
+	if err != nil {
+		t.Fatalf("the configured address for %s is %q, which is not a host:port: %v", whatBound, configured, err)
+	}
+
+	if boundHost != configuredHost {
+		t.Errorf("%s bound host %s; the configuration said %s (%q vs %q). A wildcard bind reports "+
+			"0.0.0.0 or [::] here and publishes an unauthenticated endpoint on every interface",
+			whatBound, boundHost, configuredHost, bound, configured)
+	}
 }
 
 // Get fetches a path from a server at addr, retrying until it answers, and fails the test if nothing


### PR DESCRIPTION
`testhttp.FreeAddr` binds `127.0.0.1:0`, records the address, then **closes the listener** — which returns the port to the ephemeral pool. Between that close and the caller's bind the kernel can hand the port to anything else asking for one, and on #391 it did:

```
--- FAIL: TestStartMetricsBindsTheEndpoint
    metrics_wiring_test.go:43: startMetrics: failed to start metrics collector:
      binding the metrics endpoint on 127.0.0.1:43573: listen tcp 127.0.0.1:43573:
      bind: address already in use
```

The competing binder is in the same package: `miniredis.RunT(t)` in `cache_selection_test.go:38`, which asks for an ephemeral port in parallel. Nothing in the failing test was wrong — the address was stale by the time it was used. (Probed first: 400 concurrent `FreeAddr` calls return 400 distinct addresses, so it is not FreeAddr racing itself; macOS's ephemeral range starts at 49152 and does not reproduce it, where the CI failure was on 43573, inside Linux's.)

## The fix is to remove the window, not shrink it

`internal/metrics/collector.go` already records the address the listener *actually* got (`boundAddr`) and reports it via `Addr()`. So every caller that binds now configures `127.0.0.1:0` and reads back where the kernel put it. The kernel picks at the moment of the bind; there is no interval to lose.

## What that costs, and why it costs nothing that matters

One assertion wanted the port in advance: `Addr() == addr`, the regression check for #211. It is now `testhttp.SameHost`, which compares **hosts**.

That is what #211 was always about. `fmt.Sprintf(":%d", Port)` could only produce a wildcard *host* — an unauthenticated `/metrics` and `/debug/operations` on every interface the machine routes — and a scrape of `127.0.0.1` passes against a wildcard bind, because a wildcard answers on loopback too. A wildcard reads back as `0.0.0.0` or `[::]`, never as the configured loopback address, so the host comparison catches precisely the defect; the port half never participated. `internal/metrics/wiring_test.go` already carried the comment `// fixed port: the assertion is about the host half`.

## Mutation-verified, not assumed

| Mutation | Result |
|---|---|
| bind `":"+port` instead of the configured addr (#211's defect) | both wiring tests fail: `bound host ::; the configuration said 127.0.0.1` |
| delete the `Serve` goroutine, keep `boundAddr` | the scrape fails: `nothing ever answered … connection refused` |

## FreeAddr survives, for one caller

`TestStartMetricsHonorsDisabled` needs an address before `Start` and **never binds it** — the assertion is that nothing is listening. A competing ephemeral bind cannot make that pass, since passing it requires answering HTTP 200 on `/metrics`. `FreeAddr`'s doc comment now says that, instead of describing the window as something nothing could eliminate.

## Gates

- `go test -race -count=8 -parallel 16 ./internal/adapter/ ./internal/metrics/` — ok, with the miniredis tests running alongside
- `gofmt -l`, `go vet`, `golangci-lint run` on all three packages — clean

Unblocks #391, which hit this flake on a docs-only branch.