### PR TITLE
fix(distributed): a size failure that arrived as a timeout, and a backend swap that raced (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A remote operation whose response was too large for a gossip datagram presented as a 30-second
+  timeout instead of a size error** ([#399]). Gossip is UDP, `NodeResult.Data` is a `[]byte` that
+  `encoding/json` base64-encodes, and the envelope and MAC are on top, so at the default 8192-byte
+  `max_gossip_packet` a response carries at most **5802 bytes** of object — measured against the real
+  seal path, and an inflation of 38.9% rather than base64's 33%. The kernel's `MaxRead` is 128 KiB, so
+  essentially every read is over the limit. The responder logged the refusal at Warn and returned,
+  having sent nothing, so the requester learned only that nothing arrived and reported `operation timed
+  out waiting for remote response` after its full timeout — a size failure, on a different host, at a
+  level most deployments do not collect, which sends an operator to look at the network. The verdict
+  fits in a datagram even when the bytes do not, so the failure is now sent in place of the data,
+  naming the payload size, the limit and the setting that governs it. `ErrMessageOversize` is the
+  sentinel a caller matches on.
+
+  Raising `max_gossip_packet` is not the fix and was not applied: past the ~1500-byte path MTU a
+  datagram is IP-fragmented and one lost fragment discards all of it, so a larger limit trades a clean
+  error for intermittent loss that scales with size. Fitting object bytes through this transport is not
+  the direction — [#142] warms from S3 and puts only metadata on the wire.
+
+- **`SetBackend` raced every operation a peer had asked for.** It assigned
+  `cm.coordinator.backend` while holding the *cluster's* mutex, and `executeLocally` read the field
+  under no lock at all — from the gossip receive goroutine, which is where a peer's operation runs. Two
+  different locks and an unsynchronized read of an interface value. The backend is now set and read
+  through the coordinator's own accessors, and read once per operation rather than at each switch arm,
+  so a put and its ETag read cannot land on two different backends.
+
+  It stayed latent because every existing test injected its backend *before* `Start`, when the
+  goroutine that reads the field does not yet exist — an ordering no caller is required to observe, and
+  one that [#139] makes routinely false. Found by `-race` only once a test made an injection and a peer
+  operation overlap, which is now `TestClusterManager_SetBackend_IsSafeWhileAPeerOperationRuns`.
+
 - **The Python SDK wrote configuration files the daemon refused to start on — every one of them.**
   `Configuration.to_yaml()` emitted **sixteen** keys `internal/config` does not define, across seven
   sections, and `LoadFromFile` decodes strictly, so `save_to_file` produced a document that failed at
@@ -2565,6 +2595,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#384]: https://github.com/scttfrdmn/objectfs/issues/384
 [#367]: https://github.com/scttfrdmn/objectfs/issues/367
 [#352]: https://github.com/scttfrdmn/objectfs/issues/352
+[#399]: https://github.com/scttfrdmn/objectfs/issues/399
 [#223]: https://github.com/scttfrdmn/objectfs/issues/223
 [#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#390]: https://github.com/scttfrdmn/objectfs/issues/390

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -803,10 +803,17 @@ func (cm *ClusterManager) RemoveNode(nodeID string) {
 func (cm *ClusterManager) SetBackend(b types.Backend) {
 	cm.mu.Lock()
 	cm.backend = b
-	if cm.coordinator != nil {
-		cm.coordinator.backend = b
-	}
+	coordinator := cm.coordinator
 	cm.mu.Unlock()
+
+	// Set through the coordinator's own accessor rather than by assigning the field here. This used to
+	// write cm.coordinator.backend under cm.mu, which is not the lock the reader holds:
+	// [Coordinator.executeLocally] reads it from the gossip receive goroutine, so an injection
+	// concurrent with a peer's operation was a data race on the interface value — caught by -race once
+	// a test made a remote operation and an injection overlap.
+	if coordinator != nil {
+		coordinator.setBackend(b)
+	}
 }
 
 // SetCache injects the cache instance for distributed invalidation.

--- a/internal/distributed/coordinator.go
+++ b/internal/distributed/coordinator.go
@@ -280,6 +280,26 @@ func NewCoordinator(cluster *ClusterManager, config *ClusterConfig, backend type
 	return c, nil
 }
 
+// setBackend replaces the backend operations execute against.
+//
+// It exists so that the field has one writer holding c.mu, because its reader is not on the caller's
+// goroutine: [Coordinator.executeLocally] runs from the gossip receive loop when a peer asks for an
+// operation. [ClusterManager.SetBackend] previously assigned this field directly while holding the
+// *cluster's* mutex, which excludes nothing here.
+func (c *Coordinator) setBackend(b types.Backend) {
+	c.mu.Lock()
+	c.backend = b
+	c.mu.Unlock()
+}
+
+// getBackend returns the current backend, which is nil until one is injected.
+func (c *Coordinator) getBackend() types.Backend {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.backend
+}
+
 // Start starts the coordinator
 func (c *Coordinator) Start(ctx context.Context) error {
 	slog.Info("starting distributed operations coordinator")
@@ -595,7 +615,12 @@ func (c *Coordinator) executeLocally(parent context.Context, nodeID string, op *
 	start := time.Now()
 	result := &NodeResult{NodeID: nodeID}
 
-	if c.backend == nil {
+	// Read once under the lock and use the local copy for the whole operation, rather than touching
+	// c.backend at each switch arm. Both callers reach here concurrently with [ClusterManager.SetBackend]
+	// — one from the caller's goroutine, one from the gossip receive loop — and re-reading the field
+	// mid-operation would also allow a put and its ETag read to land on two different backends.
+	backend := c.getBackend()
+	if backend == nil {
 		result.Error = "no backend configured"
 		result.Latency = time.Since(start)
 		return result
@@ -610,7 +635,7 @@ func (c *Coordinator) executeLocally(parent context.Context, nodeID string, op *
 
 	switch op.Type {
 	case OpTypeGet:
-		data, err := c.backend.GetObject(ctx, op.Key, op.Offset, op.Size)
+		data, err := backend.GetObject(ctx, op.Key, op.Offset, op.Size)
 		if err != nil {
 			result.Error = err.Error()
 		} else {
@@ -626,7 +651,7 @@ func (c *Coordinator) executeLocally(parent context.Context, nodeID string, op *
 		// the answer is definitive, and the recovery is to re-read, recompute, and CAS again — which
 		// only the caller can do, since only it knows what the new bytes should be.
 		if op.Precondition.IsZero() {
-			if err := c.backend.PutObject(ctx, op.Key, op.Data, op.Metadata); err != nil {
+			if err := backend.PutObject(ctx, op.Key, op.Data, op.Metadata); err != nil {
 				result.Error = err.Error()
 			} else {
 				result.Success = true
@@ -635,7 +660,7 @@ func (c *Coordinator) executeLocally(parent context.Context, nodeID string, op *
 			break
 		}
 
-		etag, err := c.backend.PutObjectIf(ctx, op.Key, op.Data, op.Metadata, op.Precondition)
+		etag, err := backend.PutObjectIf(ctx, op.Key, op.Data, op.Metadata, op.Precondition)
 		if err != nil {
 			result.Error = err.Error()
 			result.Conditional = classifyConditional(err)
@@ -644,13 +669,13 @@ func (c *Coordinator) executeLocally(parent context.Context, nodeID string, op *
 			result.ETag = etag
 		}
 	case OpTypeDelete:
-		if err := c.backend.DeleteObject(ctx, op.Key); err != nil {
+		if err := backend.DeleteObject(ctx, op.Key); err != nil {
 			result.Error = err.Error()
 		} else {
 			result.Success = true
 		}
 	case OpTypeList:
-		objs, err := c.backend.ListObjects(ctx, op.Key, 0)
+		objs, err := backend.ListObjects(ctx, op.Key, 0)
 		if err != nil {
 			result.Error = err.Error()
 		} else {
@@ -702,6 +727,37 @@ func (c *Coordinator) handleNetworkOperation(ctx context.Context, msg *GossipMes
 	}
 
 	if err := c.cluster.gossip.sendConsensusMsg(node.Address, MessageTypeNodeOperationResp, resp); err != nil {
+		// An oversize response is not a lost packet, and the requester must not be left to time out on
+		// it (#399). The bytes cannot fit in a datagram — with the default 8192-byte MaxGossipPacket a
+		// payload tops out at 5802, so any read past that is refused — but the *verdict* fits, so send
+		// the failure in place of the data.
+		//
+		// Retrying the send would be pointless: the size is a property of the response, not of the
+		// network, so the second attempt is the same number of bytes. Before this, the requester saw
+		// "operation timed out waiting for remote response" 30 seconds later while the real reason was
+		// logged at Warn on a different host, which sends an operator to look at the network.
+		if errors.Is(err, ErrMessageOversize) {
+			slog.Warn("operation response does not fit a gossip datagram; reporting the size to the requester",
+				"sender_id", senderID, "request_id", nm.RequestID, "key", nm.Operation.Key,
+				"payload_bytes", len(result.Data), "error", err)
+
+			resp.Result = &NodeResult{
+				NodeID:  result.NodeID,
+				Success: false,
+				Error: fmt.Sprintf("%s of %q produced %d bytes, which does not fit a gossip datagram: %v",
+					nm.Operation.Type, nm.Operation.Key, len(result.Data), err),
+				Latency: result.Latency,
+			}
+
+			if err := c.cluster.gossip.sendConsensusMsg(node.Address, MessageTypeNodeOperationResp, resp); err != nil {
+				// The failure report is small — no Data, and an error string naming one key — so this is a
+				// misconfigured limit rather than a payload problem, and there is nothing smaller to send.
+				slog.Warn("failed to send oversize-response report", "sender_id", senderID, "error", err)
+			}
+
+			return
+		}
+
 		slog.Warn("failed to send operation response", "sender_id", senderID, "error", err)
 	}
 }

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -1594,7 +1594,7 @@ func TestCoordinator_RemoteGet_ReportsAnOversizeResponseRatherThanTimingOut(t *t
 	// is a quarter of one 128 KiB kernel read.
 	cm2.SetBackend(newBlobBackend(32 * 1024))
 
-	// Long enough that the old behaviour is distinguishable from a slow reply, short enough that this
+	// Long enough that the old behavior is distinguishable from a slow reply, short enough that this
 	// test does not sit for 30 seconds when it regresses.
 	op := &DistributedOperation{
 		Type:        OpTypeGet,
@@ -1649,17 +1649,13 @@ func TestClusterManager_SetBackend_IsSafeWhileAPeerOperationRuns(t *testing.T) {
 
 	// Swapping repeatedly, because the race needs the write to land inside the window in which the
 	// receive goroutine is reading. One swap would usually miss it.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range 50 {
 			cm2.SetBackend(&mockBackend{})
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range 50 {
 			//nolint:errcheck // The outcome is irrelevant; this exists to drive the concurrent read.
 			_, _ = cm1.coordinator.ExecuteOperation(t.Context(), &DistributedOperation{
@@ -1669,7 +1665,7 @@ func TestClusterManager_SetBackend_IsSafeWhileAPeerOperationRuns(t *testing.T) {
 				Timeout:     time.Second,
 			})
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -1,6 +1,7 @@
 package distributed
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1544,4 +1545,158 @@ func TestClusterManager_CacheInvalidation_TwoNodes(t *testing.T) {
 	}
 
 	waitForDeletion(t, mc2, "foo")
+}
+
+// ── Oversize response tests (#399) ────────────────────────────────────────────
+
+// blobBackend returns a fixed object, so a remote get can be made to produce a response that cannot
+// fit in a gossip datagram.
+//
+// The bytes are built once at construction rather than held as a size and expanded per call: the
+// caller is the gossip receive goroutine, so a field this test writes after starting the cluster
+// would be read from there under -race.
+type blobBackend struct {
+	mockBackend
+	blob []byte
+}
+
+func newBlobBackend(size int) *blobBackend {
+	return &blobBackend{blob: bytes.Repeat([]byte("x"), size)}
+}
+
+func (b *blobBackend) GetObject(_ context.Context, _ string, _, _ int64) ([]byte, error) {
+	return b.blob, nil
+}
+
+// TestCoordinator_RemoteGet_ReportsAnOversizeResponseRatherThanTimingOut is #399.
+//
+// The bytes genuinely cannot cross this transport: gossip is UDP, a []byte is base64-encoded by
+// encoding/json, and the envelope and MAC are on top, so at the default 8192-byte MaxGossipPacket a
+// response tops out at 5802 bytes of object. That limit is not the defect and is not what this
+// asserts.
+//
+// The defect was how it presented. The responder logged the size error at Warn and returned, having
+// sent nothing, so the requester learned only that nothing arrived — reported as "operation timed out
+// waiting for remote response" after its full timeout, on a different host, at a level most
+// deployments do not collect. An operator debugging that looks at the network, the peer's health and
+// the timeout value, and the one thing that is actually wrong is not among them.
+//
+// Asserting on the *content* of the error is what makes this fail against the old code rather than
+// merely take longer: the pre-fix path does produce a failure eventually, so a test that only checked
+// !Success passes both ways.
+func TestCoordinator_RemoteGet_ReportsAnOversizeResponseRatherThanTimingOut(t *testing.T) {
+	t.Parallel()
+
+	cm1, cm2 := startGossipPair(t, "oversize-requester", "oversize-responder")
+	registerPeer(t, cm2, cm1)
+
+	// Comfortably over the 5802-byte ceiling, and a plausible size rather than a pathological one: this
+	// is a quarter of one 128 KiB kernel read.
+	cm2.SetBackend(newBlobBackend(32 * 1024))
+
+	// Long enough that the old behaviour is distinguishable from a slow reply, short enough that this
+	// test does not sit for 30 seconds when it regresses.
+	op := &DistributedOperation{
+		Type:        OpTypeGet,
+		Key:         "big-object",
+		TargetNodes: []string{"oversize-responder"},
+		Timeout:     5 * time.Second,
+	}
+
+	result, err := cm1.coordinator.ExecuteOperation(t.Context(), op)
+	if err == nil {
+		t.Fatal("a remote get of 32 KiB reported success; the response cannot fit a gossip datagram")
+	}
+	if result.Success {
+		t.Error("result.Success is true for an operation whose response was never delivered")
+	}
+
+	// The size, the limit, and the setting that governs it — so the message names the cause and the
+	// knob, rather than sending an operator to the network.
+	for _, want := range []string{"max_gossip_packet", "big-object", "32768"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not mention %q, so it does not explain what happened: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("a size failure is still presented as a timeout, which is the defect #399 reported: %v", err)
+	}
+}
+
+// TestClusterManager_SetBackend_IsSafeWhileAPeerOperationRuns guards the data race found while
+// writing the test above, which is in production code rather than in a test.
+//
+// [ClusterManager.SetBackend] assigned cm.coordinator.backend while holding the *cluster's* mutex,
+// and [Coordinator.executeLocally] read the field under no lock at all — from the gossip receive
+// goroutine, which is where a peer's operation is executed. Two different locks and one unsynchronized
+// read on an interface value.
+//
+// It stayed latent because every existing test injects its backend *before* Start, so the goroutine
+// that reads the field does not exist yet when it is written. That ordering is not something a caller
+// can be required to observe: a mount can enable clustering and swap a backend afterwards, and #139
+// makes an injection concurrent with peer traffic the ordinary case rather than a contrived one.
+//
+// -race is the assertion. There is nothing to check about the result — the point is that the detector
+// finds no write/read pair on the field.
+func TestClusterManager_SetBackend_IsSafeWhileAPeerOperationRuns(t *testing.T) {
+	t.Parallel()
+
+	cm1, cm2 := startGossipPair(t, "swap-requester", "swap-responder")
+	registerPeer(t, cm2, cm1)
+	cm2.SetBackend(&mockBackend{})
+
+	var wg sync.WaitGroup
+
+	// Swapping repeatedly, because the race needs the write to land inside the window in which the
+	// receive goroutine is reading. One swap would usually miss it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			cm2.SetBackend(&mockBackend{})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			//nolint:errcheck // The outcome is irrelevant; this exists to drive the concurrent read.
+			_, _ = cm1.coordinator.ExecuteOperation(t.Context(), &DistributedOperation{
+				Type:        OpTypeGet,
+				Key:         "swapped-key",
+				TargetNodes: []string{"swap-responder"},
+				Timeout:     time.Second,
+			})
+		}
+	}()
+
+	wg.Wait()
+}
+
+// registerPeer makes to aware of from, in both the cluster node map and the gossip memberlist, so a
+// message sent to it can be answered.
+//
+// startGossipPair deliberately registers in one direction only, which is all a broadcast needs. A
+// request/response exchange needs the reverse as well: the responder looks its requester up in its
+// own node map to find an address to reply to, and without this entry it abandons the response for
+// an unrelated reason — "sender not found" — which would make this test pass for the wrong cause.
+func registerPeer(t *testing.T, to, from *ClusterManager) {
+	t.Helper()
+
+	id := from.GetNodeID()
+	addr := from.gossip.LocalAddr()
+	if addr == "" {
+		t.Fatalf("%s has no local gossip address; it is not started", id)
+	}
+
+	to.UpdateNodeInfo(id, &NodeInfo{
+		ID: id, Address: addr, Status: NodeStatusAlive, Metadata: map[string]string{},
+	})
+	to.gossip.mu.Lock()
+	to.gossip.memberlist[id] = &GossipNode{
+		Info:  &NodeInfo{ID: id, Address: addr},
+		State: StateAlive,
+	}
+	to.gossip.mu.Unlock()
 }

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -133,6 +133,17 @@ const (
 	MessageTypeCacheInvalidate MessageType = "cache_invalidate"
 )
 
+// ErrMessageOversize means a sealed datagram exceeded MaxGossipPacket and was refused before it
+// reached the socket. See [GossipProtocol.sendMessage] for why that is refused rather than truncated.
+//
+// It is a sentinel because one caller can act on it. Gossip is a UDP transport, so there is a hard
+// ceiling on what a message can carry — with the default 8192-byte limit, a payload of object bytes
+// tops out at 5802 after the base64, envelope and MAC — and a sender that hits it should say so
+// rather than treat it as a lost packet. Everything else on this socket is small by construction
+// (membership, votes, an invalidation naming one key), so for those it is a misconfiguration and
+// failing the send is the whole answer.
+var ErrMessageOversize = errors.New("gossip message exceeds max_gossip_packet")
+
 // CacheInvalidateMessage is the payload for MessageTypeCacheInvalidate.
 type CacheInvalidateMessage struct {
 	Key  string `json:"key"`
@@ -1248,8 +1259,13 @@ func (gp *GossipProtocol) sendMessage(addr string, msg *GossipMessage) error {
 		gp.stats.MessagesOversize++
 		gp.stats.mu.Unlock()
 
-		return fmt.Errorf("a %s message is %d bytes sealed, over the %d-byte max_gossip_packet: "+
-			"raise it on every node in the cluster", msg.Type, len(data), gp.config.MaxGossipPacket)
+		// Wraps ErrMessageOversize so a caller that can do something better than fail — send less, or
+		// report the size to the peer that is waiting — can tell this apart from a socket error without
+		// matching on the text. See [Coordinator.handleNetworkOperation] (#399), which was dropping this
+		// error entirely and letting the requester time out 30 seconds later instead.
+		return fmt.Errorf("%w: a %s message is %d bytes sealed, over the %d-byte max_gossip_packet: "+
+			"raise it on every node in the cluster", ErrMessageOversize, msg.Type, len(data),
+			gp.config.MaxGossipPacket)
 	}
 
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)


### PR DESCRIPTION
Closes #399.

## The reported defect

A remote operation's response travels the gossip UDP socket, where the sealed datagram is capped by `max_gossip_packet`. `NodeResult.Data` is a `[]byte`, so `encoding/json` base64-encodes it and the envelope and MAC go on top: at the default 8192-byte limit a response carries at most **5802 bytes** of object — 38.9% inflation, not base64's 33%. The kernel's `MaxRead` is 128 KiB, so essentially every read is over the limit.

The ceiling is not the defect. **How it presented was.** The responder logged the refusal at Warn and returned having sent nothing, so the requester waited out its full timeout and reported `operation timed out waiting for remote response` — a size failure, 30 seconds later, on a different host, at a level most deployments do not collect. An operator debugging that examines the network, the peer's health and the timeout value, and the thing that is actually wrong is not among them.

The verdict fits in a datagram even when the bytes do not, so the failure is now sent in place of the data, naming the payload size, the limit and the setting that governs it. `ErrMessageOversize` is the sentinel, so the one caller that can do better than fail need not match on the error text.

**Raising `max_gossip_packet` is not the fix and was not applied.** Past the ~1500-byte path MTU the datagram is IP-fragmented and one lost fragment discards all of it, trading a clean error for intermittent loss that scales with size. Object bytes do not belong on this transport — #142 warms from S3 and puts only metadata on the wire. No stream transport here either; that is its own piece of work.

## A second defect, found while writing the test

`SetBackend` assigned `cm.coordinator.backend` while holding the **cluster's** mutex, and `executeLocally` read the field under **no lock at all** — from the gossip receive goroutine, which is where a peer's operation runs. Two different locks and an unsynchronized read of an interface value.

It stayed latent because every existing test injects its backend *before* `Start`, when the goroutine that reads the field does not yet exist. That is an ordering no caller is required to observe, and #139 makes it routinely false. The backend now has accessors holding the coordinator's own lock, and is read once per operation rather than at each switch arm — so a put and its ETag read cannot land on two different backends.

## Verification

Both fixes verified by mutation, not by prediction:

- Oversize branch disabled → `TestCoordinator_RemoteGet_ReportsAnOversizeResponseRatherThanTimingOut` fails after 5s on the timeout text (`error does not mention "max_gossip_packet"`). With the fix it passes in 1.5s with the real reason.
- Locked read reverted to a bare field access → `-race` reports the write/read pair in `TestClusterManager_SetBackend_IsSafeWhileAPeerOperationRuns`.

`go build ./...`, `gofmt -l`, `go vet ./...`, `golangci-lint run` clean. `go test -race ./...` green. `go test -race -tags=distributed -count=2 ./internal/distributed/...` green.