### PR TITLE
feat(cluster): a write on one node evicts what its peers cached (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A write on one node now evicts what its peers have cached** ([#141]). [#140] gave the cluster the
+  vocabulary; this is the read and write paths using it. A read that misses and fetches from S3 announces
+  the range it cached, so a peer that wants those bytes can weigh asking against reading S3 itself. A
+  flush, an unlink, an rmdir, a mkdir, a create and both halves of a rename invalidate on every peer as
+  well as locally. Until this, a two-node deployment kept serving a file's previous contents for up to
+  five minutes after another node overwrote it — every part of the invalidation machinery existed and
+  nothing called it.
+
+  The invalidation carries **the ETag the write itself reported**, which is why `Flush` now asks the write
+  path for it rather than discarding it: a receiver's replay ledger is keyed on (key, version), so a
+  version fetched from a later `HeadObject` could name a *third* node's subsequent write and suppress an
+  invalidation that was never applied. A delete has no version to name and sends an empty one, which is
+  legal and means "evict whatever you hold". Local and remote eviction go through a single call, so a
+  future mutation path cannot add the local half and forget the remote one — the half that is invisible on
+  a single-node mount.
+
+  Both directions are fire-and-forget and never fail a syscall, but they are **not** logged alike. A lost
+  announcement costs a peer an S3 read, which is slower and nothing more, so it is Debug. A lost
+  invalidation means peers serve bytes this node replaced until their cache TTL expires, and nothing else
+  in the system reports it, so it is Warn: a mount whose invalidations are all failing is serving stale
+  reads cluster-wide.
+
+  An announcement is only sent when this node already knows the object's version, from the stat the kernel
+  issues before any read. With no version known, nothing is announced rather than a version being invented
+  — a peer that fetches bytes it cannot place against an object version hands them to a reading process as
+  file content. On a single-node mount the coordinator is nil and none of this runs: measured at 4.8 µs and
+  2 allocations for a 128 KiB cached read either way, since a cache hit never reaches the announce call.
+
 - **Peers now learn which keys are cached elsewhere in the cluster** ([#140]). `AnnounceKey` and
   `QueryKeyOwnership` were stubs returning `ErrNotSupported`; both are real. A node broadcasts a
   `cache_announce` gossip message naming the key, its ETag, its size and the byte range it holds;

--- a/internal/distributed/fuse_twonode_test.go
+++ b/internal/distributed/fuse_twonode_test.go
@@ -1,0 +1,229 @@
+//go:build linux || darwin
+
+package distributed
+
+// #141's acceptance criteria name two nodes: node A writes key X through the filesystem, and node B's
+// cache entry for X is gone within a gossip round trip. Everything else about #141 is asserted in
+// internal/fuse, against a recording coordinator, because that is where "which call, with which fields"
+// belongs. What cannot be asserted there is the part that matters most to a user: that the call actually
+// crosses the wire and evicts something.
+//
+// # Why it lives in this package
+//
+// It drives internal/fuse, internal/cache, internal/vfs and internal/testaws, and none of them import
+// internal/distributed — verified rather than assumed, by compiling a probe that imports all four from
+// here. The reverse would not work: internal/fuse cannot reach startGossipPair or a *ClusterManager's
+// unexported gossip field, and exporting a join helper so a test in another package could reach it would
+// widen the production API for a test's convenience.
+//
+// # What "real" means here
+//
+// The two nodes share one S3 endpoint and have separate caches, which is the deployment shape: two hosts
+// mounting the same bucket. Both filesystems are real, the write goes through the real write path, the
+// invalidation crosses a real UDP socket, and the assertion is on node B's cache no longer holding the
+// bytes. Nothing is mocked; the only thing standing in for a second host is a second port on loopback.
+
+import (
+	"syscall"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	objectfuse "github.com/scttfrdmn/objectfs/internal/fuse"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// clusterNode is one host: a filesystem, its own cache, and the cluster manager that connects it.
+type clusterNode struct {
+	fs    *objectfuse.FileSystem
+	root  *objectfuse.DirectoryNode
+	cache *cache.LRUCache
+	cm    *ClusterManager
+}
+
+// write creates key, writes data to it, and flushes — through the same three node operations the kernel
+// performs for `echo > file`, rather than through the write path directly.
+//
+// The entry points, because what #141 wired is the FUSE layer: a test that called vfs.Writer.Flush would
+// bypass [objectfuse.FileHandle.Flush], which is where the invalidation lives, and would pass with the
+// whole of #141 reverted.
+func (n *clusterNode) write(t *testing.T, key, data string) {
+	t.Helper()
+
+	var out fuse.EntryOut
+	_, handle, _, errno := n.root.Create(t.Context(), key, uint32(syscall.O_WRONLY), 0o644, &out)
+	if errno != 0 {
+		t.Fatalf("Create(%q): %v", key, errno)
+	}
+
+	fh, ok := handle.(*objectfuse.FileHandle)
+	if !ok {
+		t.Fatalf("Create returned a %T, want *fuse.FileHandle", handle)
+	}
+
+	if _, errno := fh.Write(t.Context(), []byte(data), 0); errno != 0 {
+		t.Fatalf("Write(%q): %v", key, errno)
+	}
+
+	if errno := fh.Flush(t.Context()); errno != 0 {
+		t.Fatalf("Flush(%q): %v", key, errno)
+	}
+}
+
+// newClusterNode builds a filesystem on cm, sharing srv's bucket.
+//
+// The cache is handed to both the filesystem and the cluster manager, and it has to be the same one:
+// [GossipProtocol.handleCacheInvalidate] evicts from cm's cache, and the read path serves from the
+// filesystem's. Two caches here would make an invalidation that arrived and evicted nothing look exactly
+// like one that worked.
+func newClusterNode(t *testing.T, srv *testaws.TestServer, cm *ClusterManager) *clusterNode {
+	t.Helper()
+
+	backend := srv.Backend()
+
+	writer, err := vfs.NewWriter(t.Context(), backend)
+	if err != nil {
+		t.Fatalf("vfs.NewWriter: %v", err)
+	}
+
+	// A TTL long enough that nothing expires on its own. The property under test is that an invalidation
+	// evicts, not that staleness eventually times out — and a short TTL here would pass this test with the
+	// gossip message deleted entirely.
+	byteCache := cache.NewLRUCache(&cache.CacheConfig{
+		MaxSize:    16 << 20,
+		MaxEntries: 10000,
+		TTL:        time.Hour,
+	})
+	t.Cleanup(func() { _ = byteCache.Close() })
+
+	cm.SetBackend(backend)
+	cm.SetCache(byteCache)
+
+	fs := objectfuse.NewFileSystem(t.Context(), backend, byteCache, writer, nil, &objectfuse.Config{
+		DefaultMode:    0o644,
+		DefaultDirMode: 0o755,
+		DefaultUID:     1000,
+		DefaultGID:     1000,
+		Coordinator:    cm.GetCoordinator(),
+	})
+
+	root, ok := fs.Root().(*objectfuse.DirectoryNode)
+	if !ok {
+		t.Fatalf("FileSystem.Root returned %T, want *fuse.DirectoryNode", fs.Root())
+	}
+
+	// Attached to a bridge, because Create builds a child inode through Inode.NewInode and dereferences
+	// the bridge to do it. NullPermissions matches what internal/fuse's own mount options set.
+	timeout := time.Minute
+	_ = gofuse.NewNodeFS(root, &gofuse.Options{
+		AttrTimeout:     &timeout,
+		EntryTimeout:    &timeout,
+		NullPermissions: true,
+	})
+
+	return &clusterNode{fs: fs, root: root, cache: byteCache, cm: cm}
+}
+
+// TestTwoNodes_AWriteEvictsThePeersCachedBytes is #141's end-to-end criterion.
+//
+// The failure it exists to catch is the one a single-node test cannot see and a user cannot easily
+// diagnose: node B keeps serving the file's previous contents after node A rewrites it. Reading through
+// B's own read path afterwards would not distinguish an eviction from a re-fetch, so the assertion is on
+// the cache directly — the bytes are no longer there, which is the whole of what an invalidation can
+// promise.
+func TestTwoNodes_AWriteEvictsThePeersCachedBytes(t *testing.T) {
+	t.Parallel()
+
+	srv := testaws.Start(t)
+
+	cm1, cm2 := startGossipPair(t, "fuse-write-node-a", "fuse-write-node-b")
+	nodeA := newClusterNode(t, srv, cm1)
+	nodeB := newClusterNode(t, srv, cm2)
+
+	const (
+		key      = "shared/dataset.bin"
+		size     = 8192
+		replaced = "node A replaced every byte of this object"
+	)
+
+	original := srv.SeedRandom(key, size)
+
+	// Node B caches the object's first chunk, the way a read would. Through the cache's own Put rather
+	// than through B's read path, because what is under test is the eviction: a read here would also
+	// populate B's metadata cache and register a read-ahead pattern, and a prefetch landing after the
+	// invalidation would refill the entry and fail this test for a reason that is not a defect.
+	nodeB.cache.Put(key, 0, original[:4096])
+
+	if got := nodeB.cache.Get(key, 0, 4096); len(got) != 4096 {
+		t.Fatalf("node B's cache does not hold the bytes this test is about to have evicted: got %d", len(got))
+	}
+
+	// Node A rewrites the object and flushes, which is what broadcasts.
+	nodeA.write(t, key, replaced)
+
+	waitForEviction(t, nodeB.cache, key, 0, 4096)
+}
+
+// TestTwoNodes_ADeleteEvictsThePeersCachedBytes is the same criterion for the operation with no version
+// to name.
+//
+// Worth its own test rather than a subtest of the above: a delete's invalidation carries an empty ETag,
+// which takes a different branch in [GossipProtocol.handleCacheInvalidate] — an unversioned invalidation
+// bypasses the applied-once ledger and is applied every time. A test that only covered the versioned path
+// would leave the branch a delete actually takes uncovered end to end.
+func TestTwoNodes_ADeleteEvictsThePeersCachedBytes(t *testing.T) {
+	t.Parallel()
+
+	srv := testaws.Start(t)
+
+	cm1, cm2 := startGossipPair(t, "fuse-delete-node-a", "fuse-delete-node-b")
+	nodeA := newClusterNode(t, srv, cm1)
+	nodeB := newClusterNode(t, srv, cm2)
+
+	const (
+		key  = "shared/doomed.bin"
+		size = 8192
+	)
+
+	original := srv.SeedRandom(key, size)
+	nodeB.cache.Put(key, 0, original[:4096])
+
+	if got := nodeB.cache.Get(key, 0, 4096); len(got) != 4096 {
+		t.Fatalf("node B's cache does not hold the bytes this test is about to have evicted: got %d", len(got))
+	}
+
+	if errno := nodeA.root.Unlink(t.Context(), key); errno != 0 {
+		t.Fatalf("Unlink on node A: %v", errno)
+	}
+
+	waitForEviction(t, nodeB.cache, key, 0, 4096)
+}
+
+// waitForEviction polls c until the range is gone, or fails.
+//
+// Polling for the same reason [waitForDeletion] does: this crosses loopback UDP and a receive goroutine,
+// so a read taken immediately after the flush returns has no reason to see anything yet. The deadline is
+// generous because the failure this catches — a message never sent, or sent for the wrong key — is not one
+// more waiting fixes.
+func waitForEviction(t *testing.T, c types.Cache, key string, off, length int64) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+
+	for time.Now().Before(deadline) {
+		if c.Get(key, off, length) == nil {
+			return
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatalf("node B still holds [%d, %d) of %q two seconds after the peer that owns it wrote it. Every "+
+		"process reading that file on this host is being served the previous contents, and will be until "+
+		"the cache entry expires on its own", off, off+length, key)
+}

--- a/internal/fuse/attributes.go
+++ b/internal/fuse/attributes.go
@@ -321,15 +321,16 @@ func (f *FileNode) Setattr(
 	// value POSIX already permits a filesystem to keep only approximately.
 
 	if changed {
-		if err := f.fs.buffer.FlushContext(ctx, f.key()); err != nil {
+		etag, err := f.fs.flushReportingETag(ctx, f.key())
+		if err != nil {
 			slog.Error("setattr: flush failed", "path", f.key(), "error", err)
 
 			return toErrno(err)
 		}
 
 		// The object's size, mtime, and mode all just changed. Anything cached for the path describes
-		// what it was before.
-		f.fs.invalidate(f.key())
+		// what it was before — here and on every peer, which is what the etag names the version for.
+		f.fs.invalidateBoth(ctx, f.key(), etag)
 
 		if h, ok := fh.(*FileHandle); ok {
 			h.file.markClean()
@@ -363,14 +364,15 @@ func (f *FileNode) Fsync(ctx context.Context, fh fs.FileHandle, flags uint32) sy
 		return 0
 	}
 
-	if err := f.fs.buffer.FlushContext(ctx, f.key()); err != nil {
+	etag, err := f.fs.flushReportingETag(ctx, f.key())
+	if err != nil {
 		f.fs.countError()
 		slog.Error("fsync failed", "path", f.key(), "error", err)
 
 		return toErrno(err)
 	}
 
-	f.fs.invalidate(f.key())
+	f.fs.invalidateBoth(ctx, f.key(), etag)
 
 	if h, ok := fh.(*FileHandle); ok {
 		h.file.markClean()

--- a/internal/fuse/coordinate.go
+++ b/internal/fuse/coordinate.go
@@ -1,0 +1,173 @@
+//go:build linux || darwin
+
+package fuse
+
+// This file is the whole of what the read and write paths say to the rest of the cluster (#141): an
+// announcement when bytes land in this node's cache, and an invalidation when a write or a delete makes
+// what a peer holds wrong.
+//
+// # Both directions are fire-and-forget, and only one of them is an optimization
+//
+// An announcement that is not sent costs a peer an S3 read it could have avoided. That is slower and
+// nothing more, so a failure is logged at Debug and the read returns normally.
+//
+// An invalidation that is not sent is not symmetric with that, and it is worth being explicit because
+// the two calls look alike at every call site. A peer that never hears an invalidation keeps serving
+// the bytes this node just replaced, for as long as its cache TTL — up to five minutes on the default
+// config. Gossip has no acknowledgement to offer, so there is no version of this call that could tell
+// the caller its peers were reached; failing the write(2) that prompted it would be strictly worse,
+// since the object *is* durable and the caller's data *is* stored. What makes the gap bounded rather
+// than unbounded is the TTL, and what makes it detectable is the log line. It is recorded at Warn
+// rather than Debug for that reason: a mount whose invalidations are all failing is serving stale reads
+// cluster-wide, and that is an operator's problem, not a debugging detail.
+//
+// # Neither call blocks the syscall, and neither is on a goroutine
+//
+// Inline, on the FUSE request's own goroutine. A `go` per invalidation would decouple the send from the
+// write, which sounds like the safer shape and is not: the ordering between an invalidation and the
+// next read of the same key is the entire mechanism, and a goroutine scheduled after a peer has already
+// re-read the key evicts bytes that are once again correct while leaving the stale window open. The
+// send itself is a marshal plus a UDP write per peer — [distributed.GossipProtocol.broadcastMessage]
+// already fans out to a goroutine per target and does not wait — so inline costs microseconds and buys
+// the ordering.
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// announceCached tells peers this node now holds [off, off+len(data)) of path in its cache.
+//
+// # Why this reads a version it did not fetch
+//
+// [types.KeyAnnouncement] requires an ETag and [types.DistributedCoordinator.AnnounceKey] refuses an
+// announcement without one, because a peer that fetches bytes it cannot place against a version of the
+// object hands them to a reading process as file content. #141's specification does not carry the field
+// — its sketch fills in Key, NodeID, Size, CachedAt, Offset and Length and stops — so implemented as
+// written, every announcement this made would be refused by the layer below it.
+//
+// The bytes come from [types.Backend.GetObject], which returns no version: the S3 backend has the ETag
+// in the GET response and discards it at that boundary, and the whole read path below this point is
+// []byte. So the version comes from the metadata cache instead, which holds the [types.ObjectInfo] from
+// the HEAD that the kernel's stat issued before the read — the stat always precedes the read, because
+// the kernel needs a size before it will issue one.
+//
+// That makes the announcement's ETag *the version this node last stat'ed*, not provably the version the
+// bytes came from. The gap is real: an overwrite between the stat and the GET makes the two disagree,
+// and the ETag would name the older object. What bounds the damage is what a recipient does with it —
+// [types.DistributedCoordinator.QueryKeyOwnership] documents every announcement as a claim to be
+// checked against the ETag the fetcher wanted, precisely because a holder can have evicted, replaced,
+// or never held what it announced. A wrong ETag here therefore costs a peer a rejected fetch and an S3
+// read, which is the outcome it would have had with no announcement at all.
+//
+// What is not acceptable is inventing one. With no cached metadata this returns without announcing,
+// which is #140's fail-closed direction applied one layer up: no announcement is a peer reading S3, and
+// a fabricated version is a peer serving bytes under a name that does not describe them.
+func (fs *FileSystem) announceCached(ctx context.Context, path string, off int64, data []byte) {
+	if fs.coordinator == nil || len(data) == 0 {
+		return
+	}
+
+	// The metadata cache, not a HEAD. Issuing a request here would put one S3 round trip on every cache
+	// miss to enable an optimization whose entire purpose is removing S3 round trips, and it would pay
+	// it on single-key workloads that no peer will ever ask about.
+	info := fs.getCachedInfo(path)
+	if info == nil || info.ETag == "" {
+		slog.Debug("not announcing cached bytes: no version is known for the object",
+			"path", path, "offset", off, "length", len(data))
+
+		return
+	}
+
+	// Size is the object's, Length is the range's. [types.KeyAnnouncement] keeps them apart on purpose: a
+	// peer weighing a fetch needs the range to know what it can get here and the size to know what
+	// fraction of the object that is. Collapsing them — announcing len(data) as both — would tell a peer
+	// a 128 KiB range of a 10 GiB object is the whole file.
+	if err := fs.coordinator.AnnounceKey(ctx, types.KeyAnnouncement{
+		Key:      path,
+		ETag:     info.ETag,
+		Size:     info.Size,
+		CachedAt: time.Now(),
+		Offset:   off,
+		Length:   int64(len(data)),
+	}); err != nil {
+		// Debug: a peer that never hears this reads from S3, which is correct and merely slower. NodeID is
+		// deliberately unset above — AnnounceKey overwrites it with the cluster's own node ID, and this
+		// package has no access to it.
+		slog.Debug("could not announce cached bytes to peers",
+			"path", path, "offset", off, "length", len(data), "error", err)
+	}
+}
+
+// invalidateCluster tells peers to evict path, because the version named by etag replaced what they
+// hold. An empty etag means this caller cannot name a version, which [types.DistributedCoordinator]
+// documents as legal and applies on every receipt rather than once.
+//
+// # Two keys locally, one key on a peer
+//
+// [FileSystem.invalidate] deletes both path and metaCacheKey(path), because a write changes the bytes
+// *and* the size and mtime that a stat reports; dropping only one leaves a file whose stat size does not
+// match what read returns. A peer receiving this evicts one key —
+// [distributed.GossipProtocol.handleCacheInvalidate] calls cache.Delete(m.Key) — so this sends both, and
+// the metadata key is not an afterthought. Without it, a peer that has stat'ed the object serves its
+// pre-write size from cache for the full metadata TTL while serving post-write content, which is the
+// same disagreement locally, across a node boundary.
+//
+// The metadata key travels with no ETag even when the content key has one. The ETag names a version of
+// the object's *bytes*, and the receiver's replay ledger is keyed on (key, etag): reusing the content
+// version for the metadata key would be a second entry claiming to describe bytes that key does not
+// hold. Unversioned means "evict whatever you hold", which is exactly right for an attribute record and
+// costs a redundant eviction at worst.
+func (fs *FileSystem) invalidateCluster(ctx context.Context, path, etag string) {
+	if fs.coordinator == nil {
+		return
+	}
+
+	if err := fs.coordinator.InvalidateKey(ctx, path, etag); err != nil {
+		// Warn, unlike the announcement above. See the file comment: peers keep serving bytes this node
+		// replaced until their cache TTL expires, and nothing else reports it.
+		slog.Warn("could not tell peers to evict a key this node just wrote, so they may serve its "+
+			"previous contents until their cache entries expire",
+			"path", path, "etag", etag, "error", err)
+	}
+
+	if err := fs.coordinator.InvalidateKey(ctx, metaCacheKey(path), ""); err != nil {
+		slog.Warn("could not tell peers to evict a key's cached attributes, so they may report its "+
+			"previous size until their cache entries expire",
+			"path", path, "error", err)
+	}
+}
+
+// invalidateBoth drops path from this node's caches and from every peer's.
+//
+// It exists because the local and remote halves must not be able to drift apart. Every mutation in this
+// package already calls [FileSystem.invalidate]; a cluster call sitting beside each of those as a
+// separate statement is a pair that a future mutation path can add one half of — and the half easier to
+// forget is the remote one, whose absence is invisible on a single-node mount and on every test that
+// does not run two nodes.
+//
+// etag is the version the caller wrote, empty where it has none. A delete has no version to name, and
+// [types.DistributedCoordinator.InvalidateKey] is explicit that empty is legal and that inventing one
+// is not.
+func (fs *FileSystem) invalidateBoth(ctx context.Context, path, etag string) {
+	fs.invalidate(path)
+	fs.invalidateCluster(ctx, path, etag)
+}
+
+// flushReportingETag makes path durable and reports the version storage now holds, empty when there is
+// no version to name.
+//
+// A thin wrapper over [vfs.Writer.FlushReportingETag] whose only work is the nil-buffer guard, which
+// every flush site in this package needs: a read-only mount has no write path, and [FileNode.Fsync]
+// already returns zero for that case rather than an error. Kept here beside the coordination calls
+// because the ETag exists for them — nothing else in this package reads it.
+func (fs *FileSystem) flushReportingETag(ctx context.Context, path string) (string, error) {
+	if fs.buffer == nil {
+		return "", nil
+	}
+
+	return fs.buffer.FlushReportingETag(ctx, path)
+}

--- a/internal/fuse/coordinate_bench_test.go
+++ b/internal/fuse/coordinate_bench_test.go
@@ -1,0 +1,483 @@
+//go:build linux || darwin
+
+package fuse
+
+// #141's acceptance criteria ask for no benchmark regression on a mount with no coordinator. There was
+// nothing anywhere in the repository to compare against — its benchmarks cover the cache
+// (internal/cache, test/benchmarks), the S3 backend and URI validation, none of which run the FUSE read
+// path — so the comparison is established here rather than asserted against a number nobody measured.
+//
+// # What each pair measures, and what it cannot
+//
+// A cache hit never reaches the announce call: [FileSystem.announceCached] is called from
+// [FileSystem.fetchUncached], so the coordinator is not consulted on a hit at all. The cached pair
+// therefore measures the one thing the criterion is actually about — whether carrying a coordinator costs
+// a read anything on the path that serves most reads — and its answer should be "nothing measurable".
+// The uncached pair is where the announcement happens, and it is the pair that could show a cost.
+//
+// Neither pair can measure the cost of a *real* coordinator: [distributed.Coordinator.AnnounceKey]
+// marshals and broadcasts over UDP to every peer, and nothing about that is in this package. What is
+// measured is the call site's own cost — the nil check, the metadata-cache read the announcement's ETag
+// comes from, and the struct it builds — against a coordinator that records and returns. That is the
+// right scope: the criterion is about the mount that has no coordinator, and the non-nil arm exists to
+// bound what the other kind pays before it reaches the network.
+//
+// # Why the backend here is in-memory, in a package whose tests refuse mocks
+//
+// read_path_test.go and coordinate_test.go both drive a real S3 endpoint through internal/testaws, and
+// that is the right default: a mock on the far side of a seam agrees with its caller by construction.
+// Two things make a benchmark different.
+//
+// The first is mechanical. [testaws.Start] takes a *testing.T concretely, and so does
+// emulator.StartTestServer under it — and testing.TB has an unexported method, so no cast bridges a
+// *testing.B to it. A benchmark cannot reach that harness at all. That is a gap in the harness rather
+// than a fact about benchmarks, and it is filed upstream as substrate#605; when a testing.TB entry point
+// lands, the uncached pair below should move onto it, because HTTP is the honest cost of a miss.
+//
+// The second is that it does not weaken the measurement, and in one direction it strengthens it. The
+// cached pair asserts the backend is not called at all inside the timed loop, so which backend it holds
+// cannot affect the figure — that is checked below rather than argued. The uncached pair does call the
+// backend, and an in-memory GET is orders of magnitude cheaper than a real one, which makes any
+// coordinator overhead a *larger* fraction of the total than it would be against S3. A result of "no
+// meaningful difference" measured this way therefore holds a fortiori against a real endpoint.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// benchBackend is an in-memory [types.Backend] that counts the calls the read path makes.
+//
+// The counters are the point as much as the storage is: they are what lets the cached benchmark assert
+// that nothing in its timed loop touches the backend, which is what makes an in-memory one admissible
+// there. See the file comment.
+type benchBackend struct {
+	mu      sync.RWMutex
+	objects map[string][]byte
+	meta    map[string]map[string]string
+
+	gets  atomic.Int64
+	heads atomic.Int64
+}
+
+func newBenchBackend() *benchBackend {
+	return &benchBackend{
+		objects: make(map[string][]byte),
+		meta:    make(map[string]map[string]string),
+	}
+}
+
+// calls returns the number of GET and HEAD requests made so far.
+func (b *benchBackend) calls() int64 { return b.gets.Load() + b.heads.Load() }
+
+func (b *benchBackend) GetObject(_ context.Context, key string, offset, size int64) ([]byte, error) {
+	b.gets.Add(1)
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	data, ok := b.objects[key]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	if offset < 0 || offset > int64(len(data)) {
+		return nil, fmt.Errorf("benchBackend: offset %d outside %q", offset, key)
+	}
+
+	// A size of zero or less means "to the end of the object", per [types.Backend].
+	end := int64(len(data))
+	if size > 0 && offset+size < end {
+		end = offset + size
+	}
+
+	return data[offset:end], nil
+}
+
+func (b *benchBackend) PutObject(_ context.Context, key string, data []byte, meta map[string]string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.objects[key] = append([]byte(nil), data...)
+	b.meta[key] = maps.Clone(meta)
+
+	return nil
+}
+
+// PutObjectIf refuses rather than answering, the way tests.MockBackend does: an in-memory store cannot
+// evaluate a precondition the way S3 does, and [types.Backend] is explicit that falling back to an
+// unconditional write is the failure the mechanism exists to prevent.
+func (b *benchBackend) PutObjectIf(context.Context, string, []byte, map[string]string,
+	types.Precondition,
+) (string, error) {
+	return "", types.ErrNotSupported
+}
+
+func (b *benchBackend) SetObjectMetadata(_ context.Context, key string, meta map[string]string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, ok := b.objects[key]; !ok {
+		return os.ErrNotExist
+	}
+
+	b.meta[key] = maps.Clone(meta)
+
+	return nil
+}
+
+func (b *benchBackend) CopyObject(_ context.Context, src, dst string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	data, ok := b.objects[src]
+	if !ok {
+		return os.ErrNotExist
+	}
+
+	b.objects[dst] = append([]byte(nil), data...)
+	b.meta[dst] = maps.Clone(b.meta[src])
+
+	return nil
+}
+
+func (b *benchBackend) DeleteObject(_ context.Context, key string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	delete(b.objects, key)
+	delete(b.meta, key)
+
+	return nil
+}
+
+func (b *benchBackend) HeadObject(_ context.Context, key string) (*types.ObjectInfo, error) {
+	b.heads.Add(1)
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	data, ok := b.objects[key]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	// A real ETag, derived from the bytes. It has to be non-empty and content-derived, because
+	// [FileSystem.announceCached] refuses to announce without one — a stub returning "" here would make
+	// the uncached-with-coordinator benchmark measure the early return instead of the announce path, and
+	// the assertion at the end of it is what catches that.
+	sum := sha256.Sum256(data)
+
+	return &types.ObjectInfo{
+		Key:          key,
+		Size:         int64(len(data)),
+		LastModified: time.Unix(0, 0),
+		ETag:         hex.EncodeToString(sum[:]),
+		Metadata:     maps.Clone(b.meta[key]),
+	}, nil
+}
+
+func (b *benchBackend) GetObjects(ctx context.Context, keys []string) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(keys))
+
+	for _, key := range keys {
+		data, err := b.GetObject(ctx, key, 0, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		out[key] = data
+	}
+
+	return out, nil
+}
+
+func (b *benchBackend) PutObjects(ctx context.Context, objects map[string][]byte) error {
+	for key, data := range objects {
+		if err := b.PutObject(ctx, key, data, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *benchBackend) ListObjects(_ context.Context, prefix string, limit int) ([]types.ObjectInfo, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	out := make([]types.ObjectInfo, 0, len(b.objects))
+
+	for key, data := range b.objects {
+		if prefix != "" && !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		out = append(out, types.ObjectInfo{Key: key, Size: int64(len(data))})
+
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+
+	return out, nil
+}
+
+func (b *benchBackend) HealthCheck(context.Context) error { return nil }
+
+var _ types.Backend = (*benchBackend)(nil)
+
+// countingCoordinator is a [types.DistributedCoordinator] that counts instead of recording.
+//
+// Not [recordingCoordinator], deliberately: that one appends every announcement to a slice, and b.N
+// announcements would make the benchmark measure a growing slice's reallocation alongside the call it
+// means to measure. Counting keeps the coordinator's own cost to a mutex-free atomic increment, which is
+// the floor — anything a real coordinator does is on top of what is measured here, which is what the
+// file comment says the non-nil arm bounds.
+type countingCoordinator struct {
+	announces   atomic.Int64
+	invalidates atomic.Int64
+}
+
+func (c *countingCoordinator) ExecuteOperation(context.Context, any) (any, error) {
+	return nil, types.ErrNotSupported
+}
+
+func (c *countingCoordinator) GetStats() map[string]any { return map[string]any{} }
+
+func (c *countingCoordinator) AnnounceKey(context.Context, types.KeyAnnouncement) error {
+	c.announces.Add(1)
+
+	return nil
+}
+
+func (c *countingCoordinator) QueryKeyOwnership(context.Context, string) ([]types.KeyAnnouncement, error) {
+	return nil, nil
+}
+
+func (c *countingCoordinator) InvalidateKey(context.Context, string, string) error {
+	c.invalidates.Add(1)
+
+	return nil
+}
+
+var _ types.DistributedCoordinator = (*countingCoordinator)(nil)
+
+// benchReadFixture is the shared setup: one object seeded, its version in the metadata cache, and one
+// read already performed so the range is cached.
+//
+// Read-ahead is configured off rather than left at its default. A prefetch is an asynchronous GET on a
+// goroutine of its own, and one landing mid-loop would put a backend call inside a timed region that
+// asserts there are none. Turning it off is also what makes the two arms of each pair comparable: with
+// it on, the difference between them could be a difference in how many prefetches happened to land.
+func benchReadFixture(b *testing.B, key string, size int, coord types.DistributedCoordinator) (*FileSystem, *benchBackend, *FileHandle) {
+	b.Helper()
+
+	backend := newBenchBackend()
+
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	if err := backend.PutObject(b.Context(), key, payload, nil); err != nil {
+		b.Fatalf("seeding %q: %v", key, err)
+	}
+
+	writer, err := vfs.NewWriter(b.Context(), backend)
+	if err != nil {
+		b.Fatalf("vfs.NewWriter: %v", err)
+	}
+
+	byteCache := cache.NewLRUCache(&cache.CacheConfig{
+		MaxSize:    64 << 20,
+		MaxEntries: 10000,
+		TTL:        time.Hour,
+	})
+	b.Cleanup(func() { _ = byteCache.Close() })
+
+	fs := NewFileSystem(b.Context(), backend, byteCache, writer, nil, &Config{
+		DefaultMode:    0o644,
+		DefaultDirMode: 0o755,
+		DefaultUID:     1000,
+		DefaultGID:     1000,
+		ReadAhead:      &ReadAheadConfig{Enabled: false},
+	})
+	fs.coordinator = coord
+
+	// The version the announcement will carry, put in the metadata cache the way a stat puts it there.
+	// Through statObject — the production path Getattr and Lookup both reach — rather than by writing to
+	// the cache directly, so the uncached arm below is measuring the same lookup a mounted filesystem
+	// performs and not a shortcut.
+	if _, err := fs.statObject(b.Context(), key); err != nil {
+		b.Fatalf("statObject(%q): %v", key, err)
+	}
+
+	fh := &FileHandle{
+		fs:     fs,
+		handle: 1,
+		file: &OpenFile{
+			path:        key,
+			lastAccess:  time.Now(),
+			accessCount: 1,
+		},
+	}
+
+	// One read, so the range is cached and the write path's node exists. Both matter: without the node,
+	// the first timed iteration would pay a HEAD that none of the others do.
+	dest := make([]byte, benchReadSize)
+	if _, errno := fh.Read(b.Context(), dest, 0); errno != 0 {
+		b.Fatalf("warming read: errno %v", errno)
+	}
+
+	return fs, backend, fh
+}
+
+const (
+	// benchObjectSize is comfortably larger than a read, so no read is clamped at EOF.
+	benchObjectSize = 1 << 20
+
+	// benchReadSize is the kernel's default MaxRead, which is the size a mounted filesystem is actually
+	// asked for.
+	benchReadSize = 128 * 1024
+)
+
+// BenchmarkCachedReadWithoutCoordinator is the single-node mount, which is very nearly every mount.
+//
+// This is the number the criterion is about, and the one to compare against when the read path changes
+// again.
+func BenchmarkCachedReadWithoutCoordinator(b *testing.B) {
+	_, backend, fh := benchReadFixture(b, "bench-cached-solo.dat", benchObjectSize, nil)
+	ctx := b.Context()
+	dest := make([]byte, benchReadSize)
+
+	before := backend.calls()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		if _, errno := fh.Read(ctx, dest, 0); errno != 0 {
+			b.Fatalf("Read: errno %v", errno)
+		}
+	}
+
+	b.StopTimer()
+
+	// The claim the file comment rests on, checked rather than asserted in prose: an in-memory backend is
+	// admissible here because the timed loop never reaches it. If a change to the read path puts a request
+	// back in this loop — a metadata refresh, a size check that misses — this figure stops being a
+	// cache-hit measurement and the failure says so.
+	if got := backend.calls() - before; got != 0 {
+		b.Fatalf("the cached read benchmark made %d backend requests inside its timed loop, so it is "+
+			"measuring an uncached read and the in-memory backend under it is now load-bearing", got)
+	}
+}
+
+// BenchmarkCachedReadWithCoordinator is the clustered mount, for the difference rather than the absolute.
+//
+// A cache hit returns before reaching the announce call, so the two should be indistinguishable. If they
+// are not, the coordinator is being consulted on a path that has no need of it.
+func BenchmarkCachedReadWithCoordinator(b *testing.B) {
+	coord := &countingCoordinator{}
+	_, _, fh := benchReadFixture(b, "bench-cached-cluster.dat", benchObjectSize, coord)
+	ctx := b.Context()
+	dest := make([]byte, benchReadSize)
+
+	// From a baseline, because the fixture's warming read is a miss and announces — one announcement, and
+	// asserting zero in total reported it as the defect below rather than as setup.
+	before := coord.announces.Load()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		if _, errno := fh.Read(ctx, dest, 0); errno != 0 {
+			b.Fatalf("Read: errno %v", errno)
+		}
+	}
+
+	b.StopTimer()
+
+	// A hit must not announce. This is the same claim TestReadAnnouncesWhatItCached's fixture makes from
+	// the other direction, and it is worth re-checking here because it is the reason the two cached
+	// figures are expected to match: if a hit did announce, "no difference" would be the finding to
+	// distrust rather than the one to report.
+	if got := coord.announces.Load() - before; got != 0 {
+		b.Fatalf("%d announcements from reads served entirely from cache; announcing bytes this node "+
+			"already held tells peers nothing new and puts a coordinator call on the hot path", got)
+	}
+}
+
+// BenchmarkUncachedReadWithoutCoordinator is the miss path with nothing to tell.
+//
+// Both uncached benchmarks evict the range inside the timed loop, because a miss requires one and doing
+// it outside would measure b.N-1 hits. That makes the absolute figure a read-plus-evict rather than a
+// read, and it is the same on both sides, so the difference between the two remains attributable to the
+// coordinator. Compare the pair; do not read either number as read throughput.
+func BenchmarkUncachedReadWithoutCoordinator(b *testing.B) {
+	const key = "bench-uncached-solo.dat"
+
+	fs, _, fh := benchReadFixture(b, key, benchObjectSize, nil)
+	ctx := b.Context()
+	dest := make([]byte, benchReadSize)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		fs.cache.Delete(key)
+
+		if _, errno := fh.Read(ctx, dest, 0); errno != 0 {
+			b.Fatalf("Read: errno %v", errno)
+		}
+	}
+}
+
+// BenchmarkUncachedReadWithCoordinator is the miss path that announces, which is the only place #141 adds
+// work to a read.
+func BenchmarkUncachedReadWithCoordinator(b *testing.B) {
+	const key = "bench-uncached-cluster.dat"
+
+	coord := &countingCoordinator{}
+	fs, _, fh := benchReadFixture(b, key, benchObjectSize, coord)
+	ctx := b.Context()
+	dest := make([]byte, benchReadSize)
+
+	before := coord.announces.Load()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		fs.cache.Delete(key)
+
+		if _, errno := fh.Read(ctx, dest, 0); errno != 0 {
+			b.Fatalf("Read: errno %v", errno)
+		}
+	}
+
+	b.StopTimer()
+
+	// Every iteration must have announced. Without this the benchmark would happily report a figure for
+	// the path where announceCached returns early — no coordinator, no cached version, no bytes — and that
+	// figure is indistinguishable from the nil-coordinator one by construction, which is exactly the
+	// agreement it is supposed to be testing for.
+	if got := coord.announces.Load() - before; got < int64(b.N) {
+		b.Fatalf("%d announcements over %d uncached reads: this benchmark is not exercising the announce "+
+			"path it exists to measure", got, b.N)
+	}
+}

--- a/internal/fuse/coordinate_test.go
+++ b/internal/fuse/coordinate_test.go
@@ -1,0 +1,679 @@
+//go:build linux || darwin
+
+package fuse
+
+// These tests cover what the read and write paths tell the cluster (#141), against a real S3 endpoint, a
+// real byte-range cache, and a real write path — mocked only at the seam under test, which is the
+// coordinator itself.
+//
+// That one mock is unavoidable and worth justifying, given that read_path_test.go in this package refuses
+// mocks on principle. The alternative is two gossip sockets over loopback, and it would move the
+// assertion to the wrong place: what is under test here is *which announcements and invalidations this
+// package makes, with which fields*, and internal/distributed's own tests already cover what a peer does
+// with one. A recording coordinator is the only way to see a call whose errors are logged and never
+// returned.
+//
+// What is deliberately *not* mocked is the metadata cache, and that matters more than it looks: the ETag
+// an announcement carries comes from it, so a fake there would let the announce path pass while reading a
+// version from a source production does not have. The cache is real and the object's version is put in it
+// the way the kernel does — by a stat before the read.
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// coordFixture is a FileSystem with a recording coordinator on it.
+type coordFixture struct {
+	fs    *FileSystem
+	srv   *testaws.TestServer
+	coord *recordingCoordinator
+}
+
+func newCoordFixture(t *testing.T) *coordFixture {
+	t.Helper()
+
+	srv := testaws.Start(t)
+
+	// Every read below is ranged. Against an endpoint that ignores Range the whole object comes back, and
+	// an announcement's Length would describe the object rather than the range that was cached.
+	srv.RequireRangeGET()
+
+	backend := srv.Backend()
+
+	writer, err := vfs.NewWriter(t.Context(), backend)
+	if err != nil {
+		t.Fatalf("vfs.NewWriter: %v", err)
+	}
+
+	byteCache := cache.NewLRUCache(&cache.CacheConfig{
+		MaxSize:    16 << 20,
+		MaxEntries: 10000,
+		TTL:        time.Hour,
+	})
+	t.Cleanup(func() { _ = byteCache.Close() })
+
+	coord := &recordingCoordinator{}
+
+	fs := NewFileSystem(t.Context(), backend, byteCache, writer, nil, &Config{
+		DefaultMode:    0o644,
+		DefaultDirMode: 0o755,
+		DefaultUID:     1000,
+		DefaultGID:     1000,
+	})
+	fs.coordinator = coord
+
+	return &coordFixture{fs: fs, srv: srv, coord: coord}
+}
+
+// root returns the mount's root node, attached to a bridge.
+//
+// Attached, because Mkdir and Create build a child inode through Inode.NewInode, which dereferences the
+// bridge — a bare &DirectoryNode{} panics there. [readPathFixture.root] in attributes_test.go does the
+// same thing for the same reason; this is the same helper on a fixture that carries a coordinator.
+func (f *coordFixture) root(t *testing.T) *DirectoryNode {
+	t.Helper()
+
+	root, ok := f.fs.Root().(*DirectoryNode)
+	if !ok {
+		t.Fatalf("FileSystem.Root returned %T, want *DirectoryNode", f.fs.Root())
+	}
+
+	timeout := f.fs.attrTimeout()
+	_ = gofuse.NewNodeFS(root, &gofuse.Options{
+		AttrTimeout:     &timeout,
+		EntryTimeout:    &timeout,
+		NullPermissions: true,
+	})
+
+	return root
+}
+
+// stat populates the metadata cache the way the kernel does before a read.
+//
+// Through Lookup rather than by writing to the cache directly, because the announce path's whole
+// dependency is that the version it needs is *already there* by the time a read misses — put there by the
+// stat the kernel must issue to learn a size. A test that seeded the cache itself would pass whether or
+// not that were true.
+func (f *coordFixture) stat(t *testing.T, key string) {
+	t.Helper()
+
+	var out fuse.EntryOut
+	if _, errno := f.root(t).Lookup(t.Context(), key, &out); errno != 0 {
+		t.Fatalf("Lookup(%q) returned %v", key, errno)
+	}
+}
+
+// open returns a handle for an existing object, as [readPathFixture.open] does.
+func (f *coordFixture) open(key string) *FileHandle {
+	return &FileHandle{
+		fs:     f.fs,
+		handle: 1,
+		file: &OpenFile{
+			path:        key,
+			lastAccess:  time.Now(),
+			accessCount: 1,
+		},
+	}
+}
+
+// read performs one FUSE read of n bytes at off.
+func (f *coordFixture) read(t *testing.T, fh *FileHandle, off int64, n int) []byte {
+	t.Helper()
+
+	dest := make([]byte, n)
+
+	result, errno := fh.Read(t.Context(), dest, off)
+	if errno != 0 {
+		t.Fatalf("Read(off=%d, n=%d): errno %v", off, n, errno)
+	}
+
+	got, status := result.Bytes(dest)
+	if !status.Ok() {
+		t.Fatalf("Read(off=%d, n=%d): result status %v", off, n, status)
+	}
+
+	return got
+}
+
+// TestReadAnnouncesWhatItCached is #141's acceptance criterion for the announce half, and every field is
+// asserted because every one of them is a field a peer's fetch decision depends on.
+//
+// The Size/Length distinction is the one worth stating: Size is the whole object's and Length is the
+// range's. Announcing len(data) as both would tell a peer that a 4 KiB range of a 64 KiB object is the
+// entire file, and the peer would fetch 4 KiB believing it had the object.
+func TestReadAnnouncesWhatItCached(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+
+	const (
+		key      = "announced.dat"
+		size     = 65536
+		readAt   = 4096
+		readSize = 8192
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	info, err := f.fs.backend.HeadObject(t.Context(), key)
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	fh := f.open(key)
+	got := f.read(t, fh, readAt, readSize)
+	if len(got) != readSize {
+		t.Fatalf("read %d bytes, want %d", len(got), readSize)
+	}
+
+	anns := f.coord.announcements()
+	if len(anns) == 0 {
+		t.Fatal("a read that populated the cache announced nothing, so a peer wanting these bytes reads " +
+			"S3 while this node holds them")
+	}
+
+	// The read-ahead manager issues its own fetches, each of which announces, so this asserts on the
+	// announcement for the range actually read rather than on there being exactly one.
+	var ann *types.KeyAnnouncement
+	for i := range anns {
+		if anns[i].Offset == readAt {
+			ann = &anns[i]
+
+			break
+		}
+	}
+	if ann == nil {
+		t.Fatalf("no announcement for the range that was read (offset %d); got %+v", readAt, anns)
+	}
+
+	if ann.Key != key {
+		t.Errorf("announced key %q, want %q", ann.Key, key)
+	}
+
+	if ann.ETag != info.ETag {
+		t.Errorf("announced ETag %q, want the object's %q; a peer checks what it fetches against this, so "+
+			"a wrong version costs it a rejected fetch and an S3 read", ann.ETag, info.ETag)
+	}
+
+	if ann.Size != size {
+		t.Errorf("announced Size %d, want the object's %d — Size is the object's length, not the range's",
+			ann.Size, size)
+	}
+
+	if ann.Length != readSize {
+		t.Errorf("announced Length %d, want the range's %d — a peer that asks for more than the holder "+
+			"cached makes the holder fetch from S3, which is slower than the peer reading S3 itself",
+			ann.Length, readSize)
+	}
+
+	if ann.CachedAt.IsZero() {
+		t.Error("announced a zero CachedAt; a recipient prefers the freshest of several claims for a key " +
+			"and cannot order them without it")
+	}
+
+	// NodeID is deliberately empty here: [distributed.Coordinator.AnnounceKey] overwrites it with the
+	// cluster's own ID, because a node announcing under another's would send peers to a host that never
+	// cached the bytes. This package has no access to the node ID and must not invent one.
+	if ann.NodeID != "" {
+		t.Errorf("announced NodeID %q; this package does not know the cluster's node ID and the "+
+			"coordinator overwrites the field, so setting it here can only be wrong", ann.NodeID)
+	}
+}
+
+// TestReadWithNoKnownVersionDoesNotAnnounce is the fail-closed direction, applied to the one field #141's
+// specification does not carry.
+//
+// The bytes come from [types.Backend.GetObject], which returns no version, so the ETag comes from the
+// metadata cache — and when there is nothing there, there is no version to name. An announcement with an
+// empty ETag would be refused by [distributed.Coordinator.AnnounceKey] anyway; what must not happen is
+// this package inventing one to fill the field, because a peer that fetches bytes it cannot place against
+// a version of the object hands them to a reading process as file content.
+//
+// A read with no preceding stat is not contrived — [FileHandle.Read] does not stat, and a handle can
+// outlive its metadata cache entry, which expires on the metadata TTL while the content entry has its own.
+func TestReadWithNoKnownVersionDoesNotAnnounce(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+
+	const key = "unstatted.dat"
+	f.srv.SeedRandom(key, 32768)
+
+	// No f.stat: nothing populates the metadata cache, so no version is known for the object.
+	fh := f.open(key)
+	if got := f.read(t, fh, 0, 4096); len(got) != 4096 {
+		t.Fatalf("read %d bytes, want 4096", len(got))
+	}
+
+	if anns := f.coord.announcements(); len(anns) != 0 {
+		t.Errorf("announced %+v with no version known for the object; a peer fetching bytes it cannot "+
+			"place against an object version hands them to a reading process as file content", anns)
+	}
+}
+
+// TestReadStillSucceedsWhenAnnouncingFails is the fire-and-forget property, asserted against a call that
+// actually fails.
+//
+// An announcement is an optimization: a peer that never hears it reads from S3, which is correct and
+// merely slower. Failing the read(2) over it would turn a slower read into no read at all.
+func TestReadStillSucceedsWhenAnnouncingFails(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+	f.coord.announceErr = errors.New("gossip is not listening")
+
+	const key = "announce-fails.dat"
+	content := f.srv.SeedRandom(key, 8192)
+	f.stat(t, key)
+
+	fh := f.open(key)
+	got := f.read(t, fh, 0, 4096)
+
+	if len(got) != 4096 || string(got) != string(content[:4096]) {
+		t.Errorf("a read whose announcement failed returned %d wrong bytes; the announcement is an "+
+			"optimization and its failure must not reach the reader", len(got))
+	}
+
+	if len(f.coord.announcements()) == 0 {
+		t.Error("the announcement was not attempted, so this test asserts nothing about its failure")
+	}
+}
+
+// TestFlushInvalidatesOnPeersWithTheWriteOwnETag is the invalidate half's headline, and the ETag is the
+// assertion that matters.
+//
+// [types.DistributedCoordinator.InvalidateKey] requires the version *the write itself* reported, not one
+// from a later HeadObject, which could name a third node's subsequent write. A receiver's replay ledger is
+// keyed on (key, etag), so a version naming somebody else's write suppresses an invalidation that has not
+// been applied — and the peer keeps serving bytes that were replaced.
+func TestFlushInvalidatesOnPeersWithTheWriteOwnETag(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+
+	const key = "written.dat"
+
+	if err := f.fs.buffer.Write(key, 0, []byte("hello cluster")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	fh := f.open(key)
+	if errno := fh.Flush(t.Context()); errno != 0 {
+		t.Fatalf("Flush returned %v", errno)
+	}
+
+	info, err := f.fs.backend.HeadObject(t.Context(), key)
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	invs := f.coord.invalidations()
+	if len(invs) == 0 {
+		t.Fatal("a flush told no peer to evict the key it just wrote, so every peer holding it serves the " +
+			"previous contents until its cache expires")
+	}
+
+	var content *invalidation
+	for i := range invs {
+		if invs[i].key == key {
+			content = &invs[i]
+
+			break
+		}
+	}
+	if content == nil {
+		t.Fatalf("no invalidation for %q; got %+v", key, invs)
+	}
+
+	if content.etag == "" {
+		t.Error("invalidated with no version; every receiver then applies it on every retransmission, " +
+			"which is safe but is not what a write that knows its own ETag should send")
+	}
+
+	if content.etag != info.ETag {
+		t.Errorf("invalidated at version %q but the stored object is %q. A receiver's replay ledger is "+
+			"keyed on this, so a version naming a different write suppresses an invalidation that was "+
+			"never applied", content.etag, info.ETag)
+	}
+}
+
+// TestFlushInvalidatesTheMetadataKeyToo covers the half that is invisible on one node.
+//
+// [FileSystem.invalidate] drops both the content key and metaCacheKey(path), because a write changes the
+// bytes *and* the size and mtime a stat reports; dropping only one leaves a file whose stat size does not
+// match what read returns. A peer receiving an invalidation evicts one key —
+// [distributed.GossipProtocol.handleCacheInvalidate] calls cache.Delete(m.Key) — so both have to be sent,
+// and the absence of the metadata one produces exactly that disagreement across a node boundary.
+//
+// The metadata key travels unversioned even though the content key has an ETag. The version names the
+// object's *bytes*, and the ledger is keyed on (key, etag): reusing it for the metadata key would claim to
+// describe bytes that key does not hold.
+func TestFlushInvalidatesTheMetadataKeyToo(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+
+	const key = "both-keys.dat"
+
+	if err := f.fs.buffer.Write(key, 0, []byte("hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	fh := f.open(key)
+	if errno := fh.Flush(t.Context()); errno != 0 {
+		t.Fatalf("Flush returned %v", errno)
+	}
+
+	var meta *invalidation
+	for _, inv := range f.coord.invalidations() {
+		if inv.key == metaCacheKey(key) {
+			meta = &inv
+
+			break
+		}
+	}
+
+	if meta == nil {
+		t.Fatalf("the write did not invalidate %q on peers, so a peer that has stat'ed the object reports "+
+			"its pre-write size while serving post-write content: got %v", metaCacheKey(key),
+			f.coord.invalidatedKeys())
+	}
+
+	if meta.etag != "" {
+		t.Errorf("the metadata key was invalidated at version %q; that ETag names the object's bytes, "+
+			"which this key does not hold, and it writes a ledger entry claiming otherwise", meta.etag)
+	}
+}
+
+// TestFlushStillSucceedsWhenInvalidatingFails asserts the write path does not fail over an invalidation.
+//
+// Unlike an announcement, an unsent invalidation is not merely slower — peers keep serving replaced bytes
+// until their cache TTL expires. Failing close(2) over it would still be wrong: the object *is* durable
+// and the caller's data *is* stored, so reporting failure would tell a program its write was lost when it
+// was not. The gap is bounded by the TTL and reported by a Warn log; that is the trade, made explicitly.
+func TestFlushStillSucceedsWhenInvalidatingFails(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+	f.coord.invalidateErr = errors.New("gossip is not listening")
+
+	const key = "invalidate-fails.dat"
+	const content = "durable regardless"
+
+	if err := f.fs.buffer.Write(key, 0, []byte(content)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	fh := f.open(key)
+	if errno := fh.Flush(t.Context()); errno != 0 {
+		t.Fatalf("Flush returned %v after a failed invalidation; the object is durable and reporting "+
+			"failure would tell the program its write was lost", errno)
+	}
+
+	// The object, not the call log: what makes the errno above correct is that the bytes really are stored.
+	stored, err := f.fs.backend.GetObject(t.Context(), key, 0, 0)
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if string(stored) != content {
+		t.Errorf("stored %q, want %q", stored, content)
+	}
+}
+
+// TestDeletesInvalidateOnPeersWithNoVersion covers every mutation that has no ETag to name, in one table.
+//
+// An empty ETag is legal and documented: a delete has no version, and neither does an unconditional
+// PutObject, which reports nothing. Every receiver then applies the invalidation every time — a redundant
+// eviction, which can never serve stale bytes. What must not happen is a version being invented to fill
+// the field.
+func TestDeletesInvalidateOnPeersWithNoVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// seed prepares the bucket and returns the key the operation should invalidate.
+		seed func(t *testing.T, f *coordFixture) string
+		run  func(t *testing.T, f *coordFixture, key string)
+	}{
+		{
+			name: "unlink",
+			seed: func(t *testing.T, f *coordFixture) string {
+				t.Helper()
+
+				const key = "doomed.dat"
+				if err := f.fs.backend.PutObject(t.Context(), key, []byte("bytes"), nil); err != nil {
+					t.Fatalf("seed: %v", err)
+				}
+
+				return key
+			},
+			run: func(t *testing.T, f *coordFixture, key string) {
+				t.Helper()
+
+				root := f.root(t)
+				if errno := root.Unlink(t.Context(), key); errno != 0 {
+					t.Fatalf("Unlink returned %v", errno)
+				}
+			},
+		},
+		{
+			name: "mkdir",
+			seed: func(t *testing.T, f *coordFixture) string {
+				t.Helper()
+
+				return "newdir/"
+			},
+			run: func(t *testing.T, f *coordFixture, key string) {
+				t.Helper()
+
+				root := f.root(t)
+
+				var out fuse.EntryOut
+				if _, errno := root.Mkdir(t.Context(), strings.TrimSuffix(key, "/"), 0o755,
+					&out); errno != 0 {
+					t.Fatalf("Mkdir returned %v", errno)
+				}
+			},
+		},
+		{
+			name: "rmdir",
+			seed: func(t *testing.T, f *coordFixture) string {
+				t.Helper()
+
+				const key = "gone/"
+				if err := f.fs.backend.PutObject(t.Context(), key, []byte{}, nil); err != nil {
+					t.Fatalf("seed: %v", err)
+				}
+
+				return key
+			},
+			run: func(t *testing.T, f *coordFixture, key string) {
+				t.Helper()
+
+				root := f.root(t)
+				if errno := root.Rmdir(t.Context(), strings.TrimSuffix(key, "/")); errno != 0 {
+					t.Fatalf("Rmdir returned %v", errno)
+				}
+			},
+		},
+		{
+			name: "create",
+			seed: func(t *testing.T, f *coordFixture) string {
+				t.Helper()
+
+				return "fresh.dat"
+			},
+			run: func(t *testing.T, f *coordFixture, key string) {
+				t.Helper()
+
+				root := f.root(t)
+
+				var out fuse.EntryOut
+				_, _, _, errno := root.Create(t.Context(), key, uint32(syscall.O_WRONLY), 0o644, &out)
+				if errno != 0 {
+					t.Fatalf("Create returned %v", errno)
+				}
+
+				// The handle is deliberately left unreleased. Release flushes, and the flush invalidates
+				// the same key — so a Release here would satisfy the assertion below whether or not Create
+				// invalidated anything, which is exactly what a mutation showed: removing Create's own
+				// call left this subtest green until the Release came out.
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newCoordFixture(t)
+			key := tc.seed(t, f)
+			tc.run(t, f, key)
+
+			var found *invalidation
+			for _, inv := range f.coord.invalidations() {
+				if inv.key == key {
+					found = &inv
+
+					break
+				}
+			}
+
+			if found == nil {
+				t.Fatalf("%s did not invalidate %q on peers; got %v", tc.name, key,
+					f.coord.invalidatedKeys())
+			}
+
+			if found.etag != "" {
+				t.Errorf("%s invalidated %q at version %q; this operation reports no version, so the "+
+					"only honest answer is an empty ETag and inventing one is what the interface "+
+					"forbids", tc.name, key, found.etag)
+			}
+		})
+	}
+}
+
+// TestRenameInvalidatesBothNamesOnPeers is the one operation whose invalidations a single-node test cannot
+// distinguish from half of them.
+//
+// A rename changes two keys, and a peer that holds either serves a file that has moved. Forgetting the
+// source leaves peers serving a file that no longer exists at that name; forgetting the destination leaves
+// them serving whatever the rename overwrote.
+func TestRenameInvalidatesBothNamesOnPeers(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+
+	const (
+		src = "before.dat"
+		dst = "after.dat"
+	)
+
+	if err := f.fs.backend.PutObject(t.Context(), src, []byte("moved bytes"), nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	root := f.root(t)
+	if errno := root.Rename(t.Context(), src, root, dst, 0); errno != 0 {
+		t.Fatalf("Rename returned %v", errno)
+	}
+
+	keys := f.coord.invalidatedKeys()
+
+	for _, want := range []string{src, dst} {
+		if !slices.Contains(keys, want) {
+			t.Errorf("rename did not invalidate %q on peers; a peer holding it serves a file that has "+
+				"moved. Invalidated: %v", want, keys)
+		}
+	}
+}
+
+// TestNoCoordinatorMakesNoCalls is the single-node guarantee, asserted where it is cheapest to break.
+//
+// Nearly every mount takes this path. The assertion is not that the calls are skipped — there is nothing to
+// call — but that the read and write paths behave identically: a nil coordinator must not change a byte of
+// what a read returns or what a flush stores. A panic here would be the visible failure; a changed answer
+// would be the invisible one, which is why both are checked.
+func TestNoCoordinatorMakesNoCalls(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+	f.fs.coordinator = nil
+
+	const readKey = "solo-read.dat"
+	content := f.srv.SeedRandom(readKey, 8192)
+	f.stat(t, readKey)
+
+	if got := f.read(t, f.open(readKey), 0, 4096); string(got) != string(content[:4096]) {
+		t.Error("a read on a mount with no coordinator returned different bytes")
+	}
+
+	// A key of its own for the write half. Writing over the read key would exercise read-modify-write —
+	// correct behavior, since a partial write to an existing object must preserve the tail — and the
+	// assertion below would then be comparing against the wrong thing for reasons that have nothing to do
+	// with a coordinator.
+	const (
+		writeKey = "solo-write.dat"
+		written  = "written without a cluster"
+	)
+
+	if err := f.fs.buffer.Write(writeKey, 0, []byte(written)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if errno := f.open(writeKey).Flush(t.Context()); errno != 0 {
+		t.Fatalf("Flush returned %v on a mount with no coordinator", errno)
+	}
+
+	stored, err := f.fs.backend.GetObject(t.Context(), writeKey, 0, 0)
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if string(stored) != written {
+		t.Errorf("stored %q, want %q", stored, written)
+	}
+
+	if anns := f.coord.announcements(); len(anns) != 0 {
+		t.Errorf("the coordinator was called with %d announcements after being set to nil", len(anns))
+	}
+	if invs := f.coord.invalidations(); len(invs) != 0 {
+		t.Errorf("the coordinator was called with %d invalidations after being set to nil", len(invs))
+	}
+}
+
+// TestAnnounceCachedRefusesAnEmptyRead pins the guard on len(data), which exists for a reason worth
+// recording rather than as input hygiene.
+//
+// A read at EOF returns zero bytes and caches nothing. Announcing that would tell a peer this node holds a
+// zero-length range of the key — actionable-looking and useless: the peer dials, gets nothing, and reads
+// S3 anyway, having paid a round trip to learn what no announcement would have told it for free.
+func TestAnnounceCachedRefusesAnEmptyRead(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+
+	const key = "empty-range.dat"
+	f.srv.SeedRandom(key, 4096)
+	f.stat(t, key)
+
+	f.fs.announceCached(t.Context(), key, 4096, nil)
+	f.fs.announceCached(t.Context(), key, 4096, []byte{})
+
+	if anns := f.coord.announcements(); len(anns) != 0 {
+		t.Errorf("announced a zero-length range: %+v. A peer acting on it dials this node, receives "+
+			"nothing, and reads S3 having paid a round trip for the privilege", anns)
+	}
+}

--- a/internal/fuse/coordinator_wiring_test.go
+++ b/internal/fuse/coordinator_wiring_test.go
@@ -34,18 +34,60 @@ import (
 // anything is to record the calls. Everything is guarded by a mutex because those calls happen on
 // whichever goroutine the kernel dispatched the write on.
 //
-// The recorded slices have no reader yet, and deliberately no accessor either. Copy-returning
-// announcements()/invalidations() helpers were written here and removed: the linter reports them
-// unused, which is correct — the calls that fill them are #141's — and a //nolint to keep a helper
-// alive for a caller that does not exist is how a test fixture starts drifting from what the code
-// does. They come back with the test that reads them.
+// The accessors below came back with #141, which is the test that reads them. They were written here
+// during #139, removed because the linter correctly reported them unused, and a //nolint to keep a helper
+// alive for a caller that does not exist is how a test fixture starts drifting from what the code does.
 type recordingCoordinator struct {
-	mu           sync.Mutex
-	announced    []types.KeyAnnouncement
-	invalidated  []string
+	mu          sync.Mutex
+	announced   []types.KeyAnnouncement
+	invalidated []invalidation
+
+	// announceErr and invalidateErr make the calls fail. Both call sites are fire-and-forget with the
+	// error logged and nothing surfaced, so a test asserting the syscall still succeeds needs a way to
+	// make them fail — otherwise "the error is not surfaced" is asserted against a path where no error
+	// ever occurs.
+	announceErr   error
+	invalidateErr error
+
 	queried      []string
 	queryResults []types.KeyAnnouncement
 	queryErr     error
+}
+
+// invalidation is one InvalidateKey call, key and etag together.
+//
+// Both, because the etag is the half that is easy to get wrong invisibly: a receiver's replay ledger is
+// keyed on it, so an invalidation carrying the wrong version suppresses one that was never applied. A
+// recorder that kept only the key would agree with an implementation that passed "" everywhere.
+type invalidation struct {
+	key  string
+	etag string
+}
+
+// announcements returns what was announced.
+func (r *recordingCoordinator) announcements() []types.KeyAnnouncement {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]types.KeyAnnouncement(nil), r.announced...)
+}
+
+// invalidations returns what was invalidated, in call order.
+func (r *recordingCoordinator) invalidations() []invalidation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]invalidation(nil), r.invalidated...)
+}
+
+// invalidatedKeys returns just the keys, for the assertions that do not care about versions.
+func (r *recordingCoordinator) invalidatedKeys() []string {
+	keys := make([]string, 0, len(r.invalidated))
+	for _, inv := range r.invalidations() {
+		keys = append(keys, inv.key)
+	}
+
+	return keys
 }
 
 func (r *recordingCoordinator) ExecuteOperation(ctx context.Context, op any) (any, error) {
@@ -58,9 +100,12 @@ func (r *recordingCoordinator) AnnounceKey(ctx context.Context, ann types.KeyAnn
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Recorded even when it fails. The production AnnounceKey validates before sending — it refuses an
+	// announcement with no ETag — so a test asserting what was *attempted* needs the call regardless of
+	// its outcome.
 	r.announced = append(r.announced, ann)
 
-	return nil
+	return r.announceErr
 }
 
 func (r *recordingCoordinator) QueryKeyOwnership(ctx context.Context, key string) ([]types.KeyAnnouncement, error) {
@@ -76,9 +121,9 @@ func (r *recordingCoordinator) InvalidateKey(ctx context.Context, key, etag stri
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.invalidated = append(r.invalidated, key)
+	r.invalidated = append(r.invalidated, invalidation{key: key, etag: etag})
 
-	return nil
+	return r.invalidateErr
 }
 
 var _ types.DistributedCoordinator = (*recordingCoordinator)(nil)

--- a/internal/fuse/filesystem.go
+++ b/internal/fuse/filesystem.go
@@ -663,8 +663,10 @@ func (n *DirectoryNode) Mkdir(ctx context.Context, name string, mode uint32, out
 		return nil, toErrno(err)
 	}
 
-	// A cached negative or stale entry for this path would outlive the directory's creation.
-	n.fs.invalidate(childPath)
+	// A cached negative or stale entry for this path would outlive the directory's creation. Empty ETag:
+	// PutObject is unconditional and reports no version, and [types.DistributedCoordinator.InvalidateKey]
+	// takes that as "evict whatever you hold" rather than being told an invented one.
+	n.fs.invalidateBoth(ctx, childPath, "")
 
 	return n.newDirEntry(ctx, name, childPath, out), 0
 }
@@ -701,8 +703,9 @@ func (n *DirectoryNode) Create(ctx context.Context, name string, flags uint32, m
 	childPath := n.joinPath(name)
 
 	// Whatever is cached for this path describes an object this create supersedes, including a cached
-	// negative entry from the lookup that preceded it.
-	n.fs.invalidate(childPath)
+	// negative entry from the lookup that preceded it. On peers too: a node that had stat'ed or read the
+	// file this create replaces would otherwise serve it until its cache expired.
+	n.fs.invalidateBoth(ctx, childPath, "")
 
 	uid, gid := n.fs.callerOwner(ctx)
 	attr := vfs.Attr{
@@ -823,7 +826,9 @@ func (n *DirectoryNode) Unlink(ctx context.Context, name string) syscall.Errno {
 		return toErrno(err)
 	}
 
-	n.fs.invalidate(childPath)
+	// A delete has no version to name, which is the case [types.DistributedCoordinator.InvalidateKey]
+	// documents an empty ETag for: every receiver applies it every time, which cannot serve stale bytes.
+	n.fs.invalidateBoth(ctx, childPath, "")
 
 	n.fs.stats.mu.Lock()
 	n.fs.stats.Deletes++
@@ -885,7 +890,9 @@ func (n *DirectoryNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 		return toErrno(err)
 	}
 
-	n.fs.invalidate(childPath)
+	// A delete has no version to name, which is the case [types.DistributedCoordinator.InvalidateKey]
+	// documents an empty ETag for: every receiver applies it every time, which cannot serve stale bytes.
+	n.fs.invalidateBoth(ctx, childPath, "")
 
 	n.fs.stats.mu.Lock()
 	n.fs.stats.Deletes++
@@ -1191,6 +1198,11 @@ func (fs *FileSystem) fetchUncached(ctx context.Context, path string, off, lengt
 	// to change.
 	fs.cache.Put(path, off, data)
 
+	// Tell peers, so a node that wants these bytes can weigh asking this one against reading S3. After the
+	// Put, not before: an announcement for bytes not yet cached invites a fetch this node would have to
+	// serve from S3 itself, which is slower for the peer than reading S3 directly.
+	fs.announceCached(ctx, path, off, data)
+
 	return data, nil
 }
 
@@ -1349,17 +1361,22 @@ func (fh *FileHandle) Write(ctx context.Context, data []byte, off int64) (writte
 // kernel interrupts the syscall that triggered it instead of running to completion against a caller
 // that has gone away.
 func (fh *FileHandle) Flush(ctx context.Context) syscall.Errno {
-	if err := fh.fs.buffer.FlushContext(ctx, fh.file.path); err != nil {
+	// The ETag rather than FlushContext, so the invalidation below can name the version this write
+	// produced. It is only available from inside the flush — see [vfs.Writer.FlushReportingETag] — and an
+	// empty string here is a legitimate "no version to name", not a failure.
+	etag, err := fh.fs.flushReportingETag(ctx, fh.file.path)
+	if err != nil {
 		fh.fs.countError()
 		slog.Error("flush failed", "path", fh.file.path, "error", err)
 
 		return toErrno(err)
 	}
 
-	// Drop what the cache holds for this path now that the object has changed underneath it. Ordered
-	// after the flush, not before: invalidating first would leave a window in which a concurrent read
-	// re-populates the cache from the old object and the flush then makes that entry stale again.
-	fh.fs.invalidate(fh.file.path)
+	// Drop what the cache holds for this path now that the object has changed underneath it, here and on
+	// every peer. Ordered after the flush, not before: invalidating first would leave a window in which a
+	// concurrent read re-populates the cache from the old object and the flush then makes that entry
+	// stale again.
+	fh.fs.invalidateBoth(ctx, fh.file.path, etag)
 
 	fh.file.markClean()
 

--- a/internal/fuse/rename.go
+++ b/internal/fuse/rename.go
@@ -228,8 +228,10 @@ func (n *DirectoryNode) renameOne(ctx context.Context, srcPath, dstPath string) 
 	//
 	// The destination's buffered state is dropped rather than flushed. It belongs to the file this rename
 	// just overwrote, and flushing it would write those bytes over the file that replaced them.
+	// Peers as well as this node, with no ETag: CopyObject reports no version, and a delete has none to
+	// report. Empty is what [types.DistributedCoordinator.InvalidateKey] documents for both.
 	n.fs.buffer.DiscardPrefix(dstPath)
-	n.fs.invalidate(dstPath)
+	n.fs.invalidateBoth(ctx, dstPath, "")
 
 	if err := n.fs.backend.DeleteObject(ctx, srcPath); err != nil {
 		// The copy succeeded, so the data is safe at the destination and the rename has substantially
@@ -245,7 +247,7 @@ func (n *DirectoryNode) renameOne(ctx context.Context, srcPath, dstPath string) 
 	}
 
 	n.fs.buffer.DiscardPrefix(srcPath)
-	n.fs.invalidate(srcPath)
+	n.fs.invalidateBoth(ctx, srcPath, "")
 
 	n.fs.stats.mu.Lock()
 	n.fs.stats.Renames++
@@ -301,7 +303,7 @@ func (n *DirectoryNode) renameTree(ctx context.Context, srcPath, dstPath string,
 		}
 
 		n.fs.buffer.DiscardPrefix(newKey)
-		n.fs.invalidate(newKey)
+		n.fs.invalidateBoth(ctx, newKey, "")
 
 		if err := n.fs.backend.DeleteObject(ctx, key); err != nil {
 			n.fs.countError()
@@ -313,7 +315,7 @@ func (n *DirectoryNode) renameTree(ctx context.Context, srcPath, dstPath string,
 		}
 
 		n.fs.buffer.DiscardPrefix(key)
-		n.fs.invalidate(key)
+		n.fs.invalidateBoth(ctx, key, "")
 
 		moved++
 	}
@@ -327,10 +329,10 @@ func (n *DirectoryNode) renameTree(ctx context.Context, srcPath, dstPath string,
 	// Nothing is written here for either case; the check exists to record why. See [DirectoryNode.Mkdir]
 	// for what the marker is for.
 
-	n.fs.invalidate(srcPath)
-	n.fs.invalidate(srcPrefix)
-	n.fs.invalidate(dstPath)
-	n.fs.invalidate(dstPrefix)
+	n.fs.invalidateBoth(ctx, srcPath, "")
+	n.fs.invalidateBoth(ctx, srcPrefix, "")
+	n.fs.invalidateBoth(ctx, dstPath, "")
+	n.fs.invalidateBoth(ctx, dstPrefix, "")
 
 	n.fs.stats.mu.Lock()
 	n.fs.stats.Renames++

--- a/internal/vfs/flush_etag_test.go
+++ b/internal/vfs/flush_etag_test.go
@@ -1,0 +1,246 @@
+package vfs_test
+
+// [vfs.Writer.FlushReportingETag] exists so a caller can name the version its own write produced (#141).
+// What makes it worth its own file is that the value has exactly one valid source and three legitimate
+// ways of being absent, and getting either wrong is not a cosmetic difference: the ETag is the key of a
+// receiver's replay ledger, so a version naming somebody else's write suppresses an invalidation that
+// has not been applied, and peers keep serving bytes that were replaced.
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// TestFlushReportingETagNamesTheVersionItWrote is the ordinary case, and it asserts against the
+// backend's own record rather than against a literal.
+//
+// The fake derives its ETag from the stored length — "etag-8" for eight bytes — so a test comparing
+// against "etag-8" would pass while reporting a version read from anywhere, including from a HeadObject
+// issued after the fact. Comparing against what HeadObject says *now* is the property that matters: the
+// value came out of this write.
+func TestFlushReportingETagNamesTheVersionItWrote(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+	const key = "f"
+
+	if err := w.Write(key, 0, []byte("AAAABBBB")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	etag, err := w.FlushReportingETag(t.Context(), key)
+	if err != nil {
+		t.Fatalf("FlushReportingETag: %v", err)
+	}
+
+	info, err := backend.HeadObject(t.Context(), key)
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	if etag == "" {
+		t.Fatal("a flush that stored eight bytes reported no version, so an invalidation for it would " +
+			"be unversioned and every receiver would apply it every time")
+	}
+
+	if etag != info.ETag {
+		t.Errorf("flush reported version %q but the stored object is %q; a receiver's replay ledger is "+
+			"keyed on this, so a version naming a different write suppresses an invalidation that was "+
+			"never applied", etag, info.ETag)
+	}
+}
+
+// TestFlushReportingETagAfterAWriteRacedTheUpload asserts the version reported describes the bytes that
+// are actually in the bucket at the end.
+//
+// A write landing during the upload makes [vfs.Node.MarkFlushed] refuse, so the first attempt's ETag
+// names four bytes that the retry immediately replaces with eight. Reporting that version would tell
+// peers to evict at a version no reader can fetch, and would write a ledger entry under it.
+//
+// Be clear about what this does *not* cover: [vfs.Writer.FlushReportingETag]'s `if n.Dirty()` guard is
+// not reachable from here. Flush's retry loop converges before returning, so the node is clean by the
+// time the ETag is read — removing that guard leaves this test green, which is checked rather than
+// assumed. The guard's own comment records that it is defensive.
+func TestFlushReportingETagAfterAWriteRacedTheUpload(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+	const key = "f"
+
+	if err := w.Write(key, 0, []byte("AAAA")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var once sync.Once
+	backend.mu.Lock()
+	backend.onPut = func() {
+		once.Do(func() {
+			if err := w.Write(key, 4, []byte("BBBB")); err != nil {
+				t.Errorf("racing write: %v", err)
+			}
+		})
+	}
+	backend.mu.Unlock()
+
+	etag, err := w.FlushReportingETag(t.Context(), key)
+	if err != nil {
+		t.Fatalf("FlushReportingETag: %v", err)
+	}
+
+	stored, _ := backend.Object(key)
+	if string(stored) != "AAAABBBB" {
+		t.Fatalf("the racing write was lost: stored %q", stored)
+	}
+
+	info, err := backend.HeadObject(t.Context(), key)
+	if err != nil {
+		t.Fatalf("HeadObject: %v", err)
+	}
+
+	// The version of the eight-byte object, not the four-byte one the first attempt uploaded. Reporting
+	// the first attempt's ETag would name a version that existed for the duration of one upload and is
+	// no longer what any reader can fetch.
+	if etag != info.ETag {
+		t.Errorf("flush reported version %q after a write raced the upload, but the stored object is "+
+			"%q — that names content the next flush already replaced", etag, info.ETag)
+	}
+}
+
+// TestFlushReportingETagOnAnUnbufferedKey covers the first of the three legitimate empties.
+//
+// Nothing was buffered, so no write happened and there is no version to name. An error here would break
+// fsync on a file with no pending writes and a second close(2), both of which are no-ops.
+func TestFlushReportingETagOnAnUnbufferedKey(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+
+	etag, err := w.FlushReportingETag(t.Context(), "never-written")
+	if err != nil {
+		t.Fatalf("FlushReportingETag on an unbuffered key: %v, want nil", err)
+	}
+
+	if etag != "" {
+		t.Errorf("reported version %q for a key nothing was buffered for; there is no write for it to "+
+			"name", etag)
+	}
+
+	if calls := backend.Calls(); len(calls) != 0 {
+		t.Errorf("a flush of an unbuffered key issued %d requests: %v", len(calls), calls)
+	}
+}
+
+// TestFlushReportingETagOnAnAttrOnlyFlushOfAnAbsentObject covers the second empty, and it is the one
+// most easily mistaken for a bug.
+//
+// A file created and chmod'ed without ever being written has attributes pending and no object in
+// storage. [vfs.Flusher] takes the attribute-only arm, SetObjectMetadata reports absence, and the node
+// is deliberately left dirty so the pending mode survives to the flush that has content. Nothing was
+// stored, so there is no version — and the flush reports success, because failing would make close(2)
+// fail on a legal sequence.
+func TestFlushReportingETagOnAnAttrOnlyFlushOfAnAbsentObject(t *testing.T) {
+	t.Parallel()
+
+	w, _ := newWriter(t)
+	const key = "created-not-written"
+
+	if err := w.SetAttr(t.Context(), key, true, false, false, vfs.Attr{Mode: 0o600}); err != nil {
+		t.Fatalf("SetAttr: %v", err)
+	}
+
+	etag, err := w.FlushReportingETag(t.Context(), key)
+	if err != nil {
+		t.Fatalf("FlushReportingETag: %v", err)
+	}
+
+	if etag != "" {
+		t.Errorf("reported version %q for a flush that stored nothing: the object does not exist, so no "+
+			"version of it can be named", etag)
+	}
+}
+
+// TestFlushReportingETagPropagatesTheFailure asserts the error path reports no version.
+//
+// An ETag alongside an error would be the worst combination available: a caller that checked the string
+// before the error — which is the shape of every fire-and-forget invalidation — would broadcast a version
+// for a write that never landed, and peers would evict bytes that are still correct.
+//
+// # Why the file is written twice
+//
+// The first flush succeeds, which is what puts a version *on the node*. Without it the node's ETag is
+// empty whatever the code does — a file being created for the first time has no stored version — so a
+// mutation returning `n.Attr().ETag` on the error path would pass, and the test would be asserting
+// nothing. Verified by mutation: with a single write it survives; with the successful flush first it dies.
+func TestFlushReportingETagPropagatesTheFailure(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+	const key = "f"
+
+	if err := w.Write(key, 0, []byte("AAAA")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	firstETag, err := w.FlushReportingETag(t.Context(), key)
+	if err != nil {
+		t.Fatalf("first FlushReportingETag: %v", err)
+	}
+	if firstETag == "" {
+		t.Fatal("the first flush reported no version, so this test cannot tell a suppressed ETag from " +
+			"an absent one")
+	}
+
+	// A second write, whose upload fails. The node now carries firstETag — the version the *previous*
+	// write produced and the one still in the bucket, which is precisely the version peers must not be
+	// told to evict.
+	if err := w.Write(key, 4, []byte("BBBB")); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	wantErr := errors.New("AccessDenied")
+	backend.mu.Lock()
+	backend.putErr = wantErr
+	backend.mu.Unlock()
+
+	etag, err := w.FlushReportingETag(t.Context(), key)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("FlushReportingETag error = %v, want it to wrap %v", err, wantErr)
+	}
+
+	if etag != "" {
+		t.Errorf("reported version %q from a flush that failed; the bucket still holds %q, so peers told "+
+			"to evict at that version would drop bytes that are still current", etag, firstETag)
+	}
+}
+
+// TestFlushContextStillReportsOnlyTheError pins the delegation, because FlushContext is what nearly
+// every caller uses and it is now a wrapper.
+//
+// Trivial-looking, and kept for the reason kernel_options_test.go in internal/fuse rejects copy checks
+// on principle: this one is not a copy check. It asserts the wrapper performs the work — the object is
+// in the bucket afterwards — rather than that two fields agree.
+func TestFlushContextStillReportsOnlyTheError(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+	const key = "f"
+
+	if err := w.Write(key, 0, []byte("AAAA")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := w.FlushContext(t.Context(), key); err != nil {
+		t.Fatalf("FlushContext: %v", err)
+	}
+
+	if got, _ := backend.Object(key); string(got) != "AAAA" {
+		t.Errorf("FlushContext stored %q, want %q", got, "AAAA")
+	}
+
+	if w.Dirty(key) {
+		t.Error("the key is still dirty after a flush that reported success")
+	}
+}

--- a/internal/vfs/writer.go
+++ b/internal/vfs/writer.go
@@ -446,8 +446,33 @@ func (w *Writer) Flush(key string) error {
 
 // FlushContext is [Writer.Flush] with an explicit context.
 func (w *Writer) FlushContext(ctx context.Context, key string) error {
+	_, err := w.FlushReportingETag(ctx, key)
+
+	return err
+}
+
+// FlushReportingETag is [Writer.FlushContext] returning the version the object now holds.
+//
+// # Why the ETag has to come out of here
+//
+// It is read from the node *after* the flush and *before* the node is dropped, which is the only window
+// it exists in. [Node.MarkFlushed] records the ETag that [types.Backend.HeadObject] confirmed, and the
+// delete below is the last reference to the node — so a caller that wanted the version and asked
+// afterwards would have to issue its own HeadObject, and that answer could name a *third* node's
+// subsequent write. [types.DistributedCoordinator.InvalidateKey] is explicit that the etag must be the
+// one the write itself reported for exactly that reason: a receiver's replay ledger is keyed on it, so a
+// version that names someone else's write suppresses an invalidation that has not been applied.
+//
+// An empty ETag with a nil error is a legitimate answer and the caller must not treat it as a failure.
+// Three paths produce it: nothing was buffered for the key, so no write happened; the flush took the
+// attribute-only arm on a file that does not exist in storage yet, which stores nothing; or a write
+// landed during the upload and the node is still dirty, in which case the version in hand describes
+// content that has already been superseded. In every one of those, "I cannot name a version" is the
+// truth, and [types.DistributedCoordinator.InvalidateKey] accepts it as such — it costs a receiver a
+// redundant eviction and can never serve stale bytes.
+func (w *Writer) FlushReportingETag(ctx context.Context, key string) (string, error) {
 	if key == "" {
-		return fmt.Errorf("%w: empty key", ErrInvalid)
+		return "", fmt.Errorf("%w: empty key", ErrInvalid)
 	}
 
 	w.mu.Lock()
@@ -457,21 +482,40 @@ func (w *Writer) FlushContext(ctx context.Context, key string) error {
 	if !ok {
 		// Nothing buffered for this key. Not an error: fsync on a file with no pending writes is a
 		// no-op, and so is a second close.
-		return nil
+		return "", nil
 	}
 
 	if err := w.flusher.Flush(ctx, n); err != nil {
-		return err
+		return "", err
 	}
 
 	// Drop the node only once it is clean. A node still dirty after a flush that reported success
 	// would mean the flusher is broken; dropping it anyway would convert that into data loss.
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if !n.Dirty() {
-		delete(w.nodes, key)
+
+	// Read only when the node is clean, which is a defensive guard rather than a tested path — and worth
+	// saying which, because a mutation removing it leaves this package's tests green.
+	//
+	// A dirty node here means a write landed in the window between [Flusher.Flush] returning nil and this
+	// lock. Nothing deterministic reaches it: Flush's own retry loop converges — a write during an upload
+	// makes MarkFlushed refuse, and the next attempt includes it — so every path that returns nil has just
+	// marked the node clean. The one exception is the attribute-only flush of an object that does not exist
+	// in storage yet, which reports success without marking anything, and there the ETag is empty anyway.
+	//
+	// It is kept because what it guards is not a slower answer. The ETag a dirty node holds is the version
+	// the *last* flush produced, and the pending write means that version is about to be replaced; naming
+	// it in an invalidation writes a ledger entry under a version peers should be told about again, and a
+	// receiver's ledger suppresses the second one. One comparison against a write that just uploaded an
+	// object is not a cost worth trading for that.
+	if n.Dirty() {
+		return "", nil
 	}
-	return nil
+
+	etag := n.Attr().ETag
+	delete(w.nodes, key)
+
+	return etag, nil
 }
 
 // FlushAll makes every buffered key durable. It implements [types.WriteBuffer].


### PR DESCRIPTION
Closes #141. Third of the warming chain, after #399 and #140.

## What this is

#140 gave the cluster the vocabulary — `AnnounceKey`, `QueryKeyOwnership`, `InvalidateKey` over gossip. This is the read and write paths using it:

- a read that misses and fetches from S3 **announces** the range it cached, so a peer wanting those bytes can weigh asking against reading S3
- a flush, an unlink, an rmdir, a mkdir, a create and **both halves of a rename** invalidate on every peer as well as locally

Until this, every part of the invalidation machinery existed and nothing called it. A two-node deployment served a file's previous contents for up to five minutes after another node overwrote it, with nothing in the logs to say so.

## Three decisions worth review

**The invalidation carries the ETag the write itself reported.** This is why `vfs.Writer` grows `FlushReportingETag` and `FileHandle.Flush` asks for it. A receiver's replay ledger is keyed on `(key, version)`, so a version fetched from a later `HeadObject` could name a *third* node's subsequent write and suppress an invalidation that was never applied. A delete has no version to name and sends an empty one — legal, means "evict whatever you hold", and cannot serve wrong bytes. An empty ETag with a nil error is a legitimate answer from the flush and is documented as such in three places, because reading it as a failure would fail writes that succeeded.

**Local and remote eviction go through a single call.** Every mutation already called `invalidate`; a cluster call sitting beside each of those as a separate statement is a pair a future mutation path can add one half of, and the half easier to forget is the remote one — invisible on a single-node mount and on every test that does not run two nodes.

**An announcement without a known version is not sent.** The ETag comes from the metadata cache, populated by the stat the kernel must issue before any read. With nothing there, nothing is announced rather than a version being invented: a peer that fetches bytes it cannot place against an object version hands them to a reading process as file content. The gap that remains — an overwrite between the stat and the GET — costs a peer a rejected fetch and an S3 read, which is what it would have had with no announcement at all. That reasoning is in the code, at `announceCached`.

Both directions are fire-and-forget and neither fails a syscall. They are not logged alike: a lost announcement costs a peer an S3 read, which is slower and nothing more (Debug), while a lost invalidation means peers serve bytes this node replaced until their cache TTL expires and nothing else in the system reports it (Warn).

## Tests

**`internal/fuse/coordinate_test.go`** — ten tests against a recording coordinator, a real S3 endpoint via `internal/testaws`, a real byte-range cache and a real write path. The coordinator is the only mock and the file says why: what is under test is *which* announcements and invalidations this package makes with which fields, and a call whose errors are logged and never returned cannot be observed any other way. The metadata cache is deliberately **not** mocked — the announcement's ETag comes from it, so a fake there would let the announce path pass while reading a version production does not have.

Covered: the announcement's Size is the object's and its Length is the range's (not collapsed); `NodeID` is left empty because this package does not know it and the coordinator overwrites it; a read with no preceding stat announces nothing; a failing announce or invalidate still returns errno 0 with the right bytes read and stored; the metadata key is invalidated too, with an empty ETag; every delete-shaped operation invalidates with no version; a nil coordinator changes neither the bytes read nor the bytes stored.

**`internal/distributed/fuse_twonode_test.go`** — the two-node criterion, and nothing here is mocked but the second host. Two real filesystems, two real gossip sockets on loopback via the existing `startGossipPair`, one shared bucket. Node A writes through `Create` → `Write` → `Flush` (the node entry points, so a test cannot pass with #141 reverted) and node B's cached bytes are gone; then the same for `Unlink`, which is worth its own test because an unversioned invalidation takes a different branch in `handleCacheInvalidate` and bypasses the applied-once ledger. It lives in `internal/distributed` because `internal/fuse` cannot reach `startGossipPair` or a `*ClusterManager`'s unexported gossip field, and the absence of an import cycle was verified by compiling a probe rather than reasoned about.

**Mutation testing.** Fifteen mutations applied to the production code, fifteen killed: announce field swaps, a zeroed `CachedAt`, a fabricated ETag, a zero-length announce, the dropped metadata-key invalidation, an empty and a bogus flush ETag, all four per-operation invalidations, both rename halves, and two end-to-end (flush and unlink downgraded to local-only, caught by the two-node tests).

One of those found a real weakness rather than confirming a strength: the create subtest released its handle, `Release` flushes, and the flush invalidates the same key — so it passed with `Create`'s own invalidation removed. The handle is now left unreleased and the finding is recorded in the test.

## Benchmarks

#141's criterion asks for no regression with a nil coordinator, and there was **nothing anywhere in the repository** to compare against: its benchmarks cover the cache, the S3 backend and URI validation, none of which run the FUSE read path. So the comparison is established rather than asserted against a number nobody measured.

| | ns/op | allocs/op |
|---|---|---|
| cached read, no coordinator | 4747 | 2 |
| cached read, with coordinator | 4884 | 2 |
| uncached read, no coordinator | 10586 | 15 |
| uncached read, with coordinator | 13778 | 25 |

The cached pair is the criterion and the two are indistinguishable — a hit never reaches the announce call. The miss pair is where the work is: ~3.2 µs and 10 allocations, nearly all of it the metadata-cache read the ETag comes from, against a call that in production is followed by a UDP fan-out.

Three guards keep those figures honest and all three are mutation-killed: the cached benchmark asserts zero backend requests inside its timed loop, the cached-with-coordinator one asserts zero announcements, and the uncached-with-coordinator one asserts one announcement per iteration — without that last, it would happily report a figure for the early-return path, which is identical to the nil-coordinator path by construction.

They use an in-memory `types.Backend` rather than `internal/testaws`, which is a departure from this package's convention and is justified in the file. `emulator.StartTestServer` takes a `*testing.T` concretely and `testing.TB` has an unexported method, so no cast bridges a `*testing.B` to it — filed upstream as [substrate#605](https://github.com/scttfrdmn/substrate/issues/605). It does not weaken the measurement: the cached pair proves the backend is never reached inside its loop, and for the uncached pair an in-memory GET makes any coordinator overhead a *larger* fraction of the total than it would be against S3, so "no meaningful difference" holds a fortiori.

## Verification

- `go build ./...`, `gofmt -l .`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — clean
- `go test -race -count=1 -tags=distributed ./internal/distributed/...` — clean
- `golangci-lint run --new-from-merge-base=origin/main` — 0 issues
- coverage: `internal/fuse` 69.4%, `internal/vfs` 98.4%, `internal/distributed` 81.8%
- benchmarks at `-count=5`, figures above

One known mutation survivor, pre-existing and documented in both the code and `internal/vfs/flush_etag_test.go`: the `if n.Dirty()` guard in `FlushReportingETag` is unreachable by design.