### PR TITLE
fix: a config filename with two dots in it was not directory traversal (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reintroducing one key fails the Python comparison on all six documents, and regenerating with it
   fails the Go loader gate naming the key and line.
 
+- **`--config ./objectfs..staging.yaml` failed with "path contains directory traversal."**
+  `ValidatePath` tested `strings.Contains(cleanPath, "..")` *after* `filepath.Clean`, which conflates
+  "contains two dots in a row" with "escapes the working directory." Clean has already resolved every
+  resolvable `..` by then, so a surviving one can only be leading — but `Contains` also matches an
+  adjacent pair *inside* a component, and those are ordinary names. A config file with a dotted
+  environment suffix, a log file named `run..1.log`, a directory `v1..2/` were all refused, with an
+  error naming a cause that was not the reason. The check is now a leading-`..` test, so `..foo` and
+  `...` are not caught either — they are names too ([#384]).
+
+  The table-driven test's only "dots in filename" case was `config/app.config.yaml`, whose dots are
+  not adjacent, so it passed under the broken check and the correct one alike — a case that cannot
+  tell the fix from the defect. Thirteen cases now cover both directions, and mutation-checking
+  confirms they are independent: reverting to `Contains` fails six subtests, all false positives;
+  deleting the check entirely fails six *different* subtests, all real traversal. A new
+  `FuzzValidatePath` states the property instead of a case list — it walks the cleaned path's
+  components tracking depth and asks whether resolving it leaves the starting directory — and finds
+  the original defect in under a second. It also caught the same `Contains` mistake in the first draft
+  of its own oracle, on `/..0`.
+
+  The doc comment now says what the function refuses, which was the issue's second question and is
+  narrower than the name suggests. Clean treats the root as its own parent, so `/../etc/passwd` and
+  `/var/../etc/passwd` both become `/etc/passwd`: an absolute path never reaches the traversal check
+  with a `..` in it. With `allowAbsolute: true` — which all three callers pass, for an operator's own
+  config, discount-file, and log paths — the only thing refused beyond an empty string is a *relative*
+  path that climbs out. That is a typo check, not a security boundary, and it is written down in those
+  words with test cases pinning Clean's behavior so the claim fails rather than quietly rots.
+  `SecureJoin` got a note for a related reason: it *joins* an absolute element rather than refusing it
+  (`SecureJoin("/var/cache", "/etc/passwd")` → `/var/cache/etc/passwd`), which is `filepath.Join`'s
+  documented behavior and still contained — the surprise is in the return value, not the safety.
+
 - **A compatibility probe reported a finding by failing the run.** `conditional_compat_test.go`
   called `t.Errorf` when an endpoint accepted `If-None-Match: *` over an existing key and replaced its
   contents, which contradicts the suite's own contract: record what an endpoint does and fail only on
@@ -2479,6 +2509,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#283]: https://github.com/scttfrdmn/objectfs/issues/283
 [#284]: https://github.com/scttfrdmn/objectfs/issues/284
 [#385]: https://github.com/scttfrdmn/objectfs/issues/385
+[#384]: https://github.com/scttfrdmn/objectfs/issues/384
 [#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#390]: https://github.com/scttfrdmn/objectfs/issues/390
 [#378]: https://github.com/scttfrdmn/objectfs/issues/378

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -6,20 +6,45 @@ import (
 	"strings"
 )
 
-// ValidatePath validates that a file path is safe and does not contain directory traversal attempts.
-// It checks for common directory traversal patterns and ensures the cleaned path doesn't escape
-// the intended directory structure.
+// ValidatePath rejects an empty path, a relative path that escapes the working directory, and — when
+// allowAbsolute is false — an absolute path.
 //
-// Returns an error if the path contains:
-//   - ".." directory traversal sequences
-//   - Absolute paths when not expected
-//   - Other potentially unsafe patterns
+// It returns an error if, after [filepath.Clean]:
+//   - the path is empty
+//   - the path is relative and begins with "..", so resolving it leaves the working directory
+//   - the path is absolute and allowAbsolute is false
+//
+// It does *not* check containment within any particular directory, because no base directory is
+// supplied; [ValidatePathWithinBase] is that check. What this function offers a caller is a cheap
+// refusal of the two shapes an operator most often supplies by mistake.
+//
+// # What it does and does not catch, given allowAbsolute
+//
+// Worth stating plainly, because the answer is asymmetric and [#384] was filed partly to settle it.
+// Clean removes every ".." it can resolve, and for an *absolute* path it can always resolve them: it
+// treats the root as its own parent, so Clean("/../etc/passwd") is "/etc/passwd" and
+// Clean("/var/../etc/passwd") is "/etc/passwd". An absolute path therefore never reaches the traversal
+// check with a ".." left in it — verified by execution, not read from the documentation.
+//
+// So with allowAbsolute true, the only thing this function refuses beyond an empty string is a
+// *relative* path that climbs out of the working directory: "../x" is rejected while "/etc/passwd" is
+// accepted. That is not incoherent — the caller has said absolute paths are the operator's business,
+// and a relative path that escapes is more likely a mistake than an intention — but it is narrow, and
+// a caller should not read a call to this function as containment.
+//
+// All three call sites in this repository pass allowAbsolute true and all three take an operator's own
+// configuration or log path ([config.Configuration.LoadFromFile], the pricing manager's discount file,
+// and the log destination). For them this is a typo check, not a security boundary: an operator who
+// can pass --config can pass an absolute path to anything. It is kept because a clear early refusal
+// costs nothing, and named honestly here so nobody builds on it as more than that.
 //
 // Example usage:
 //
 //	if err := ValidatePath(userProvidedPath, false); err != nil {
 //		return fmt.Errorf("invalid path: %w", err)
 //	}
+//
+// [#384]: https://github.com/scttfrdmn/objectfs/issues/384
 func ValidatePath(path string, allowAbsolute bool) error {
 	if path == "" {
 		return fmt.Errorf("path cannot be empty")
@@ -28,8 +53,17 @@ func ValidatePath(path string, allowAbsolute bool) error {
 	// Clean the path to resolve any . or .. elements
 	cleanPath := filepath.Clean(path)
 
-	// Check for directory traversal attempts
-	if strings.Contains(cleanPath, "..") {
+	// Reject traversal, which after Clean means a *leading* "..".
+	//
+	// Deliberately not strings.Contains(cleanPath, ".."), which is what this was and which is the
+	// defect #384 reports. Clean has already resolved every resolvable ".." by the time this runs, so
+	// a remaining one can only be leading — but Contains also matches an adjacent pair *inside* a
+	// component, and those are ordinary filenames. `--config ./objectfs..staging.yaml` failed with
+	// "path contains directory traversal", and a log file named `run..1.log` was refused the same way:
+	// an error message naming a cause that is not the reason, which is the kind that costs an
+	// afternoon. Checked against the separator rather than by prefix on ".." alone, so "..foo" and
+	// "...", which are also just names, are not caught by the fix either.
+	if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("path contains directory traversal: %s", path)
 	}
 
@@ -90,6 +124,15 @@ func ValidatePathWithinBase(base, path string) error {
 // SecureJoin safely joins path elements and ensures the result stays within the base directory.
 // Unlike filepath.Join, this function validates that the result doesn't escape the base through
 // directory traversal.
+//
+// # An absolute element is joined, not refused
+//
+// SecureJoin("/var/cache", "/etc/passwd") returns "/var/cache/etc/passwd" and no error. That is
+// [filepath.Join]'s documented behavior — it discards the leading separator rather than restarting at
+// the root, which is why the result is still contained — and it is arguably the right answer for a
+// "join under a base" helper. It is stated here because a caller who assumed an absolute element would
+// be *rejected* would be wrong about the return value rather than about the containment, and that is a
+// harder mistake to notice. If a caller needs absolute elements refused, it must check for them.
 //
 // Example usage:
 //

--- a/pkg/utils/path_fuzz_test.go
+++ b/pkg/utils/path_fuzz_test.go
@@ -1,0 +1,119 @@
+package utils
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FuzzValidatePath checks ValidatePath against an independent statement of what it should do.
+//
+// The oracle is deliberately not a second copy of the implementation. It asks a question the
+// implementation does not ask — "does resolving this path against a directory leave that directory?" —
+// answered by walking the cleaned path's components and tracking depth. That is the property a
+// traversal check is *for*, and it is derivable without reference to how the check is written, which is
+// what makes disagreement informative rather than tautological.
+//
+// #384 is the reason this exists. The defect was `strings.Contains(cleanPath, "..")`, which conflates
+// "contains two dots in a row" with "escapes" — a false positive on `a..b.log`, and the table-driven
+// test missed it for as long as it did because every dotted case someone thought to write was either
+// real traversal or had non-adjacent dots. A fuzzer generating names is not limited to the cases
+// someone thought to write, and this one finds the disagreement in well under a second.
+func FuzzValidatePath(f *testing.F) {
+	// Seeds: the #384 false positives, the traversals that must still be caught, and the shapes Clean
+	// collapses. Seeded rather than left to chance because these are the cases with known answers, and
+	// a seed corpus that contains the regression means the fuzz target is also a regression test.
+	for _, seed := range []string{
+		"a..b.log", "my..file", "v1..2/x", "./objectfs..staging.yaml", "..foo/bar", ".../x",
+		"..", "../x", "a/../..", "sub/../../x", "./x/../../y", "../../../etc/passwd",
+		"config/app.yaml", "/etc/passwd", "/var/../etc/passwd", "/../etc/passwd",
+		".", "./", "/", "", "...", "....", "a/./b", "a//b", "a/..", "a/../b",
+	} {
+		f.Add(seed, true)
+		f.Add(seed, false)
+	}
+
+	f.Fuzz(func(t *testing.T, path string, allowAbsolute bool) {
+		err := ValidatePath(path, allowAbsolute)
+
+		if path == "" {
+			if err == nil {
+				t.Fatal("an empty path was accepted")
+			}
+
+			return
+		}
+
+		clean := filepath.Clean(path)
+
+		if filepath.IsAbs(clean) {
+			// An absolute path's only question is whether the caller allows one. Clean resolves every
+			// ".." in an absolute path — it treats the root as its own parent — so traversal cannot
+			// survive to be judged here. Asserted rather than assumed: if that ever stopped holding,
+			// this branch would start failing instead of the doc comment quietly becoming wrong.
+			//
+			// Checked per *component*, not with strings.Contains. The first version of this assertion
+			// used Contains and the fuzzer failed it in under a second on "/..0" — whose single
+			// component is "..0", an ordinary name. That is #384's own mistake, reproduced in the
+			// oracle written to catch #384, which is a reasonable argument for having a fuzzer at all.
+			for component := range strings.SplitSeq(clean, string(filepath.Separator)) {
+				if component == ".." {
+					t.Fatalf("Clean left a %q component in the absolute path %q -> %q, which "+
+						"ValidatePath's documentation says cannot happen", "..", path, clean)
+				}
+			}
+
+			if allowAbsolute && err != nil {
+				t.Fatalf("absolute path %q rejected with allowAbsolute: %v", path, err)
+			}
+
+			if !allowAbsolute && err == nil {
+				t.Fatalf("absolute path %q accepted without allowAbsolute", path)
+			}
+
+			return
+		}
+
+		// The relative case, where the oracle earns its keep. escapes reports whether resolving the
+		// path against some directory ends up above it.
+		wantErr := escapes(clean)
+
+		if wantErr && err == nil {
+			t.Fatalf("path %q (clean %q) resolves above its starting directory and was accepted",
+				path, clean)
+		}
+
+		if !wantErr && err != nil {
+			t.Fatalf("path %q (clean %q) stays within its starting directory and was rejected: %v",
+				path, clean, err)
+		}
+	})
+}
+
+// escapes reports whether a cleaned relative path resolves to somewhere above where it started.
+//
+// Walks components and tracks depth. A ".." at depth zero is an escape; a component whose *name*
+// merely contains dots is a component like any other, which is the distinction #384 was wrong about.
+// Written against the meaning of the path rather than against ValidatePath's implementation, which is
+// the point of an oracle — if it were the same expression, agreement would prove nothing.
+func escapes(clean string) bool {
+	depth := 0
+
+	for component := range strings.SplitSeq(clean, string(filepath.Separator)) {
+		switch component {
+		case "", ".":
+			// Clean removes both, so these are unreachable for a cleaned path. Handled anyway so the
+			// function is honest about a non-cleaned argument rather than counting "" as a directory.
+		case "..":
+			if depth == 0 {
+				return true
+			}
+
+			depth--
+		default:
+			depth++
+		}
+	}
+
+	return false
+}

--- a/pkg/utils/path_test.go
+++ b/pkg/utils/path_test.go
@@ -69,6 +69,107 @@ func TestValidatePath(t *testing.T) {
 			allowAbsolute: false,
 			wantErr:       false,
 		},
+
+		// The #384 cases. Every one of these is an ordinary filename that happens to contain an
+		// adjacent pair of dots, and every one was rejected as "directory traversal" before the fix.
+		//
+		// The case above — "config/app.config.yaml" — is why that went unnoticed for as long as it did:
+		// it was the table's only "dots in filename" entry and its dots are not adjacent, so it passed
+		// under the broken check and under the correct one alike. A regression case has to be able to
+		// tell the two apart.
+		{
+			name:          "adjacent dots inside a filename are not traversal",
+			path:          "a..b.log",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+		{
+			name:          "adjacent dots with no extension are not traversal",
+			path:          "my..file",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+		{
+			name:          "adjacent dots in a directory component are not traversal",
+			path:          "v1..2/x",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+		{
+			name:          "the concrete case from the issue",
+			path:          "./objectfs..staging.yaml",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+		{
+			name:          "leading dots that are not a pair",
+			path:          "..foo/bar",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+		{
+			name:          "three dots is a legal directory name",
+			path:          ".../x",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+
+		// The other direction: traversal that must still be refused, including the two forms Clean
+		// produces that a naive prefix check would miss. Without these the fix could have been "delete
+		// the check", which passes every false-positive case above.
+		{
+			name:          "traversal that Clean reduces to exactly ..",
+			path:          "a/../..",
+			allowAbsolute: true,
+			wantErr:       true,
+			errContains:   "directory traversal",
+		},
+		{
+			name:          "traversal surviving Clean as a leading ..",
+			path:          "sub/../../x",
+			allowAbsolute: true,
+			wantErr:       true,
+			errContains:   "directory traversal",
+		},
+		{
+			name:          "traversal through a current-directory reference",
+			path:          "./x/../../y",
+			allowAbsolute: true,
+			wantErr:       true,
+			errContains:   "directory traversal",
+		},
+		{
+			name:          "relative traversal is refused even when absolute paths are allowed",
+			path:          "../../../etc/passwd",
+			allowAbsolute: true,
+			wantErr:       true,
+			errContains:   "directory traversal",
+		},
+
+		// Absolute paths with .. in them, asserted so the doc comment's claim is checked rather than
+		// stated. Clean treats the root as its own parent, so it resolves these to /etc/passwd and no
+		// ".." reaches the traversal check — they are accepted under allowAbsolute, as any other
+		// absolute path is. That is the honest boundary of this function, and if Clean's behavior ever
+		// changed these would fail rather than the comment quietly becoming wrong.
+		{
+			name:          "absolute path whose traversal Clean resolves away",
+			path:          "/var/../etc/passwd",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+		{
+			name:          "absolute path climbing above the root",
+			path:          "/../etc/passwd",
+			allowAbsolute: true,
+			wantErr:       false,
+		},
+		{
+			name:          "the same absolute path is refused for being absolute, not for traversal",
+			path:          "/../etc/passwd",
+			allowAbsolute: false,
+			wantErr:       true,
+			errContains:   "absolute paths not allowed",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #384.

## The defect

`pkg/utils/path.go` tested `strings.Contains(cleanPath, "..")` **after** `filepath.Clean`. Clean has already resolved every resolvable `..` by that point, so a surviving one can only be *leading* — but `Contains` also matches an adjacent pair *inside* a component, and those are ordinary names:

| path | before | after |
|---|---|---|
| `./objectfs..staging.yaml` | ❌ "directory traversal" | ✅ |
| `run..1.log` | ❌ | ✅ |
| `v1..2/x` | ❌ | ✅ |
| `..foo/bar` | ❌ | ✅ |
| `sub/../../x` | ❌ | ❌ (correctly) |

The check is now `cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator))`. The separator is part of the prefix deliberately, so `..foo` and `...` are not caught either.

All three callers pass operator-supplied paths — `internal/config`'s `--config`, the pricing manager's discount file, `pkg/utils/logging.go`'s log destination — so this was reachable by anyone with a dotted filename convention.

## Why the existing test missed it

`TestValidatePath`'s only "dots in filename" case was `config/app.config.yaml`, whose dots are **not adjacent**. It passed under the broken check and the correct one alike — a case that cannot tell the fix from the defect.

Thirteen cases now cover both directions, and mutation-checking confirms they are independent rather than redundant:

- revert to `strings.Contains` → **6 subtests fail**, all false positives
- delete the check entirely → **6 _different_ subtests fail**, all real traversal

Either half alone would have been satisfied by the wrong fix. A table full of false-positive cases and no traversal cases would have accepted "delete the check."

## The fuzzer

`FuzzValidatePath` states the *property* rather than a case list: it walks the cleaned path's components tracking depth and asks whether resolving the path leaves its starting directory. That is derivable without reference to how the check is written, which is what makes disagreement informative rather than tautological. 60s run: 42.8M executions, 136 corpus entries, pass. Against the original defect it fails immediately on `a..b.log`.

It also caught the same `Contains` mistake in the first draft of *its own oracle*, on `/..0` — whose single component is `..0`, an ordinary name. #384's exact error, reproduced in the test written to catch #384, found in under a second. That is a reasonable argument for having a fuzzer at all.

## The issue's second question, settled by execution

> With `allowAbsolute: true` and no base path, what does this still refuse?

Clean treats the root as its own parent, so `Clean("/../etc/passwd")` is `/etc/passwd` and `Clean("/var/../etc/passwd")` is `/etc/passwd` — verified by running it, not read from the docs. **An absolute path never reaches the traversal check with a `..` left in it.**

So with `allowAbsolute: true` the only thing refused beyond an empty string is a *relative* path that climbs out. That is a typo check, not a security boundary, and the doc comment now says so in those words rather than leaving a check whose only observable effect was the false positive. Three test cases pin Clean's behavior so the claim fails rather than quietly rotting.

`SecureJoin` gets a note for a related reason, also probed: `SecureJoin("/var/cache", "/etc/passwd")` returns `/var/cache/etc/passwd` and no error. That is `filepath.Join`'s documented behavior and containment still holds — the surprise is in the return value, not the safety, which is the harder mistake to notice.

## The unreachable helpers

`ValidatePathWithinBase` and `SecureJoin` have no non-test callers. Checked the one place remote input could plausibly reach a path: `internal/cache/persistent.go`'s `generateFilePath` **hashes the key** before joining, so it is already guarded and offers `SecureJoin` no load-bearing caller. Not deleted here — `.coverage-floors` sets `pkg/utils 82` and removing tested functions moves the ratio. Noted on the issue; this PR closes on the live defect.

## Verification

- `go build ./... && gofmt -l . && go vet ./... && golangci-lint run` — clean
- `go test -race ./...` — full suite, not `-short`, exit 0
- `FuzzValidatePath -fuzztime=60s` — pass; crash corpus not committed