### PR TITLE
feat(cluster): peers learn which keys are cached elsewhere (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Peers now learn which keys are cached elsewhere in the cluster** ([#140]). `AnnounceKey` and
+  `QueryKeyOwnership` were stubs returning `ErrNotSupported`; both are real. A node broadcasts a
+  `cache_announce` gossip message naming the key, its ETag, its size and the byte range it holds;
+  receivers record the claim against the peer that sent it, expire it after `cluster.announcement_ttl`
+  (default five minutes), and answer a local lookup with the holders freshest-first. It is metadata
+  only — no object bytes cross gossip, because a datagram cannot carry a 128 KiB read ([#399]) — so what
+  this buys is knowing *which* keys are worth warming, and the bytes still come from S3.
+
+  Three details are worth an operator's attention because each departs from what a reader might assume.
+  A node does **not** record its own announcements: the query exists to answer a miss on this node's own
+  cache, so a self-entry would be a holder guaranteed not to hold, returned in place of a peer that
+  might. Expiry uses the moment *this* node received the claim, never the sender's `cached_at`, whose own
+  contract forbids comparison against a local deadline — otherwise a peer whose clock runs an hour behind
+  would have every announcement expire on arrival, and one running fast would sort itself to the front of
+  every key in the cluster. And the announcement is credited to the peer the message came from rather
+  than to the node named in the payload, so a member cannot send the cluster to fetch bytes some third
+  node never cached.
+
+  An announcement missing its ETag is refused rather than sent, and refused with the field named. This is
+  the integrity boundary: an invalidation with no version is still safe, since "evict whatever you hold"
+  cannot serve wrong bytes, while a peer that fetches bytes it cannot place against an object version
+  hands them to a reading process as file content. Announcing with gossip not running returns
+  `ErrNotSupported` rather than nil — a caller told nil believes the cluster knows something it was never
+  sent, which is precisely the defect [#284] deleted a `CacheReplicator` for. `announced_keys` is now in
+  the coordinator's statistics, counting keys *retained*, so the gap between it and what a query returns
+  is how far behind the expiry sweep is running.
+
 - **`cluster.enabled: true` now actually starts cluster coordination** ([#139]). Every part of
   `internal/distributed` was built, tested and reachable by nothing: no code path anywhere constructed
   a `ClusterManager`, so a two-node deployment whose configuration said it was clustered got no

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -477,11 +477,16 @@ func (a *Adapter) clusterCoordinator() types.DistributedCoordinator {
 //
 // The two ClusterConfig types are disjoint and this is the only conversion between them, which is
 // most of why #139 existed: internal/config.ClusterConfig has seven fields an operator can set,
-// internal/distributed.ClusterConfig has eighteen, and there was no function anywhere that turned one
+// internal/distributed.ClusterConfig has nineteen, and there was no function anywhere that turned one
 // into the other. Fields left unset here are filled by applyConfigDefaults — the timeouts, the gossip
 // triple, and the concurrency and retry settings are all tuning for a subsystem whose defaults are
 // measured (see defaultMaxGossipPacket), so exposing them as YAML before anyone needs to change one
-// would be seven more keys that mostly should not be touched.
+// would be eight more keys that mostly should not be touched.
+//
+// AnnouncementTTL (#140) is the newest of those and is left unset for the same reason, with one
+// difference worth recording: its default is applied at the point of use in
+// [distributed.Coordinator.announcementTTL] rather than in applyConfigDefaults, because a zero there is
+// not a slower cluster but a silently inert one — every announcement would expire on arrival.
 //
 // EnableConsensus is deliberately not set and has no key in the config schema. See
 // [distributed.ClusterConfig.EnableConsensus]: coordination in ObjectFS is compare-and-swap against

--- a/internal/distributed/cache_announce.go
+++ b/internal/distributed/cache_announce.go
@@ -1,0 +1,412 @@
+package distributed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// heldKey is one peer's claim to hold one key, with the moment this node learned of it.
+//
+// recordedAt is stamped from the *local* clock on receipt, and is deliberately not
+// [types.KeyAnnouncement.CachedAt]. That field's own documentation forbids what expiry needs it for:
+// it is the holder's clock, nodes are not synchronized, and it "must never be compared against a local
+// deadline to decide validity". A peer whose clock runs an hour behind would have every announcement
+// expire on arrival; one running an hour ahead would have none of them ever expire. The local stamp
+// measures the only thing this node can measure — how long ago the message arrived.
+//
+// CachedAt is still carried, in ann, because it is what a *recipient comparing two holders* wants: of
+// two peers claiming the same ETag, the one that cached it later is likelier to still hold it. Advisory
+// for that, unusable for expiry.
+type heldKey struct {
+	ann        types.KeyAnnouncement
+	recordedAt time.Time
+}
+
+// defaultAnnouncementTTL is how long a peer's claim to hold a key is believed.
+//
+// Five minutes is a bound on wasted work rather than on correctness: what an expired announcement costs
+// is one attempt to warm from a peer that has since evicted, and [types.DistributedCoordinator] already
+// requires every caller to check what it receives against the ETag it wanted, precisely because a
+// holder can evict, replace, or never have held what it announced. So the failure mode of believing a
+// stale claim is a fetch that misses, and the failure mode of forgetting a live one is a read from S3 —
+// both merely slower.
+//
+// It is sized against the read patterns warming exists for. A traversal that walks a dataset over
+// minutes wants a claim made at its start to still be good at its end; a claim older than that names a
+// key the cluster has moved on from, and following it is likelier to waste a round trip than to save
+// one.
+const defaultAnnouncementTTL = 5 * time.Minute
+
+// maxAnnouncedKeys bounds how many distinct keys this node remembers peer claims for.
+//
+// The bound has to exist and it has to be on keys rather than on total entries: the number of peers is
+// bounded by the cluster, so entries per key are bounded too, while the number of keys a busy cluster
+// announces over an uptime is not. Without it a long-lived mount accumulates one entry per key any peer
+// has ever cached, which is a leak proportional to the bucket.
+//
+// 65536 keys at a key string plus a node ID and an ETag is a few tens of megabytes at the extreme,
+// against a cache measured in gigabytes. Overflow drops the oldest claims, which costs a read from S3.
+const maxAnnouncedKeys = 65536
+
+// announcementCleanupInterval is how often expired claims are swept.
+//
+// The sweep is for memory, not for correctness: [Coordinator.QueryKeyOwnership] filters expired entries
+// on every read, so a caller never sees one whether the sweep has run or not. That split is deliberate.
+// Filtering on read is what makes the TTL exact — it cannot be late — and sweeping on a timer is what
+// keeps a key nobody ever queries again from being remembered forever.
+const announcementCleanupInterval = time.Minute
+
+// recordAnnouncement stores a peer's claim to hold ann's bytes, replacing any earlier claim from the
+// same node for the same key.
+//
+// Replace rather than append, because a node announcing a key twice has not become two holders: the
+// second announcement is the current state of one cache, and keeping the first would offer a caller an
+// ETag that node has already replaced.
+//
+// It refuses an announcement naming this node. Such a message is what a node's own broadcast looks like
+// coming back — and, more importantly, admitting it would corrupt the answer to the only question
+// [Coordinator.QueryKeyOwnership] is asked: a caller queries *because it just missed its own cache*, so
+// a self-claim is a holder guaranteed not to hold, returned in place of a peer that does. See
+// [Coordinator.AnnounceKey], which for the same reason does not record what it sends.
+func (c *Coordinator) recordAnnouncement(ann types.KeyAnnouncement) {
+	// Every field checked here is one the announcement is useless without, and ETag is the one worth
+	// being explicit about: [types.KeyAnnouncement] requires it where an invalidation does not, because
+	// a peer that fetches bytes it cannot place against a version hands them to a reading process as
+	// file content. A holder that cannot name its own version has nothing to announce.
+	if ann.Key == "" || ann.NodeID == "" || ann.ETag == "" {
+		return
+	}
+
+	if ann.NodeID == c.cluster.GetNodeID() {
+		return
+	}
+
+	now := time.Now()
+
+	c.announcementsMu.Lock()
+	defer c.announcementsMu.Unlock()
+
+	if c.announcements == nil {
+		c.announcements = make(map[string][]heldKey)
+	}
+
+	holders := c.announcements[ann.Key]
+	for i := range holders {
+		if holders[i].ann.NodeID == ann.NodeID {
+			holders[i] = heldKey{ann: ann, recordedAt: now}
+			c.announcements[ann.Key] = holders
+
+			return
+		}
+	}
+
+	// Bounded before the insert, and only when this is a new key — a replacement above cannot grow the
+	// map, so charging it the eviction cost would drop live claims for no gain.
+	if len(c.announcements) >= maxAnnouncedKeys {
+		c.evictAnnouncementsLocked(now)
+	}
+
+	c.announcements[ann.Key] = append(holders, heldKey{ann: ann, recordedAt: now})
+}
+
+// evictAnnouncementsLocked makes room in the announcements map. c.announcementsMu must be held.
+//
+// Expired entries first, since dropping those costs nothing at all — they would be filtered out of
+// every read anyway. Only if that frees nothing does it drop live claims, oldest first, because the
+// oldest claim is the one likeliest to have been evicted by its holder already.
+//
+// Sorting to find the oldest is O(n log n) against a map that has just reached 65536 keys, and it runs
+// only on overflow. The alternative — the invalidation ledger's "drop an arbitrary tenth" — is right
+// there because that ledger records versions with no age to prefer between; these have one, and
+// dropping the freshest claim by luck would discard exactly the entry warming is most likely to use.
+func (c *Coordinator) evictAnnouncementsLocked(now time.Time) {
+	ttl := c.announcementTTL()
+
+	for key, holders := range c.announcements {
+		live := holders[:0]
+		for _, held := range holders {
+			if now.Sub(held.recordedAt) <= ttl {
+				live = append(live, held)
+			}
+		}
+
+		if len(live) == 0 {
+			delete(c.announcements, key)
+
+			continue
+		}
+
+		c.announcements[key] = live
+	}
+
+	if len(c.announcements) < maxAnnouncedKeys {
+		return
+	}
+
+	// Still full: every entry is live, so age is the only thing left to choose by. A key's age is its
+	// freshest claim, since that is what a query would return.
+	type keyAge struct {
+		key      string
+		freshest time.Time
+	}
+
+	ages := make([]keyAge, 0, len(c.announcements))
+	for key, holders := range c.announcements {
+		newest := holders[0].recordedAt
+		for _, held := range holders[1:] {
+			if held.recordedAt.After(newest) {
+				newest = held.recordedAt
+			}
+		}
+
+		ages = append(ages, keyAge{key: key, freshest: newest})
+	}
+
+	sort.Slice(ages, func(i, j int) bool { return ages[i].freshest.Before(ages[j].freshest) })
+
+	// A tenth, so overflow is amortized rather than paid on every subsequent insert.
+	for _, entry := range ages[:max(1, len(ages)/10)] {
+		delete(c.announcements, entry.key)
+	}
+}
+
+// announcementTTL is how long a claim is believed, from configuration or the default.
+//
+// This is the *only* place the default is applied, and deliberately not applyConfigDefaults, where the
+// cluster's other sixteen defaults live. A [Coordinator] can be constructed with a ClusterConfig that
+// never passed through that function — every test in this package does exactly that — and a zero TTL
+// there is not a slower cluster but a broken one: every announcement expires the instant it arrives, so
+// QueryKeyOwnership always returns empty and the subsystem looks like it works while doing nothing.
+// Reading the default at the point of use cannot be bypassed that way.
+//
+// One place, for the reason recorded beside the deleted default literal in cluster.go: MaxGossipPacket
+// was once defaulted twice, the copies disagreed, and fixing one left the other stale (#277).
+func (c *Coordinator) announcementTTL() time.Duration {
+	if c.config != nil && c.config.AnnouncementTTL > 0 {
+		return c.config.AnnouncementTTL
+	}
+
+	return defaultAnnouncementTTL
+}
+
+// AnnounceKey tells peers this node has ann's bytes cached.
+//
+// It broadcasts and does not record locally, which is a deliberate departure from #140's specification.
+// The map answers [Coordinator.QueryKeyOwnership], and that is called *because a read missed this node's
+// own cache* — so an entry naming this node is a holder guaranteed not to hold, offered in place of a
+// peer that might. The local cache is already the authority on what this node has; a second copy of that
+// answer in the ownership map could only ever disagree with it.
+//
+// Failing when gossip is not running rather than returning nil, for the reason in
+// [ClusterManager.invalidateCacheKey]: #284 deleted a replicator whose success was indistinguishable
+// from having sent nothing. A caller told [types.ErrNotSupported] falls back to S3, which is correct.
+//
+// A running cluster with no peers is a nil error and no sends, since there is nobody to tell.
+func (c *Coordinator) AnnounceKey(_ context.Context, ann types.KeyAnnouncement) error {
+	// Both required, and the ETag is the one that needs saying. [types.KeyAnnouncement] demands it where
+	// an invalidation does not: a peer that fetches bytes it cannot place against a version hands them to
+	// a reading process as file content. Refused rather than sent with the field empty, because a
+	// receiver has no way to tell an announcement missing its version from one whose version is "".
+	if ann.Key == "" {
+		return fmt.Errorf("refusing to announce an unnamed key: an announcement names the key a peer " +
+			"would fetch, so there is nothing to send")
+	}
+
+	if ann.ETag == "" {
+		return fmt.Errorf("refusing to announce %q with no ETag: a peer cannot place bytes it fetches "+
+			"against a version of the object, and would hand them to a reading process as file content",
+			ann.Key)
+	}
+
+	if c.cluster == nil {
+		return fmt.Errorf("cannot announce %q: this coordinator has no cluster: %w", ann.Key,
+			types.ErrNotSupported)
+	}
+
+	c.cluster.mu.RLock()
+	gossip := c.cluster.gossip
+	nodeID := c.cluster.nodeID
+	c.cluster.mu.RUnlock()
+
+	if gossip == nil {
+		return fmt.Errorf("cannot announce %q to peers: this cluster has no gossip protocol, so it has "+
+			"no way to reach them: %w", ann.Key, types.ErrNotSupported)
+	}
+
+	// Overwritten rather than trusted from the caller. A node announcing under another node's ID would
+	// send peers to fetch from a host that never cached the bytes, and the caller here is the read path,
+	// which has no reason to name anyone but itself.
+	ann.NodeID = nodeID
+
+	if ann.CachedAt.IsZero() {
+		ann.CachedAt = time.Now()
+	}
+
+	payload, err := json.Marshal(ann)
+	if err != nil {
+		return fmt.Errorf("marshaling the announcement for %q: %w", ann.Key, err)
+	}
+
+	// Wrapped so the key is in the message. broadcastMessage names the message *type*, which is all it
+	// knows, and "cannot broadcast cache_announce" in a log tells an operator debugging cold reads nothing
+	// about which object went unannounced. The %w keeps [types.ErrNotSupported] reachable through both
+	// layers, which is what a caller deciding whether to fall back permanently tests for.
+	if err := gossip.broadcastMessage(&GossipMessage{
+		Type:      MessageTypeCacheAnnounce,
+		From:      nodeID,
+		Timestamp: time.Now(),
+		MessageID: gossip.generateMessageID(),
+		Data:      payload,
+	}); err != nil {
+		return fmt.Errorf("announcing %q to peers: %w", ann.Key, err)
+	}
+
+	return nil
+}
+
+// QueryKeyOwnership reports the peers claiming to hold key, freshest first.
+//
+// Local map only, no network call: the announcements arrived by gossip as peers made them, so this is a
+// read of what has already been learned. That is what makes it callable from a cache miss — a read that
+// had to wait for a round of queries before falling back to S3 would be slower than not warming at all.
+//
+// Ordered by when *this node* recorded each claim, never by [types.KeyAnnouncement.CachedAt]. Peer
+// clocks are not synchronized, so ordering by CachedAt lets a node with a fast clock sort itself to the
+// front of every key in the cluster. See [heldKey.recordedAt].
+//
+// Expired claims are filtered here rather than only swept on a timer, so the TTL cannot be late.
+//
+// An empty slice with a nil error is the ordinary answer for a key no peer has cached, and per the
+// interface contract callers must read it as "fetch from the object store" rather than "the key does not
+// exist" — this reports what is cached in the cluster and says nothing about what the bucket holds.
+func (c *Coordinator) QueryKeyOwnership(_ context.Context, key string) ([]types.KeyAnnouncement, error) {
+	if key == "" {
+		return nil, fmt.Errorf("cannot query which peers hold an unnamed key")
+	}
+
+	ttl := c.announcementTTL()
+	now := time.Now()
+
+	c.announcementsMu.RLock()
+	holders := c.announcements[key]
+
+	live := make([]heldKey, 0, len(holders))
+	for _, held := range holders {
+		if now.Sub(held.recordedAt) <= ttl {
+			live = append(live, held)
+		}
+	}
+	c.announcementsMu.RUnlock()
+
+	sort.Slice(live, func(i, j int) bool { return live[i].recordedAt.After(live[j].recordedAt) })
+
+	// Non-nil even when empty, matching the interface's "empty slice and a nil error is the ordinary
+	// answer" — a caller ranging over it should not have to distinguish the two.
+	out := make([]types.KeyAnnouncement, 0, len(live))
+	for _, held := range live {
+		out = append(out, held.ann)
+	}
+
+	return out, nil
+}
+
+// cleanupAnnouncements sweeps expired claims until the coordinator stops.
+//
+// For memory only. QueryKeyOwnership filters on read, so nothing this reclaims was reachable by a
+// caller — see [announcementCleanupInterval].
+func (c *Coordinator) cleanupAnnouncements(ctx context.Context) {
+	ticker := time.NewTicker(announcementCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.sweepExpiredAnnouncements()
+		}
+	}
+}
+
+// sweepExpiredAnnouncements drops every claim past its TTL, and every key left with none.
+func (c *Coordinator) sweepExpiredAnnouncements() {
+	ttl := c.announcementTTL()
+	now := time.Now()
+
+	c.announcementsMu.Lock()
+	defer c.announcementsMu.Unlock()
+
+	for key, holders := range c.announcements {
+		live := holders[:0]
+		for _, held := range holders {
+			if now.Sub(held.recordedAt) <= ttl {
+				live = append(live, held)
+			}
+		}
+
+		if len(live) == 0 {
+			delete(c.announcements, key)
+
+			continue
+		}
+
+		c.announcements[key] = live
+	}
+}
+
+// announcedKeys is how many keys this node currently holds peer claims for, expired ones included.
+//
+// Expired ones included, because this reports what is *retained* rather than what a query would return,
+// and the gap between the two is the thing worth being able to see: it is how far behind the sweep is
+// running. See [Coordinator.GetStats], which is where an operator reads it.
+func (c *Coordinator) announcedKeys() int {
+	c.announcementsMu.RLock()
+	defer c.announcementsMu.RUnlock()
+
+	return len(c.announcements)
+}
+
+// handleCacheAnnounce records a peer's claim to hold a key.
+//
+// The shape follows [GossipProtocol.handleCacheInvalidate] — validate, then hand to the subsystem that
+// owns the state — with one difference worth naming: there is no applied-once ledger here, and none is
+// needed. An invalidation is an *action*, so applying a retransmission of an older one throws away bytes
+// legitimately re-cached since. An announcement is a *fact* about a (key, node) pair, and recording the
+// same fact twice is idempotent by construction — recordAnnouncement replaces that node's entry rather
+// than appending. A retransmission overwrites an identical value.
+//
+// Not re-broadcast. One hop to every alive peer is what [GossipProtocol.broadcastMessage] does, and a
+// peer that never hears an announcement reads from S3, which is correct and merely slower. Forwarding
+// would turn each announcement into a flood over a UDP transport with no de-duplication above the replay
+// window.
+func (gp *GossipProtocol) handleCacheAnnounce(msg *GossipMessage) {
+	coordinator := gp.cluster.getCoordinator()
+	if coordinator == nil {
+		return
+	}
+
+	var ann types.KeyAnnouncement
+	if err := json.Unmarshal(msg.Data, &ann); err != nil {
+		slog.Debug("discarding a malformed cache announcement", "peer", msg.From, "error", err)
+
+		return
+	}
+
+	// The envelope's sender wins over the payload's claim about itself. Both are authenticated by the
+	// same MAC, so this is not a defense against an outsider — it is a defense against a *member*
+	// announcing that some third node holds a key, which would send peers to fetch bytes that node never
+	// cached and has no way to correct.
+	if msg.From != "" {
+		ann.NodeID = msg.From
+	}
+
+	coordinator.recordAnnouncement(ann)
+}

--- a/internal/distributed/cache_announce_test.go
+++ b/internal/distributed/cache_announce_test.go
@@ -1,0 +1,605 @@
+package distributed
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// waitForHolders polls node's view of who holds key until want holders are visible, and returns them.
+//
+// Polling rather than a single read, and the reason is the same as [waitForDeletion]'s: this waits on
+// loopback UDP plus a receive goroutine, so a read taken immediately after a broadcast has no reason to
+// see anything yet. The deadline is generous because the failure this exists to catch — a message never
+// sent, or a dispatch arm that does not exist — is not one that more waiting would fix.
+func waitForHolders(t *testing.T, node *ClusterManager, key string, want int) []types.KeyAnnouncement {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var last []types.KeyAnnouncement
+
+	for time.Now().Before(deadline) {
+		holders, err := node.GetCoordinator().QueryKeyOwnership(t.Context(), key)
+		if err != nil {
+			t.Fatalf("QueryKeyOwnership(%q) on %s: %v", key, node.GetNodeID(), err)
+		}
+		if len(holders) >= want {
+			return holders
+		}
+
+		last = holders
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatalf("%s never saw %d holder(s) of %q within 2s; it has %d: %+v",
+		node.GetNodeID(), want, key, len(last), last)
+
+	return nil
+}
+
+// TestAnnounceKey_TwoNodes is #140's own acceptance criterion: node A announces a key, node B — reachable
+// only over loopback UDP — reports A as a holder.
+//
+// It asserts the fields as well as the count. An announcement whose ETag did not survive the wire is
+// worse than one that never arrived: [types.KeyAnnouncement] requires the version precisely because a
+// peer that fetches bytes it cannot place against an object hands them to a reading process as file
+// content, so a warming path acting on an empty ETag is an integrity failure rather than a slow read.
+func TestAnnounceKey_TwoNodes(t *testing.T) {
+	t.Parallel()
+
+	cm1, cm2 := startGossipPair(t, "announce-node-a", "announce-node-b")
+
+	want := types.KeyAnnouncement{
+		Key:    "datasets/reads.bam",
+		ETag:   `"etag-announced"`,
+		Size:   1 << 20,
+		Offset: 0,
+		Length: 64 * 1024,
+	}
+
+	if err := cm1.GetCoordinator().AnnounceKey(t.Context(), want); err != nil {
+		t.Fatalf("AnnounceKey: %v", err)
+	}
+
+	holders := waitForHolders(t, cm2, want.Key, 1)
+	got := holders[0]
+
+	if got.NodeID != "announce-node-a" {
+		t.Errorf("holder is %q, want the announcing node %q", got.NodeID, "announce-node-a")
+	}
+	if got.ETag != want.ETag {
+		t.Errorf("ETag is %q, want %q — a peer cannot place bytes against a version it does not have",
+			got.ETag, want.ETag)
+	}
+	if got.Size != want.Size {
+		t.Errorf("Size is %d, want %d", got.Size, want.Size)
+	}
+	if got.Length != want.Length {
+		t.Errorf("Length is %d, want %d; a range that does not survive the wire invites a peer to ask "+
+			"for bytes the holder does not have", got.Length, want.Length)
+	}
+	if got.CachedAt.IsZero() {
+		t.Error("CachedAt is zero; AnnounceKey should have stamped it, since a recipient comparing two " +
+			"holders of one ETag has nothing else to prefer between them by")
+	}
+}
+
+// TestAnnounceKey_DoesNotRecordItself is the departure from #140's specification, asserted.
+//
+// The spec says to record the announcement locally as well as broadcast it. This does not, because
+// QueryKeyOwnership is called *from a cache miss on this very node* — so a self-entry is a holder
+// guaranteed not to hold, returned in place of a peer that might, and a warming path would spend a round
+// trip discovering what the cache lookup that preceded it already knew.
+//
+// Both halves are checked, because only the pair distinguishes the intended behavior from a broadcast
+// that failed: the announcer must not list itself, and the peer must list it.
+func TestAnnounceKey_DoesNotRecordItself(t *testing.T) {
+	t.Parallel()
+
+	cm1, cm2 := startGossipPair(t, "selfrec-node-a", "selfrec-node-b")
+
+	ann := types.KeyAnnouncement{Key: "self.dat", ETag: `"etag-self"`, Size: 10}
+	if err := cm1.GetCoordinator().AnnounceKey(t.Context(), ann); err != nil {
+		t.Fatalf("AnnounceKey: %v", err)
+	}
+
+	// The peer first, so that reaching the self-check means the broadcast demonstrably happened.
+	waitForHolders(t, cm2, ann.Key, 1)
+
+	holders, err := cm1.GetCoordinator().QueryKeyOwnership(t.Context(), ann.Key)
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership on the announcer: %v", err)
+	}
+	if len(holders) != 0 {
+		t.Errorf("the announcing node lists %d holder(s) of its own announcement: %+v. A query happens "+
+			"because this node's cache missed, so an entry naming this node cannot be a holder",
+			len(holders), holders)
+	}
+}
+
+// TestHandleCacheAnnounce_TheEnvelopeSenderWins asserts a member cannot announce that some *other* node
+// holds a key.
+//
+// Both the envelope's From and the payload's NodeID are authenticated by the same MAC, so this is not a
+// defense against an outsider — it is a defense against a member, compromised or merely buggy, sending
+// peers to fetch bytes a third node never cached and has no way to correct. The receiver credits the node
+// it actually heard from.
+//
+// Driven through handleCacheAnnounce rather than over the wire because what is being tested is a
+// disagreement between two fields of one message, and [Coordinator.AnnounceKey] deliberately makes that
+// disagreement unconstructible on the sending side.
+func TestHandleCacheAnnounce_TheEnvelopeSenderWins(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "envelope-local"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	payload, err := json.Marshal(types.KeyAnnouncement{
+		Key: "k", NodeID: "innocent-third-node", ETag: `"v1"`,
+	})
+	if err != nil {
+		t.Fatalf("marshaling the announcement: %v", err)
+	}
+
+	cm.gossip.handleCacheAnnounce(&GossipMessage{
+		Type: MessageTypeCacheAnnounce,
+		From: "lying-peer",
+		Data: payload,
+	})
+
+	holders, err := cm.coordinator.QueryKeyOwnership(t.Context(), "k")
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership: %v", err)
+	}
+	if len(holders) != 1 {
+		t.Fatalf("got %d holders, want 1: %+v", len(holders), holders)
+	}
+	if holders[0].NodeID != "lying-peer" {
+		t.Errorf("the holder is recorded as %q, want %q — the payload's claim about a third node was "+
+			"believed over the peer the message actually came from, which sends warming reads to a node "+
+			"that never cached the bytes", holders[0].NodeID, "lying-peer")
+	}
+}
+
+// TestHandleCacheAnnounce_DiscardsAMalformedPayload asserts a message whose payload is not a
+// [types.KeyAnnouncement] is dropped rather than recorded as a zero-valued claim.
+//
+// A zero claim is the dangerous outcome, not a panic: it would carry an empty ETag, and an empty ETag is
+// the one thing a warming path cannot check its bytes against.
+func TestHandleCacheAnnounce_DiscardsAMalformedPayload(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "malformed-local"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	cm.gossip.handleCacheAnnounce(&GossipMessage{
+		Type: MessageTypeCacheAnnounce,
+		From: "peer-1",
+		Data: []byte("{not json"),
+	})
+
+	if got := cm.coordinator.announcedKeys(); got != 0 {
+		t.Errorf("a malformed announcement left %d key(s) recorded, want 0", got)
+	}
+}
+
+// TestRecordAnnouncement_ReplacesAPeersEarlierClaim asserts a node announcing the same key twice is one
+// holder at its newer ETag, not two holders at conflicting ones.
+//
+// Keeping the first would offer a caller a version that node has already replaced — which the caller
+// would then request from it and not receive, since the whole point of the second announcement is that
+// the first ETag is gone.
+func TestRecordAnnouncement_ReplacesAPeersEarlierClaim(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "replace-local")
+
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "k", NodeID: "peer-1", ETag: `"v1"`})
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "k", NodeID: "peer-1", ETag: `"v2"`})
+
+	holders, err := c.QueryKeyOwnership(t.Context(), "k")
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership: %v", err)
+	}
+
+	if len(holders) != 1 {
+		t.Fatalf("one node announced %q twice and is recorded as %d holders: %+v", "k", len(holders), holders)
+	}
+	if holders[0].ETag != `"v2"` {
+		t.Errorf("holder is at ETag %s, want the newer %s — the older version is the one that node has "+
+			"replaced", holders[0].ETag, `"v2"`)
+	}
+}
+
+// TestRecordAnnouncement_KeepsDistinctPeers is the other half of the replacement rule: two *different*
+// nodes holding one key are two holders, and collapsing them would throw away the choice warming exists
+// to make.
+func TestRecordAnnouncement_KeepsDistinctPeers(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "distinct-local")
+
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "k", NodeID: "peer-1", ETag: `"v1"`})
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "k", NodeID: "peer-2", ETag: `"v1"`})
+
+	holders, err := c.QueryKeyOwnership(t.Context(), "k")
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership: %v", err)
+	}
+	if len(holders) != 2 {
+		t.Fatalf("two nodes announced %q and it is recorded as %d holder(s): %+v", "k", len(holders), holders)
+	}
+}
+
+// TestRecordAnnouncement_RejectsUnusableClaims checks each field an announcement is useless without, and
+// the self-claim.
+//
+// ETag is the one that matters beyond tidiness. A holder that cannot name its own version has nothing to
+// announce, and recording the claim anyway would put an entry with an empty ETag in front of a warming
+// path whose only defense against wrong bytes is comparing that ETag to the one it wanted.
+func TestRecordAnnouncement_RejectsUnusableClaims(t *testing.T) {
+	t.Parallel()
+
+	const localID = "reject-local"
+
+	tests := []struct {
+		name string
+		ann  types.KeyAnnouncement
+	}{
+		{"no key", types.KeyAnnouncement{NodeID: "peer-1", ETag: `"v1"`}},
+		{"no node", types.KeyAnnouncement{Key: "k", ETag: `"v1"`}},
+		{"no etag", types.KeyAnnouncement{Key: "k", NodeID: "peer-1"}},
+		{"this node", types.KeyAnnouncement{Key: "k", NodeID: localID, ETag: `"v1"`}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newAnnouncementCoordinator(t, localID)
+			c.recordAnnouncement(tc.ann)
+
+			if got := c.announcedKeys(); got != 0 {
+				t.Errorf("an announcement with %s was recorded (%d key(s) retained): %+v", tc.name, got, tc.ann)
+			}
+		})
+	}
+}
+
+// TestQueryKeyOwnership_FiltersExpiredClaims asserts the TTL is enforced on read rather than only by the
+// background sweep.
+//
+// That split is the design: filtering on read is what makes the TTL exact — a query cannot see a claim
+// one tick of the sweeper too late — and the sweep is only for memory. A test that waited for the sweeper
+// would be testing the wrong one of the two, and would take a minute to do it.
+func TestQueryKeyOwnership_FiltersExpiredClaims(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "expiry-local")
+	c.config.AnnouncementTTL = time.Nanosecond
+
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "k", NodeID: "peer-1", ETag: `"v1"`})
+
+	// Retained but not returned, which is the distinction announcedKeys exists to expose.
+	if got := c.announcedKeys(); got != 1 {
+		t.Fatalf("the claim was not recorded at all; announcedKeys is %d, want 1", got)
+	}
+
+	holders, err := c.QueryKeyOwnership(t.Context(), "k")
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership: %v", err)
+	}
+	if len(holders) != 0 {
+		t.Errorf("a claim past its %v TTL is still returned: %+v", c.announcementTTL(), holders)
+	}
+}
+
+// TestSweepExpiredAnnouncements_ReclaimsTheKey is the memory half. QueryKeyOwnership already hides the
+// expired claim, so what this asserts is that the map stops holding it — the leak the sweeper exists to
+// prevent is a key nobody queries again, which no amount of read-side filtering reclaims.
+func TestSweepExpiredAnnouncements_ReclaimsTheKey(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "sweep-local")
+	c.config.AnnouncementTTL = time.Nanosecond
+
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "gone", NodeID: "peer-1", ETag: `"v1"`})
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "kept", NodeID: "peer-1", ETag: `"v1"`})
+
+	if got := c.announcedKeys(); got != 2 {
+		t.Fatalf("announcedKeys is %d before the sweep, want 2", got)
+	}
+
+	c.sweepExpiredAnnouncements()
+
+	if got := c.announcedKeys(); got != 0 {
+		t.Errorf("announcedKeys is %d after sweeping claims past a %v TTL, want 0", got, c.announcementTTL())
+	}
+}
+
+// TestQueryKeyOwnership_OrdersByWhenThisNodeLearned asserts the freshest claim comes first, ordered by the
+// *local* stamp.
+//
+// The peers here disagree wildly about the time, and that is the point: ordering by
+// [types.KeyAnnouncement.CachedAt] would let a node with a fast clock sort itself to the front of every
+// key in the cluster, which its own documentation forbids relying on. peer-1 announces with a CachedAt an
+// hour in the future and is recorded first; peer-2 announces second with a CachedAt an hour in the past,
+// and must still be preferred, because arriving later is the only freshness this node can actually
+// observe.
+func TestQueryKeyOwnership_OrdersByWhenThisNodeLearned(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "order-local")
+	now := time.Now()
+
+	c.recordAnnouncement(types.KeyAnnouncement{
+		Key: "k", NodeID: "peer-1", ETag: `"v1"`, CachedAt: now.Add(time.Hour),
+	})
+	c.recordAnnouncement(types.KeyAnnouncement{
+		Key: "k", NodeID: "peer-2", ETag: `"v2"`, CachedAt: now.Add(-time.Hour),
+	})
+
+	holders, err := c.QueryKeyOwnership(t.Context(), "k")
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership: %v", err)
+	}
+	if len(holders) != 2 {
+		t.Fatalf("got %d holders, want 2: %+v", len(holders), holders)
+	}
+
+	if holders[0].NodeID != "peer-2" {
+		t.Errorf("holders are ordered %q then %q; want the most recently *received* claim first. "+
+			"peer-1 claims a CachedAt an hour ahead of peer-2 — ordering by that field lets one node's "+
+			"clock skew put it in front of the whole cluster",
+			holders[0].NodeID, holders[1].NodeID)
+	}
+}
+
+// TestQueryKeyOwnership_UncachedKeyIsEmptyAndNotNil pins the two things the interface contract says about
+// the ordinary miss: a nil error, and a slice a caller can range over without a nil check. It says nothing
+// about the bucket — only about what the cluster has cached — and returning an error here would tell a
+// caller the query failed when the honest answer is that nobody has it.
+func TestQueryKeyOwnership_UncachedKeyIsEmptyAndNotNil(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "miss-local")
+
+	holders, err := c.QueryKeyOwnership(t.Context(), "never-announced")
+	if err != nil {
+		t.Fatalf("a key no peer has cached is not an error: %v", err)
+	}
+	if holders == nil {
+		t.Error("holders is nil; the contract is an empty slice, so a caller need not distinguish the two")
+	}
+	if len(holders) != 0 {
+		t.Errorf("got %d holders for a key nobody announced: %+v", len(holders), holders)
+	}
+}
+
+// TestAnnounceKey_RefusesAnAnnouncementNoPeerCouldUse checks the two fields that make an announcement
+// actionable, and — the part worth the test — that they are refused rather than sent.
+//
+// A receiver has no way to tell an announcement missing its ETag from one whose ETag is legitimately "".
+// So sending it would push the problem onto every peer, each of which would record a holder that a
+// warming path cannot verify. The error names the field, because the caller is the read path and the
+// person reading it is debugging why warming does nothing.
+func TestAnnounceKey_RefusesAnAnnouncementNoPeerCouldUse(t *testing.T) {
+	t.Parallel()
+
+	cm1, _ := startGossipPair(t, "refuse-node-a", "refuse-node-b")
+
+	tests := []struct {
+		name    string
+		ann     types.KeyAnnouncement
+		mustSay string
+	}{
+		{"no key", types.KeyAnnouncement{ETag: `"v1"`}, "unnamed key"},
+		{"no etag", types.KeyAnnouncement{Key: "k"}, "ETag"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := cm1.GetCoordinator().AnnounceKey(t.Context(), tc.ann)
+			if err == nil {
+				t.Fatalf("AnnounceKey accepted an announcement with %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.mustSay) {
+				t.Errorf("the error does not mention %q, so it does not name the missing field: %v",
+					tc.mustSay, err)
+			}
+		})
+	}
+}
+
+// TestAnnounceKey_WithoutGossipSaysSoRatherThanSucceeding is why these methods return an error where a nil
+// would be simpler.
+//
+// #284 deleted a CacheReplicator whose success was indistinguishable from having sent nothing: it counted
+// bytes as replicated when gossip was not running, and it survived four releases because the only test
+// covering it asserted its field was non-nil. A caller told [types.ErrNotSupported] falls back to the
+// object store, which is correct and merely slower; a caller told nil believes the cluster knows something
+// it was never sent.
+func TestAnnounceKey_WithoutGossipSaysSoRatherThanSucceeding(t *testing.T) {
+	t.Parallel()
+
+	// Not started, so no gossip socket exists — the state a mount is in before Start and after Stop.
+	cm, err := NewClusterManager(testConfig(t, "nogossip-node"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	cm.gossip = nil
+
+	err = cm.GetCoordinator().AnnounceKey(t.Context(), types.KeyAnnouncement{Key: "k", ETag: `"v1"`})
+	if err == nil {
+		t.Fatal("AnnounceKey reported success with no gossip protocol; nothing was sent to anyone")
+	}
+	if !errors.Is(err, types.ErrNotSupported) {
+		t.Errorf("error does not wrap types.ErrNotSupported, so a caller cannot tell this from a real "+
+			"failure and fall back to the object store: %v", err)
+	}
+}
+
+// TestCoordinatorWrapper_WithNoCoordinatorRefusesBoth covers the guards in the wrapper itself, which the
+// unstarted-cluster test above cannot reach: a ClusterManager from [NewClusterManager] always has a
+// coordinator, so a nil one means a value that did not come from the constructor.
+//
+// Guarded rather than left to panic because [ClusterManager.GetCoordinator] returns an interface, and an
+// interface holding a nil pointer is not nil — so a caller's `if coord != nil` passes and the call
+// dereferences. Both methods refuse, including the query, which is the one case where an empty slice would
+// be wrong: it is the documented answer for a cold cluster, so giving it here would report "warming does
+// not help" where the truth is "warming is not running".
+func TestCoordinatorWrapper_WithNoCoordinatorRefusesBoth(t *testing.T) {
+	t.Parallel()
+
+	var coord types.DistributedCoordinator = &coordinatorWrapper{}
+
+	err := coord.AnnounceKey(t.Context(), types.KeyAnnouncement{Key: "k", ETag: `"v1"`})
+	if !errors.Is(err, types.ErrNotSupported) {
+		t.Errorf("AnnounceKey = %v, want ErrNotSupported", err)
+	}
+
+	holders, err := coord.QueryKeyOwnership(t.Context(), "k")
+	if !errors.Is(err, types.ErrNotSupported) {
+		t.Errorf("QueryKeyOwnership = %v, want ErrNotSupported", err)
+	}
+	if holders != nil {
+		t.Errorf("got %d holders alongside the error; a caller reading the slice first must find nothing",
+			len(holders))
+	}
+}
+
+// TestCoordinatorStats_ReportsRetainedAnnouncements asserts the count reaches the map an operator reads.
+//
+// The number is deliberately of *retained* keys rather than queryable ones — see
+// [Coordinator.announcedKeys] — so the gap between it and a query is how far behind the sweep is running.
+func TestCoordinatorStats_ReportsRetainedAnnouncements(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "stats-local")
+
+	for i := range 3 {
+		c.recordAnnouncement(types.KeyAnnouncement{
+			Key: fmt.Sprintf("k-%d", i), NodeID: "peer-1", ETag: `"v1"`,
+		})
+	}
+
+	stats := c.GetStats()
+	got, ok := stats["announced_keys"]
+	if !ok {
+		t.Fatalf("GetStats has no announced_keys key, so the subsystem is invisible to an operator: %v", stats)
+	}
+	if got != 3 {
+		t.Errorf("announced_keys is %v, want 3", got)
+	}
+}
+
+// newAnnouncementCoordinator builds a Coordinator with a cluster and no network.
+//
+// The announcement map, its TTL, and the eviction rules are all local state, so these tests need a node
+// identity — recordAnnouncement compares against it to reject a self-claim — and nothing else.
+// startGossipPair exists for the half that genuinely crosses the wire and is used there; paying for two
+// UDP sockets to test a map would make every one of these tests slower and none of them stronger.
+func newAnnouncementCoordinator(t *testing.T, nodeID string) *Coordinator {
+	t.Helper()
+
+	cm, err := NewClusterManager(testConfig(t, nodeID))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	return cm.coordinator
+}
+
+// TestRecordAnnouncement_BoundsTheMap drives the map past maxAnnouncedKeys and asserts it stops growing.
+//
+// The bound has to be exercised rather than reasoned about, because what it protects against is the one
+// failure mode a short test never reaches on its own: a mount that runs for weeks accumulating one entry
+// per key any peer has ever cached, which is a leak proportional to the bucket rather than to the cache.
+//
+// Every claim here is live, so this is specifically the second, harder half of
+// [Coordinator.evictAnnouncementsLocked] — the path where expiring nothing frees nothing and age is the
+// only thing left to choose by.
+func TestRecordAnnouncement_BoundsTheMap(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "bound-local")
+
+	for i := range maxAnnouncedKeys + 1 {
+		c.recordAnnouncement(types.KeyAnnouncement{
+			Key: fmt.Sprintf("k-%d", i), NodeID: "peer-1", ETag: `"v1"`,
+		})
+	}
+
+	got := c.announcedKeys()
+	if got > maxAnnouncedKeys {
+		t.Errorf("announcedKeys is %d after %d distinct keys, over the %d bound: the map grows without "+
+			"limit for the lifetime of the mount", got, maxAnnouncedKeys+1, maxAnnouncedKeys)
+	}
+
+	// A tenth dropped and one inserted, so a bound that worked leaves roughly nine tenths. Asserted
+	// loosely, because the exact figure is amortization policy; asserted at all, because an eviction that
+	// emptied the map would satisfy the check above while destroying the subsystem's usefulness.
+	if floor := maxAnnouncedKeys / 2; got < floor {
+		t.Errorf("announcedKeys is %d, under %d: eviction is discarding far more than the tenth it "+
+			"should, so warming loses claims it could have used", got, floor)
+	}
+}
+
+// TestRecordAnnouncement_EvictsExpiredBeforeLiveClaims asserts the cheap half of eviction runs first.
+//
+// Dropping an expired claim costs nothing — QueryKeyOwnership filters it out anyway — while dropping a
+// live one costs a read from S3. So a map that overflows while full of expired entries should lose exactly
+// those and stop, rather than paying the sort and dropping a tenth of the claims warming could still use.
+//
+// The two paths are distinguishable by count, which is what makes this an assertion rather than a
+// restatement: expiring everything leaves 1 key, and falling through to the oldest-tenth rule would leave
+// roughly nine tenths of 65536. The entries are back-dated in the map instead of by waiting, since the
+// alternative is a test that sleeps past a real TTL.
+func TestRecordAnnouncement_EvictsExpiredBeforeLiveClaims(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "evict-order-local")
+
+	for i := range maxAnnouncedKeys {
+		c.recordAnnouncement(types.KeyAnnouncement{
+			Key: fmt.Sprintf("stale-%d", i), NodeID: "peer-1", ETag: `"v1"`,
+		})
+	}
+
+	stale := time.Now().Add(-2 * defaultAnnouncementTTL)
+	c.announcementsMu.Lock()
+	for key, holders := range c.announcements {
+		for i := range holders {
+			holders[i].recordedAt = stale
+		}
+		c.announcements[key] = holders
+	}
+	c.announcementsMu.Unlock()
+
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "fresh", NodeID: "peer-1", ETag: `"v1"`})
+
+	if got := c.announcedKeys(); got != 1 {
+		t.Errorf("announcedKeys is %d after overflowing a map of expired claims, want 1: eviction is "+
+			"discarding live claims while %d free ones sit there expired", got, maxAnnouncedKeys)
+	}
+
+	holders, err := c.QueryKeyOwnership(t.Context(), "fresh")
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership: %v", err)
+	}
+	if len(holders) != 1 {
+		t.Errorf("got %d holders of %q, want 1; the claim that triggered the eviction was itself dropped",
+			len(holders), "fresh")
+	}
+}

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -95,6 +95,18 @@ type ClusterConfig struct {
 	// no code in the repository, and the subsystem whose name it carried put an object's own bytes back
 	// to itself on N-1 peers; both it and the CacheReplicator are gone. Actual cache warming is #141.
 
+	// AnnouncementTTL is how long a peer's claim to hold a key in its cache is believed (#140).
+	//
+	// Tuning, not correctness: what expiry decides is whether this node bothers asking a peer's cache
+	// about a key, and [types.DistributedCoordinator] already requires every caller to check what comes
+	// back against the ETag it asked for — because a holder can evict at any moment, TTL or no TTL. Too
+	// long wastes a round trip on a peer that has evicted; too short sends a read to S3 that a peer could
+	// have served. Both are slower and neither is wrong.
+	//
+	// Left at zero it becomes defaultAnnouncementTTL. Sized against the traversals warming exists for —
+	// see that constant for the reasoning.
+	AnnouncementTTL time.Duration `yaml:"announcement_ttl"`
+
 	// Performance settings
 	MaxConcurrentOps int           `yaml:"max_concurrent_ops"`
 	OperationTimeout time.Duration `yaml:"operation_timeout"`
@@ -936,7 +948,24 @@ func (cm *ClusterManager) invalidateCacheKey(m CacheInvalidateMessage) error {
 
 // GetCoordinator returns the operation coordinator
 func (cm *ClusterManager) GetCoordinator() types.DistributedCoordinator {
-	return &coordinatorWrapper{cm.coordinator}
+	return &coordinatorWrapper{cm.getCoordinator()}
+}
+
+// getCoordinator returns the coordinator, which may be nil.
+//
+// Deliberately without cm.mu, unlike almost everything else that touches a ClusterManager field. This one
+// is assigned exactly once, in [NewClusterManager], before any goroutine that could read it exists — the
+// `go` statements that start the receive loop and the background tasks are all downstream of that
+// assignment, so publication is already ordered and a lock would only add contention. It would add it in
+// the worst place, too: [GossipProtocol.handleCacheAnnounce] calls this from the receive goroutine, and
+// startLocked holds cm.mu for *writing* across gossip.Start, so a lock here would stall inbound messages
+// behind the rest of startup for no benefit.
+//
+// Nil is therefore not a startup window but a ClusterManager that did not come from the constructor.
+// Guarded anyway, and for the same reason [coordinatorWrapper.AnnounceKey] guards: the alternative is a
+// panic on the gossip receive goroutine, which takes the whole cluster's membership down with it.
+func (cm *ClusterManager) getCoordinator() *Coordinator {
+	return cm.coordinator
 }
 
 // coordinatorWrapper adapts Coordinator to DistributedCoordinator interface
@@ -955,30 +984,39 @@ func (cw *coordinatorWrapper) ExecuteOperation(ctx context.Context, op any) (any
 	return nil, fmt.Errorf("invalid operation type: %T", op)
 }
 
-// AnnounceKey is not implemented yet and says so.
+// AnnounceKey tells peers this node holds ann's bytes. Implemented in #140; see
+// [Coordinator.AnnounceKey].
 //
-// The gossip message type it needs does not exist — [MessageTypeCacheInvalidate] is the only
-// cache-related one — so there is nothing to send and no receiver to send it to. #140 builds both.
-//
-// It returns an error rather than nil because a nil here would mean "announced" to every caller, and
-// #284 deleted a CacheReplicator that did exactly that: it added bytes to BytesReplicated when gossip
-// was not running and it had sent nothing, and it survived four releases because the only test covering
-// it asserted that its field was non-nil. A caller told [types.ErrNotSupported] falls back to reading
-// from the object store, which is correct and merely slower.
-func (cw *coordinatorWrapper) AnnounceKey(_ context.Context, ann types.KeyAnnouncement) error {
-	return fmt.Errorf("announcing %q to peers is not implemented (#140): %w", ann.Key, types.ErrNotSupported)
+// The nil check is what the stub this replaced was for. Both methods returned [types.ErrNotSupported]
+// unconditionally, and the reasoning recorded there survives the implementation and is why this guard
+// exists rather than a bare delegation: a nil answer here would mean "announced" to every caller, and
+// #284 deleted a CacheReplicator that did exactly that — it counted bytes as replicated when gossip was
+// not running and it had sent nothing, and it survived four releases because the only test covering it
+// asserted that its field was non-nil. A caller told ErrNotSupported falls back to the object store,
+// which is correct and merely slower.
+func (cw *coordinatorWrapper) AnnounceKey(ctx context.Context, ann types.KeyAnnouncement) error {
+	if cw.Coordinator == nil {
+		return fmt.Errorf("cannot announce %q: this coordinator has no cluster: %w", ann.Key,
+			types.ErrNotSupported)
+	}
+
+	return cw.Coordinator.AnnounceKey(ctx, ann)
 }
 
-// QueryKeyOwnership is not implemented yet and says so, for the reason on [coordinatorWrapper.AnnounceKey]:
-// nothing announces, so no node has ownership information to report.
+// QueryKeyOwnership reports the peers claiming to hold key. Implemented in #140; see
+// [Coordinator.QueryKeyOwnership].
 //
-// Specifically it does not return an empty slice with a nil error. That is the documented answer for a
-// key no peer has cached, so returning it here would be indistinguishable from a working query against
-// a cold cluster — and a caller measuring peer-fetch hit rates would read a flat zero as "warming does
-// not help" rather than "warming is not built".
-func (cw *coordinatorWrapper) QueryKeyOwnership(_ context.Context, key string) ([]types.KeyAnnouncement, error) {
-	return nil, fmt.Errorf("querying which peers hold %q is not implemented (#140): %w", key,
-		types.ErrNotSupported)
+// Note what the guard does *not* do: return an empty slice and a nil error. That is the documented answer
+// for a key no peer has cached, so giving it for "there is no coordinator" would be indistinguishable
+// from a working query against a cold cluster — and a caller measuring warming hit rates would read a
+// flat zero as "warming does not help" rather than "warming is not running".
+func (cw *coordinatorWrapper) QueryKeyOwnership(ctx context.Context, key string) ([]types.KeyAnnouncement, error) {
+	if cw.Coordinator == nil {
+		return nil, fmt.Errorf("cannot query which peers hold %q: this coordinator has no cluster: %w",
+			key, types.ErrNotSupported)
+	}
+
+	return cw.Coordinator.QueryKeyOwnership(ctx, key)
 }
 
 // InvalidateKey broadcasts a cache invalidation for key at etag. This one is real: the message type,

--- a/internal/distributed/coordinator.go
+++ b/internal/distributed/coordinator.go
@@ -28,6 +28,14 @@ type Coordinator struct {
 	// pendingOps maps requestID → response channel for in-flight remote ops.
 	pendingOpsMu sync.Mutex
 	pendingOps   map[string]chan *NodeResult
+
+	// announcements maps a key to the peers claiming to hold it, and never to this node — see
+	// [Coordinator.recordAnnouncement]. Lazily created, bounded by maxAnnouncedKeys, entries expiring at
+	// announcementTTL. Guarded by its own mutex rather than by c.mu, because its writer is the gossip
+	// receive goroutine and its reader is a filesystem read on a cache miss: sharing the lock that
+	// serializes remote operation execution would put every announcement behind an S3 round trip.
+	announcementsMu sync.RWMutex
+	announcements   map[string][]heldKey
 }
 
 // NodeOperationMessage is the on-wire request for a remote node execution.
@@ -307,6 +315,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	// Start background tasks
 	go c.cleanupOperations(ctx)
 	go c.updateLoadBalancerStats(ctx)
+	go c.cleanupAnnouncements(ctx)
 
 	return nil
 }
@@ -982,6 +991,7 @@ func (c *Coordinator) GetStats() map[string]any {
 	// happen is the reason the audit distrusted this package's numbers.
 	return map[string]any{
 		"active_operations": activeOps,
+		"announced_keys":    c.announcedKeys(),
 		"load_balancer":     &loadBalancerStats,
 	}
 }

--- a/internal/distributed/coordinator_test.go
+++ b/internal/distributed/coordinator_test.go
@@ -1239,25 +1239,34 @@ func TestClusterManager_InvalidateCacheKey_NoGossip(t *testing.T) {
 	}
 }
 
-// TestCoordinatorWrapper_UnimplementedMethodsRefuse pins that the two cache-coordination methods with no
-// implementation say so, rather than reporting success.
+// TestCoordinatorWrapper_CacheCoordinationOnAnUnstartedCluster pins the two cache-coordination methods
+// against a constructed-but-not-started cluster, where they answer *differently* — and the difference is
+// the point.
 //
-// The assertion is errors.Is against types.ErrNotSupported and not merely "err != nil", because the
-// caller of AnnounceKey is a cache write path that has to distinguish "this cluster cannot announce" —
-// fall back to the object store, permanently — from a transient send failure worth retrying.
+// Both used to be stubs returning [types.ErrNotSupported] unconditionally, and this test asserted exactly
+// that. #140 implemented them, and only one of the two still refuses: announcing is a broadcast, so with
+// no socket open there is nobody to tell and success would be a lie, while querying is a read of a local
+// map that gossip filled — a cluster that has heard from nobody honestly holds nothing, and that is the
+// documented empty answer rather than a failure.
 //
-// #284 deleted a CacheReplicator that returned nil having sent nothing, counted the bytes as replicated,
-// and survived four releases because the only test covering it asserted that its field was non-nil.
-// These are the assertions that would have caught it.
-func TestCoordinatorWrapper_UnimplementedMethodsRefuse(t *testing.T) {
+// The refusal is asserted with errors.Is rather than "err != nil", because the caller of AnnounceKey is a
+// cache write path that must tell "this cluster cannot announce" — fall back to the object store,
+// permanently — from a transient send failure worth retrying. #284 deleted a CacheReplicator that returned
+// nil having sent nothing, counted the bytes as replicated, and survived four releases because the only
+// test covering it asserted its field was non-nil.
+func TestCoordinatorWrapper_CacheCoordinationOnAnUnstartedCluster(t *testing.T) {
 	t.Parallel()
 
 	cm := makeClusterWithNode(t, "wrapper-refuse")
 	coord := cm.GetCoordinator()
 	ctx := t.Context()
 
-	t.Run("AnnounceKey", func(t *testing.T) {
+	t.Run("AnnounceKey refuses", func(t *testing.T) {
 		t.Parallel()
+
+		// gossip.conn is nil rather than gossip itself: NewClusterManager builds the protocol and only
+		// Start opens its socket, so this is the state a mount is in before Start and after Stop — a whole
+		// gossip object whose every send would dial out from an unbound port and reach nobody.
 		err := coord.AnnounceKey(ctx, types.KeyAnnouncement{
 			Key: "some/key", NodeID: "wrapper-refuse", ETag: `"v1"`, Size: 10,
 		})
@@ -1265,21 +1274,25 @@ func TestCoordinatorWrapper_UnimplementedMethodsRefuse(t *testing.T) {
 			t.Errorf("AnnounceKey = %v, want ErrNotSupported", err)
 		}
 		if err != nil && !strings.Contains(err.Error(), "some/key") {
-			t.Errorf("error %q does not name the key it failed to announce", err)
+			t.Errorf("error %q does not name the key it failed to announce, which is what an operator "+
+				"debugging cold reads needs from it", err)
 		}
 	})
 
-	t.Run("QueryKeyOwnership", func(t *testing.T) {
+	t.Run("QueryKeyOwnership answers empty", func(t *testing.T) {
 		t.Parallel()
+
 		holders, err := coord.QueryKeyOwnership(ctx, "some/key")
-		if !errors.Is(err, types.ErrNotSupported) {
-			t.Errorf("QueryKeyOwnership = %v, want ErrNotSupported", err)
+		if err != nil {
+			t.Errorf("QueryKeyOwnership = %v; a local read of what peers have announced cannot fail just "+
+				"because no peer has announced anything", err)
 		}
-		// An empty slice with a nil error is the documented answer for "no peer holds this", so returning
-		// it here would be indistinguishable from a working query against a cold cluster.
-		if holders != nil {
-			t.Errorf("QueryKeyOwnership returned %d holders alongside its error; a caller that reads the "+
-				"slice before the error must find nothing", len(holders))
+		if len(holders) != 0 {
+			t.Errorf("got %d holders on a cluster that has never received a message: %+v", len(holders), holders)
+		}
+		if holders == nil {
+			t.Error("holders is nil; the contract is an empty slice, so a caller can range over it without " +
+				"distinguishing the two")
 		}
 	})
 }

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -131,6 +131,15 @@ const (
 	// MessageTypeCacheInvalidate requests that peers evict a key from their
 	// local cache.  The payload is a CacheInvalidateMessage.
 	MessageTypeCacheInvalidate MessageType = "cache_invalidate"
+
+	// MessageTypeCacheAnnounce tells peers the sender holds a version of a key in its local cache, so a
+	// peer weighing a read can learn the key is hot in this cluster (#140). The payload is a
+	// [types.KeyAnnouncement].
+	//
+	// It carries no object bytes and is not a request for any: see
+	// [GossipProtocol.handleCacheAnnounce]. Metadata over gossip, bytes from S3 — a datagram cannot hold
+	// a 128 KiB read, which is what makes that split a constraint rather than a preference (#399).
+	MessageTypeCacheAnnounce MessageType = "cache_announce"
 )
 
 // ErrMessageOversize means a sealed datagram exceeded MaxGossipPacket and was refused before it
@@ -551,9 +560,11 @@ func (gp *GossipProtocol) handleIncomingMessage(ctx context.Context, data []byte
 			gp.cluster.coordinator.handleNetworkOperationResp(msg)
 		}
 
-	// Cache invalidation
+	// Cache coordination
 	case MessageTypeCacheInvalidate:
 		gp.handleCacheInvalidate(msg)
+	case MessageTypeCacheAnnounce:
+		gp.handleCacheAnnounce(msg)
 	}
 }
 


### PR DESCRIPTION
Closes #140.

`AnnounceKey` and `QueryKeyOwnership` were stubs returning `ErrNotSupported`. Both are real now: a node broadcasts a `cache_announce` gossip message naming the key, its ETag, its size and the byte range it holds; receivers record the claim against the sending peer, expire it after `cluster.announcement_ttl` (default five minutes), and answer a local lookup with the holders freshest-first.

**Metadata only.** No object bytes cross gossip, because a datagram cannot carry a 128 KiB read (#399). What this buys is knowing *which* keys are worth warming — a peer holding a key at the current ETag is evidence it is hot in this cluster, which a cold node cannot learn on its own. The bytes still come from S3, which is #142.

## Three departures from the issue's written spec

Each is recorded in the code, not just here.

1. **A node does not record its own announcements.** The spec says to. But `QueryKeyOwnership` is called *because a read missed this node's own cache*, so a self-entry is a holder guaranteed not to hold, returned in place of a peer that might. The local cache is already the authority on what this node has.

2. **Expiry uses a locally stamped `recordedAt`, never the wire's `CachedAt`.** That field's own documentation forbids comparing it against a local deadline: clocks across nodes are not synchronized, so a peer running an hour behind would have every announcement expire on arrival, and one running fast would sort itself to the front of every key in the cluster. `CachedAt` is still carried, for a recipient comparing two holders of one ETag — advisory for that, unusable for expiry.

3. **No applied-once ledger,** unlike `handleCacheInvalidate`, which was otherwise the precedent followed closely. An invalidation is an *action*, so applying a retransmission of an older one throws away bytes legitimately re-cached since. An announcement is a *fact* about a (key, node) pair, and `recordAnnouncement` replaces that node's entry rather than appending — a retransmission overwrites an identical value.

## The integrity boundary

An announcement missing its ETag is **refused rather than sent**, with the field named in the error. An invalidation with no version is still safe, since "evict whatever you hold" cannot serve wrong bytes; an announcement with no version is not, because a peer that fetches bytes it cannot place against an object version hands them to a reading process as file content.

Announcing with gossip not running returns `ErrNotSupported` rather than nil — a caller told nil believes the cluster knows something it was never sent, which is exactly the defect #284 deleted a `CacheReplicator` for. And the receiver credits the **envelope's sender** over the payload's `NodeID`: both are authenticated by the same MAC, so this is not a defense against an outsider but against a member announcing that some third node holds a key, which would send peers to fetch bytes that node never cached and has no way to correct.

## Also

- `cluster.announcement_ttl` on `distributed.ClusterConfig`, with no `internal/config` key — tuning for a subsystem whose defaults are measured, like the gossip triple beside it. Its default is applied at the point of use rather than in `applyConfigDefaults`, because a zero TTL there is not a slower cluster but a silently inert one.
- `announced_keys` in the coordinator's statistics, counting keys **retained** rather than queryable, so the gap between it and a query is how far behind the expiry sweep is running.
- `TestCoordinatorWrapper_UnimplementedMethodsRefuse` asserted both stubs refuse, and is rewritten as `TestCoordinatorWrapper_CacheCoordinationOnAnUnstartedCluster` — where the two now answer *differently*, which is the point: announcing with no socket open is a lie if it succeeds, while querying a cluster that has heard from nobody honestly holds nothing, and that is the documented empty answer rather than a failure.

## Verification

- `go build` / `gofmt` / `go vet` clean; `go test -race -count=1 ./...` green; `go test -race -tags=distributed ./internal/distributed/...` green.
- `golangci-lint run --new-from-merge-base=origin/main`: 0 issues.
- `internal/distributed` coverage **81.8%**.
- #140's own acceptance criterion, over loopback UDP: node A announces, node B queries and sees A's entry — via the existing `startGossipPair` harness rather than a second one.
- **Twenty mutations, all killed:** a removed dispatch arm, local self-recording, append-instead-of-replace, dropped field validation, an admitted self-claim, ordering by `CachedAt`, a missing read-side expiry filter, an unbounded map, eviction skipping its expired pass, a nil slice for a miss, an inert sweep, absent stats, an accepted empty ETag, a nil answer with gossip down, a removed envelope-sender override, a recorded malformed payload, an error that drops the key it names, and both wrapper nil guards.