### PR TITLE
docs: say that pjdfstest runs on demand only, and why (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coordination declines to start there. The page's title and overview said "S3-Compatible Object
   Storage" where the project targets AWS S3. Replaced with what varies, which is coordination, and a
   link to the probed matrix — plain filesystem use is unaffected on any S3-compatible endpoint.
+- **`scripts/pjdfstest.sh` now says it runs on demand only, and why** ([#352]). The script works —
+  real `mount` subcommand, prerequisite checks, an EXIT/INT/TERM trap, `${PIPESTATUS[0]}` propagated
+  past the `tee` — and nothing runs it. That is a statement about infrastructure, not about the
+  script: it needs `/dev/fuse`, real credentials and a real bucket, and this repository has no
+  scheduled real-AWS job at all, so wiring it in means adding one with a bucket and a role. Written
+  into the script header and beside `make test-posix`, matching what `make test-fuse-mount` already
+  does, because the failure mode of an unrun conformance suite is that it reads as a passing one.
+
+  Kept rather than deleted: it is the only *third-party* POSIX conformance suite this project has, and
+  `internal/difftest` — which does run in CI — makes a weaker claim, comparing against the local OS
+  filesystem over an operation sequence this repository chose rather than one nobody here wrote and
+  cannot have tuned to what already works. Both notes point at `README.md`'s supported-operations
+  table for reading the output: ObjectFS is not POSIX-compliant, so a clean run is not the goal, and
+  the useful question is whether the failing set grew.
 
 ### Fixed
 
@@ -2534,6 +2548,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#385]: https://github.com/scttfrdmn/objectfs/issues/385
 [#384]: https://github.com/scttfrdmn/objectfs/issues/384
 [#367]: https://github.com/scttfrdmn/objectfs/issues/367
+[#352]: https://github.com/scttfrdmn/objectfs/issues/352
 [#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#390]: https://github.com/scttfrdmn/objectfs/issues/390
 [#378]: https://github.com/scttfrdmn/objectfs/issues/378

--- a/Makefile
+++ b/Makefile
@@ -330,9 +330,19 @@ test-fuse-mount:
 	@echo "$(COLOR_BLUE)Running kernel-observable FUSE tests (requires /dev/fuse)...$(COLOR_RESET)"
 	@go test -race -tags=fuse_mount -run 'TestDirectIO|TestKeepCache' ./internal/fuse/
 
-# POSIX compliance test using pjdfstest.
-# Requires: pjdfstest in PATH, OBJECTFS_TEST_BUCKET set, and a running mount.
-# Run `make build` first.
+# Third-party POSIX conformance, via pjdfstest. ON DEMAND ONLY — no CI job runs this, and none can:
+# it needs /dev/fuse, real AWS credentials and a real bucket, and this repository has no scheduled
+# real-AWS job at all (the only cron: in the tree belongs to the security scan). Adding one means a
+# bucket and a role, which is a decision with a cost attached — issue #352.
+#
+# Said out loud here and in the script's header because the failure mode of an unrun conformance suite
+# is that it reads as a passing one. `make test-fuse-mount` above is the same situation for the same
+# reason, and internal/difftest is what does run: a differential oracle over an operation sequence
+# this repository chose, which is a weaker claim than a suite nobody here wrote.
+#
+# Requires: pjdfstest in PATH, OBJECTFS_TEST_BUCKET set. `build` runs first via the prerequisite.
+# ObjectFS is not POSIX-compliant, so a clean run is not the goal — README.md's supported-operations
+# table is what to read the results against, and the useful question is whether the failing set grew.
 test-posix: build
 	@echo "$(COLOR_BLUE)Running pjdfstest POSIX compliance suite...$(COLOR_RESET)"
 	@scripts/pjdfstest.sh

--- a/scripts/pjdfstest.sh
+++ b/scripts/pjdfstest.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 # pjdfstest.sh — run the pjdfstest POSIX compliance suite against ObjectFS.
 #
+# ON DEMAND ONLY. Nothing runs this automatically, and that is a statement about infrastructure
+# rather than about the script, which works. It needs /dev/fuse, real AWS credentials, and a real
+# bucket, so a GitHub-hosted runner cannot execute it: there is no scheduled real-AWS job in this
+# repository at all (the only cron: in the tree belongs to the security scan). Wiring it into CI
+# would mean adding one, with a bucket and a role, which is a decision with a cost attached and not
+# something a script comment can make.
+#
+# Written down instead of left implied, because the failure mode of an unrun conformance suite is
+# that it reads as a passing one. `internal/fuse/kernel_options_live_test.go` documents its own
+# unrunnability for the same reason, and `make test-fuse-mount` says so beside its target. Tracked as
+# https://github.com/scttfrdmn/objectfs/issues/352.
+#
+# Kept rather than deleted: this is the only *third-party* POSIX conformance suite this project has.
+# `internal/difftest` is the closest thing that does run in CI, and it makes a weaker claim — it
+# compares ObjectFS against the local OS filesystem over an operation sequence this repository chose,
+# where pjdfstest is a suite nobody here wrote and cannot have tuned to what already works. Run it by
+# hand before a release, and read README.md's supported-operations table for what is expected to fail
+# by design: ObjectFS is not a POSIX-compliant filesystem, so a clean pjdfstest run is not the goal —
+# knowing which cases fail, and that the set has not grown, is.
+#
 # Prerequisites:
 #   - pjdfstest binary in $PATH (https://github.com/pjd/pjdfstest)
 #   - ./bin/objectfs binary (run `make build` first)


### PR DESCRIPTION
Closes #352 by taking **option 2**, because option 1 is blocked on infrastructure that does not exist.

## The script is not broken

Checked before deciding what to do with it:

- real `mount` subcommand invocation, not a placeholder
- prerequisite checks for both `pjdfstest` in `$PATH` and the `objectfs` binary, each with an actionable error
- `trap cleanup EXIT INT TERM`, with `fusermount -u` → `umount` fallback and `rmdir` of the temp mount dir
- `${PIPESTATUS[0]}` captured past the `tee`, so a failing suite is a failing exit code rather than `tee`'s success

## Why option 1 is blocked

It needs `/dev/fuse`, real AWS credentials, and a real bucket. A GitHub-hosted runner cannot supply those, and this repository has **no scheduled real-AWS job at all** — the only `cron:` in the tree belongs to the security scan. So "wire it into CI" is really "add the first scheduled real-AWS job, with a bucket and a role, and own its cost." That is a decision with a price tag, not something a script comment can make on the project's behalf.

## What this PR does instead

States it plainly in both places a reader arrives from:

- **`scripts/pjdfstest.sh` header** — an `ON DEMAND ONLY` note saying what it needs, why CI cannot supply it, and what would have to change.
- **beside `make test-posix`** — same, matching the wording style `make test-fuse-mount` already uses two targets above (`Needs /dev/fuse, so it is not part of make test`).

The reason for saying it at all: **the failure mode of an unrun conformance suite is that it reads as a passing one.** A suite in the tree with a Makefile target looks like coverage. `internal/fuse/kernel_options_live_test.go` is the precedent — it documents its own unrunnability rather than skipping into a false pass.

Both notes also name what *does* run, and why it is the weaker claim: `internal/difftest` is a differential oracle over an operation sequence **this repository chose**, where pjdfstest is a suite nobody here wrote and therefore cannot have tuned to what already works.

## Not deleted

It is the only third-party POSIX **conformance** suite this project has. Both notes point at `README.md`'s supported-operations table for reading the output, because ObjectFS is explicitly not a POSIX-compliant filesystem: a clean run is not the goal, and the useful question is whether the set of failing cases *grew*.

## Verification

No code path changes.

- `make -n test-posix` — resolves
- `bash -n scripts/pjdfstest.sh` — clean
- `shellcheck scripts/pjdfstest.sh` — only the two known false positives: `SC2329` on `cleanup` (invoked via `trap`) and `SC2034` on the deliberate retry counter `i`
- `npx markdownlint-cli@0.37.0 CHANGELOG.md` — no new findings
- Grepped for a stale claim that the suite runs automatically: the only other mention anywhere is the v0.6.0-era CHANGELOG line recording that the script was added, which is a historical record and correctly left alone.