### PR TITLE
fix(sdk): the Python SDK wrote config files the daemon refused to start on (#385)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,16 @@ jobs:
       # `pytest tests/` rather than the one metrics file, so tests/test_storage.py,
       # tests/test_config.py and tests/test_client.py are covered by this step as they land —
       # including the assertion that download_object leaves an existing local file intact.
+      #
+      # tests/test_config.py carries a second cross-language contract in the other direction, and
+      # this step is the half that enforces it. sdks/testdata/presets/*.yaml is what
+      # Configuration.to_yaml() emits, committed, and internal/config's
+      # TestSDKPresetsLoadUnderTheGoLoader puts every one through the Go loader. Because that Go test
+      # reads committed files, it would stay green on stale ones — so the Python test compares rather
+      # than writes, and a config.py change that is not regenerated fails here. Without both halves
+      # the gate asserts against whatever was committed last, which is the shape of the defect it
+      # exists to catch (#385): to_yaml emitted sixteen keys the Go schema does not define, and
+      # save_to_file wrote a document the daemon refused at startup.
       - name: Python SDK tests
         working-directory: sdks/python
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Python SDK wrote configuration files the daemon refused to start on — every one of them.**
+  `Configuration.to_yaml()` emitted **sixteen** keys `internal/config` does not define, across seven
+  sections, and `LoadFromFile` decodes strictly, so `save_to_file` produced a document that failed at
+  startup naming the first key it hit. This affected the default `Configuration()` and all five presets,
+  which means the SDK's documented path — build a config, save it, mount with it — could not work at
+  all. Removed rather than added to the Go schema, because in each case the setting either had a real
+  home under another name or had nothing to reach:
+
+  - `global.pid_file`, `global.daemon` — ObjectFS does not fork, so there is no background mode to
+    select and no forked child's pid to record.
+  - `storage.s3.timeout` — an `int` of unstated unit; the real settings are
+    `network.timeouts.connect`/`read`/`write`, as durations.
+  - `performance.read_ahead_size`, `performance.max_write_buffer` — the first was removed from the Go
+    side in v0.11.0 for naming a second read-ahead size beside `performance.read_ahead.window_size`
+    ([#176]); the second is `write_buffer.max_memory`.
+  - `cluster.election_timeout`, `cluster.heartbeat_interval`, `cluster.join_timeout` — these exist on
+    `internal/distributed.ClusterConfig`, a *disjoint* type from `internal/config.ClusterConfig` with no
+    conversion between them ([#139]). Nothing in `sdks/` consumed any of the three.
+  - `security.tls_ca_path` — no CA path in the schema's `security` block; trust configuration is the
+    `security.tls` block.
+  - `monitoring.opentelemetry.headers` — where an OTLP bearer token would go, in a document the loader
+    rejected. An unloadable place to put a credential is worse than no key.
+  - the entire `fuse` block — `allow_other`, `allow_root`, `default_permissions`, `uid`, `gid`, `umask`,
+    replaced by the three keys the Go schema has: `direct_io`, `keep_cache`, `sync_read`. The removed
+    six were doubly inert: discarded by the loader, and three of them are ones `cmd/objectfs/doc.go`
+    already records as *not settable* because nothing on the adapter's mount path reads them.
+
+  [#385] named three of the sixteen, and the other thirteen were found by the test that closes it —
+  which is the argument for its shape. Each preset's `to_yaml()` output is committed under
+  `sdks/testdata/presets/`, and `internal/config`'s `TestSDKPresetsLoadUnderTheGoLoader` globs that
+  directory and runs every file through `LoadFromFile` and `Validate`. It asserts the *property* — the
+  Go loader accepts what the SDK writes — rather than comparing emitted keys against a list, because a
+  list is a second copy of the schema and would have had to be right about all sixteen. The Python half
+  compares rather than writes (`OBJECTFS_UPDATE_FIXTURES=1` to regenerate), because a Go test reading
+  committed files would otherwise stay green on stale ones. Verified by mutation in both directions:
+  reintroducing one key fails the Python comparison on all six documents, and regenerating with it
+  fails the Go loader gate naming the key and line.
+
 - **A compatibility probe reported a finding by failing the run.** `conditional_compat_test.go`
   called `t.Errorf` when an endpoint accepted `If-None-Match: *` over an existing key and replaced its
   contents, which contradicts the suite's own contract: record what an endpoint does and fail only on

--- a/internal/config/sdk_presets_test.go
+++ b/internal/config/sdk_presets_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// sdkPresetGlob locates the config documents the Python SDK emits.
+//
+// sdks/python/tests/test_config.py's WritePresetFixturesTest writes one file per preset here, plus
+// default.yaml for the unmodified Configuration. Located by glob rather than by a list of preset
+// names, for the same reason shippedConfigGlobs is: a preset added on the Python side should be
+// checked here without anyone editing this file, and a hand-written list is precisely what drifted
+// to produce the defect below.
+const sdkPresetGlob = "sdks/testdata/presets/*.yaml"
+
+// TestSDKPresetsLoadUnderTheGoLoader is the consuming half of a cross-language contract, and it is
+// the assertion #385 needed.
+//
+// The Python SDK's documented path is: build a Configuration, save_to_file, mount with it. That path
+// was broken for every preset and for the default. Configuration.to_yaml() emitted sixteen keys the
+// Go schema does not define, across seven sections — global.pid_file, global.daemon,
+// storage.s3.timeout, performance.read_ahead_size, performance.max_write_buffer,
+// cluster.election_timeout, cluster.heartbeat_interval, cluster.join_timeout, security.tls_ca_path,
+// monitoring.opentelemetry.headers, and all six keys of the fuse block — and LoadFromFile decodes
+// strictly, so the daemon refused the file at startup naming the first one.
+//
+// #385 named three of the sixteen: it was filed from a Go-side reading of ClusterConfig, which is
+// where somebody happened to look. The other thirteen were found by this test on its first run, which
+// is the argument for its shape. It asserts a *property* — the Go loader accepts what the SDK writes —
+// rather than comparing the emitted keys against a list, because a list is a second copy of the schema
+// and would have had to be right about all sixteen to catch them.
+//
+// The direction matters. internal/metrics generates sdks/testdata/metrics-scrape.txt for the SDKs to
+// parse, because the Go exporter is the authority on metric names; here the Go loader is the authority
+// on config keys, so the SDK generates and Go checks. Either way the producing side is the one that
+// defines the contract, and both halves run in CI — the Python half in the `sdk-metrics` job.
+func TestSDKPresetsLoadUnderTheGoLoader(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	paths, err := filepath.Glob(filepath.Join(root, sdkPresetGlob))
+	if err != nil {
+		t.Fatalf("glob %q: %v", sdkPresetGlob, err)
+	}
+
+	if len(paths) == 0 {
+		t.Fatalf("found no SDK preset documents under %s.\n\n"+
+			"They are written by sdks/python/tests/test_config.py's WritePresetFixturesTest and "+
+			"committed. An empty set passes every assertion below, so this is a failure rather than a "+
+			"skip: regenerate with\n\n"+
+			"    cd sdks/python && pytest tests/test_config.py\n\n"+
+			"and commit what it writes.", filepath.Join(root, sdkPresetGlob))
+	}
+
+	for _, path := range paths {
+		t.Run(shortName(t, path), func(t *testing.T) {
+			t.Parallel()
+
+			cfg := NewDefault()
+
+			if err := cfg.LoadFromFile(path); err != nil {
+				t.Fatalf("the Python SDK emits a config document this loader refuses, so "+
+					"Configuration.save_to_file produces a file the daemon will not start on "+
+					"(#385):\n\n%v\n\nFix the dataclass in sdks/python/objectfs/config.py — do not add "+
+					"the key here to make this pass unless the setting has somewhere to reach. The "+
+					"top-level keys this schema accepts are: %s",
+					err, strings.Join(TopLevelKeys(), ", "))
+			}
+
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("the Python SDK emits a config document that loads but does not validate, so "+
+					"the daemon rejects it one step later (#385): %v", err)
+			}
+		})
+	}
+}
+
+// TestSDKPresetsAreNotAllDefaults asserts each emitted document actually sets something.
+//
+// This is the same property internal/config's TestShippedConfigsSetWhatTheySay checks for the files
+// this repository ships, and it is here for the same reason: a document that loads cleanly and leaves
+// every value at its default is not evidence the contract holds. If the Python side ever emitted an
+// empty `{}` — or a document whose every key the loader happened to ignore — the test above would pass
+// while the SDK produced nothing usable.
+//
+// default.yaml is exempt by name and by design: it is Configuration() unmodified, so equalling the Go
+// defaults is what it is *for*. That it equals them is itself worth asserting, since the two languages
+// arrived at those defaults independently — but they are not required to agree on every value, so the
+// assertion here is only that the file loads (above) and that the presets differ from it.
+func TestSDKPresetsAreNotAllDefaults(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	paths, err := filepath.Glob(filepath.Join(root, sdkPresetGlob))
+	if err != nil {
+		t.Fatalf("glob %q: %v", sdkPresetGlob, err)
+	}
+
+	for _, path := range paths {
+		if filepath.Base(path) == "default.yaml" {
+			continue
+		}
+
+		t.Run(shortName(t, path), func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(path) //nolint:gosec // a path from a glob over this repository
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			if len(strings.TrimSpace(string(raw))) == 0 {
+				t.Fatal("this preset document is empty, so the loader accepting it says nothing")
+			}
+
+			cfg := NewDefault()
+			if err := cfg.LoadFromFile(path); err != nil {
+				t.Fatalf("load: %v", err) // reported properly by the test above
+			}
+
+			// Compared against the SDK's own default document rather than against NewDefault, because
+			// the two languages are not required to pick the same defaults — only to agree on the set
+			// of keys. What must hold is that a preset differs from the SDK's baseline: a preset that
+			// does not is documentation of settings that do not apply.
+			base := NewDefault()
+			basePath := filepath.Join(filepath.Dir(path), "default.yaml")
+
+			if err := base.LoadFromFile(basePath); err != nil {
+				t.Skipf("no SDK default document to compare against: %v", err)
+			}
+
+			if reflect.DeepEqual(*cfg, *base) {
+				t.Errorf("this preset is byte-for-byte the SDK's default configuration once loaded, so "+
+					"selecting it changes nothing — from_preset(%q) sets fields the emitted document "+
+					"does not carry, or sets none at all",
+					strings.TrimSuffix(filepath.Base(path), ".yaml"))
+			}
+		})
+	}
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -170,6 +170,13 @@ async def cluster_example():
         await client.mount('s3://my-bucket', '/mnt/objectfs')
 ```
 
+"This is what the daemon reads" is checked rather than asserted, as of #385. Every preset's
+`to_yaml()` output is committed under `sdks/testdata/presets/` and put through the Go loader by
+`internal/config`'s `TestSDKPresetsLoadUnderTheGoLoader`. It had to be: the sentence above was false
+for every configuration this SDK could produce — `to_yaml` emitted sixteen keys the Go schema does not
+define, and the loader decodes strictly, so `save_to_file` wrote a document the daemon refused at
+startup. Changing a key here now fails a test in the other language.
+
 ObjectFS's own distributed layer is experimental; see the top-level README before depending on it.
 
 ### Cache Operations

--- a/sdks/python/objectfs/config.py
+++ b/sdks/python/objectfs/config.py
@@ -15,23 +15,34 @@ from .exceptions import ConfigurationError
 
 @dataclass
 class GlobalConfig:
-    """Global configuration settings."""
+    """Global configuration settings.
+
+    Two keys, matching ``internal/config.GlobalConfig`` exactly. ``pid_file`` and ``daemon`` were
+    here and are gone (#385): the Go schema has never had either, and neither describes anything
+    ObjectFS does. It does not fork -- it serves the mount in the process that started it until that
+    process is signalled -- so there is no background mode for ``daemon: true`` to select and no
+    forked child for ``pid_file`` to record. Run it under a systemd unit with ``Type=simple``; the
+    unit file is ``configs/systemd/objectfs@.service``.
+    """
     log_level: str = "INFO"
     log_file: str = ""
-    pid_file: str = ""
-    daemon: bool = False
 
 
 @dataclass
 class S3Config:
-    """S3 storage configuration."""
+    """S3 storage configuration.
+
+    ``timeout`` is gone (#385). It was an ``int`` of unstated unit sitting in the ``storage.s3``
+    block, and the Go schema has no such key: the request timeouts are
+    ``network.timeouts.connect``/``read``/``write``, as durations, one level up from storage. A single
+    number here could not have said which of the three it meant.
+    """
     region: str = "us-east-1"
     endpoint: str = ""
     profile: str = ""
     use_acceleration: bool = False
     force_path_style: bool = False
     max_retries: int = 3
-    timeout: int = 30
 
     # Cost optimization. One key, matching the Go schema exactly, because ``to_yaml``
     # writes this dict straight into a document the Go loader decodes strictly: a key
@@ -62,17 +73,25 @@ class StorageConfig:
 
 @dataclass
 class PerformanceConfig:
-    """Performance and caching configuration."""
+    """Performance and caching configuration.
+
+    ``read_ahead_size`` and ``max_write_buffer`` are gone (#385). Neither is in the Go schema, and
+    each had a real setting beside it under a different name: read-ahead is the
+    ``performance.read_ahead`` block and its size is ``window_size`` -- the flat key was removed from
+    the Go side in v0.11.0 for the same reason it is removed here, that a document naming two
+    read-ahead sizes has neither of them take effect (#176) -- and the write-buffer ceiling is
+    ``write_buffer.max_memory``, a section this dataclass does not model.
+
+    ``connection_pool_size`` is deliberately not added to fill the gap. It is validated ``> 0`` by the
+    Go loader, so a default here would have to agree with a default there, and the SDK's job is to
+    emit a document the loader accepts rather than to restate every key it defines.
+    """
     cache_size: str = "4GB"
     max_concurrency: int = 200
     multilevel_caching: bool = True
     predictive_caching: bool = False
     ml_model_path: str = ""
-
-    # I/O optimization
-    read_ahead_size: str = "4MB"
     write_buffer_size: str = "4MB"
-    max_write_buffer: str = "64MB"
 
     def validate(self):
         """Validate performance configuration."""
@@ -91,11 +110,14 @@ class ClusterConfig:
     key -- which is the intended outcome: what replaced it is a per-write precondition evaluated by
     S3, not a per-mount level, and no key here can express that.
 
-    The three timeouts below are a separate, older problem and are left as they are: the Go
-    ``cluster`` schema has never had ``election_timeout``, ``heartbeat_interval`` or
-    ``join_timeout`` -- those live on the disjoint ``internal/distributed.ClusterConfig`` (#139) --
-    so ``to_yaml`` emits a cluster block the loader refuses on the first of them. Verified against
-    the loader rather than inferred. Fixing that is not #284's to do; it is filed as #385.
+    ``election_timeout``, ``heartbeat_interval`` and ``join_timeout`` are gone as of #385. They were
+    the older half of the same problem: the Go ``cluster`` schema has never had any of them. Fields by
+    those names exist on ``internal/distributed.ClusterConfig``, which is a *disjoint* type -- same
+    name, different package, no conversion between the two (#139) -- so this dataclass was written
+    against one struct while ``to_yaml`` targets the other. Grepped for a consumer of the three across
+    ``sdks/``: there was none, including ``join_timeout``, which #385 singled out as needing a
+    decision. They are not added to the Go schema instead, because the distributed timeouts reach
+    ``NewClusterManager`` by another path and two places to set one value is worse than one.
     """
     enabled: bool = False
     node_id: str = ""
@@ -103,11 +125,6 @@ class ClusterConfig:
     advertise_addr: str = "127.0.0.1:8080"
     seed_nodes: List[str] = field(default_factory=list)
     replication_factor: int = 3
-
-    # Timeouts
-    election_timeout: str = "5s"
-    heartbeat_interval: str = "1s"
-    join_timeout: str = "30s"
 
     def validate(self):
         """Validate cluster configuration."""
@@ -117,13 +134,18 @@ class ClusterConfig:
 
 @dataclass
 class SecurityConfig:
-    """Security configuration."""
+    """Security configuration.
+
+    ``tls_ca_path`` is gone (#385). The Go schema's ``security`` block has ``tls_cert_path`` and
+    ``tls_key_path`` and no CA path; what it has instead is a ``security.tls`` block with
+    ``verify_certificates`` and ``min_version``, which this dataclass does not model. A CA bundle the
+    loader would reject is worse than no key at all -- it reads as configured trust.
+    """
     enabled: bool = False
     auth_method: str = "none"
     tls_enabled: bool = False
     tls_cert_path: str = ""
     tls_key_path: str = ""
-    tls_ca_path: str = ""
 
     def validate(self):
         """Validate security configuration."""
@@ -151,6 +173,12 @@ class MonitoringConfig:
     Both endpoints below are unauthenticated -- ``/metrics`` reports per-operation counts and
     timings, ``/health`` reports component names and error strings -- which is why the defaults
     are loopback. Publishing them further is a choice you write down.
+
+    The OpenTelemetry block's ``headers`` key is gone as of #385. ``internal/config.OpenTelemetryConfig``
+    has ``enabled``, ``endpoint`` and ``service_name`` and nothing else, so a document carrying
+    per-export headers -- the place an OTLP bearer token would go -- failed the mount naming the key.
+    An unloadable place to put a credential is the worst of the three options; emitting no key at all
+    at least does not suggest the token was sent.
     """
     enabled: bool = False
 
@@ -172,19 +200,27 @@ class MonitoringConfig:
         "enabled": False,
         "endpoint": "localhost:4317",
         "service_name": "objectfs",
-        "headers": {}
     })
 
 
 @dataclass
 class FUSEConfig:
-    """FUSE filesystem configuration."""
-    allow_other: bool = False
-    allow_root: bool = False
-    default_permissions: bool = False
-    uid: int = -1
-    gid: int = -1
-    umask: int = 0o022
+    """FUSE filesystem configuration.
+
+    Every key this class had was rejected by the loader, and none of them has been kept (#385). It
+    declared ``allow_other``, ``allow_root``, ``default_permissions``, ``uid``, ``gid`` and ``umask``;
+    ``internal/config.FUSEConfig`` has ``direct_io``, ``keep_cache`` and ``sync_read``, which is a
+    disjoint set. That is not an accident of naming. The Go block is three keys rather than nine
+    because it admits only settings with a demonstrated effect on the kernel's behavior, and
+    ``allow_other``, ``uid`` and ``gid`` are three of the ones ``cmd/objectfs/doc.go`` records as *not
+    settable*: the fields exist, and nothing on the adapter's mount path populates them.
+
+    So the six removed keys were doubly inert -- discarded by the loader, and with nothing to reach
+    even if they had loaded. The three below are the ones that take effect.
+    """
+    direct_io: bool = False
+    keep_cache: bool = False
+    sync_read: bool = False
 
 
 @dataclass

--- a/sdks/python/tests/test_config.py
+++ b/sdks/python/tests/test_config.py
@@ -11,6 +11,14 @@ The merge assertions come in pairs -- the override applied *and* its siblings su
 merge passes any test that only checks the override, which is how the equivalent bug lived through
 a release in the JavaScript SDK.
 
+``PresetFixturesMatchWhatTheSDKEmitsTest`` is the producing half of a cross-language contract, and it
+is the reason #385 was found to be sixteen keys rather than the three it names. Each preset's
+``to_yaml()`` is committed under ``sdks/testdata/presets/``, and ``TestSDKPresetsLoadUnderTheGoLoader``
+in ``internal/config`` reads that directory by glob and puts every file through ``LoadFromFile`` and
+``Validate``. The Go loader is the authority on what a config document may contain, so the assertion
+has to be made by the Go loader; asserting the emitted keys against a list written here would only pin
+the list, and the list is what drifted.
+
 Run from ``sdks/python``::
 
     pip install . pytest && pytest tests/ -q
@@ -32,6 +40,10 @@ PRESETS = (
     'high-performance',
     'cost-optimized',
     'cluster',
+)
+
+FIXTURE_DIR = os.path.join(
+    os.path.dirname(__file__), '..', '..', 'testdata', 'presets'
 )
 
 
@@ -89,14 +101,21 @@ class MergeIsDeepTest(unittest.TestCase):
     """Each test asserts the override applied *and* that its siblings survived."""
 
     def test_nested_s3_field(self):
-        merged = Configuration().merge({'storage': {'s3': {'region': 'eu-west-1'}}})
+        # Merged from the production preset rather than from Configuration(), because the sibling
+        # assertion below only means something if a sibling holds a *non-default* value. A one-level
+        # merge replaces the whole s3 section and S3Config's dataclass defaults then supply what was
+        # lost -- so a sibling that already equals its default survives a broken merge and asserting
+        # on it proves nothing. That is exactly how the equivalent bug went unnoticed in the
+        # JavaScript SDK. `use_acceleration` is True in this preset and False by default, so it can
+        # tell the two apart. (It used to be asserted on `max_retries` and `s3.timeout`, both at
+        # their defaults; `timeout` was then removed in #385 for not existing in the Go schema.)
+        base = Configuration.from_preset('production')
+        self.assertTrue(base.storage.s3.use_acceleration)
+
+        merged = base.merge({'storage': {'s3': {'region': 'eu-west-1'}}})
         self.assertEqual(merged.storage.s3.region, 'eu-west-1')
-        # The sibling assertion. A one-level merge replaces the whole s3 section, and
-        # S3Config's dataclass defaults would then have to supply these -- which is exactly why
-        # the JavaScript equivalent went unnoticed: the dataclass hid the loss for most fields.
-        default = Configuration()
-        self.assertEqual(merged.storage.s3.max_retries, default.storage.s3.max_retries)
-        self.assertEqual(merged.storage.s3.timeout, default.storage.s3.timeout)
+        self.assertTrue(merged.storage.s3.use_acceleration)
+        self.assertEqual(merged.storage.s3.max_retries, base.storage.s3.max_retries)
 
     def test_untouched_sections_survive(self):
         default = Configuration()
@@ -131,6 +150,81 @@ class RoundTripTest(unittest.TestCase):
             path = os.path.join(directory, 'objectfs.yaml')
             config.save_to_file(path)
             self.assertEqual(Configuration.from_file(path).to_dict(), config.to_dict())
+
+
+class PresetFixturesMatchWhatTheSDKEmitsTest(unittest.TestCase):
+    """Keep ``sdks/testdata/presets/`` equal to what this SDK writes today.
+
+    Compare by default, write only under ``OBJECTFS_UPDATE_FIXTURES=1``. That asymmetry is the whole
+    value. A test that simply wrote the files would make the Go-side gate assert against whatever was
+    committed last: edit ``config.py``, do not run pytest, and ``TestSDKPresetsLoadUnderTheGoLoader``
+    stays green on stale documents while ``save_to_file`` emits a key the daemon refuses. Comparing
+    means the drift fails *here*, in the language that caused it, in a job that already runs.
+
+    It is the same arrangement as ``sdks/testdata/metrics-scrape.txt`` in the other direction -- Go's
+    ``TestSDKFixtureMatchesTheLiveScrape`` regenerates the scrape and compares rather than writing it,
+    and takes ``-update-fixture`` to write. Regenerate here with::
+
+        cd sdks/python && OBJECTFS_UPDATE_FIXTURES=1 pytest tests/test_config.py
+
+    and commit what it writes, so a reviewer sees in the diff what the SDK now emits.
+
+    Deliberately a loop over ``PRESETS``, so a preset added later is covered without editing the Go
+    side -- that test globs the directory.
+    """
+
+    def _documents(self):
+        """Every (filename, YAML) pair the SDK is expected to be able to emit.
+
+        ``default.yaml`` is here as well as the five presets because each preset is a mutation of
+        ``Configuration()``: a key that is wrong in the defaults is wrong in all five, and emitting the
+        unmodified object means a Go-side failure points at the dataclass rather than at a preset.
+        """
+        documents = [('default.yaml', Configuration())]
+        documents += [(f'{name}.yaml', Configuration.from_preset(name)) for name in PRESETS]
+
+        for filename, config in documents:
+            # validate() first: a document the SDK itself rejects is not worth asking the Go loader
+            # about, and the failure should name the SDK rather than arrive as a confusing Go-side
+            # error about a file that should never have been written.
+            config.validate()
+            yield filename, config.to_yaml()
+
+    def test_fixtures_are_current(self):
+        updating = os.environ.get('OBJECTFS_UPDATE_FIXTURES') == '1'
+
+        if updating:
+            os.makedirs(FIXTURE_DIR, exist_ok=True)
+
+        for filename, emitted in self._documents():
+            with self.subTest(fixture=filename):
+                path = os.path.join(FIXTURE_DIR, filename)
+
+                if updating:
+                    with open(path, 'w', encoding='utf-8') as handle:
+                        handle.write(emitted)
+                    continue
+
+                self.assertTrue(
+                    os.path.exists(path),
+                    f"{path} does not exist. internal/config's TestSDKPresetsLoadUnderTheGoLoader "
+                    f"checks these documents against the Go loader, and a missing file is a check "
+                    f"that does not run. Regenerate with "
+                    f"OBJECTFS_UPDATE_FIXTURES=1 pytest tests/test_config.py",
+                )
+
+                with open(path, 'r', encoding='utf-8') as handle:
+                    committed = handle.read()
+
+                self.assertEqual(
+                    emitted,
+                    committed,
+                    f"{filename} no longer matches what this SDK emits. The Go loader is checked "
+                    f"against the committed file, so leaving it stale means a config key the daemon "
+                    f"refuses can ship green (#385). If the change is intended, regenerate with "
+                    f"OBJECTFS_UPDATE_FIXTURES=1 pytest tests/test_config.py and run "
+                    f"go test ./internal/config/ -run TestSDKPresets",
+                )
 
 
 if __name__ == '__main__':

--- a/sdks/testdata/presets/cluster.yaml
+++ b/sdks/testdata/presets/cluster.yaml
@@ -1,0 +1,52 @@
+global:
+  log_level: INFO
+  log_file: ''
+storage:
+  s3:
+    region: us-east-1
+    endpoint: ''
+    profile: ''
+    use_acceleration: false
+    force_path_style: false
+    max_retries: 3
+    cost_optimization:
+      small_objects_on_standard: false
+performance:
+  cache_size: 4GB
+  max_concurrency: 200
+  multilevel_caching: true
+  predictive_caching: false
+  ml_model_path: ''
+  write_buffer_size: 4MB
+cluster:
+  enabled: true
+  node_id: ''
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 127.0.0.1:8080
+  seed_nodes: []
+  replication_factor: 3
+security:
+  enabled: true
+  auth_method: none
+  tls_enabled: false
+  tls_cert_path: ''
+  tls_key_path: ''
+monitoring:
+  enabled: true
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:8080
+    prometheus: true
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
+    interval: 30s
+    timeout: 5s
+  opentelemetry:
+    enabled: false
+    endpoint: localhost:4317
+    service_name: objectfs
+fuse:
+  direct_io: false
+  keep_cache: false
+  sync_read: false

--- a/sdks/testdata/presets/cost-optimized.yaml
+++ b/sdks/testdata/presets/cost-optimized.yaml
@@ -1,0 +1,52 @@
+global:
+  log_level: INFO
+  log_file: ''
+storage:
+  s3:
+    region: us-east-1
+    endpoint: ''
+    profile: ''
+    use_acceleration: false
+    force_path_style: false
+    max_retries: 3
+    cost_optimization:
+      small_objects_on_standard: true
+performance:
+  cache_size: 2GB
+  max_concurrency: 100
+  multilevel_caching: true
+  predictive_caching: false
+  ml_model_path: ''
+  write_buffer_size: 4MB
+cluster:
+  enabled: false
+  node_id: ''
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 127.0.0.1:8080
+  seed_nodes: []
+  replication_factor: 3
+security:
+  enabled: false
+  auth_method: none
+  tls_enabled: false
+  tls_cert_path: ''
+  tls_key_path: ''
+monitoring:
+  enabled: false
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:8080
+    prometheus: true
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
+    interval: 30s
+    timeout: 5s
+  opentelemetry:
+    enabled: false
+    endpoint: localhost:4317
+    service_name: objectfs
+fuse:
+  direct_io: false
+  keep_cache: false
+  sync_read: false

--- a/sdks/testdata/presets/default.yaml
+++ b/sdks/testdata/presets/default.yaml
@@ -1,0 +1,52 @@
+global:
+  log_level: INFO
+  log_file: ''
+storage:
+  s3:
+    region: us-east-1
+    endpoint: ''
+    profile: ''
+    use_acceleration: false
+    force_path_style: false
+    max_retries: 3
+    cost_optimization:
+      small_objects_on_standard: false
+performance:
+  cache_size: 4GB
+  max_concurrency: 200
+  multilevel_caching: true
+  predictive_caching: false
+  ml_model_path: ''
+  write_buffer_size: 4MB
+cluster:
+  enabled: false
+  node_id: ''
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 127.0.0.1:8080
+  seed_nodes: []
+  replication_factor: 3
+security:
+  enabled: false
+  auth_method: none
+  tls_enabled: false
+  tls_cert_path: ''
+  tls_key_path: ''
+monitoring:
+  enabled: false
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:8080
+    prometheus: true
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
+    interval: 30s
+    timeout: 5s
+  opentelemetry:
+    enabled: false
+    endpoint: localhost:4317
+    service_name: objectfs
+fuse:
+  direct_io: false
+  keep_cache: false
+  sync_read: false

--- a/sdks/testdata/presets/development.yaml
+++ b/sdks/testdata/presets/development.yaml
@@ -1,0 +1,52 @@
+global:
+  log_level: DEBUG
+  log_file: ''
+storage:
+  s3:
+    region: us-east-1
+    endpoint: ''
+    profile: ''
+    use_acceleration: false
+    force_path_style: false
+    max_retries: 3
+    cost_optimization:
+      small_objects_on_standard: false
+performance:
+  cache_size: 1GB
+  max_concurrency: 50
+  multilevel_caching: true
+  predictive_caching: false
+  ml_model_path: ''
+  write_buffer_size: 4MB
+cluster:
+  enabled: false
+  node_id: ''
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 127.0.0.1:8080
+  seed_nodes: []
+  replication_factor: 3
+security:
+  enabled: false
+  auth_method: none
+  tls_enabled: false
+  tls_cert_path: ''
+  tls_key_path: ''
+monitoring:
+  enabled: false
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:8080
+    prometheus: true
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
+    interval: 30s
+    timeout: 5s
+  opentelemetry:
+    enabled: false
+    endpoint: localhost:4317
+    service_name: objectfs
+fuse:
+  direct_io: false
+  keep_cache: false
+  sync_read: false

--- a/sdks/testdata/presets/high-performance.yaml
+++ b/sdks/testdata/presets/high-performance.yaml
@@ -1,0 +1,52 @@
+global:
+  log_level: WARN
+  log_file: ''
+storage:
+  s3:
+    region: us-east-1
+    endpoint: ''
+    profile: ''
+    use_acceleration: true
+    force_path_style: false
+    max_retries: 3
+    cost_optimization:
+      small_objects_on_standard: false
+performance:
+  cache_size: 16GB
+  max_concurrency: 1000
+  multilevel_caching: true
+  predictive_caching: true
+  ml_model_path: ''
+  write_buffer_size: 4MB
+cluster:
+  enabled: false
+  node_id: ''
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 127.0.0.1:8080
+  seed_nodes: []
+  replication_factor: 3
+security:
+  enabled: false
+  auth_method: none
+  tls_enabled: false
+  tls_cert_path: ''
+  tls_key_path: ''
+monitoring:
+  enabled: false
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:8080
+    prometheus: true
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
+    interval: 30s
+    timeout: 5s
+  opentelemetry:
+    enabled: false
+    endpoint: localhost:4317
+    service_name: objectfs
+fuse:
+  direct_io: false
+  keep_cache: false
+  sync_read: false

--- a/sdks/testdata/presets/production.yaml
+++ b/sdks/testdata/presets/production.yaml
@@ -1,0 +1,52 @@
+global:
+  log_level: INFO
+  log_file: ''
+storage:
+  s3:
+    region: us-east-1
+    endpoint: ''
+    profile: ''
+    use_acceleration: true
+    force_path_style: false
+    max_retries: 3
+    cost_optimization:
+      small_objects_on_standard: false
+performance:
+  cache_size: 8GB
+  max_concurrency: 500
+  multilevel_caching: true
+  predictive_caching: false
+  ml_model_path: ''
+  write_buffer_size: 4MB
+cluster:
+  enabled: false
+  node_id: ''
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 127.0.0.1:8080
+  seed_nodes: []
+  replication_factor: 3
+security:
+  enabled: false
+  auth_method: none
+  tls_enabled: false
+  tls_cert_path: ''
+  tls_key_path: ''
+monitoring:
+  enabled: true
+  metrics:
+    enabled: true
+    addr: 127.0.0.1:8080
+    prometheus: true
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081
+    interval: 30s
+    timeout: 5s
+  opentelemetry:
+    enabled: false
+    endpoint: localhost:4317
+    service_name: objectfs
+fuse:
+  direct_io: false
+  keep_cache: false
+  sync_read: false


### PR DESCRIPTION
## What was wrong

`Configuration.to_yaml()` in the Python SDK emitted **sixteen** keys `internal/config` does not define, across seven sections. `LoadFromFile` decodes strictly, so `save_to_file` produced a document the daemon refused at startup, naming the first key it hit:

```
line 4: field pid_file not found in type config.GlobalConfig
```

This affected the default `Configuration()` and **all five presets** — so the SDK's documented path (build a config, `save_to_file`, mount with it) could not work at all. `sdks/python/README.md`'s "Written out, this is what the daemon reads" was false for every configuration the SDK could produce.

#385 named three of the sixteen. The other thirteen were found by the test that closes it, on its first run.

## What was removed, and why not added to the Go schema instead

| Key(s) | Why removed |
|---|---|
| `global.pid_file`, `global.daemon` | ObjectFS does not fork — no background mode to select, no forked child's pid to record |
| `storage.s3.timeout` | An `int` of unstated unit; the real settings are `network.timeouts.connect`/`read`/`write`, as durations |
| `performance.read_ahead_size` | Removed Go-side in v0.11.0 for naming a second read-ahead size beside `performance.read_ahead.window_size` (#176) |
| `performance.max_write_buffer` | Is `write_buffer.max_memory` |
| `cluster.election_timeout`, `heartbeat_interval`, `join_timeout` | Exist on `internal/distributed.ClusterConfig` — a **disjoint** type from `internal/config.ClusterConfig`, no conversion between them (#139). Grepped `sdks/`: no consumer of any of the three, which answers #385's open question about `join_timeout` |
| `security.tls_ca_path` | No CA path in the schema's `security` block; trust configuration is the `security.tls` block |
| `monitoring.opentelemetry.headers` | Where an OTLP bearer token would go, in a document the loader rejected. An unloadable place to put a credential is worse than no key |
| the entire `fuse` block (6 keys) | Replaced by the three the Go schema has: `direct_io`, `keep_cache`, `sync_read`. The removed six were **doubly inert** — discarded by the loader, and `allow_other`/`uid`/`gid` are ones `cmd/objectfs/doc.go` already records as *not settable* because nothing on the adapter's mount path reads them |

## The gate

A cross-language contract in the reverse direction from the metrics fixture. `internal/metrics` generates `sdks/testdata/metrics-scrape.txt` for the SDKs to parse because the Go exporter is the authority on metric names; here the **Go loader** is the authority on config keys, so the SDK generates and Go checks.

- Each preset's `to_yaml()` output is committed under `sdks/testdata/presets/`.
- `internal/config`'s `TestSDKPresetsLoadUnderTheGoLoader` **globs** that directory and runs every file through `LoadFromFile` + `Validate` — so a preset added on the Python side is covered without editing the Go side.
- It asserts the **property**, not a key list. #385's acceptance criteria asked for exactly this, and the reason is visible in the outcome: a list is a second copy of the schema and would have had to be right about all sixteen keys to catch them.
- `TestSDKPresetsAreNotAllDefaults` is the companion assertion, matching `TestShippedConfigsSetWhatTheySay`: a document that loads cleanly and changes nothing is not evidence the contract holds.

**The Python half compares rather than writes**, taking `OBJECTFS_UPDATE_FIXTURES=1` to regenerate. Without that, the Go gate would read committed files and stay green on stale ones — edit `config.py`, skip pytest, and a refused key ships green. That is the same asymmetry `TestSDKFixtureMatchesTheLiveScrape` uses with `-update-fixture`. Both halves run in CI; the Python half in the existing `sdk-metrics` job, whose comment now says so.

## Verification

Mutation-checked in both directions (reintroduced `cluster.join_timeout`):

- Without regenerating → the **Python** comparison fails on all six documents, naming the regeneration command.
- Regenerating with it → the **Go** gate fails naming the key *and the line*: `line 28: field join_timeout not found in type config.ClusterConfig`.

Also: `go build ./... && gofmt -l . && go vet ./...` clean, `golangci-lint run` → 0 issues, `go test -race ./...` clean, `pytest tests/` → 72 passed / 31 subtests.

## One test defect fixed in passing

`MergeIsDeepTest.test_nested_s3_field` asserted its siblings survived a merge using `max_retries` and `s3.timeout` — **both already at their dataclass defaults**, so a broken one-level merge would have left them looking correct. That is precisely the failure mode the test's own comment warns about ("the dataclass hid the loss for most fields"). Removing `s3.timeout` surfaced it. It now merges from the `production` preset and asserts on `use_acceleration`, which is `True` there and `False` by default, so it can actually tell the two apart.

Closes #385