### PR TITLE
feat(cluster): make cluster.enabled actually start cluster coordination (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cluster.enabled: true` now actually starts cluster coordination** ([#139]). Every part of
+  `internal/distributed` was built, tested and reachable by nothing: no code path anywhere constructed
+  a `ClusterManager`, so a two-node deployment whose configuration said it was clustered got no
+  membership, no cache invalidation and no warming — the `cluster:` block's only live effect was
+  selecting a Redis cache. `internal/adapter` now builds one, injects the backend and cache, starts it
+  before the mount and stops it during teardown, and passes its coordinator down through
+  `MountConfig` to the FileSystem.
+
+  Two things it deliberately does not do. It does not start Raft: `ClusterConfig.EnableConsensus` is
+  new, off by default, and a mount leaves it off, because coordination here is compare-and-swap
+  against S3 — the store evaluates a conditional write, which needs no quorum and keeps working with
+  one node reachable — so an election would decide nothing a filesystem read asks about while making a
+  cluster below quorum degrade a mount that never needed one. And it does not degrade: a cluster that
+  cannot start fails the mount, with the reason, rather than continuing single-node. Coherence is a
+  correctness capability, and a node that believes it is clustered and is not serves cached bytes a
+  peer has already overwritten with nothing in its logs to say why.
+
+  A single-node mount gets a **nil** coordinator, which is what every path added here is guarded by,
+  and that nil is asserted rather than assumed: `GetCoordinator` returns a wrapper that is a non-nil
+  interface value whatever it holds, so the adapter checks before calling it.
+
+- **`cluster.secret_file`, the key `LoadClusterSecret`'s error message had been naming before it
+  existed** ([#139]). A cluster refuses to start without a shared gossip secret ([#206]), the error
+  told operators to set `OBJECTFS_CLUSTER_SECRET` **or** `cluster.secret_file`, and only the first of
+  those was real. The path — never the secret itself — is now a key in the `cluster:` block, and the
+  file it points at must be mode 0600 or startup refuses it. The environment variable still takes
+  precedence, which is what a container orchestrator injects.
+
 - **Wasabi probed and added to the conditional-write compatibility matrix.** It is the first endpoint
   in the matrix to answer success to **every** cell: `If-None-Match: *` over an existing key replaces
   it, `If-Match` with an ETag that cannot possibly match performs the write, and `If-Match` against an
@@ -40,6 +68,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   protects a deployment if a later beta regresses.
 
 ### Changed
+
+- **BREAKING: `cluster.enabled: true` now requires a gossip secret, including for a Redis-only
+  deployment** ([#139]). `cluster.enabled` is what selects the shared Redis cache and it is also what
+  starts the gossip layer, so a configuration that set it purely to get Redis will now fail at startup
+  with `no cluster secret configured` until `cluster.secret_file` or `OBJECTFS_CLUSTER_SECRET` is set.
+
+  The coupling is deliberate rather than an oversight of the wiring. A Redis cache shared by several
+  mounts with no invalidation between them is precisely the incoherence the `cluster:` block exists to
+  prevent: one node overwrites an object, the others keep serving what they cached, and nothing in any
+  log says why they disagree. Before this release the invalidation half did not exist at all, so the
+  shared-cache half was the only thing on offer; now that both do, having the cache without the
+  coherence is not a configuration worth supporting. Generate the secret with
+  `openssl rand -hex 32 > /etc/objectfs/cluster.secret && chmod 600 /etc/objectfs/cluster.secret`.
 
 - **The support posture is now stated as a thesis rather than left implicit: AWS S3 is the primary
   backend and ObjectFS uses every S3 capability that benefits it; S3-compatible endpoints are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A read-ahead prefetch that fell behind the reader re-fetched bytes already cached.** A prefetch is
+  queued and the reader does not wait for it, so under load the reader can consume the front of the very
+  range predicted for it before a worker picks the request up. Those reads are then finished — removed
+  from the in-flight set that the existing trim consults — and the prefetch's full range is not a cache
+  hit either, because its tail was never cached and a partial hit is a miss. Neither guard saw them, and
+  the prefetch re-read the overlap: measured on CI, a 16 KiB file read in 1 KiB steps transferred 18432
+  bytes, the last GET re-reading 2048 bytes two earlier reads had already fetched. The prefetch now
+  advances past what the reader has consumed, and trims rather than skipping — dropping it outright also
+  stops the byte count exceeding the file, by turning read-ahead off.
+
 - **A remote operation whose response was too large for a gossip datagram presented as a 30-second
   timeout instead of a size error** ([#399]). Gossip is UDP, `NodeResult.Data` is a `[]byte` that
   `encoding/json` base64-encodes, and the envelope and MAC are on top, so at the default 8192-byte

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -305,30 +305,44 @@ features:
   metadata_caching: true
   offline_mode: false
 
-# Multi-node coordination. Experimental and incomplete — the Raft log is not applied and
-# "strong" consistency fans the same PUT to N nodes rather than ordering operations. Do not
-# depend on this for correctness.
+# Multi-node coordination. Still experimental, and what it does and does not do is worth reading
+# before enabling it.
 #
-# The redis: block is the one part of this section that a mount reaches. Setting both `enabled`
-# here and `redis.enabled` below replaces the in-process cache with a shared Redis one for the
-# whole mount; everything else under cluster: is read only by the experimental coordinator.
-# A Redis that cannot be reached at startup fails the mount rather than falling back, so two
-# nodes cannot both come up believing they share a cache when they do not.
+# What `enabled: true` now starts, as of #139: the gossip layer — membership, cache invalidation, and
+# the key announcements that let a node learn which objects its peers hold. That is the whole of it,
+# and it is what a shared cache needs to stay coherent. Until #139 this section started nothing at
+# all: every key below was decoded, defaulted and read by no mount, so a two-node deployment whose
+# configuration said it was clustered got no invalidation and no warming.
 #
-# There is no secret_file key here, and its absence is deliberate rather than an omission. Gossip
-# messages are authenticated with a shared cluster secret and a cluster refuses to start without one
-# (#206), but the secret is configured on internal/distributed.ClusterConfig — a type disjoint from
-# this one (#139) — or through OBJECTFS_CLUSTER_SECRET. It is never a key in this file: packaging
-# installs this configuration world-readable, so a secret written here would be readable by every
-# user on the node. Generate one with `openssl rand -hex 32 > /etc/objectfs/cluster.secret` and
-# `chmod 600` it. Adding the key here before anything reads it would be a setting that silently
-# does nothing, which is the class of defect this file has been cleaned of.
+# What it deliberately does not start: Raft. There are no elections, no leader and no replicated log
+# on a mount. Coordination here is compare-and-swap against S3 — the store evaluates a conditional
+# write, which needs no quorum and keeps working with a single node reachable — so an election would
+# decide nothing a filesystem read asks about while making a cluster that cannot hold a quorum degrade
+# a mount that never needed one.
+#
+# The redis: block is separate from all of the above and works with `enabled` alone: setting both
+# `enabled` here and `redis.enabled` below replaces the in-process cache with a shared Redis one for
+# the whole mount. A Redis that cannot be reached at startup fails the mount rather than falling back,
+# so two nodes cannot both come up believing they share a cache when they do not. Gossip does the same
+# — a cluster that cannot start fails the mount — for the same reason: coherence is a correctness
+# property, and a node that thinks it is clustered and is not serves bytes a peer has overwritten.
 cluster:
   enabled: false
   node_id: ""                         # empty = derived at startup
   listen_addr: 0.0.0.0:8080
   advertise_addr: 127.0.0.1:8080
   seed_nodes: []
+  # Path to the shared secret that authenticates gossip messages. Required whenever `enabled` is true,
+  # here or as OBJECTFS_CLUSTER_SECRET, which takes precedence and is what a container orchestrator
+  # injects; a cluster refuses to start without one, because an unauthenticated gossip port lets any
+  # host on the network join and announce ownership of cached objects (#206).
+  #
+  # The path, never the secret itself. This file is installed world-readable, so a secret written here
+  # would be readable by every user on the node — the file it points at must be mode 0600 or startup
+  # refuses it. Generate one with:
+  #
+  #   openssl rand -hex 32 > /etc/objectfs/cluster.secret && chmod 600 /etc/objectfs/cluster.secret
+  secret_file: ""
   # How many nodes an operation selects, in preference order. Only the first performs the write —
   # there is one copy of the bytes and S3 holds it — so this is a selection width, not a number of
   # copies made.

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/scttfrdmn/objectfs/internal/awsname"
 	"github.com/scttfrdmn/objectfs/internal/cache"
 	"github.com/scttfrdmn/objectfs/internal/config"
+	"github.com/scttfrdmn/objectfs/internal/distributed"
 	"github.com/scttfrdmn/objectfs/internal/fuse"
 	"github.com/scttfrdmn/objectfs/internal/health"
 	"github.com/scttfrdmn/objectfs/internal/metrics"
@@ -46,6 +47,17 @@ type Adapter struct {
 	mountMgr    fuse.PlatformFileSystem
 	metrics     *metrics.Collector
 	monitor     *health.Monitor
+
+	// clusterMgr is nil unless `cluster.enabled` is set, which is the ordinary case. It is the gossip
+	// layer — membership, cache invalidation, and the key announcements a cold node warms from — and
+	// **not** the Raft engine: see [distributed.ClusterConfig.EnableConsensus], which this deliberately
+	// leaves off.
+	//
+	// This is the field #139 was filed for. Every part of internal/distributed built and tested and
+	// reached no mount, because nothing here constructed one: `cluster.enabled: true` selected a Redis
+	// cache through cache.NewFromConfig and otherwise did nothing at all, so a two-node deployment got
+	// no invalidation and no warming while its configuration said it was clustered.
+	clusterMgr *distributed.ClusterManager
 
 	// mountCtx bounds work that outlives the call that started it — a flush runs when the kernel
 	// decides to, which is typically long after Start has returned. Start's own ctx is the wrong
@@ -172,11 +184,26 @@ func (a *Adapter) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize write path: %w", err)
 	}
 
-	// 5. Initialize platform-specific FUSE filesystem
+	// 5. Start cluster coordination, when configured.
+	//
+	// Before the mount, so that the coordinator the filesystem is handed is already running: a mount
+	// serves reads the moment Mount returns, and a coordinator started afterwards would have a window
+	// in which invalidations were silently dropped.
+	//
+	//nolint:contextcheck // a.mountCtx for the same reason as the write path and read-ahead above: the
+	// gossip receive loop and the membership ticker live as long as the mount, not as long as Start.
+	if err := a.startCluster(a.mountCtx); err != nil {
+		return err
+	}
+
+	// 6. Initialize platform-specific FUSE filesystem
 	mountConfig := &fuse.MountConfig{
 		MountPoint: a.mountPoint,
 		Options:    a.buildMountOptions(),
 		ReadAhead:  a.buildReadAheadConfig(),
+		// Nil when clustering is off, which is what every single-node path branches on. See
+		// FileSystem.coordinator.
+		Coordinator: a.clusterCoordinator(),
 	}
 
 	//nolint:contextcheck // a.mountCtx, not ctx, for the same reason as the write path above and with
@@ -187,7 +214,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 	// cancellation, which is the whole point. Stop cancels it, and that is now what stops them.
 	a.mountMgr = fuse.CreatePlatformMountManager(a.mountCtx, a.backend, a.cache, a.writeBuffer, a.metrics, mountConfig)
 
-	// 6. Initialize and start health monitor
+	// 7. Initialize and start health monitor
 	if a.config.Monitoring.HealthChecks.Enabled {
 		monCfg := &health.MonitorConfig{
 			Enabled:          true,
@@ -261,7 +288,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 		slog.Info("health monitor started", "addr", a.config.Monitoring.HealthChecks.Addr)
 	}
 
-	// 7. Mount filesystem
+	// 8. Mount filesystem
 	if err := a.mountMgr.Mount(ctx); err != nil {
 		return fmt.Errorf("failed to mount filesystem: %w", err)
 	}
@@ -309,13 +336,28 @@ func (a *Adapter) Stop(ctx context.Context) error {
 		}
 	}
 
-	// 3. Cancel the mount context, releasing anything still blocked on a backend call. Only after the
+	// 3. Stop cluster coordination.
+	//
+	// After the flush and before the backend closes, which is the only window that is correct in both
+	// directions. The gossip receive loop executes operations on behalf of peers against a.backend and
+	// evicts from a.cache, so it must stop before either of those is closed — otherwise a peer's
+	// message arriving during teardown reaches a closed backend or a closed cache. And it must stop
+	// after the flush rather than before the unmount, because the flush is the last chance for this
+	// node's own pending writes to become durable and nothing about a running cluster impedes it.
+	if a.clusterMgr != nil {
+		if err := a.clusterMgr.Stop(); err != nil {
+			slog.Error("error stopping cluster manager", "error", err)
+			lastErr = err
+		}
+	}
+
+	// 4. Cancel the mount context, releasing anything still blocked on a backend call. Only after the
 	// flush above: canceling first would abort the flush it exists to permit.
 	if a.cancelMount != nil {
 		a.cancelMount()
 	}
 
-	// 4. Close backend connections
+	// 5. Close backend connections
 	if a.backend != nil {
 		if err := a.backend.Close(); err != nil {
 			slog.Error("error closing backend", "error", err)
@@ -323,7 +365,7 @@ func (a *Adapter) Stop(ctx context.Context) error {
 		}
 	}
 
-	// 5. Stop health monitor
+	// 6. Stop health monitor
 	if a.monitor != nil {
 		if err := a.monitor.Stop(); err != nil {
 			slog.Error("error stopping health monitor", "error", err)
@@ -331,7 +373,7 @@ func (a *Adapter) Stop(ctx context.Context) error {
 		}
 	}
 
-	// 6. Clear the cache, then release the goroutines behind it.
+	// 7. Clear the cache, then release the goroutines behind it.
 	//
 	// The Close is what retires the prefetch workers. Prefetch is enabled unconditionally for the
 	// in-process cache, so that mount wraps L1 in a predictive cache with four workers and a statistics
@@ -358,7 +400,7 @@ func (a *Adapter) Stop(ctx context.Context) error {
 		}
 	}
 
-	// 7. Stop metrics collection
+	// 8. Stop metrics collection
 	if a.metrics != nil {
 		if err := a.metrics.Stop(ctx); err != nil {
 			slog.Error("error stopping metrics collector", "error", err)
@@ -369,6 +411,98 @@ func (a *Adapter) Stop(ctx context.Context) error {
 	a.started = false
 	slog.Info("ObjectFS adapter stopped successfully")
 	return lastErr
+}
+
+// startCluster brings up gossip-based cluster coordination when `cluster.enabled` is set, and is a
+// no-op otherwise.
+//
+// A failure here fails the mount rather than degrading to a single node, and that asymmetry is
+// deliberate. Coordination is a correctness capability, not a performance one: a node that believes
+// it is clustered and is not will serve cached bytes that a peer has already overwritten, with
+// nothing in its logs to say why. The same reasoning is why the Redis cache fails the mount rather
+// than falling back — see cache.NewFromConfig — and it is the project thesis's rule for the kind of
+// capability this is.
+//
+// The commonest failure by far is the missing cluster secret, which [distributed.LoadClusterSecret]
+// reports naming both places it can come from.
+func (a *Adapter) startCluster(ctx context.Context) error {
+	if !a.config.Cluster.Enabled {
+		return nil
+	}
+
+	clusterMgr, err := distributed.NewClusterManager(a.buildClusterConfig())
+	if err != nil {
+		return fmt.Errorf("failed to initialize cluster manager: %w", err)
+	}
+
+	// Both injections before Start, so the gossip receive loop cannot dispatch a peer's message at a
+	// nil backend or a nil cache. Both setters are safe to call afterwards as well — that is what
+	// [distributed.ClusterManager.SetBackend]'s locking is for — but "before Start" is the ordering
+	// that needs no argument at all.
+	clusterMgr.SetBackend(a.backend)
+	clusterMgr.SetCache(a.cache)
+
+	if err := clusterMgr.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start cluster manager: %w", err)
+	}
+
+	a.clusterMgr = clusterMgr
+	slog.Info("cluster coordination started",
+		"node_id", clusterMgr.GetNodeID(),
+		"listen_addr", a.config.Cluster.ListenAddr,
+		"seed_nodes", len(a.config.Cluster.SeedNodes))
+
+	return nil
+}
+
+// clusterCoordinator returns the coordinator the filesystem should use, or nil when clustering is off.
+//
+// The nil is the point, and it is why this is a method rather than a call to GetCoordinator at the use
+// site. Two things go wrong without the guard. GetCoordinator reads cm.coordinator, so calling it on a
+// nil manager panics — that is what a mount with clustering disabled would do, on every start. And
+// moving the check inside GetCoordinator would not be enough either: it returns
+// `&coordinatorWrapper{...}`, a non-nil [types.DistributedCoordinator] whatever it wraps, so a mount
+// handed one would take the coordinated branch at every `if fs.coordinator != nil` in internal/fuse
+// and dereference the nothing inside. A nil interface is the only value those guards read correctly.
+func (a *Adapter) clusterCoordinator() types.DistributedCoordinator {
+	if a.clusterMgr == nil {
+		return nil
+	}
+
+	return a.clusterMgr.GetCoordinator()
+}
+
+// buildClusterConfig maps the operator-facing cluster: block onto the distributed package's own
+// configuration.
+//
+// The two ClusterConfig types are disjoint and this is the only conversion between them, which is
+// most of why #139 existed: internal/config.ClusterConfig has seven fields an operator can set,
+// internal/distributed.ClusterConfig has eighteen, and there was no function anywhere that turned one
+// into the other. Fields left unset here are filled by applyConfigDefaults — the timeouts, the gossip
+// triple, and the concurrency and retry settings are all tuning for a subsystem whose defaults are
+// measured (see defaultMaxGossipPacket), so exposing them as YAML before anyone needs to change one
+// would be seven more keys that mostly should not be touched.
+//
+// EnableConsensus is deliberately not set and has no key in the config schema. See
+// [distributed.ClusterConfig.EnableConsensus]: coordination in ObjectFS is compare-and-swap against
+// S3, so a mount has no use for a leader, and putting an election on the path of a filesystem read
+// would make a cluster that cannot hold a quorum degrade a mount that never needed one.
+func (a *Adapter) buildClusterConfig() *distributed.ClusterConfig {
+	c := a.config.Cluster
+
+	return &distributed.ClusterConfig{
+		NodeID:        c.NodeID,
+		ListenAddr:    c.ListenAddr,
+		AdvertiseAddr: c.AdvertiseAddr,
+		SeedNodes:     c.SeedNodes,
+
+		// The path only, never the secret — see [config.ClusterConfig.SecretFile]. May be empty, in
+		// which case OBJECTFS_CLUSTER_SECRET is the only source and LoadClusterSecret fails naming
+		// both if it is unset too.
+		SecretFile: c.SecretFile,
+
+		ReplicationFactor: c.ReplicationFactor,
+	}
 }
 
 // startMetrics constructs the metrics collector and binds its HTTP endpoint.

--- a/internal/adapter/cache_selection_test.go
+++ b/internal/adapter/cache_selection_test.go
@@ -38,6 +38,15 @@ func TestStartReachesTheCacheTheConfigNames(t *testing.T) {
 		mr := miniredis.RunT(t)
 		a := startAdapterWithCluster(t, func(cfg *config.Configuration) {
 			cfg.Cluster.Enabled = true
+
+			// A gossip secret and a loopback port, because as of #139 `cluster.enabled` starts the gossip
+			// layer as well as selecting this cache — and a cluster that cannot start fails the mount, so
+			// without these Start fails before reaching the assertion below. That coupling is deliberate:
+			// a shared cache with no invalidation between its users is the incoherence the whole cluster
+			// block exists to prevent.
+			cfg.Cluster.ListenAddr = "127.0.0.1:0"
+			cfg.Cluster.SecretFile = writeClusterSecret(t)
+
 			cfg.Cluster.Redis = config.RedisConfig{
 				Enabled:    true,
 				Address:    mr.Addr(),

--- a/internal/adapter/cluster_wiring_test.go
+++ b/internal/adapter/cluster_wiring_test.go
@@ -1,0 +1,244 @@
+package adapter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/objectfs/internal/config"
+	"github.com/scttfrdmn/objectfs/internal/distributed"
+)
+
+// A secret long enough for LoadClusterSecret's minimum, which is what `openssl rand -hex 32` produces.
+const testClusterSecret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// TestStartClusterIsANoOpUnlessEnabled is the whole safety argument for #139 in one assertion.
+//
+// Every path added for cluster coordination is guarded by a nil coordinator, and nil is what a
+// single-node mount must get — not an empty one, not a disabled one. If this leaves a cluster manager
+// behind, then every mount on the planet opens a UDP socket and runs a gossip ticker to talk to
+// nobody, and does it without a cluster secret configured, which would fail the mount outright.
+//
+// Note what it asserts about the coordinator specifically. Dropping clusterCoordinator's nil guard
+// makes this test panic on the spot, because GetCoordinator dereferences the manager — so the guard is
+// load-bearing at every single-node start, not only in the subtler case. The subtler case is why the
+// assertion is on the interface value rather than on a.clusterMgr: GetCoordinator returns a
+// *coordinatorWrapper, which is a non-nil types.DistributedCoordinator whatever it wraps, so a
+// nil-check moved one layer down would hand internal/fuse something every `if fs.coordinator != nil`
+// treats as present.
+func TestStartClusterIsANoOpUnlessEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewDefault()
+	if cfg.Cluster.Enabled {
+		t.Fatal("cluster.enabled defaults to true, which would put gossip on every single-node mount")
+	}
+
+	a := &Adapter{config: cfg}
+
+	if err := a.startCluster(t.Context()); err != nil {
+		t.Fatalf("startCluster with clustering disabled: %v", err)
+	}
+
+	if a.clusterMgr != nil {
+		t.Error("a cluster manager was constructed with cluster.enabled false")
+	}
+
+	if coord := a.clusterCoordinator(); coord != nil {
+		t.Errorf("clusterCoordinator returned %T rather than nil, so the filesystem's nil guards would "+
+			"all take the coordinated branch on a single-node mount", coord)
+	}
+}
+
+// TestStartClusterStartsGossipAndReachesTheMount covers the other half: with clustering on, a manager
+// exists, it is running, and the coordinator handed to the mount is the live one.
+//
+// Started on loopback with port 0 so it does not need the network or a fixed port. The gossip socket's
+// own reported address is the evidence it bound — a cluster manager that failed to start is non-nil
+// too, which is the same trap TestStartMetricsBindsTheEndpoint was written for.
+func TestStartClusterStartsGossipAndReachesTheMount(t *testing.T) {
+	t.Parallel()
+
+	a := &Adapter{config: clusterEnabledConfig(t)}
+
+	if err := a.startCluster(t.Context()); err != nil {
+		t.Fatalf("startCluster: %v", err)
+	}
+	t.Cleanup(func() { _ = a.clusterMgr.Stop() })
+
+	if a.clusterMgr == nil {
+		t.Fatal("cluster.enabled is set and no cluster manager was constructed, which is #139 exactly")
+	}
+
+	if addr := a.clusterMgr.GossipAddr(); addr == "" {
+		t.Error("the gossip socket reports no local address, so nothing bound and no peer could reach " +
+			"this node — the manager is non-nil either way")
+	}
+
+	if coord := a.clusterCoordinator(); coord == nil {
+		t.Error("clusterCoordinator returned nil with a running cluster, so the mount would coordinate " +
+			"nothing")
+	}
+}
+
+// TestStartClusterDoesNotAskForConsensus asserts the decision recorded on
+// [distributed.ClusterConfig.EnableConsensus] survives the wiring: a mount asks for gossip and not for
+// Raft. What can regress here is a future buildClusterConfig setting the field, and the consequence
+// lands on a mount — an election on the path of a filesystem read, deciding nothing that path asks
+// about, and a cluster below quorum degrading a mount that never needed one.
+//
+// It asserts on the request and not on the outcome, deliberately, and the reason is worth stating so
+// nobody strengthens this into something that cannot fail. The behavior — no leader, no term, state
+// stays follower — is asserted by TestClusterManager_Start_DoesNotStartConsensusUnlessAskedTo in
+// internal/distributed, which can set a 20ms election timeout and watch ~25 of them pass. From here
+// those same assertions are unmeasurable: ElectionTimeout is not an operator-facing setting, so this
+// cluster runs on the 5-second default, and a freshly started node has not held an election yet
+// whether the engine is running or not. Leadership checks added at this level would pass with the gate
+// removed, which is exactly the shape of a test that measures nothing.
+func TestStartClusterDoesNotAskForConsensus(t *testing.T) {
+	t.Parallel()
+
+	a := &Adapter{config: clusterEnabledConfig(t)}
+
+	if a.buildClusterConfig().EnableConsensus {
+		t.Error("buildClusterConfig sets EnableConsensus, so every clustered mount would run leader " +
+			"elections to decide nothing a filesystem read asks about")
+	}
+
+	// And that a cluster actually starts under that config, so the assertion above is not passing
+	// because the whole thing is inert.
+	if err := a.startCluster(t.Context()); err != nil {
+		t.Fatalf("startCluster: %v", err)
+	}
+	t.Cleanup(func() { _ = a.clusterMgr.Stop() })
+
+	if a.clusterMgr.GossipAddr() == "" {
+		t.Error("gossip did not bind, so consensus being off is not evidence of anything")
+	}
+}
+
+// TestBuildClusterConfigCarriesTheOperatorSettings guards the conversion between the two disjoint
+// ClusterConfig types, which is the only one in the repository.
+//
+// Every value here differs from both the config default and the distributed package's default, because
+// a fixture equal to either passes whether the field was copied or not. That is how a mapping gets
+// written, tested, and quietly stops carrying a field.
+func TestBuildClusterConfigCarriesTheOperatorSettings(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewDefault()
+	cfg.Cluster.Enabled = true
+	cfg.Cluster.NodeID = "node-from-config"
+	cfg.Cluster.ListenAddr = "127.0.0.1:19001"
+	cfg.Cluster.AdvertiseAddr = "10.1.2.3:19001"
+	cfg.Cluster.SeedNodes = []string{"10.1.2.4:19001", "10.1.2.5:19001"}
+	cfg.Cluster.SecretFile = "/etc/objectfs/from-config.secret"
+	cfg.Cluster.ReplicationFactor = 5
+
+	a := &Adapter{config: cfg}
+	got := a.buildClusterConfig()
+
+	checks := []struct {
+		field string
+		got   any
+		want  any
+	}{
+		{"NodeID", got.NodeID, "node-from-config"},
+		{"ListenAddr", got.ListenAddr, "127.0.0.1:19001"},
+		{"AdvertiseAddr", got.AdvertiseAddr, "10.1.2.3:19001"},
+		{"SecretFile", got.SecretFile, "/etc/objectfs/from-config.secret"},
+		{"ReplicationFactor", got.ReplicationFactor, 5},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v: the operator's setting did not reach the cluster",
+				c.field, c.got, c.want)
+		}
+	}
+
+	if len(got.SeedNodes) != 2 || got.SeedNodes[0] != "10.1.2.4:19001" {
+		t.Errorf("SeedNodes = %v, want the two configured seeds; without them a node cannot join "+
+			"anything and forms a cluster of one", got.SeedNodes)
+	}
+}
+
+// TestStartClusterFailsTheMountWithoutASecret asserts the degradation rule for a correctness
+// capability: refuse, with a reason, rather than continue unclustered.
+//
+// A mount that silently fell back to single-node here would serve cached bytes a peer had already
+// overwritten, with nothing in its logs to say why — and its configuration would still say it was
+// clustered. The project thesis's rule is that a correctness capability fails closed, and coherence is
+// one.
+func TestStartClusterFailsTheMountWithoutASecret(t *testing.T) {
+	// Not Parallel: it unsets a process-wide environment variable. t.Setenv would fail the test
+	// outright in a parallel test, which is the runtime telling us the same thing.
+	t.Setenv(distributed.ClusterSecretEnv, "")
+	if err := os.Unsetenv(distributed.ClusterSecretEnv); err != nil {
+		t.Fatalf("unsetting %s: %v", distributed.ClusterSecretEnv, err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Cluster.Enabled = true
+	cfg.Cluster.ListenAddr = "127.0.0.1:0"
+	// No SecretFile and no environment variable, which is the state an operator who enabled clustering
+	// and read no further is in.
+
+	a := &Adapter{config: cfg}
+
+	err := a.startCluster(context.Background())
+	if err == nil {
+		t.Fatal("clustering started with no secret configured; an unauthenticated gossip port lets any " +
+			"host on the network announce ownership of cached objects")
+	}
+	if a.clusterMgr != nil {
+		t.Error("a failed startCluster left a cluster manager on the adapter, which Stop would then " +
+			"try to stop")
+	}
+
+	// The operator has to be able to act on this. "failed to start cluster manager" alone sends them to
+	// the network; naming the environment variable names the missing step.
+	if !strings.Contains(err.Error(), distributed.ClusterSecretEnv) {
+		t.Errorf("the error does not name %s, so it does not say what to do: %v",
+			distributed.ClusterSecretEnv, err)
+	}
+}
+
+// clusterEnabledConfig returns a configuration that starts a real one-node cluster on loopback.
+//
+// The secret goes in a file rather than in OBJECTFS_CLUSTER_SECRET, for two reasons. t.Setenv forbids
+// t.Parallel, so an environment-based helper would serialize every test that used it. And the file is
+// the path an operator takes and the one `cluster.secret_file` was added for, so this exercises the new
+// config field end to end instead of bypassing it.
+//
+// Port 0 rather than a preallocated one: a port read back from a closed listener is already stale, and
+// this package's tests run in parallel with a miniredis that asks for ephemeral ports too.
+func clusterEnabledConfig(t *testing.T) *config.Configuration {
+	t.Helper()
+
+	cfg := config.NewDefault()
+	cfg.Cluster.Enabled = true
+	cfg.Cluster.NodeID = "adapter-cluster-test"
+	cfg.Cluster.ListenAddr = "127.0.0.1:0"
+	cfg.Cluster.AdvertiseAddr = "127.0.0.1:0"
+	cfg.Cluster.SecretFile = writeClusterSecret(t)
+
+	return cfg
+}
+
+// writeClusterSecret writes a valid cluster secret to a temporary file and returns its path.
+//
+// Mode 0600, because LoadClusterSecret refuses anything group- or world-readable rather than chmod-ing
+// a file the operator placed. A fixture written 0644 fails with a permissions error and looks like a
+// wiring defect.
+func writeClusterSecret(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "cluster.secret")
+	if err := os.WriteFile(path, []byte(testClusterSecret), 0o600); err != nil {
+		t.Fatalf("writing the cluster secret fixture: %v", err)
+	}
+
+	return path
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -684,11 +684,23 @@ type S3CostOptimization struct {
 // request count and not the guarantee. What replaced it is per-operation rather than per-mount:
 // distributed.DistributedOperation.Precondition, evaluated by S3 on the one write it guards.
 type ClusterConfig struct {
-	Enabled           bool        `yaml:"enabled"`
-	NodeID            string      `yaml:"node_id"`
-	ListenAddr        string      `yaml:"listen_addr"`
-	AdvertiseAddr     string      `yaml:"advertise_addr"`
-	SeedNodes         []string    `yaml:"seed_nodes"`
+	Enabled       bool     `yaml:"enabled"`
+	NodeID        string   `yaml:"node_id"`
+	ListenAddr    string   `yaml:"listen_addr"`
+	AdvertiseAddr string   `yaml:"advertise_addr"`
+	SeedNodes     []string `yaml:"seed_nodes"`
+
+	// SecretFile names the file holding the shared cluster secret that authenticates gossip messages.
+	// A cluster does not start without one, from here or from OBJECTFS_CLUSTER_SECRET, which takes
+	// precedence — see distributed.LoadClusterSecret, whose error already told operators to set this
+	// key before the key existed.
+	//
+	// The *path* is what goes here and never the secret. This file is installed world-readable by
+	// packaging, so a secret written in it would be published to every user on the node; the file this
+	// points at must be mode 0600 or startup refuses it. Generate one with
+	// `openssl rand -hex 32 > /etc/objectfs/cluster.secret && chmod 600 /etc/objectfs/cluster.secret`.
+	SecretFile string `yaml:"secret_file"`
+
 	ReplicationFactor int         `yaml:"replication_factor"`
 	Redis             RedisConfig `yaml:"redis"`
 }

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -49,6 +49,24 @@ type ClusterConfig struct {
 	HeartbeatInterval time.Duration `yaml:"heartbeat_interval"`
 	LeadershipTTL     time.Duration `yaml:"leadership_ttl"`
 
+	// EnableConsensus starts the Raft engine — elections, heartbeats and the replicated log. It is
+	// **off by default**, and a mount does not turn it on.
+	//
+	// Coordination in ObjectFS is compare-and-swap against S3, not Raft: a conditional write is
+	// evaluated by the store, needs no quorum, and keeps working with one node reachable. See
+	// docs/design/conditional-writes-vs-raft.md. What a mount enables clustering *for* is the gossip
+	// layer — membership, cache invalidation, and the key announcements that let a cold node learn
+	// which objects are worth warming (#140, #142) — and none of that consults a leader.
+	//
+	// So this is not a performance switch. Starting consensus on a mount would put leader election on
+	// the path a filesystem read takes, to decide nothing that path asks about, and would make a
+	// cluster that cannot hold a quorum degrade a mount that has no need of one. Left in the tree and
+	// reachable because the `-tags=distributed` suite drives elections deliberately, and because
+	// nothing outside this package calls [ClusterManager.IsLeader] or [ClusterManager.GetLeader] — the
+	// seam is clean, which is what makes leaving it unstarted a one-line decision rather than a
+	// refactor.
+	EnableConsensus bool `yaml:"enable_consensus"`
+
 	// Gossip protocol
 	GossipInterval  time.Duration `yaml:"gossip_interval"`
 	GossipFanout    int           `yaml:"gossip_fanout"`
@@ -333,8 +351,14 @@ func (cm *ClusterManager) startLocked(ctx context.Context) error {
 		return fmt.Errorf("failed to start gossip protocol: %w", err)
 	}
 
-	if err := cm.consensus.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start consensus engine: %w", err)
+	// Consensus is opt-in; see [ClusterConfig.EnableConsensus] for why a mount leaves it off. The
+	// engine is constructed either way, so the gossip receive loop's vote and append-entries arms stay
+	// harmless rather than needing their own guard: with no election loop running, this node never
+	// becomes a candidate and never has a term to defend.
+	if cm.config.EnableConsensus {
+		if err := cm.consensus.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start consensus engine: %w", err)
+		}
 	}
 
 	if err := cm.coordinator.Start(ctx); err != nil {
@@ -376,6 +400,24 @@ func (cm *ClusterManager) Stop() error {
 // GetNodeID returns the current node ID
 func (cm *ClusterManager) GetNodeID() string {
 	return cm.nodeID
+}
+
+// GossipAddr returns the address the gossip socket is actually bound to, or "" if nothing is bound.
+//
+// The bound address rather than the configured one, which is the only version worth reporting: a
+// cluster manager whose Start failed is non-nil and reports its configuration back just as happily as
+// a running one, and `listen_addr: 127.0.0.1:0` — what a test asks for so the kernel picks the port —
+// is not an address any peer can be told about until the bind has happened.
+func (cm *ClusterManager) GossipAddr() string {
+	cm.mu.RLock()
+	gossip := cm.gossip
+	cm.mu.RUnlock()
+
+	if gossip == nil {
+		return ""
+	}
+
+	return gossip.LocalAddr()
 }
 
 // IsLeader returns true if this node is the current leader
@@ -543,15 +585,21 @@ func (cm *ClusterManager) performHealthChecks(ctx context.Context) {
 				node.Status = NodeStatusDead
 				slog.Info("node marked as dead", "node_id", nodeID, "last_seen_ago", timeSinceLastSeen)
 
-				// If the dead node was the leader, trigger election
+				// If the dead node was the leader, trigger election.
+				//
+				// Unreachable with consensus off, since cm.leader is only ever set by an election, but
+				// gated explicitly rather than left to that: relying on it would mean this arm's
+				// correctness depends on no other writer of cm.leader ever appearing.
 				if nodeID == cm.leader {
 					cm.leader = ""
 					cm.isLeader = false
-					go func() {
-						// Use the cluster lifecycle context so the election
-						// goroutine exits cleanly when the manager stops (#110).
-						_ = cm.consensus.TriggerElection(ctx)
-					}()
+					if cm.config.EnableConsensus {
+						go func() {
+							// Use the cluster lifecycle context so the election
+							// goroutine exits cleanly when the manager stops (#110).
+							_ = cm.consensus.TriggerElection(ctx)
+						}()
+					}
 				}
 			}
 

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -31,6 +31,17 @@ func testConfig(t *testing.T, nodeID string) *ClusterConfig {
 		ElectionTimeout:   30 * time.Second,
 		HeartbeatInterval: 100 * time.Millisecond,
 		SecretFile:        writeTestSecret(t),
+
+		// On here and off for a mount, which is the asymmetry this package's tests exist to hold: the
+		// consensus code is exercised deliberately by the election suite, and is not started by
+		// [ClusterManager.Start] when a filesystem enables clustering. See
+		// [ClusterConfig.EnableConsensus].
+		//
+		// Set in the shared helper rather than in each election test so that turning it off here is what
+		// a reviewer does to check the gate is real — see
+		// TestClusterManager_Start_DoesNotStartConsensusUnlessAskedTo, which asserts the mount-shaped
+		// configuration directly.
+		EnableConsensus: true,
 	}
 }
 
@@ -175,6 +186,64 @@ func TestNewClusterManager_DefaultMaxGossipPacketHoldsAThreeNodeSync(t *testing.
 	if len(chunks) != 1 {
 		t.Errorf("a three-member sync took %d datagrams at the %d-byte default, want 1: the default "+
 			"cannot carry the smallest cluster that needs a quorum", len(chunks), defaultMaxGossipPacket)
+	}
+}
+
+// TestClusterManager_Start_DoesNotStartConsensusUnlessAskedTo is the assertion behind #139's decision
+// to wire the gossip and cache halves of clustering into a mount and leave Raft unstarted.
+//
+// Coordination here is compare-and-swap against S3, decided by the store on one request, and what a
+// mount enables clustering for — membership, invalidation, and the key announcements that tell a cold
+// node which objects are worth warming — consults no leader. Starting elections anyway would put
+// quorum on the path a filesystem read takes in order to decide nothing that path asks about.
+//
+// The configuration here is deliberately the *mount's* shape rather than testConfig's: testConfig sets
+// EnableConsensus so the election suite keeps working, so a test built on it could not observe this
+// gate at all. What is asserted is that no election happens — a leaderless cluster after several
+// election timeouts' worth of wall clock — rather than that a flag is false, because the flag being
+// false is the code under test and not evidence about it.
+func TestClusterManager_Start_DoesNotStartConsensusUnlessAskedTo(t *testing.T) {
+	t.Parallel()
+
+	// Short timeouts so a running election loop would have fired repeatedly by the time this checks.
+	cfg := testConfig(t, "mount-shaped")
+	cfg.EnableConsensus = false
+	cfg.ElectionTimeout = 20 * time.Millisecond
+	cfg.HeartbeatInterval = 10 * time.Millisecond
+
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	if err := cm.Start(t.Context()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = cm.Stop() })
+
+	// A one-node cluster elects itself within one timeout when the loop is running —
+	// TestConsensusEngine_SingleNodeLeadershipIsStable relies on exactly that — so 500ms is ~25
+	// timeouts of margin.
+	time.Sleep(500 * time.Millisecond)
+
+	if cm.consensus.IsLeader() {
+		t.Error("consensus elected a leader on a mount-shaped configuration: enabling clustering for " +
+			"cache coordination must not start Raft")
+	}
+	if state := cm.consensus.GetCurrentState(); state != StateFollower {
+		t.Errorf("consensus state is %v, want %v: the election loop is running", state, StateFollower)
+	}
+	if term := cm.consensus.GetCurrentTerm(); term != 0 {
+		t.Errorf("consensus term advanced to %d, want 0: a term only advances by standing for election",
+			term)
+	}
+
+	// And the half that a mount *does* want is running, so this is not passing because Start failed
+	// early or because clustering is off altogether.
+	if cm.gossip.LocalAddr() == "" {
+		t.Error("gossip is not listening, so this asserts nothing about consensus specifically")
+	}
+	if leader := cm.GetLeader(); leader != "" {
+		t.Errorf("cluster reports leader %q with consensus off", leader)
 	}
 }
 

--- a/internal/distributed/doc.go
+++ b/internal/distributed/doc.go
@@ -22,7 +22,15 @@ bucket does. The Raft issues are closed (#128, #130, #133, #151) and the replace
 taxonomy) and #285 (verifying non-AWS backends).
 
 So what is below describes code that exists and has shrunk, not a design being completed.
-Gossip-based membership and leader election stay.
+Gossip-based membership stays.
+
+What changed in v0.13.0 (#139): a mount reaches this package. Until then nothing outside
+internal/distributed constructed a [ClusterManager], so `cluster.enabled: true` in an operator's
+configuration started none of this — internal/adapter now does, when that key is set. And the
+consensus engine is off on that path: [ClusterConfig.EnableConsensus] is new, defaults to false, and a
+mount leaves it false, because a filesystem read consults no leader and a cluster below quorum should
+not degrade a mount that never needed one. Elections still run when a caller asks for them, which is
+what the -tags=distributed suite does; they do not run under a mount.
 
 Architecture
 
@@ -113,10 +121,12 @@ distributed:
 	openssl rand -hex 32 > /etc/objectfs/cluster.secret
 	chmod 600 /etc/objectfs/cluster.secret
 
-Then name it in the cluster configuration, or set OBJECTFS_CLUSTER_SECRET, which takes precedence
-and is what a container orchestrator injects. The secret is never a field in the YAML configuration:
-packaging installs that file world-readable, so a secret in it would be published to every user on
-the node. A secret file readable by anyone but its owner is refused for the same reason.
+Then name it in the cluster configuration — `cluster.secret_file` in the operator-facing YAML, or
+[ClusterConfig.SecretFile] for a caller of this package — or set OBJECTFS_CLUSTER_SECRET, which takes
+precedence and is what a container orchestrator injects. The *path* is configurable and the secret
+itself never is: packaging installs the configuration file world-readable, so a secret written in it
+would be published to every user on the node. A secret file readable by anyone but its owner is
+refused for the same reason.
 
 Each message carries an HMAC-SHA256 over its exact bytes, plus a timestamp and message ID checked
 against a 30-second freshness window, so a captured datagram cannot be replayed later to reassert

--- a/internal/fuse/coordinator_wiring_test.go
+++ b/internal/fuse/coordinator_wiring_test.go
@@ -1,0 +1,151 @@
+//go:build linux || darwin
+
+package fuse
+
+// This file covers the seam #139 opened: a coordinator set by internal/adapter has to arrive at the
+// FileSystem that serves reads, through MountConfig and CreatePlatformMountManager.
+//
+// It is a plumbing assertion, and the reason for saying so out loud is that kernel_options_test.go in
+// this same package rejects copy checks on principle — nine fields reached a release because
+// `opts.X == cfg.X` passes whether anything downstream reads X. The distinction here is that at this
+// commit *nothing downstream reads the coordinator yet*: the calls that will are #141's, on the cache
+// and write paths. So there is no observable behavior to assert on, and the honest thing is a test that
+// pins the chain and a fake that #141's tests can assert against once the calls exist.
+//
+// What is asserted rather than copied, and does matter today: that a mount configured with no
+// coordinator has a nil one. Nil is the whole safety argument for #139 — every path added from here is
+// guarded by it — and a non-nil-interface-wrapping-nothing would defeat every one of those guards while
+// looking correct from the adapter's side.
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// recordingCoordinator is a types.DistributedCoordinator that records what it was asked to do.
+//
+// It exists for #141 and #142 as much as for this file: the announce and invalidate calls are
+// fire-and-forget with errors logged at Debug, so the only way to assert that a write announced
+// anything is to record the calls. Everything is guarded by a mutex because those calls happen on
+// whichever goroutine the kernel dispatched the write on.
+//
+// The recorded slices have no reader yet, and deliberately no accessor either. Copy-returning
+// announcements()/invalidations() helpers were written here and removed: the linter reports them
+// unused, which is correct — the calls that fill them are #141's — and a //nolint to keep a helper
+// alive for a caller that does not exist is how a test fixture starts drifting from what the code
+// does. They come back with the test that reads them.
+type recordingCoordinator struct {
+	mu           sync.Mutex
+	announced    []types.KeyAnnouncement
+	invalidated  []string
+	queried      []string
+	queryResults []types.KeyAnnouncement
+	queryErr     error
+}
+
+func (r *recordingCoordinator) ExecuteOperation(ctx context.Context, op any) (any, error) {
+	return nil, types.ErrNotSupported
+}
+
+func (r *recordingCoordinator) GetStats() map[string]any { return map[string]any{} }
+
+func (r *recordingCoordinator) AnnounceKey(ctx context.Context, ann types.KeyAnnouncement) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.announced = append(r.announced, ann)
+
+	return nil
+}
+
+func (r *recordingCoordinator) QueryKeyOwnership(ctx context.Context, key string) ([]types.KeyAnnouncement, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.queried = append(r.queried, key)
+
+	return r.queryResults, r.queryErr
+}
+
+func (r *recordingCoordinator) InvalidateKey(ctx context.Context, key, etag string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.invalidated = append(r.invalidated, key)
+
+	return nil
+}
+
+var _ types.DistributedCoordinator = (*recordingCoordinator)(nil)
+
+// TestCoordinatorReachesTheFilesystem walks the chain internal/adapter uses.
+//
+// Through CreatePlatformMountManager rather than NewFileSystem directly, because the derivation from
+// MountConfig to Config is the step that has historically dropped fields — it hardcoded uid, gid and
+// mode for a whole release, and discarded MountConfig.Permissions entirely (#180). Calling
+// NewFileSystem with a Config would skip exactly the code most likely to be wrong.
+func TestCoordinatorReachesTheFilesystem(t *testing.T) {
+	t.Parallel()
+
+	coord := &recordingCoordinator{}
+	fs := filesystemFromMountConfig(t, coord)
+
+	if fs.coordinator == nil {
+		t.Fatal("the coordinator set on MountConfig did not reach the FileSystem, so a clustered mount " +
+			"would coordinate nothing while its configuration said it was clustered")
+	}
+
+	if fs.coordinator != types.DistributedCoordinator(coord) {
+		t.Error("the FileSystem holds a coordinator other than the one configured")
+	}
+}
+
+// TestNoCoordinatorLeavesItNil is the assertion the nil-guard safety argument rests on.
+//
+// Every mount that does not set cluster.enabled takes this path, which is very nearly all of them, and
+// each coordinator call added from #141 onward is guarded by a nil check. A non-nil coordinator here —
+// an empty struct, or an interface wrapping a nil pointer — would send every one of those guards down
+// the coordinated branch on a single-node mount.
+func TestNoCoordinatorLeavesItNil(t *testing.T) {
+	t.Parallel()
+
+	fs := filesystemFromMountConfig(t, nil)
+
+	if fs.coordinator != nil {
+		t.Errorf("coordinator is %T on a mount that configured none; every nil guard in this package "+
+			"would take the coordinated branch", fs.coordinator)
+	}
+}
+
+// filesystemFromMountConfig builds a FileSystem the way internal/adapter does and returns it.
+//
+// In-package, so it can reach mm.filesystem — the same access kernel_options_test.go uses for the
+// open-flag assertions.
+func filesystemFromMountConfig(t *testing.T, coord types.DistributedCoordinator) *FileSystem {
+	t.Helper()
+
+	srv := testaws.Start(t)
+
+	writer, err := vfs.NewWriter(t.Context(), srv.Backend())
+	if err != nil {
+		t.Fatalf("vfs.NewWriter: %v", err)
+	}
+
+	pfs := CreatePlatformMountManager(t.Context(), srv.Backend(), nil, writer, nil, &MountConfig{
+		MountPoint:  t.TempDir(),
+		Options:     &MountOptions{FSName: "objectfs", MaxWrite: 128 * 1024},
+		Coordinator: coord,
+	})
+
+	mm, ok := pfs.(*MountManager)
+	if !ok {
+		t.Fatalf("CreatePlatformMountManager returned %T, want *MountManager", pfs)
+	}
+
+	return mm.filesystem
+}

--- a/internal/fuse/filesystem.go
+++ b/internal/fuse/filesystem.go
@@ -82,6 +82,21 @@ type FileSystem struct {
 
 	metrics types.MetricsCollector
 
+	// coordinator is the cluster's cache coordination, and is **nil on a single-node mount** — which
+	// is every mount that does not set `cluster.enabled`. Nil is the whole of the safety argument: no
+	// path here branches on it except to skip, so a mount without clustering does exactly what it did
+	// before this field existed, at no cost.
+	//
+	// It is deliberately [types.DistributedCoordinator] and not *distributed.ClusterManager. This
+	// package must not import internal/distributed: the dependency would run FUSE → distributed →
+	// gossip → consensus, and the interface is four methods about keys and ETags that a warming
+	// implementation could satisfy without a gossip socket at all.
+	//
+	// What reaches it is the gossip and cache half of clustering only. Consensus is not started on a
+	// mount — see [distributed.ClusterConfig.EnableConsensus] — so nothing on the read or write path
+	// waits on an election.
+	coordinator types.DistributedCoordinator
+
 	// Configuration
 	config *Config
 
@@ -235,6 +250,11 @@ type Config struct {
 	// operator-facing names are config.ReadAheadConfig's, and nothing decodes YAML into this type
 	// anyway. The tags above are kept only because they predate that discovery.
 	ReadAhead *ReadAheadConfig
+
+	// Coordinator is the cluster's cache coordination, or nil for a single-node mount. See
+	// [FileSystem.coordinator], which it is copied to, and [MountConfig.Coordinator], which it comes
+	// from. No yaml tag: it is not a value a config file can express.
+	Coordinator types.DistributedCoordinator
 }
 
 // OpenFile is the per-descriptor state one open(2) produced.
@@ -349,14 +369,15 @@ func NewFileSystem(ctx context.Context, backend types.Backend, cache types.Cache
 	}
 
 	filesystem := &FileSystem{
-		backend:    backend,
-		cache:      cache,
-		buffer:     buffer,
-		metrics:    metrics,
-		config:     config,
-		openFiles:  make(map[uint64]*OpenFile),
-		nextHandle: 1,
-		stats:      &Stats{},
+		backend:     backend,
+		cache:       cache,
+		buffer:      buffer,
+		metrics:     metrics,
+		config:      config,
+		coordinator: config.Coordinator,
+		openFiles:   make(map[uint64]*OpenFile),
+		nextHandle:  1,
+		stats:       &Stats{},
 	}
 
 	// Initialize performance optimizations.

--- a/internal/fuse/mount.go
+++ b/internal/fuse/mount.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 
 	"github.com/scttfrdmn/objectfs/pkg/status"
+	"github.com/scttfrdmn/objectfs/pkg/types"
 )
 
 // FilesystemStats represents filesystem operation statistics
@@ -52,6 +53,17 @@ type MountConfig struct {
 	// [DefaultReadAheadConfig], which is what every caller got unconditionally before
 	// performance.read_ahead was wired (#176).
 	ReadAhead *ReadAheadConfig
+
+	// Coordinator is the cluster's cache coordination, or nil for a single-node mount. See
+	// [FileSystem.coordinator], which it is copied to.
+	//
+	// A field rather than a `WithCoordinator(...)` functional option, which is what #139 specified.
+	// This package has no functional-option pattern — there is not one `func With…` constructor
+	// argument in it — so introducing one for a single nilable field would mean two ways to configure a
+	// mount, and the next field would have to choose between them. It has no yaml tag because a
+	// coordinator is not decodable from a config file; `cluster.enabled` is the operator-facing switch,
+	// and internal/adapter is what turns it into this.
+	Coordinator types.DistributedCoordinator
 }
 
 // MountOptions contains FUSE mount options.

--- a/internal/fuse/optimizations.go
+++ b/internal/fuse/optimizations.go
@@ -213,6 +213,36 @@ func (ram *ReadAheadManager) prefetchLength(size int64) int64 {
 	return ram.config.WindowSize
 }
 
+// consumedThrough returns the first offset of path that the reader has not read yet, or 0 if this
+// manager has no pattern for it.
+//
+// This is [ReadPattern.predictedNext] under a different name, and the rename is the point: the detector
+// stores it as a prediction of where the reader is going, and [ReadAheadManager.performPrefetch] needs
+// it as a fact about where the reader has been. Both readings are the same number — the end of the last
+// read reported — but only one of them is a bound it is safe to skip bytes on the strength of, and
+// naming it here keeps a future change to the prediction from silently moving the bound.
+//
+// It reads the detector's state rather than probing the cache, and the difference matters twice. A
+// cache probe for each candidate prefix would allocate and copy the bytes it found only to discard
+// them, and — the reason it is not merely wasteful — every probe would land in the cache's hit and miss
+// counters, so the prefetcher would be scored as a reader in a statistic the read path exports.
+//
+// The bound is conservative in the safe direction. A read the detector never saw leaves this behind
+// where the reader actually is, so a prefetch trims less than it could and duplicates a range; it can
+// never run *ahead* of the reader, which would skip bytes nobody has fetched and leave a hole the
+// following read pays for at full price.
+func (ram *ReadAheadManager) consumedThrough(path string) int64 {
+	ram.mu.RLock()
+	defer ram.mu.RUnlock()
+
+	pattern, exists := ram.activeReads[path]
+	if !exists {
+		return 0
+	}
+
+	return pattern.predictedNext
+}
+
 // schedulePrefetch schedules a prefetch operation
 func (ram *ReadAheadManager) schedulePrefetch(path string, offset, size int64) {
 	select {
@@ -277,6 +307,32 @@ func (ram *ReadAheadManager) performPrefetch(mount context.Context, req *Prefetc
 	// it was given and cannot answer for bytes past EOF — so each traversal would re-fetch that tail.
 	if ram.fs.cache.Get(req.path, req.offset, length) != nil {
 		return // Already cached
+	}
+
+	// Advance past bytes the reader has already read, and drop a prefetch left entirely behind it.
+	//
+	// A prefetch is queued, and the reader does not wait for it. Between schedulePrefetch and a worker
+	// picking the request up, the reader may have read the front of the very range predicted for it —
+	// and those reads are then *finished*: absent from the in-flight set, because finish removes them,
+	// and no longer a whole-range cache hit either, because the tail beyond them was never cached and
+	// [types.Cache.Get] answers only for a range it holds in full. So neither the check above nor the
+	// trim below sees them, and the prefetch re-fetches bytes already paid for.
+	//
+	// Measured on CI, which is loaded enough for the queue to fall behind — a 16 KiB file read in 1 KiB
+	// steps transferred 18432 bytes, across GETs of 0-1023 … 4096-5119 and then 3072-16383. That last
+	// request re-read 2048 bytes the reads at 3072 and 4096 had already fetched. The same traversal
+	// passed locally 28 times in a row, because there the worker kept up and the trim below caught it.
+	//
+	// This is the trim below one lifecycle stage later, and both are needed: the reader's own reads move
+	// from in-flight to consumed as it advances, while a *concurrent* flight on the same path — another
+	// handle, or another prefetch — is only ever in the in-flight set.
+	if start := ram.consumedThrough(req.path); start > req.offset {
+		length -= start - req.offset
+		req.offset = start
+
+		if length <= 0 {
+			return
+		}
 	}
 
 	// Trim this prefetch past the end of any read already in flight, and drop it if nothing is left.

--- a/internal/fuse/platform.go
+++ b/internal/fuse/platform.go
@@ -84,6 +84,11 @@ func CreatePlatformMountManager(ctx context.Context, backend types.Backend, cach
 	// DefaultReadAheadConfig, which is what every mount ran on before this was plumbed.
 	fuseConfig.ReadAhead = config.ReadAhead
 
+	// Nil for every single-node mount, which is the same nil-is-meaningful pattern as ReadAhead above,
+	// with the difference that nothing substitutes a default: nil means the filesystem skips cache
+	// coordination entirely. See FileSystem.coordinator.
+	fuseConfig.Coordinator = config.Coordinator
+
 	if o := config.Options; o != nil {
 		fuseConfig.ReadOnly = o.ReadOnly
 

--- a/internal/fuse/read_path_test.go
+++ b/internal/fuse/read_path_test.go
@@ -431,6 +431,99 @@ func TestConcurrentIdenticalReadsShareOneGET(t *testing.T) {
 	}
 }
 
+// TestPrefetchSkipsRangeTheReaderHasAlreadyRead is the queued-prefetch-falls-behind case, made
+// deterministic.
+//
+// TestPrefetchStopsAtEndOfFile below asserts the same property end to end, and that is exactly why this
+// test exists: there, whether the duplication happens depends on who wins a race between a prefetch
+// worker and the application's next read(2). It passed 28 consecutive local runs and failed on CI, where
+// the queue falls behind — 18432 bytes for a 16384-byte file, the last GET re-reading 2048 bytes two
+// earlier reads had already fetched.
+//
+// So this one removes the race rather than trying to win it. No workers drain the queue, the reads run
+// to completion first, and performPrefetch is then called directly with the request the detector queued
+// several reads ago. That is the state CI produced: the reads are *finished*, so they are absent from
+// the in-flight set that finish removed them from, and the prefetch's full range is not a cache hit
+// because its tail was never cached.
+func TestPrefetchSkipsRangeTheReaderHasAlreadyRead(t *testing.T) {
+	t.Parallel()
+
+	const (
+		step = 1024
+		size = 16 * step
+	)
+
+	f := newReadPathFixture(t)
+	f.srv.SeedRandom("behind.dat", size)
+
+	// ConcurrentReads: 0 is what makes this deterministic — schedulePrefetch fills the queue and nothing
+	// drains it, so every prefetch below happens when and only when this test says so.
+	f.stopReadAhead()
+	f.fs.readAhead = NewReadAheadManager(t.Context(), f.fs, &ReadAheadConfig{
+		Enabled:         true,
+		WindowSize:      64 * 1024,
+		MinSequential:   3,
+		ConcurrentReads: 0,
+		TTL:             time.Minute,
+	})
+
+	fh := f.open(t, "behind.dat")
+
+	// Five reads, the shape CI reported: the detector predicts 3072 on its third read, and by the time a
+	// worker would run, the reader has consumed through 5120.
+	for off := int64(0); off < 5*step; off += step {
+		f.read(t, fh, off, step)
+	}
+
+	before := f.srv.BytesRead("behind.dat")
+	if before != 5*step {
+		t.Fatalf("the reads themselves transferred %d bytes for %d bytes of file read; this test needs "+
+			"them to fetch each byte once or it is not measuring the prefetch", before, 5*step)
+	}
+
+	// The request the detector queued at the third read, run now that the reader is two reads past it.
+	f.fs.readAhead.performPrefetch(t.Context(), &PrefetchRequest{
+		path:   "behind.dat",
+		offset: 3 * step,
+		size:   64 * 1024,
+	})
+
+	gets := f.srv.GETs("behind.dat")
+	ranges := make([]string, 0, len(gets))
+	for _, req := range gets {
+		ranges = append(ranges, req.Range)
+	}
+
+	// One assertion in two directions, because the two failures are opposite and a message written for
+	// one of them lies about the other.
+	//
+	// Over the file size is the defect itself: the front of the prefetch was fetched twice. Under it is
+	// the fix's own failure mode — a prefetch that skips the range instead of advancing past it also
+	// stops the byte count from exceeding the file, by fetching nothing at all, and would pass an
+	// assertion written only against the excess.
+	switch got := f.srv.BytesRead("behind.dat"); {
+	case got > size:
+		t.Errorf("a prefetch queued at offset %d and run after the reader had consumed through %d "+
+			"transferred %d bytes in total for a %d-byte file, %d too many. It re-fetched the bytes "+
+			"between those two offsets: the reads that cached them have finished, so they are gone from "+
+			"the in-flight set that finish removed them from, and the prefetch's whole range is not a "+
+			"cache hit because its tail was never cached. Ranges: %v",
+			3*step, 5*step, got, size, got-size, ranges)
+
+	case got == before:
+		t.Errorf("the prefetch transferred nothing, leaving the total at %d for a %d-byte file. A "+
+			"prefetch whose front the reader has passed must advance past it and fetch the rest, not "+
+			"give up the tail: dropping it keeps the byte count from exceeding the file by turning "+
+			"read-ahead off, which is the one other way to pass the check above. Ranges: %v",
+			got, size, ranges)
+
+	case got != size:
+		t.Errorf("the prefetch stopped short: %d bytes transferred in total for a %d-byte file, %d "+
+			"short of the tail from offset %d that the reader has not reached. Ranges: %v",
+			got, size, size-got, 5*step, ranges)
+	}
+}
+
 // TestPrefetchStopsAtEndOfFile is the tail of a traversal: the 416 past EOF, and the tail fetched twice.
 //
 // A sequential reader's predicted next offset runs past EOF by construction — the last read of a


### PR DESCRIPTION
Closes #139.

`cluster.enabled: true` did nothing. Every part of `internal/distributed` was built and tested and
reached no mount, because nothing in `internal/adapter` constructed a `ClusterManager`: the flag
selected a Redis cache through `cache.NewFromConfig` and otherwise had no effect, so a two-node
deployment got no cache invalidation and no key announcements while its configuration said it was
clustered.

## What this wires

`Adapter.startCluster` (step 5 of `Start`, before the mount) constructs the manager, injects the
backend and cache, and starts it. `Adapter.clusterCoordinator()` hands the coordinator to
`MountConfig` → `fuse.Config` → `FileSystem.coordinator`. `Stop` tears it down in step 3.

The teardown window is the one that is correct in both directions: **after** the write-path flush,
which is the last chance for this node's pending writes to become durable, and **before** the backend
and cache close, because the gossip receive loop executes peers' operations against the backend and
evicts from the cache.

## Nil is the single-node value, and the guard cannot move

`clusterCoordinator()` returns a nil interface when clustering is off. Two things go wrong without
that method:

- `GetCoordinator()` dereferences `cm.coordinator`, so calling it on a nil manager **panics** — that
  is what every single-node mount would do, on every start.
- Pushing the check inside `GetCoordinator` would not help: it returns `&coordinatorWrapper{...}`, a
  non-nil `types.DistributedCoordinator` whatever it wraps, so a mount handed one would take the
  coordinated branch at every `if fs.coordinator != nil` in `internal/fuse` and dereference the
  nothing inside.

Verified by mutation, which is how both failure modes were found — the first comment I wrote here
claimed only the typed-nil case.

## Raft stays unstarted

`buildClusterConfig` deliberately does not set `EnableConsensus`, and the config schema has no key for
it. Coordination in ObjectFS is compare-and-swap against S3 (the recorded 2026-08-03 decision), so a
mount has no use for a leader, and putting an election on the path of a filesystem read would make a
cluster that cannot hold a quorum degrade a mount that never needed one.

The adapter test asserts the **request** (`buildClusterConfig().EnableConsensus == false`) and says so
explicitly, because from the adapter the behavior is unmeasurable: `ElectionTimeout` is not
operator-facing, so the cluster runs on the 5s default and a freshly started node has held no election
either way. Leadership assertions at that level pass with the gate removed. The behavioral half lives
in `TestClusterManager_Start_DoesNotStartConsensusUnlessAskedTo`, which sets 20ms and watches ~25
timeouts pass.

## Failing closed, and the breaking change that follows

A cluster that cannot start **fails the mount** rather than degrading to a single node. Coordination
is a correctness capability, not a performance one: a node that believes it is clustered and is not
serves cached bytes a peer has already overwritten, with nothing in its logs to say why. That is the
project thesis's rule for this kind of capability, and the same reasoning the Redis cache already
follows.

**BREAKING:** because `cluster.enabled` gates both subsystems, an existing Redis-only deployment now
needs a gossip secret. Found from a real failure in `TestStartReachesTheCacheTheConfigNames`, not
predicted. It is justified rather than papered over: a shared cache with no invalidation between its
users is exactly the incoherence the cluster block exists to prevent. Recorded in the CHANGELOG under
`### Changed`.

## Two adjacent defects the wiring made reachable

- **`cluster.secret_file` did not exist.** `LoadClusterSecret`'s error had been telling operators to
  "set `OBJECTFS_CLUSTER_SECRET` or `cluster.secret_file`" — a key absent from the schema. Added, with
  the path-not-secret and mode-0600 requirements documented; the env var still takes precedence.
- **`examples/config.yaml` described the old behavior**, including a comment asserting that the block
  started nothing and that `secret_file`'s absence was deliberate. Rewritten, with an
  `openssl rand -hex 32 && chmod 600` recipe.

## Tests

`internal/adapter/cluster_wiring_test.go` (5 tests): the no-op-unless-enabled path, gossip actually
binding and the coordinator reaching the mount, the consensus request, the operator settings carried
across two disjoint `ClusterConfig` types, and the missing-secret mount failure.
`internal/fuse/coordinator_wiring_test.go` (2 tests) goes through the real
`CreatePlatformMountManager` and `testaws` rather than constructing a `FileSystem` by hand.

Verified: `go build ./...`, `gofmt -l .`, `go vet ./...` clean; `go test -race -count=1 ./...` and
`-count=2 -tags=distributed ./internal/distributed/...` pass; `golangci-lint run
--new-from-merge-base=origin/main` reports 0 issues.
