### PR TITLE
docs: probe Wasabi and fill in its conditional-write row (#389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Wasabi probed and added to the conditional-write compatibility matrix.** It is the first endpoint
+  in the matrix to answer success to **every** cell: `If-None-Match: *` over an existing key replaces
+  it, `If-Match` with an ETag that cannot possibly match performs the write, and `If-Match` against an
+  absent key creates it. Conditional headers are accepted and never evaluated. The capability probe
+  reports `ConditionalWrite=false`, `PutObjectIf` returns `ErrNotSupported`, and coordination features
+  decline to start — the fail-closed direction, and the reason this is less dangerous than Ceph RGW,
+  which enforces *some* preconditions and so passes a probe that only asks whether one was ever
+  evaluated. Plain filesystem use is unaffected; this is a coordination limitation, not a storage one.
+
+  "Every request succeeds" is also what a client dropping the header would look like, so the SDK was
+  ruled out at the wire before the row was written — the same standard the RGW quoted-ETag row was held
+  to. With a request dumper in place, `If-Match` is present as a header *and* inside
+  `SignedHeaders=…;if-match;…`, Wasabi answers `200`, and a following `GET` returns the contender's
+  bytes. The row is dated rather than versioned because Wasabi returns no `Server` header and publishes
+  no build identifier, so re-run the suite rather than reading the date as a guarantee.
+
 - **RustFS `1.0.0-beta.12` probed and added to the conditional-write compatibility matrix.** Run, not
   read: the same `s3compat` suite that produced the AWS, MinIO and RGW rows, pointed at a local
   container, with each of the four cells the suite does not print measured on its own key. It is the
@@ -44,6 +60,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   link to the probed matrix — plain filesystem use is unaffected on any S3-compatible endpoint.
 
 ### Fixed
+
+- **A compatibility probe reported a finding by failing the run.** `conditional_compat_test.go`
+  called `t.Errorf` when an endpoint accepted `If-None-Match: *` over an existing key and replaced its
+  contents, which contradicts the suite's own contract: record what an endpoint does and fail only on
+  what would be unsafe. That cell is safe, because it is exactly what the capability probe detects and
+  refuses. The branch had never fired — AWS, MinIO, RGW and RustFS all enforce absence on `PutObject`
+  — and Wasabi is the first endpoint to reach it, turning a correctly-refused endpoint into a red run.
+  It is now a `t.Logf("FINDING: ...")`, and the assertion that matters is the one below it: the probe
+  must report the capability unsupported.
 
 - **A flaky test that failed a CI run, in a helper written to make tests reliable.**
   `testhttp.FreeAddr` binds `127.0.0.1:0`, records the address and closes the listener — which

--- a/docs/design/conditional-write-compatibility.md
+++ b/docs/design/conditional-write-compatibility.md
@@ -37,7 +37,7 @@ indistinguishable until it matters.
 | MinIO | `RELEASE.2025-09-07T16-13-09Z` (commit `07c3a429bfed433e49018cb0f78a52145d4bedeb`) | container, local |
 | Ceph RGW | `19.2.0 squid` (commit `16063ff2022298c9300e49a547a16ffda59baf13`) | `quay.io/ceph/demo`, local |
 | RustFS | `1.0.0-beta.12` (revision `8601179c3989d131fb68fa311fd517fe281270fe`, image digest `sha256:186743df6fdf85c1f10ce246bbee5fb22f1d35c3ec1a73fc9058c560c5f6b505`) | `docker.io/rustfs/rustfs`, local |
-| Wasabi | — | **not probed.** No endpoint was available. See [Wasabi](#wasabi) below. |
+| Wasabi | unversioned — `s3.wasabisys.com` (`us-east-1`), probed 2026-08-08. The service returns no `Server` header and publishes no build identifier, so this row is dated rather than versioned | the real service, an account's own credentials; each test creates its own bucket and removes it |
 
 ## The matrix
 
@@ -45,20 +45,20 @@ Cells are the HTTP status and S3 error code as returned, because that pair is wh
 `translateConditionalError` dispatches on. A row naming a code is a row a mapping can be checked
 against; a row naming a message is not, since message text is not stable.
 
-| Check | AWS S3 | MinIO | Ceph RGW 19.2.0 | RustFS 1.0.0-beta.12 |
-|---|---|---|---|---|
-| `If-None-Match: *`, key absent | success | success | success | success |
-| `If-None-Match: *`, key exists | `412 PreconditionFailed`, holder's bytes intact | `412 PreconditionFailed`, intact | `412 PreconditionFailed`, intact | `412 PreconditionFailed`, intact |
-| `If-Match` with the **quoted** ETag the store just returned | success | success | **`412 PreconditionFailed`** | success |
-| `If-Match` with the bare hex digest | success | success | success | success |
-| `If-Match: *` | **`501 NotImplemented`** | success | success | success |
-| `If-Match` with a **stale** ETag | `412 PreconditionFailed` | `412 PreconditionFailed` | `412 PreconditionFailed` | `412 PreconditionFailed` |
-| `If-Match`, key **absent** | `404 NoSuchKey` | `404 NoSuchKey` | **`412 PreconditionFailed`** | `404 NoSuchKey` |
-| 8 concurrent `If-None-Match: *` on one key | 1 winner, 7 × `412` | 1 winner, 7 × `412` | 1 winner, 7 × `412` | 1 winner, 7 × `412` |
-| Precondition on `CompleteMultipartUpload`, key exists | `412`, holder intact | `412`, holder intact | **success — contender's bytes land** | `412`, holder intact |
-| Multipart ETag (`<hex>-<N>`) reused in a later `If-Match` | — | success | success | success |
-| `DeleteObject` with a stale `If-Match` | `412 PreconditionFailed`, object survives | **success — object deleted** | **success — object deleted** | `412 PreconditionFailed`, object survives |
-| **ObjectFS capability probe verdict** | supported | supported | **unsupported** | supported |
+| Check | AWS S3 | MinIO | Ceph RGW 19.2.0 | RustFS 1.0.0-beta.12 | Wasabi |
+|---|---|---|---|---|---|
+| `If-None-Match: *`, key absent | success | success | success | success | success |
+| `If-None-Match: *`, key exists | `412 PreconditionFailed`, holder's bytes intact | `412 PreconditionFailed`, intact | `412 PreconditionFailed`, intact | `412 PreconditionFailed`, intact | **success — contender's bytes land** |
+| `If-Match` with the **quoted** ETag the store just returned | success | success | **`412 PreconditionFailed`** | success | success |
+| `If-Match` with the bare hex digest | success | success | success | success | success |
+| `If-Match: *` | **`501 NotImplemented`** | success | success | success | success |
+| `If-Match` with a **stale** ETag | `412 PreconditionFailed` | `412 PreconditionFailed` | `412 PreconditionFailed` | `412 PreconditionFailed` | **success — the write lands** |
+| `If-Match`, key **absent** | `404 NoSuchKey` | `404 NoSuchKey` | **`412 PreconditionFailed`** | `404 NoSuchKey` | **success — the key is created** |
+| 8 concurrent `If-None-Match: *` on one key | 1 winner, 7 × `412` | 1 winner, 7 × `412` | 1 winner, 7 × `412` | 1 winner, 7 × `412` | not run — the probe refuses first, so there is no race to arbitrate |
+| Precondition on `CompleteMultipartUpload`, key exists | `412`, holder intact | `412`, holder intact | **success — contender's bytes land** | `412`, holder intact | **success — contender's bytes land** |
+| Multipart ETag (`<hex>-<N>`) reused in a later `If-Match` | — | success | success | success | success |
+| `DeleteObject` with a stale `If-Match` | `412 PreconditionFailed`, object survives | **success — object deleted** | **success — object deleted** | `412 PreconditionFailed`, object survives | **success — object deleted** |
+| **ObjectFS capability probe verdict** | supported | supported | **unsupported** | supported | **unsupported** |
 
 ## What the exceptional cells mean
 
@@ -148,21 +148,41 @@ declining to start rather than as two lease holders. Nothing about this row chan
 posture, which is that AWS S3 is the target and an S3-compatible endpoint gets best-effort support —
 what it changes is that a RustFS deployment is not expected to lose coordination.
 
-### Wasabi
+### Wasabi accepts every conditional header and evaluates none of them
 
-**Unverified. No endpoint was available when this page was written**, and Wasabi has no local or
-emulated form to stand up — it needs a real account against the real service.
+Wasabi is the first endpoint probed here that answers **success to every cell**. Not one 412, not one
+404, not one 501 — `If-None-Match: *` over an existing key replaces it, `If-Match` with an ETag that
+cannot possibly match performs the write, `If-Match` against a key that does not exist creates it.
+The headers are accepted and the writes happen regardless.
 
-Recorded as unverified rather than filled in from Wasabi's documentation, deliberately. Two rows on
-this page were documentation reads before 2026-08-08 and both were wrong: MinIO was recorded as
-"source read, server enforcement unverified" and enforces everything AWS enforces, while Ceph RGW was
-recorded as "no conditional write support — documentation absence" and in fact implements it
-*partially*, which is strictly more dangerous than not implementing it. A documented behavior is a
-claim about an endpoint; only a probe is an observation of one.
+This is the shape the top of this page calls the dangerous variation, and it is why the probe asserts
+rather than asks. Two writers asserting `If-None-Match: *` on the same lease key would both be told
+they won.
 
-The capability probe treats Wasabi like any other unknown endpoint — it establishes the answer at
-mount time from the endpoint in front of it, so an unprobed store is not an unguarded one. Filling in
-this row needs credentials and the suite above; it does not need any new code.
+**The SDK was ruled out at the wire before this row was written.** "Every request succeeds" is also
+exactly what a client dropping the header would look like, and the RGW quoted-ETag row above was held
+to the same standard. With an `http.RoundTripper` dumper in place: `If-Match: "f97c…"` is present as a
+request header *and* inside `SignedHeaders=…;if-match;…`, so it is signed and cannot be stripped in
+transit; Wasabi answers `200`; and a `GET` afterwards returns the contender's bytes where an enforcing
+store returns the holder's. The finding is about the service.
+
+**It fails closed, which is the difference between this row and RGW's.** The probe reports
+`ConditionalWrite=false` with the detail *"the endpoint accepted an If-Match that could not possibly
+match and performed the write anyway, so it does not evaluate preconditions"*, `PutObjectIf` returns
+`types.ErrNotSupported`, and a coordination feature declines to start. Nothing races, because nothing
+runs. RGW is more dangerous precisely because it enforces *some* preconditions: it passes a probe that
+only checks whether a precondition was ever evaluated, and then loses the guarantee on multipart. An
+endpoint that ignores preconditions uniformly is detected by the first thing that looks.
+
+The concurrency test therefore **skips** on Wasabi rather than failing:
+`TestCompatConcurrentAbsentWritersElectExactlyOne` exists to check that exactly one of N contenders
+wins, and there are no contenders when `PutObjectIf` refuses to issue the write. A skip there is the
+suite agreeing with the probe.
+
+**No version to record.** Wasabi returns no `Server` header and publishes no build identifier, so the
+Endpoints table dates this row instead of versioning it. Re-run the suite rather than reading the date
+as a guarantee — this is a hosted service and the row cannot be pinned to a build the way MinIO,
+RGW, and RustFS can.
 
 ## What ObjectFS does about it
 
@@ -191,6 +211,7 @@ where the failure is loud.
 | **MinIO** ≥ `RELEASE.2025-09-07` | Coordination features work. Enforcement is real, verified here rather than assumed — but it is an extension of the S3 API, not a contract, so the version above is part of the claim. |
 | **Ceph RGW** ≤ 19.2.0 | Coordination features **refuse to start**, correctly. Conditional writes are partially implemented in a way that cannot be worked around from the client: no CAS (ETag rejected), and multipart writes unconditional. Use a coordination backend other than the object store. |
 | **RustFS** `1.0.0-beta.12` | Coordination features work. It matched AWS on every cell probed, including the two RGW fails. It is a pre-release, so re-run the suite against the build you deploy rather than trusting this row — the probe will refuse at mount time if a later beta regresses. |
+| **Wasabi** | Coordination features **refuse to start**, correctly. Conditional headers are accepted and never evaluated, so there is nothing to work around from the client. Use a coordination backend other than the object store. Everything else — reads, writes, multipart, tiering — is unaffected: this is a coordination limitation, not a storage one. |
 | **anything else** | The probe decides at mount time. If it reports unsupported, `ConditionalWriteDetail` says what the endpoint did; add a row here by running the `s3compat` suite against it. |
 
 ## Keeping this page honest

--- a/docs/design/conditional-writes-vs-raft.md
+++ b/docs/design/conditional-writes-vs-raft.md
@@ -263,6 +263,11 @@ not-found error, matching on `smithy.APIError`'s code rather than on message tex
 >   ETag its own `PutObject` returned. It therefore **passed the probe as originally written** and had
 >   to be caught by disambiguating the 412 — see the linked page.
 >
+> - **Wasabi** is no longer unverified. Probed 2026-08-08: it accepts every conditional header and
+>   evaluates none of them, so the "treat as Ceph until probed" cell below happened to land on the
+>   right side of safe for the wrong reason. Ceph is the *partial* case; Wasabi is the uniform one, and
+>   the probe catches it on the first request that looks. Coordination declines to start on both.
+>
 > The reasoning in this section is unchanged and load-bearing; only its per-backend cells are stale.
 > Read the linked page for what endpoints actually do.
 

--- a/internal/storage/s3/conditional_compat_test.go
+++ b/internal/storage/s3/conditional_compat_test.go
@@ -53,10 +53,20 @@ package s3_test
 // bucket. Each test creates its own bucket and removes it, including any incomplete multipart uploads,
 // since a bucket holding one cannot be deleted and this suite creates uploads that may not complete.
 //
-// Or against Wasabi, or any other S3-compatible store, by pointing the same variables at it. Wasabi
-// needs a real account and was not reachable when this landed; that is recorded in the matrix as
-// unverified-for-want-of-an-endpoint rather than inferred from documentation, which is the state that
-// produced #285 in the first place.
+// Against Wasabi, which has no local or emulated form — it needs a real account and the real service.
+// The region is part of the endpoint host, and a bucket created in one is not reachable through another:
+//
+//	OBJECTFS_COMPAT_ENDPOINT=https://s3.wasabisys.com OBJECTFS_COMPAT_REGION=us-east-1 \
+//	  OBJECTFS_COMPAT_ACCESS_KEY=... OBJECTFS_COMPAT_SECRET_KEY=... \
+//	  go test -race -tags=s3compat -v -count=1 ./internal/storage/s3/
+//
+// Wasabi accepts every conditional header and evaluates none of them, so it is the endpoint that
+// exercises the recorded-not-failed paths below: the capability probe reports unsupported, PutObjectIf
+// returns ErrNotSupported, and TestCompatConcurrentAbsentWritersElectExactlyOne skips because a refused
+// write leaves no contenders to arbitrate between. That is the fail-closed direction and the suite
+// passes on it.
+//
+// Or against any other S3-compatible store, by pointing the same variables at it.
 //
 // Every test here is written to *record* what an endpoint does and fail only on what would be unsafe.
 // So a store that declines conditional writes outright passes: refusing is harmless, since PutObjectIf
@@ -326,10 +336,20 @@ func TestCompatCapabilityProbeMatchesObservedBehavior(t *testing.T) {
 	enforcesAbsence := secondErr != nil
 	t.Logf("If-None-Match: * over an existing key -> %s", compatCode(secondErr))
 
+	// Recorded, not failed. An endpoint that ignores If-None-Match entirely is a matrix row, and the
+	// probe below is what decides whether it is a problem: this is the fail-closed direction, so
+	// PutObjectIf returns ErrNotSupported and nothing races. The check that matters is the probe
+	// agreeing, which the switch at the end of this test makes.
+	//
+	// This was a t.Errorf until Wasabi was probed, and the message it printed was the finding rather
+	// than a defect — the suite's contract is to fail only on what would be unsafe. It had never fired
+	// because AWS, MinIO, RGW and RustFS all enforce absence on PutObject; Wasabi is the first endpoint
+	// to reach it, and it made the run red for behavior the probe had already correctly refused.
 	if !enforcesAbsence {
 		if got := compatGet(t, ctx, client, bucket, key); !bytes.Equal(got, []byte("first")) {
-			t.Errorf("the endpoint accepted If-None-Match: * over an existing key and replaced its "+
-				"contents with %q. Two writers asserting absence would both believe they won", got)
+			t.Logf("FINDING: the endpoint accepted If-None-Match: * over an existing key and replaced "+
+				"its contents with %q. Two writers asserting absence would both believe they won, so "+
+				"conditional writes must be reported unsupported — asserted below", got)
 		}
 	}
 

--- a/internal/storage/s3/conditional_probe_test.go
+++ b/internal/storage/s3/conditional_probe_test.go
@@ -6,8 +6,9 @@ package s3
 // builds a lease on it. The endpoint to worry about is the one that accepts an If-Match, ignores it,
 // and answers 200 — because from every angle except the outcome of a race it is indistinguishable from
 // one that honors preconditions. A configuration flag or an endpoint-URL heuristic would call it
-// capable. `docs/design/conditional-writes-vs-raft.md` §4 names Ceph RGW as documenting conditional
-// headers for GET/HEAD only, with Wasabi unverified and treated the same until probed.
+// capable. `docs/design/conditional-write-compatibility.md` records an endpoint that does exactly this:
+// Wasabi, probed 2026-08-08, accepts If-Match with an ETag that cannot possibly match and performs the
+// write. These tests are the reason that is detected rather than deployed on.
 //
 // These are in-package tests because they need endpoints that misbehave in specific ways, which
 // internal/testaws cannot provide — and testaws imports this package, so an external test could not


### PR DESCRIPTION
Fills in the last unverified row of [the conditional-write compatibility matrix](https://github.com/scttfrdmn/objectfs/blob/main/docs/design/conditional-write-compatibility.md), against a real Wasabi account.

## What Wasabi does

**Success on every cell.** Not one 412, not one 404, not one 501:

| Check | Wasabi |
|---|---|
| `If-None-Match: *`, key absent | success |
| `If-None-Match: *`, key exists | **success — contender's bytes land** |
| `If-Match` quoted ETag / bare hex / `*` | success |
| `If-Match` with a **stale** ETag | **success — the write lands** |
| `If-Match`, key **absent** | **success — the key is created** |
| Precondition on `CompleteMultipartUpload`, key exists | **success — contender's bytes land** |
| `DeleteObject` with a stale `If-Match` | **success — object deleted** |
| **Capability probe verdict** | **unsupported** |

It accepts conditional headers and evaluates none of them.

## Why this is safe, and less dangerous than RGW

The probe reports `ConditionalWrite=false` with the detail *"the endpoint accepted an If-Match that could not possibly match and performed the write anyway, so it does not evaluate preconditions"*, `PutObjectIf` returns `ErrNotSupported`, and a coordination feature declines to start. Nothing races because nothing runs.

RGW is worse precisely because it enforces *some* preconditions: it passes a probe that only asks whether a precondition was ever evaluated, then loses the guarantee on `CompleteMultipartUpload`. An endpoint that ignores preconditions uniformly is caught by the first thing that looks.

Plain filesystem use on Wasabi is unaffected — this is a coordination limitation, not a storage one.

## The SDK was ruled out at the wire

"Every request succeeds" is also what a client dropping the header would look like, and the RGW quoted-ETag row was held to this same standard. With an `http.RoundTripper` dumper in place: `If-Match` is present as a request header **and** inside `SignedHeaders=…;if-match;…` (so it is signed and cannot be stripped in transit), Wasabi answers `200`, and a following `GET` returns the contender's bytes where an enforcing store returns the holder's.

## Test defect fixed

`conditional_compat_test.go` called `t.Errorf` when an endpoint accepted `If-None-Match: *` over an existing key — which contradicts the suite's own stated contract: record what an endpoint does and fail only on what would be unsafe. That cell is safe; it is exactly what the probe detects and refuses. AWS, MinIO, RGW and RustFS all enforce absence on `PutObject`, so the branch had never fired. Wasabi is the first endpoint to reach it, and it turned a correctly-refused endpoint into a red run. Now a `t.Logf("FINDING: …")`; the assertion that matters is the one below it — the probe must report the capability unsupported.

`TestCompatConcurrentAbsentWritersElectExactlyOne` **skips** on Wasabi, correctly: a refused write leaves no contenders to arbitrate between.

## Notes

- **Dated, not versioned.** Wasabi returns no `Server` header and publishes no build identifier, so unlike MinIO/RGW/RustFS this row cannot be pinned to a build. Re-run the suite rather than reading the date as a guarantee.
- Also updates the two places that still called Wasabi unverified: the superseded table in `conditional-writes-vs-raft.md` and the header comment on `conditional_probe_test.go`.

Closes #389