### PR TITLE
feat(cluster): warm a cold read on a peer's evidence, and a joiner on a join (#142, #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A cache miss now reads further when a peer holds more of the object** ([#142]). A read that misses
+  asks the cluster who holds the key and, if some peer holds a range reaching past what was just read,
+  reads ahead to the end of that range — capped at 4 MiB per miss. The bytes come from **S3, not from the
+  peer**: a gossip datagram carries 5802 bytes of object at the default limit, so a 128 KiB read is 21×
+  over and fails as a 30-second timeout on the requesting host ([#399]). What a peer's claim is evidence
+  of is that the key is hot in this cluster, which is the one thing a cold node cannot learn on its own,
+  and it is worth acting on even when the bytes still cost an S3 read.
+
+  A claim is acted on **only at the version this node is reading**. A holder's range describes the object
+  it cached; against a different version the object may have a different length entirely, so warming on it
+  would fetch bytes chosen by a claim about something else. A version mismatch — or no known version on
+  either side — warms nothing, which costs exactly the read the application asked for. Every claim at the
+  matching version is considered and the furthest-reaching one wins, since holders arrive freshest-first
+  and freshest is not furthest.
+
+  Warming goes through the existing read-ahead queue, so it inherits clamping to EOF, skipping what is
+  already cached, standing off reads in flight, and sharing a fetch with a covering request. It does not
+  touch the read pattern: another node's reads must not decide whether this reader looks sequential. It
+  is triggered by the application's read alone and never by a warm's own fetch, so a warm cannot feed
+  itself and walk the whole object. **`cache.read_ahead.enabled: false` suppresses it entirely**, and
+  suppresses the ownership query too rather than asking and discarding the answer — an operator who
+  turned read-ahead off has said not to read bytes nobody asked for.
+
+- **A joining node is told which keys are hot** ([#143]). A node answering a join follows the membership
+  sync with a `cache_warmup` message listing what it holds, freshest first, and the joiner records those
+  as ownership claims — so it starts knowing where the cluster's working set lives instead of discovering
+  it one miss at a time. Metadata only, like [#140]: the bytes are still fetched from S3 when a read wants
+  them.
+
+  The message is bounded by **measured sealed bytes, not by an entry count**, reusing the mechanism the
+  membership sync already uses. The specification's "max 256 entries" would not have worked: at 52-character
+  keys, 256 announcements seal to 65631 bytes against the default 8192-byte limit, 8× over, so every warmup
+  datagram would be refused at the socket and a joining node would warm nothing at all. 31 fit at that key
+  length — and 31 is not a constant to hardcode either, since it moves with key length, which is why the
+  chunk is grown one entry at a time and sealed to check. A join sends at most four datagrams, ~124 keys at
+  that density, and logs what it held back; the rest reaches the joiner through ordinary announcements.
+
+  A batch is recorded through the same path as a single announcement, so the self-claim refusal, the
+  per-node replacement, the map bound, the local timestamp and the empty-ETag refusal all apply to it
+  unchanged — batching is not a way around any of them. Each entry is credited to the peer the datagram
+  came from rather than to the node named inside it, so one member cannot populate a joiner's whole
+  ownership map with fabricated holders.
+
 - **A write on one node now evicts what its peers have cached** ([#141]). [#140] gave the cluster the
   vocabulary; this is the read and write paths using it. A read that misses and fetches from S3 announces
   the range it cached, so a peer that wants those bytes can weigh asking against reading S3 itself. A

--- a/internal/distributed/cache_announce.go
+++ b/internal/distributed/cache_announce.go
@@ -115,6 +115,110 @@ func (c *Coordinator) recordAnnouncement(ann types.KeyAnnouncement) {
 	c.announcements[ann.Key] = append(holders, heldKey{ann: ann, recordedAt: now})
 }
 
+// recordSelfHolding remembers that this node announced ann, so it can tell a joining peer about it.
+//
+// One entry per key, replacing any earlier one, for the same reason [Coordinator.recordAnnouncement]
+// replaces rather than appends: a node announcing a key twice has not come to hold two versions of it,
+// and offering a joiner an ETag this node has already replaced sends it to fetch bytes that are gone.
+//
+// Bounded by the same maxAnnouncedKeys as the peer map, and evicted the same way — oldest first, since a
+// claim this node made long ago is the one its own cache is likeliest to have evicted since.
+func (c *Coordinator) recordSelfHolding(ann types.KeyAnnouncement) {
+	if ann.Key == "" || ann.ETag == "" {
+		return
+	}
+
+	now := time.Now()
+
+	c.announcementsMu.Lock()
+	defer c.announcementsMu.Unlock()
+
+	if c.selfAnnounced == nil {
+		c.selfAnnounced = make(map[string]heldKey)
+	}
+
+	// Bounded only when this is a new key: a replacement cannot grow the map, so charging it an eviction
+	// would drop live holdings for no gain. Same shape as recordAnnouncement's bound, deliberately.
+	if _, exists := c.selfAnnounced[ann.Key]; !exists && len(c.selfAnnounced) >= maxAnnouncedKeys {
+		c.evictSelfHoldingsLocked(now)
+	}
+
+	c.selfAnnounced[ann.Key] = heldKey{ann: ann, recordedAt: now}
+}
+
+// evictSelfHoldingsLocked makes room in selfAnnounced. c.announcementsMu must be held.
+//
+// Expired first, then oldest, mirroring [Coordinator.evictAnnouncementsLocked]. Dropping an entry costs a
+// joiner one key it will not be told about, so it reads from S3 — slower, never wrong.
+func (c *Coordinator) evictSelfHoldingsLocked(now time.Time) {
+	ttl := c.announcementTTL()
+
+	for key, held := range c.selfAnnounced {
+		if now.Sub(held.recordedAt) > ttl {
+			delete(c.selfAnnounced, key)
+		}
+	}
+
+	if len(c.selfAnnounced) < maxAnnouncedKeys {
+		return
+	}
+
+	type keyAge struct {
+		key      string
+		recorded time.Time
+	}
+
+	ages := make([]keyAge, 0, len(c.selfAnnounced))
+	for key, held := range c.selfAnnounced {
+		ages = append(ages, keyAge{key: key, recorded: held.recordedAt})
+	}
+
+	sort.Slice(ages, func(i, j int) bool { return ages[i].recorded.Before(ages[j].recorded) })
+
+	// A tenth, so overflow is amortized rather than paid on every subsequent insert.
+	for _, entry := range ages[:max(1, len(ages)/10)] {
+		delete(c.selfAnnounced, entry.key)
+	}
+}
+
+// recentHoldings reports what this node has announced holding, freshest first, expired claims excluded.
+//
+// This is what a node sends a joiner (#143), and freshest-first is what makes a truncated answer the
+// useful half rather than an arbitrary one: the warmup message is bounded by the datagram size, not by a
+// count, so the caller sends a prefix of this and drops the tail. Sorting by when this node cached the
+// bytes puts the keys most likely still hot at the front of that prefix.
+//
+// limit is a ceiling on the slice length, applied after sorting; a non-positive limit means no ceiling.
+// It is a guard against building a 65536-entry slice to hand to a caller that can send thirty of them,
+// and it is emphatically not the bound on the message — see [GossipProtocol.marshalWarmupChunk], which
+// measures sealed bytes. A count cannot bound a byte limit.
+func (c *Coordinator) recentHoldings(limit int) []types.KeyAnnouncement {
+	ttl := c.announcementTTL()
+	now := time.Now()
+
+	c.announcementsMu.RLock()
+	live := make([]heldKey, 0, len(c.selfAnnounced))
+	for _, held := range c.selfAnnounced {
+		if now.Sub(held.recordedAt) <= ttl {
+			live = append(live, held)
+		}
+	}
+	c.announcementsMu.RUnlock()
+
+	sort.Slice(live, func(i, j int) bool { return live[i].recordedAt.After(live[j].recordedAt) })
+
+	if limit > 0 && len(live) > limit {
+		live = live[:limit]
+	}
+
+	out := make([]types.KeyAnnouncement, 0, len(live))
+	for _, held := range live {
+		out = append(out, held.ann)
+	}
+
+	return out
+}
+
 // evictAnnouncementsLocked makes room in the announcements map. c.announcementsMu must be held.
 //
 // Expired entries first, since dropping those costs nothing at all — they would be filtered out of
@@ -253,6 +357,13 @@ func (c *Coordinator) AnnounceKey(_ context.Context, ann types.KeyAnnouncement) 
 		return fmt.Errorf("marshaling the announcement for %q: %w", ann.Key, err)
 	}
 
+	// Recorded in selfAnnounced — not in announcements, per the paragraph above — before the send rather
+	// than after it. What this remembers is what this node *holds*, and the cache Put that prompted the
+	// call has already happened; whether the datagram reaches a peer says nothing about that. Recording
+	// only on a successful send would leave a node whose gossip is briefly unreachable unable to warm a
+	// joiner about bytes it demonstrably has.
+	c.recordSelfHolding(ann)
+
 	// Wrapped so the key is in the message. broadcastMessage names the message *type*, which is all it
 	// knows, and "cannot broadcast cache_announce" in a log tells an operator debugging cold reads nothing
 	// about which object went unannounced. The %w keeps [types.ErrNotSupported] reachable through both
@@ -337,12 +448,22 @@ func (c *Coordinator) cleanupAnnouncements(ctx context.Context) {
 }
 
 // sweepExpiredAnnouncements drops every claim past its TTL, and every key left with none.
+//
+// Both maps, and the second one is the half that would leak unnoticed: nothing reads selfAnnounced except
+// [Coordinator.recentHoldings], which filters expired entries itself and so would keep working while the
+// map grew for the life of the mount.
 func (c *Coordinator) sweepExpiredAnnouncements() {
 	ttl := c.announcementTTL()
 	now := time.Now()
 
 	c.announcementsMu.Lock()
 	defer c.announcementsMu.Unlock()
+
+	for key, held := range c.selfAnnounced {
+		if now.Sub(held.recordedAt) > ttl {
+			delete(c.selfAnnounced, key)
+		}
+	}
 
 	for key, holders := range c.announcements {
 		live := holders[:0]

--- a/internal/distributed/cache_warmup.go
+++ b/internal/distributed/cache_warmup.go
@@ -1,0 +1,237 @@
+package distributed
+
+// Cache warming on join (#143): a node that receives a join tells the joiner which keys it holds, so the
+// new node starts with a view of what is hot in this cluster instead of discovering it one cache miss at
+// a time.
+//
+// # What crosses the wire, and what does not
+//
+// Announcements. Metadata, not object bytes — the same split [MessageTypeCacheAnnounce] is under, and for
+// the same measured reason: a sealed datagram at the default limit can carry 5802 bytes of object, so a
+// single 128 KiB read is 21× over (#399). What the joiner does with them is record them in the ownership
+// map, exactly as if the peers had announced each key normally; the bytes still come from S3 when a read
+// actually wants them. The value is knowing *which* keys are worth reading, which is precisely what a
+// cold node cannot learn on its own.
+//
+// This is why the issue's `cache.Warmup(keys)` call is not made here. [cache.MultiLevelCache.Warmup] is
+// one GetObject per key, so calling it on a warmup message would have a joining node issue a whole-object
+// GET for every key in it — turning the cold-start cost this feature exists to reduce into a burst of
+// egress before the node serves a single read, and, on a large-object workload, gigabytes of it. #143's
+// own acceptance criterion ("100% hit rate before any S3 request") cannot be met by that function under
+// any bound, since Warmup *is* the S3 traffic. Recording the announcements meets what the criterion was
+// reaching for and costs nothing.
+//
+// # Why the bound is bytes and never a count
+//
+// #143 specifies "max 256 entries per warmup message to bound UDP payload". Measured against the real
+// seal path at the default 8192-byte limit, with 52-character keys shaped like a research bucket's: 256
+// announcements seal to 65631 bytes, 8× over, so [GossipProtocol.sendMessage] refuses the datagram
+// outright and a joining node warms nothing at all — with the failure visible only in whatever the caller
+// does with the error. 31 of them fit.
+//
+// And 31 is not a constant to write down instead. It is a function of key length, so a deployment with
+// long prefixes gets fewer and one with short keys gets more; TestMarshalWarmupChunk_TheCountVariesWithKeyLength
+// asserts exactly that, because it is the reason no number here would be right. A count cannot bound a
+// byte limit. So each chunk is grown one entry at a time and the whole message sealed to check, which is
+// what [GossipProtocol.syncChunkFits] already does for membership sync.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// maxWarmupDatagrams bounds how many warmup messages one join produces.
+//
+// This is a bound on a burst, which is a real resource, rather than a proxy for a byte limit — the
+// per-message size is decided by measurement below. A node holding 65536 keys would otherwise answer a
+// single join with two thousand datagrams at the 31 entries each fits, aimed at a node that has been alive
+// for milliseconds and is simultaneously receiving a membership sync.
+//
+// Four is sized against what it is for: ~124 keys at that measured density, which is a working set rather
+// than a bucket listing. The joiner learns the rest of the cluster's hot set the ordinary way, from the
+// announcements peers make as they read, over at most one announcementTTL; warmup exists to shorten that,
+// not to replace it. What the joiner gets here is the freshest keys — see [Coordinator.recentHoldings] — so
+// the prefix that fits is the useful part rather than an arbitrary one.
+const maxWarmupDatagrams = 4
+
+// maxWarmupCandidates bounds the slice built to pack from.
+//
+// Only a guard against materializing 65536 announcements to send a few dozen; the number of entries
+// actually sent is decided by sealed size and maxWarmupDatagrams. Generously above what four datagrams
+// can hold at any plausible key length, so it never becomes the effective bound.
+const maxWarmupCandidates = 1024
+
+// sendCacheWarmup tells the node at addr which keys this node holds.
+//
+// Best-effort throughout, and it returns nothing: a joiner that hears no warmup reads from S3, which is
+// correct and merely slower. Every failure is logged at Debug for that reason — with one exception, an
+// entry too large to send at all, which is a misconfiguration rather than a lost packet.
+func (gp *GossipProtocol) sendCacheWarmup(addr string) {
+	coordinator := gp.cluster.getCoordinator()
+	if coordinator == nil {
+		return
+	}
+
+	candidates := coordinator.recentHoldings(maxWarmupCandidates)
+
+	gp.mu.RLock()
+	from := gp.localNode.ID
+	gp.mu.RUnlock()
+
+	sent := 0
+	for range maxWarmupDatagrams {
+		// Also the "this node holds nothing" case, which is every node that has just started, and #143 asks
+		// for it explicitly: an empty warmup message is a datagram a receiver has to parse to learn there is
+		// nothing in it. There is deliberately no separate guard above for that — a second check of the same
+		// condition is one a test cannot distinguish from this one, so removing it would look untested while
+		// being covered, which is worse than having one place to look.
+		if len(candidates) == 0 {
+			break
+		}
+
+		payload, fitted, err := gp.marshalWarmupChunk(candidates)
+		if err != nil {
+			slog.Debug("could not build a cache warmup message", "peer", addr, "error", err)
+
+			return
+		}
+
+		if fitted == 0 {
+			// One announcement alone does not fit a datagram. No chunking can help, and skipping it
+			// silently would drop the freshest key in the cluster with nothing logged — so it is reported
+			// and the rest are attempted, since the entries behind it may be shorter.
+			slog.Warn("a single cache announcement does not fit max_gossip_packet, so it cannot be sent "+
+				"to a joining node; that node will read this key from the object store",
+				"key", candidates[0].Key, "max_gossip_packet", gp.config.MaxGossipPacket)
+
+			candidates = candidates[1:]
+
+			continue
+		}
+
+		if err := gp.sendMessage(addr, &GossipMessage{
+			Type:      MessageTypeCacheWarmup,
+			From:      from,
+			Timestamp: time.Now(),
+			MessageID: gp.generateMessageID(),
+			Data:      payload,
+		}); err != nil {
+			slog.Debug("could not send a cache warmup message to a joining node",
+				"peer", addr, "keys", fitted, "error", err)
+
+			return
+		}
+
+		sent += fitted
+		candidates = candidates[fitted:]
+	}
+
+	// Logged rather than dropped quietly: a bound that silently truncates reads as "everything was sent"
+	// to whoever debugs a joiner that is warm for some keys and cold for others.
+	if len(candidates) > 0 {
+		slog.Debug("sent a joining node the freshest of this node's cached keys; the rest will reach it "+
+			"through ordinary announcements",
+			"peer", addr, "sent", sent, "held_back", len(candidates))
+	}
+}
+
+// marshalWarmupChunk packs as many of anns as fit one sealed datagram, returning the payload and how many
+// entries went into it. A zero count with a nil error means the first entry alone does not fit.
+//
+// The measurement is of the whole sealed message, not of the payload: seal wraps it in JSON with a hex MAC
+// and base64-encodes the data field, so the ratio between the two is not a constant anyone should
+// hardcode — it was measured at 38.9% for object bytes, where base64 alone would suggest 33%. Growing the
+// chunk one entry at a time and sealing each candidate is what [GossipProtocol.syncChunkFits] does for
+// membership, and this runs on the same path: once per join, not per gossip round.
+func (gp *GossipProtocol) marshalWarmupChunk(anns []types.KeyAnnouncement) ([]byte, int, error) {
+	var (
+		best  []byte
+		count int
+	)
+
+	for i := range anns {
+		payload, err := json.Marshal(&CacheWarmupMessage{Keys: anns[:i+1]})
+		if err != nil {
+			return nil, 0, err
+		}
+
+		fits, err := gp.warmupChunkFits(payload)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if !fits {
+			break
+		}
+
+		best = payload
+		count = i + 1
+	}
+
+	return best, count, nil
+}
+
+// warmupChunkFits reports whether a warmup message carrying payload would fit MaxGossipPacket once
+// sealed.
+//
+// The same message sendMessage would build, so the measurement includes the envelope, the MAC and the
+// message ID rather than a guess at their combined size. MessageID is generated here and discarded: it
+// varies in content but not in length.
+func (gp *GossipProtocol) warmupChunkFits(payload []byte) (bool, error) {
+	gp.mu.RLock()
+	from := gp.localNode.ID
+	gp.mu.RUnlock()
+
+	sealed, err := gp.auth.seal(&GossipMessage{
+		Type:      MessageTypeCacheWarmup,
+		From:      from,
+		Timestamp: time.Now(),
+		MessageID: gp.generateMessageID(),
+		Data:      payload,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return len(sealed) <= gp.config.MaxGossipPacket, nil
+}
+
+// handleCacheWarmup records what a peer says it holds, as if it had announced each key individually.
+//
+// Through [Coordinator.recordAnnouncement] rather than into the map directly, which is what makes the two
+// paths impossible to drift apart: that function is where a self-claim is refused, where an entry replaces
+// an earlier one from the same node, where the bound and the local timestamp are applied, and where an
+// announcement missing its ETag is discarded. A warmup message is a batch of announcements and gets
+// exactly the same treatment.
+//
+// The envelope's sender overrides each entry's NodeID for the reason [GossipProtocol.handleCacheAnnounce]
+// does it: both are authenticated by the same MAC, so this is not a defense against an outsider but
+// against a *member* claiming that some third node holds a key — which would send the joiner to fetch
+// bytes that node never cached, with no way for it to correct the record.
+//
+// Not re-broadcast, and not answered with a warmup of the joiner's own. It has nothing to tell anyone yet,
+// which is why it was sent one.
+func (gp *GossipProtocol) handleCacheWarmup(msg *GossipMessage) {
+	coordinator := gp.cluster.getCoordinator()
+	if coordinator == nil {
+		return
+	}
+
+	var m CacheWarmupMessage
+	if err := json.Unmarshal(msg.Data, &m); err != nil {
+		slog.Debug("discarding a malformed cache warmup message", "peer", msg.From, "error", err)
+
+		return
+	}
+
+	for _, ann := range m.Keys {
+		if msg.From != "" {
+			ann.NodeID = msg.From
+		}
+
+		coordinator.recordAnnouncement(ann)
+	}
+}

--- a/internal/distributed/cache_warmup_test.go
+++ b/internal/distributed/cache_warmup_test.go
@@ -1,0 +1,659 @@
+package distributed
+
+// Tests for cache warming on join (#143). The load-bearing ones are the two that measure rather than
+// count: the issue specifies "max 256 entries", 256 entries seal to 7.6× the default limit, and a test
+// that asserted a count would pass on exactly the broken value the issue asks for.
+//
+// There is precedent for that shape in this package.
+// TestNewClusterManager_DefaultMaxGossipPacketHoldsAThreeNodeSync exists because a limit of 1024 could not
+// carry the smallest cluster needing a quorum, and its comment notes that a test comparing the constant to
+// 8192 would have passed on the broken value. Same lesson, same remedy: seal the message and measure it.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// warmupAnnouncements builds n announcements shaped like a real deployment's.
+//
+// The key length is what decides how many fit a datagram, so these are sized like keys a research bucket
+// actually holds — a prefix, a sample identifier, a filename — rather than "k0". A test packing "k0".."k99"
+// would fit several times more entries per message than production and would report a bound nobody will
+// see.
+func warmupAnnouncements(n int) []types.KeyAnnouncement {
+	anns := make([]types.KeyAnnouncement, 0, n)
+	for i := range n {
+		anns = append(anns, types.KeyAnnouncement{
+			Key:      fmt.Sprintf("genomics/project-alpha/sample-%05d/reads.sorted.bam", i),
+			NodeID:   "compute-node-17.cluster.example.org",
+			ETag:     fmt.Sprintf("%q", fmt.Sprintf("d41d8cd98f00b204e9800998ecf8427%d", i%10)),
+			Size:     4 << 30,
+			CachedAt: time.Now(),
+			Offset:   int64(i) * (128 << 10),
+			Length:   128 << 10,
+		})
+	}
+
+	return anns
+}
+
+// TestMarshalWarmupChunk_EveryChunkFitsASealedDatagram is the bound, asserted the only way it can be: by
+// sealing what would go on the wire and measuring it.
+//
+// It packs far more candidates than can fit, so the chunk returned is decided by the limit rather than by
+// running out of input, and then checks the sealed length against MaxGossipPacket — the same comparison
+// [GossipProtocol.sendMessage] makes, which is what would refuse an oversize datagram outright.
+func TestMarshalWarmupChunk_EveryChunkFitsASealedDatagram(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "warmup-fits"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	// 256 is the count #143 specifies. Measured at 7.6× the default limit, so this is also the input that
+	// makes the count-based bound visibly wrong.
+	candidates := warmupAnnouncements(256)
+
+	payload, fitted, err := cm.gossip.marshalWarmupChunk(candidates)
+	if err != nil {
+		t.Fatalf("marshalWarmupChunk: %v", err)
+	}
+
+	if fitted == 0 {
+		t.Fatal("no announcement fit a datagram at the default max_gossip_packet, so a joining node would " +
+			"be warmed with nothing at all")
+	}
+	if fitted >= len(candidates) {
+		t.Fatalf("all %d announcements were packed into one message; the limit was never reached, so this "+
+			"test is not measuring the bound", fitted)
+	}
+
+	sealed, err := cm.gossip.auth.seal(&GossipMessage{
+		Type:      MessageTypeCacheWarmup,
+		From:      cm.gossip.localNode.ID,
+		Timestamp: time.Now(),
+		MessageID: cm.gossip.generateMessageID(),
+		Data:      payload,
+	})
+	if err != nil {
+		t.Fatalf("sealing the chunk: %v", err)
+	}
+
+	if len(sealed) > cm.gossip.config.MaxGossipPacket {
+		t.Errorf("a warmup chunk of %d entries seals to %d bytes, over max_gossip_packet of %d; "+
+			"sendMessage refuses it and the joining node warms nothing",
+			fitted, len(sealed), cm.gossip.config.MaxGossipPacket)
+	}
+
+	// And the payload really carries what was counted, so a chunk that fits by having dropped its contents
+	// cannot pass.
+	var m CacheWarmupMessage
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshaling the chunk: %v", err)
+	}
+	if len(m.Keys) != fitted {
+		t.Errorf("the chunk reports %d entries and carries %d", fitted, len(m.Keys))
+	}
+}
+
+// TestMarshalWarmupChunk_TheCountVariesWithKeyLength is why the bound cannot be a constant.
+//
+// #143 asks for 256 entries; the measurement that refuted it found 32 at ~50-character keys. This asserts
+// that 32 is not a constant either — the same limit fits materially more short keys than long ones, so any
+// number written into the code is wasteful for one deployment and refused for another.
+func TestMarshalWarmupChunk_TheCountVariesWithKeyLength(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "warmup-varies"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	pack := func(keyLen int) int {
+		t.Helper()
+
+		anns := warmupAnnouncements(256)
+		for i := range anns {
+			anns[i].Key = strings.Repeat("a", keyLen-4) + fmt.Sprintf("%04d", i)
+		}
+
+		_, fitted, err := cm.gossip.marshalWarmupChunk(anns)
+		if err != nil {
+			t.Fatalf("marshalWarmupChunk at key length %d: %v", keyLen, err)
+		}
+
+		return fitted
+	}
+
+	short, long := pack(16), pack(200)
+
+	if short <= long {
+		t.Errorf("%d entries fit at 16-byte keys and %d at 200-byte keys; if the count does not vary with "+
+			"key length then this test is not measuring what bounds the message", short, long)
+	}
+	if long == 0 {
+		t.Error("no 200-byte-key announcement fits a default datagram, which would mean deployments with " +
+			"long prefixes cannot be warmed at all")
+	}
+}
+
+// TestMarshalWarmupChunk_ReportsAnEntryThatCannotFitAlone asserts the zero-count answer rather than an
+// empty message.
+//
+// A single announcement larger than the datagram cannot be helped by chunking, and the caller has to be
+// able to tell that from "nothing to send" — one is a misconfiguration worth a Warn, the other is the
+// ordinary state of an idle node. See [GossipProtocol.sendCacheWarmup].
+func TestMarshalWarmupChunk_ReportsAnEntryThatCannotFitAlone(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "warmup-toobig"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	huge := types.KeyAnnouncement{
+		Key:    strings.Repeat("k", cm.gossip.config.MaxGossipPacket),
+		NodeID: "peer-1",
+		ETag:   `"v1"`,
+	}
+
+	payload, fitted, err := cm.gossip.marshalWarmupChunk([]types.KeyAnnouncement{huge})
+	if err != nil {
+		t.Fatalf("marshalWarmupChunk: %v", err)
+	}
+	if fitted != 0 {
+		t.Errorf("an announcement whose key alone exceeds max_gossip_packet was packed (%d entries), so "+
+			"sendMessage would refuse the datagram", fitted)
+	}
+	if payload != nil {
+		t.Errorf("a chunk that fits nothing returned a %d-byte payload, which a caller would send", len(payload))
+	}
+}
+
+// TestMarshalWarmupChunk_HonoursAReconfiguredLimit asserts the bound follows MaxGossipPacket rather than
+// the default it happens to be tested at.
+//
+// The plan calls for this explicitly: a byte bound that only works at 8192 is a constant with extra steps.
+func TestMarshalWarmupChunk_HonoursAReconfiguredLimit(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t, "warmup-reconfigured")
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	candidates := warmupAnnouncements(256)
+
+	_, atDefault, err := cm.gossip.marshalWarmupChunk(candidates)
+	if err != nil {
+		t.Fatalf("marshalWarmupChunk at the default limit: %v", err)
+	}
+
+	// Halved after construction, which is legitimate here because nothing has been sent: what is under
+	// test is that the packing reads the configured value at pack time rather than a value baked in.
+	cm.gossip.config.MaxGossipPacket /= 2
+
+	payload, atHalf, err := cm.gossip.marshalWarmupChunk(candidates)
+	if err != nil {
+		t.Fatalf("marshalWarmupChunk at half the limit: %v", err)
+	}
+
+	if atHalf >= atDefault {
+		t.Errorf("halving max_gossip_packet packed %d entries where the full limit packed %d; the bound is "+
+			"not reading the configured size", atHalf, atDefault)
+	}
+
+	sealed, err := cm.gossip.auth.seal(&GossipMessage{
+		Type:      MessageTypeCacheWarmup,
+		From:      cm.gossip.localNode.ID,
+		Timestamp: time.Now(),
+		MessageID: cm.gossip.generateMessageID(),
+		Data:      payload,
+	})
+	if err != nil {
+		t.Fatalf("sealing: %v", err)
+	}
+	if len(sealed) > cm.gossip.config.MaxGossipPacket {
+		t.Errorf("a chunk sealed to %d bytes against a reconfigured limit of %d",
+			len(sealed), cm.gossip.config.MaxGossipPacket)
+	}
+}
+
+// TestSendCacheWarmup_SendsNothingWhenNothingIsHeld is #143's third acceptance criterion, and it is worth
+// asserting rather than assuming: a datagram whose payload is `{"keys":[]}` is a message a receiver has to
+// parse to learn there is nothing in it, sent by every node that has just started.
+func TestSendCacheWarmup_SendsNothingWhenNothingIsHeld(t *testing.T) {
+	t.Parallel()
+
+	cm1, cm2 := startGossipPair(t, "warmup-empty-a", "warmup-empty-b")
+
+	before := messagesOfType(cm2, MessageTypeCacheWarmup)
+
+	cm1.gossip.sendCacheWarmup(cm2.gossip.LocalAddr())
+
+	// Nothing to wait for, which is the assertion. A short poll rather than an immediate read, so that a
+	// message in flight has time to arrive and fail this.
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got := messagesOfType(cm2, MessageTypeCacheWarmup) - before; got != 0 {
+			t.Fatalf("a node holding nothing sent %d warmup message(s)", got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// messagesOfType reports how many messages of msgType node has received.
+func messagesOfType(node *ClusterManager, msgType MessageType) int64 {
+	node.gossip.stats.mu.Lock()
+	defer node.gossip.stats.mu.Unlock()
+
+	return node.gossip.stats.MessagesByType[string(msgType)]
+}
+
+// TestJoinWarmsTheJoiner is #143's headline criterion, restated as the plan requires: not a hit rate, but
+// **where the keys came from** — the joiner learns holders it was never told about individually.
+//
+// The original criterion, "cache.Stats().HitRate for warmed keys is 100% before any S3 request", cannot
+// pass against any implementation: [cache.MultiLevelCache.Warmup] is one GetObject per key, so it *is* the
+// S3 traffic the criterion forbids. What warming actually delivers is the ownership map, and that is what
+// this asserts.
+//
+// Driven through a real join over loopback UDP rather than by calling sendCacheWarmup directly, because the
+// thing most likely to be wrong is not the packing but whether anything calls it at all — the same reason
+// #140's tests go over the wire.
+func TestJoinWarmsTheJoiner(t *testing.T) {
+	t.Parallel()
+
+	// A is the established node with a warm cache; B joins it.
+	cmA, cmB := startGossipPair(t, "warmup-join-a", "warmup-join-b")
+
+	held := []types.KeyAnnouncement{
+		{Key: "genomics/sample-1/reads.bam", ETag: `"etag-1"`, Size: 1 << 30, Length: 128 << 10},
+		{Key: "genomics/sample-2/reads.bam", ETag: `"etag-2"`, Size: 2 << 30, Length: 256 << 10},
+		{Key: "genomics/sample-3/reads.bam", ETag: `"etag-3"`, Size: 3 << 30, Length: 512 << 10},
+	}
+
+	// B is taken out of A's memberlist *before* anything is announced, and that is what makes this test
+	// mean what it says. startGossipPair puts B there so a broadcast reaches it — so with B still a member,
+	// every announcement below is delivered to B directly and B ends up holding the right ownership map
+	// whether the warmup exists or not. Clearing B's map after announcing does not fix it either: delivery
+	// is asynchronous, on B's receive goroutine, so a broadcast still in flight lands after the clear. That
+	// version of this test passed with recordSelfHolding removed entirely.
+	//
+	// With B gone from the memberlist, A has no peers, AnnounceKey sends nothing, and the join below is the
+	// only channel by which B can learn any of this.
+	cmA.gossip.mu.Lock()
+	delete(cmA.gossip.memberlist, "warmup-join-b")
+	cmA.gossip.mu.Unlock()
+
+	// B advertises the port it actually bound. A join carries the joiner's own NodeInfo and A replies to
+	// the Address in it, so this is what makes a reply reachable at all: testConfig sets AdvertiseAddr to
+	// "127.0.0.1:0" — a request for any free port, which is right for ListenAddr and is not an address
+	// anything can send to. A real deployment advertises a routable address, so this is the fixture catching
+	// up with production rather than an accommodation.
+	//
+	// It matters more here than in the earlier tests in this file, which reach B by broadcast: startGossipPair
+	// puts B's *bound* address in A's memberlist, so those never consult what B advertises.
+	cmB.gossip.mu.Lock()
+	cmB.gossip.localNode.Address = cmB.gossip.LocalAddr()
+	cmB.gossip.mu.Unlock()
+
+	// Announced, which is how a node comes to hold anything: the read path calls AnnounceKey after caching
+	// bytes. Seeding selfAnnounced directly would let the test pass with AnnounceKey recording nothing,
+	// which is the wiring most likely to be missing.
+	for _, ann := range held {
+		if err := cmA.GetCoordinator().AnnounceKey(t.Context(), ann); err != nil {
+			t.Fatalf("AnnounceKey(%q): %v", ann.Key, err)
+		}
+	}
+
+	// Nothing reached B, since A has nobody to broadcast to. Asserted rather than assumed: if a broadcast
+	// did arrive, every assertion below would hold with no warmup implemented at all.
+	if got := messagesOfType(cmB, MessageTypeCacheAnnounce); got != 0 {
+		t.Fatalf("B received %d announcement(s) before joining; the assertions below would then pass "+
+			"whether or not a join warms anything", got)
+	}
+
+	// A join from B, which A answers with a sync and then a warmup.
+	if err := cmB.gossip.JoinNode(t.Context(), cmA.gossip.LocalAddr()); err != nil {
+		t.Fatalf("JoinNode: %v", err)
+	}
+
+	for _, ann := range held {
+		holders := waitForHolders(t, cmB, ann.Key, 1)
+
+		if holders[0].NodeID != "warmup-join-a" {
+			t.Errorf("%q is held by %q, want the warming node %q",
+				ann.Key, holders[0].NodeID, "warmup-join-a")
+		}
+		if holders[0].ETag != ann.ETag {
+			t.Errorf("%q arrived at ETag %q, want %q; a warmed entry whose version did not survive is one "+
+				"a read cannot check its bytes against", ann.Key, holders[0].ETag, ann.ETag)
+		}
+		if holders[0].Size != ann.Size {
+			t.Errorf("%q arrived with Size %d, want %d", ann.Key, holders[0].Size, ann.Size)
+		}
+		if holders[0].Length != ann.Length {
+			t.Errorf("%q arrived with Length %d, want %d; the range is what tells a reader how much of the "+
+				"object is worth warming", ann.Key, holders[0].Length, ann.Length)
+		}
+	}
+}
+
+// TestRecentHoldings_ExcludesPeersClaims is the separation between the two maps, asserted.
+//
+// A node must warm a joiner with what *it* holds. Answering with peers' claims would tell the joiner to
+// fetch from nodes the sender merely heard about — and, in the two-node case, would tell B that B holds
+// the keys, which is a self-claim recordAnnouncement then correctly discards, so the warming would silently
+// do nothing.
+func TestRecentHoldings_ExcludesPeersClaims(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "holdings-local")
+
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "peers.dat", NodeID: "peer-1", ETag: `"v1"`})
+	c.recordSelfHolding(types.KeyAnnouncement{Key: "mine.dat", NodeID: "holdings-local", ETag: `"v2"`})
+
+	got := c.recentHoldings(0)
+	if len(got) != 1 {
+		t.Fatalf("recentHoldings returned %d entries, want 1: %+v", len(got), got)
+	}
+	if got[0].Key != "mine.dat" {
+		t.Errorf("recentHoldings returned %q; a node warms a joiner with what it holds itself, not with "+
+			"what it has heard about", got[0].Key)
+	}
+}
+
+// TestRecentHoldings_FreshestFirst is what makes a truncated warmup the useful half.
+//
+// The message is bounded by bytes, so the tail is dropped — and which entries end up in the tail is
+// decided entirely by this order. Freshest first puts the keys most likely still cached in the prefix that
+// gets sent.
+func TestRecentHoldings_FreshestFirst(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "holdings-order")
+
+	for i := range 5 {
+		c.recordSelfHolding(types.KeyAnnouncement{
+			Key: fmt.Sprintf("k%d", i), NodeID: "holdings-order", ETag: `"v1"`,
+		})
+		// recordSelfHolding stamps time.Now(), and five inserts can land inside one clock tick on a coarse
+		// timer. A short sleep is what makes the order observable at all.
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	got := c.recentHoldings(0)
+	if len(got) != 5 {
+		t.Fatalf("recentHoldings returned %d entries, want 5", len(got))
+	}
+
+	for i, want := range []string{"k4", "k3", "k2", "k1", "k0"} {
+		if got[i].Key != want {
+			t.Fatalf("recentHoldings()[%d] is %q, want %q; the order decides which entries survive the "+
+				"byte bound, so oldest-first would warm a joiner with the keys likeliest to be evicted "+
+				"already. Got: %+v", i, got[i].Key, want, got)
+		}
+	}
+}
+
+// TestRecentHoldings_ExcludesExpiredClaims asserts the TTL is applied on read, not only by the sweep.
+//
+// Same reasoning as [Coordinator.QueryKeyOwnership]'s: filtering on read is what makes the TTL exact,
+// since the sweep runs on a minute timer and a joiner arriving between ticks would otherwise be warmed
+// with keys this node stopped believing in.
+func TestRecentHoldings_ExcludesExpiredClaims(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t, "holdings-expiry")
+	cfg.AnnouncementTTL = time.Millisecond
+
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	cm.coordinator.recordSelfHolding(types.KeyAnnouncement{
+		Key: "stale.dat", NodeID: "holdings-expiry", ETag: `"v1"`,
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	if got := cm.coordinator.recentHoldings(0); len(got) != 0 {
+		t.Errorf("recentHoldings returned %d expired entries: %+v", len(got), got)
+	}
+}
+
+// TestRecentHoldings_ReplacesAnEarlierVersion is the same rule [Coordinator.recordAnnouncement] applies to
+// peers, applied to this node: announcing a key twice does not make it two holdings, and the older ETag is
+// the one this node has replaced.
+func TestRecentHoldings_ReplacesAnEarlierVersion(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "holdings-replace")
+
+	c.recordSelfHolding(types.KeyAnnouncement{Key: "k", NodeID: "holdings-replace", ETag: `"v1"`})
+	c.recordSelfHolding(types.KeyAnnouncement{Key: "k", NodeID: "holdings-replace", ETag: `"v2"`})
+
+	got := c.recentHoldings(0)
+	if len(got) != 1 {
+		t.Fatalf("one key announced twice is recorded as %d holdings: %+v", len(got), got)
+	}
+	if got[0].ETag != `"v2"` {
+		t.Errorf("the holding is at %s, want the newer %s", got[0].ETag, `"v2"`)
+	}
+}
+
+// TestRecordSelfHolding_BoundsTheMap drives the map past maxAnnouncedKeys and asserts it stops growing.
+//
+// The peer map has the same bound and its own test; this one is for the map that would otherwise grow one
+// entry per key this mount has ever read, which on a traversal of a large bucket is every key in it.
+func TestRecordSelfHolding_BoundsTheMap(t *testing.T) {
+	t.Parallel()
+
+	c := newAnnouncementCoordinator(t, "holdings-bound")
+
+	for i := range maxAnnouncedKeys + 1 {
+		c.recordSelfHolding(types.KeyAnnouncement{
+			Key: fmt.Sprintf("key-%d", i), NodeID: "holdings-bound", ETag: `"v1"`,
+		})
+	}
+
+	c.announcementsMu.RLock()
+	size := len(c.selfAnnounced)
+	c.announcementsMu.RUnlock()
+
+	if size > maxAnnouncedKeys {
+		t.Errorf("selfAnnounced holds %d keys, over the bound of %d", size, maxAnnouncedKeys)
+	}
+	if size == 0 {
+		t.Error("selfAnnounced was emptied entirely, so a joiner would be warmed with nothing")
+	}
+}
+
+// TestSweepExpiredAnnouncements_SweepsBothMaps asserts the sweep reclaims this node's own holdings too.
+//
+// This is the leak that would be invisible: recentHoldings filters expired entries on read, so the map
+// could grow for the life of the mount while every caller saw correct answers.
+func TestSweepExpiredAnnouncements_SweepsBothMaps(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t, "sweep-both")
+	cfg.AnnouncementTTL = time.Millisecond
+
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	c := cm.coordinator
+
+	c.recordSelfHolding(types.KeyAnnouncement{Key: "mine", NodeID: "sweep-both", ETag: `"v1"`})
+	c.recordAnnouncement(types.KeyAnnouncement{Key: "theirs", NodeID: "peer-1", ETag: `"v1"`})
+
+	time.Sleep(20 * time.Millisecond)
+	c.sweepExpiredAnnouncements()
+
+	c.announcementsMu.RLock()
+	self, peers := len(c.selfAnnounced), len(c.announcements)
+	c.announcementsMu.RUnlock()
+
+	if self != 0 {
+		t.Errorf("the sweep left %d expired self-holding(s); nothing else reclaims them, so the map grows "+
+			"for the life of the mount while recentHoldings filters them out of every answer", self)
+	}
+	if peers != 0 {
+		t.Errorf("the sweep left %d expired peer claim(s)", peers)
+	}
+}
+
+// TestHandleCacheWarmup_TheEnvelopeSenderWins asserts a member cannot warm a joiner with claims about a
+// third node.
+//
+// Same defense as [GossipProtocol.handleCacheAnnounce]'s, and it needs its own test because a warmup
+// message is a *batch*: a loop that credited each entry's own NodeID would look right and would let one
+// peer populate a joiner's whole ownership map with fabricated holders.
+func TestHandleCacheWarmup_TheEnvelopeSenderWins(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "warmup-envelope"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	payload, err := json.Marshal(&CacheWarmupMessage{Keys: []types.KeyAnnouncement{
+		{Key: "a", NodeID: "innocent-third-node", ETag: `"v1"`},
+		{Key: "b", NodeID: "another-third-node", ETag: `"v1"`},
+	}})
+	if err != nil {
+		t.Fatalf("marshaling: %v", err)
+	}
+
+	cm.gossip.handleCacheWarmup(&GossipMessage{
+		Type: MessageTypeCacheWarmup,
+		From: "lying-peer",
+		Data: payload,
+	})
+
+	for _, key := range []string{"a", "b"} {
+		holders, err := cm.coordinator.QueryKeyOwnership(t.Context(), key)
+		if err != nil {
+			t.Fatalf("QueryKeyOwnership(%q): %v", key, err)
+		}
+		if len(holders) != 1 {
+			t.Fatalf("%q has %d holders, want 1: %+v", key, len(holders), holders)
+		}
+		if holders[0].NodeID != "lying-peer" {
+			t.Errorf("%q is credited to %q, want the peer the message came from, %q — a warmed read would "+
+				"be sent to a node that never cached the bytes", key, holders[0].NodeID, "lying-peer")
+		}
+	}
+}
+
+// TestHandleCacheWarmup_DiscardsUnusableEntries asserts a warmup goes through the same validation an
+// individual announcement does.
+//
+// An entry with no ETag is the one that matters: it would sit in the ownership map as a claim a reader
+// cannot check its bytes against, which is the integrity failure #140's fail-closed rule exists to
+// prevent. Batching must not be a way around it.
+func TestHandleCacheWarmup_DiscardsUnusableEntries(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "warmup-unusable"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	payload, err := json.Marshal(&CacheWarmupMessage{Keys: []types.KeyAnnouncement{
+		{Key: "no-etag", NodeID: "peer-1"},
+		{Key: "", NodeID: "peer-1", ETag: `"v1"`},
+		{Key: "good", NodeID: "peer-1", ETag: `"v1"`},
+	}})
+	if err != nil {
+		t.Fatalf("marshaling: %v", err)
+	}
+
+	cm.gossip.handleCacheWarmup(&GossipMessage{
+		Type: MessageTypeCacheWarmup,
+		From: "peer-1",
+		Data: payload,
+	})
+
+	if got := cm.coordinator.announcedKeys(); got != 1 {
+		t.Errorf("a warmup carrying one usable entry and two unusable ones recorded %d keys, want 1", got)
+	}
+
+	holders, err := cm.coordinator.QueryKeyOwnership(t.Context(), "no-etag")
+	if err != nil {
+		t.Fatalf("QueryKeyOwnership: %v", err)
+	}
+	if len(holders) != 0 {
+		t.Errorf("an entry with no ETag was recorded as a holder: %+v. A reader has nothing to check the "+
+			"bytes it fetches against", holders)
+	}
+}
+
+// TestHandleCacheWarmup_DiscardsAMalformedPayload asserts a truncated or corrupt message records nothing,
+// rather than the zero-valued entries a partial unmarshal would leave.
+func TestHandleCacheWarmup_DiscardsAMalformedPayload(t *testing.T) {
+	t.Parallel()
+
+	cm, err := NewClusterManager(testConfig(t, "warmup-malformed"))
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+
+	cm.gossip.handleCacheWarmup(&GossipMessage{
+		Type: MessageTypeCacheWarmup,
+		From: "peer-1",
+		Data: []byte(`{"keys":[{"key":"a","etag":`),
+	})
+
+	if got := cm.coordinator.announcedKeys(); got != 0 {
+		t.Errorf("a malformed warmup message left %d key(s) recorded, want 0", got)
+	}
+}
+
+// TestSendCacheWarmup_BoundsTheBurst asserts one join cannot produce an unbounded stream of datagrams.
+//
+// The per-message bound is bytes; this is the bound on how many messages, which is a different resource: a
+// node holding tens of thousands of keys would otherwise answer one join with thousands of datagrams aimed
+// at a node that has been alive for milliseconds and is still receiving its membership sync.
+func TestSendCacheWarmup_BoundsTheBurst(t *testing.T) {
+	t.Parallel()
+
+	cmA, cmB := startGossipPair(t, "warmup-burst-a", "warmup-burst-b")
+
+	// Well past what maxWarmupDatagrams can carry at any key length.
+	for _, ann := range warmupAnnouncements(2000) {
+		cmA.coordinator.recordSelfHolding(ann)
+	}
+
+	before := messagesOfType(cmB, MessageTypeCacheWarmup)
+
+	cmA.gossip.sendCacheWarmup(cmB.gossip.LocalAddr())
+
+	// Poll for a while after the sends complete, so a burst still in flight is counted.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	var got int64
+	for time.Now().Before(deadline) {
+		got = messagesOfType(cmB, MessageTypeCacheWarmup) - before
+		if got > maxWarmupDatagrams {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got > maxWarmupDatagrams {
+		t.Errorf("one join produced %d warmup datagrams, over the bound of %d", got, maxWarmupDatagrams)
+	}
+	if got == 0 {
+		t.Error("a node holding 2000 keys sent a joining node no warmup at all")
+	}
+}

--- a/internal/distributed/coordinator.go
+++ b/internal/distributed/coordinator.go
@@ -36,6 +36,22 @@ type Coordinator struct {
 	// serializes remote operation execution would put every announcement behind an S3 round trip.
 	announcementsMu sync.RWMutex
 	announcements   map[string][]heldKey
+
+	// selfAnnounced is what *this* node has told peers it holds, one entry per key, under the same mutex
+	// and the same TTL as announcements.
+	//
+	// It is a second map rather than an entry in the first one, and that separation is load-bearing:
+	// announcements answers [Coordinator.QueryKeyOwnership], which is asked *because a read missed this
+	// node's own cache*, so a self-claim there is a holder guaranteed not to hold, returned in place of a
+	// peer that does. See [Coordinator.AnnounceKey].
+	//
+	// What it exists for is [Coordinator.recentHoldings], which a node answers a join with (#143). Without
+	// it a two-node cluster warms nothing at all: A's announcements map holds only B's claims, so A tells a
+	// joining C about B and never about the cache A itself has been filling. The cache cannot be enumerated
+	// instead — [types.Cache] stores bytes with no version beside them, and an announcement without an ETag
+	// is refused precisely because a version is what makes it actionable — so the only record of what this
+	// node holds *and at which version* is what it announced.
+	selfAnnounced map[string]heldKey
 }
 
 // NodeOperationMessage is the on-wire request for a remote node execution.

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -140,6 +140,15 @@ const (
 	// [GossipProtocol.handleCacheAnnounce]. Metadata over gossip, bytes from S3 — a datagram cannot hold
 	// a 128 KiB read, which is what makes that split a constraint rather than a preference (#399).
 	MessageTypeCacheAnnounce MessageType = "cache_announce"
+
+	// MessageTypeCacheWarmup tells a node that has just joined which keys the sender holds, so the joiner
+	// starts with a view of what is hot in this cluster instead of learning it one miss at a time (#143).
+	// The payload is a [CacheWarmupMessage].
+	//
+	// It carries announcements, which is to say metadata: the same constraint as
+	// [MessageTypeCacheAnnounce], for the same reason, and here it also bounds how many entries a message
+	// can hold. See [GossipProtocol.marshalWarmupChunk].
+	MessageTypeCacheWarmup MessageType = "cache_warmup"
 )
 
 // ErrMessageOversize means a sealed datagram exceeded MaxGossipPacket and was refused before it
@@ -172,6 +181,22 @@ type CacheInvalidateMessage struct {
 	// Deleted marks an invalidation caused by the key being removed rather than replaced. A receiver
 	// cannot infer this from an empty ETag, because an unconditional put has one too.
 	Deleted bool `json:"deleted,omitempty"`
+}
+
+// CacheWarmupMessage is the payload for MessageTypeCacheWarmup: the keys the sender holds, freshest
+// first, as many as fit one datagram.
+//
+// A slice of full [types.KeyAnnouncement]s rather than of bare keys, because the ETag is what makes an
+// entry actionable — the receiver records these into the same ownership map that
+// [Coordinator.QueryKeyOwnership] answers from, and that map's whole contract is that a caller checks
+// what it fetches against the version it wanted. Keys alone would populate it with claims no reader could
+// verify.
+//
+// There is no count field and no "more to follow" flag. Each message is a complete, independently useful
+// statement of "these keys, as I hold them" — the same property that makes [SyncMessage] chunkable — so a
+// lost message costs the joiner the keys it carried and nothing else.
+type CacheWarmupMessage struct {
+	Keys []types.KeyAnnouncement `json:"keys"`
 }
 
 // JoinMessage represents a join request
@@ -565,6 +590,8 @@ func (gp *GossipProtocol) handleIncomingMessage(ctx context.Context, data []byte
 		gp.handleCacheInvalidate(msg)
 	case MessageTypeCacheAnnounce:
 		gp.handleCacheAnnounce(msg)
+	case MessageTypeCacheWarmup:
+		gp.handleCacheWarmup(msg)
 	}
 }
 
@@ -681,7 +708,18 @@ func (gp *GossipProtocol) handleJoinMessage(msg *GossipMessage) {
 
 	// Send sync message back to the joining node (in a goroutine to avoid
 	// holding the lock while sendSyncMessage attempts to reacquire it for reading).
-	go func() { _ = gp.sendSyncMessage(joinMsg.Node.Address) }()
+	//
+	// The warmup follows the sync, on the same goroutine and in that order, and both parts of that are
+	// deliberate. A goroutine because gp.mu is held here and both sends reacquire it for reading; after
+	// the sync because membership is what the joiner needs first — a node that knows which keys are hot
+	// but not who its peers are cannot act on either. Sequential rather than a second goroutine so the
+	// two do not race to the same socket while the joiner's receive loop is still starting.
+	//
+	// Cache warming is #143. It sends nothing when this node holds nothing.
+	go func() {
+		_ = gp.sendSyncMessage(joinMsg.Node.Address)
+		gp.sendCacheWarmup(joinMsg.Node.Address)
+	}()
 }
 
 func (gp *GossipProtocol) handleLeaveMessage(msg *GossipMessage) {

--- a/internal/fuse/coordinate.go
+++ b/internal/fuse/coordinate.go
@@ -102,6 +102,120 @@ func (fs *FileSystem) announceCached(ctx context.Context, path string, off int64
 	}
 }
 
+// maxPeerWarmBytes bounds how much one cache miss will read ahead on a peer's evidence.
+//
+// Warming reads bytes no application has asked for, so the bound is on wasted egress: at worst a miss
+// transfers this much and the reader stops at the byte it wanted. Four megabytes is two orders of
+// magnitude above the kernel's 128 KiB read, so a peer's claim is worth acting on rather than rounding to
+// nothing, and small enough that a traversal that turns out to touch one block of each of a thousand
+// objects wastes gigabytes rather than terabytes.
+//
+// It is deliberately not [ReadAheadConfig.WindowSize]. That window is a prediction from *this* reader's
+// last few offsets and is floored at one read; this is a claim by another node that it holds a range, which
+// is both stronger evidence and evidence about a different thing — what the cluster reads, not what this
+// process is about to. Tying them would mean a deployment tuning sequential read-ahead silently retuning
+// how much it fetches on a peer's word.
+const maxPeerWarmBytes = 4 << 20
+
+// warmFromPeers reads ahead on the strength of a peer holding more of path than this read asked for.
+//
+// # What a peer's claim is evidence of, and what it is not
+//
+// It is not a source of bytes. A peer cannot serve them: an operation response travels the gossip
+// datagram, which carries 5802 bytes of object at the default limit, so a 128 KiB read is 21× over and
+// fails as a 30-second timeout on the requesting host (#399). Every byte here comes from S3, which is
+// #142's rescope and the reason it is buildable on this transport.
+//
+// What the claim *is* evidence of is that the key is hot in this cluster — the one thing a cold node cannot
+// learn on its own, and the thing worth acting on. So a miss on a key some peer already caches reads
+// further than the application asked for, up to the end of the range the peer claims and no further than
+// [maxPeerWarmBytes].
+//
+// # Why the ETag decides whether to act at all
+//
+// A holder's range describes the version it cached. If that is not the version this node is reading, the
+// range says nothing about the object in hand — the object may have been rewritten to a different length
+// entirely — and warming on it would fetch bytes chosen by a claim about something else. So a version
+// mismatch, or no known version on either side, skips warming rather than guessing. That is the same
+// fail-closed rule [FileSystem.announceCached] applies in the other direction, and it costs exactly the
+// read the application asked for, which is what it would have paid with no cluster at all.
+//
+// The comparison is against the metadata cache's ETag, with the caveat recorded on announceCached: it is
+// the version this node last stat'ed, not provably the version these bytes came from. A stale value here
+// costs a warm skipped or a warm of a range that has moved, both of which are bytes and never correctness
+// — the cache stores what S3 returns for the range requested, whatever the announcement claimed.
+//
+// # Why this is queued rather than fetched
+//
+// Through the prefetch queue, so warming inherits the whole of what [ReadAheadManager.performPrefetch]
+// already does: clamping to EOF, skipping what is cached, trimming past reads already in flight, and
+// fetching through [FileSystem.fetch] so a covering request is shared rather than duplicated. A goroutine
+// per warm would have none of that and no bound on how many run at once. The queue send is
+// non-blocking — a full queue drops the warm, which is the correct answer for speculative work.
+func (fs *FileSystem) warmFromPeers(ctx context.Context, path string, off, length int64) {
+	// Nothing to warm into, so nothing to ask about. Checked before the query rather than left to
+	// [ReadAheadManager.warm]'s own guard: reaching that guard costs a gossip round trip per cache miss
+	// whose answer is then discarded.
+	if fs.coordinator == nil || !fs.readAhead.warmingEnabled() {
+		return
+	}
+
+	holders, err := fs.coordinator.QueryKeyOwnership(ctx, path)
+	if err != nil {
+		// Debug: this is an optimization, and the read it belongs to has already succeeded.
+		slog.Debug("could not ask peers which of them hold a key this node just missed",
+			"path", path, "error", err)
+
+		return
+	}
+
+	if len(holders) == 0 {
+		return
+	}
+
+	// The version this node is reading. No version means nothing to compare a claim against.
+	info := fs.getCachedInfo(path)
+	if info == nil || info.ETag == "" {
+		slog.Debug("not warming from peers: no version is known for the object", "path", path)
+
+		return
+	}
+
+	end := off + length
+
+	// The furthest any holder of *this version* claims to reach. Holders come back freshest first, and all
+	// of them are considered rather than only the first: they are claims about ranges, so the one that
+	// reaches furthest is the most informative, and it is not necessarily the most recent.
+	var want int64
+	for _, holder := range holders {
+		if holder.ETag != info.ETag {
+			continue
+		}
+
+		// A Length of 0 means the full object from Offset, per [types.KeyAnnouncement]. Size is the whole
+		// object's, so that is where such a range ends.
+		holderEnd := holder.Offset + holder.Length
+		if holder.Length <= 0 {
+			holderEnd = info.Size
+		}
+
+		if holderEnd > want {
+			want = holderEnd
+		}
+	}
+
+	if want <= end {
+		// No holder of this version reaches past what was just read, so there is nothing to warm. This is
+		// the ordinary case for a peer that read the same range, and it is why warming cannot loop: the
+		// bytes a warm fetches are cached, so the next miss is further along or does not happen.
+		return
+	}
+
+	length = min(want-end, maxPeerWarmBytes)
+
+	fs.readAhead.warm(path, end, length)
+}
+
 // invalidateCluster tells peers to evict path, because the version named by etag replaced what they
 // hold. An empty etag means this caller cannot name a version, which [types.DistributedCoordinator]
 // documents as legal and applies on every receipt rather than once.

--- a/internal/fuse/coordinator_wiring_test.go
+++ b/internal/fuse/coordinator_wiring_test.go
@@ -80,6 +80,18 @@ func (r *recordingCoordinator) invalidations() []invalidation {
 	return append([]invalidation(nil), r.invalidated...)
 }
 
+// queries returns the keys whose ownership was asked about, in call order.
+//
+// #142's read path asks peers who holds a key it just missed, and one of the things worth asserting is
+// that it does *not* ask — with no coordinator, and with read-ahead disabled, since a query whose answer
+// is discarded is a gossip broadcast per cache miss.
+func (r *recordingCoordinator) queries() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]string(nil), r.queried...)
+}
+
 // invalidatedKeys returns just the keys, for the assertions that do not care about versions.
 func (r *recordingCoordinator) invalidatedKeys() []string {
 	keys := make([]string, 0, len(r.invalidated))

--- a/internal/fuse/filesystem.go
+++ b/internal/fuse/filesystem.go
@@ -1115,6 +1115,15 @@ func (fh *FileHandle) Read(ctx context.Context, dest []byte, off int64) (fuse.Re
 	// Trigger read-ahead analysis. OnRead tolerates a nil manager.
 	fh.fs.readAhead.OnRead(fh.file.path, off, int64(len(data)))
 
+	// And read further on a peer's evidence, if any peer holds more of this object than was just read
+	// (#142). A no-op on a single-node mount, where the coordinator is nil.
+	//
+	// Here rather than in fetchUncached, which is where the announcement is made, because the prefetcher
+	// calls fetchUncached too: warming from there would let each warm's own GET query ownership and queue
+	// another, so one miss could walk the whole object one window at a time on nothing but its own output.
+	// This is the application's read, and only the application's read.
+	fh.fs.warmFromPeers(ctx, fh.file.path, off, int64(len(data)))
+
 	return fuse.ReadResultData(data), 0
 }
 

--- a/internal/fuse/optimizations.go
+++ b/internal/fuse/optimizations.go
@@ -243,6 +243,40 @@ func (ram *ReadAheadManager) consumedThrough(path string) int64 {
 	return pattern.predictedNext
 }
 
+// warm queues a fetch of [offset, offset+size) on evidence from outside this reader's own pattern — a
+// peer holding more of the object than this node just read (#142). See [FileSystem.warmFromPeers].
+//
+// It goes through the same queue and the same workers as a predicted prefetch, which is the point: those
+// workers already clamp to EOF, skip what is cached, trim past reads in flight, and fetch through the
+// shared path. What it deliberately does *not* do is touch the read pattern. The pattern models this
+// process's sequential behavior, and folding a cluster-derived range into it would let another node's
+// reads decide whether this reader looks sequential.
+//
+// A nil manager and a disabled config are tolerated, as in [ReadAheadManager.OnRead], so the call site
+// needs no guard. Disabled means disabled: an operator who turned read-ahead off has said not to read
+// bytes nobody asked for, and a peer's claim is not an exception to that.
+func (ram *ReadAheadManager) warm(path string, offset, size int64) {
+	if !ram.warmingEnabled() || size <= 0 {
+		return
+	}
+
+	ram.schedulePrefetch(path, offset, size)
+}
+
+// warmingEnabled reports whether a call to [ReadAheadManager.warm] could queue anything.
+//
+// It exists so [FileSystem.warmFromPeers] can answer that question *before* it asks peers who holds a
+// key, rather than after. The guard in warm is the one that keeps the promise; this one keeps a mount
+// with read-ahead off from paying a gossip round trip per cache miss to reach it — which on a
+// read-heavy workload is one broadcast per miss whose answer is discarded, the sort of cost that
+// presents as unexplained cluster traffic rather than as a wrong result.
+//
+// Both checks are kept deliberately. Collapsing them into this one would leave warm callable with
+// read-ahead disabled, and warm is the guarantee an operator's setting rests on.
+func (ram *ReadAheadManager) warmingEnabled() bool {
+	return ram != nil && ram.config.Enabled
+}
+
 // schedulePrefetch schedules a prefetch operation
 func (ram *ReadAheadManager) schedulePrefetch(path string, offset, size int64) {
 	select {

--- a/internal/fuse/warm_test.go
+++ b/internal/fuse/warm_test.go
@@ -1,0 +1,685 @@
+//go:build linux || darwin
+
+package fuse
+
+// These tests cover what a cache miss does with a peer's claim (#142): read further, from S3, on the
+// strength of another node holding more of the object than this read asked for.
+//
+// # Two kinds of assertion, and why both are here
+//
+// Most of them read the prefetch queue directly, with no workers draining it. That is the shape
+// read_path_test.go arrived at for the same reason — a prefetch worker issues asynchronous GETs, so an
+// assertion made against request counts while one is running depends on goroutine scheduling, which is
+// how TestPrefetchSkipsRangeTheReaderHasAlreadyRead came to pass 28 times locally and fail on CI. What
+// the queue holds is exactly what warmFromPeers decided, with the arithmetic visible and nothing racing.
+//
+// But a queued request is a decision, not an effect, and a decision nothing acts on is worth nothing. So
+// TestWarmingReallyFetchesTheRange runs a real worker and asserts on observed GETs and on bytes landing
+// in the cache, which is the property the feature exists for. Queue assertions alone would pass against
+// a `warm` that queued onto a channel no worker read.
+//
+// # The coordinator is the only mock, as in coordinate_test.go
+//
+// A peer's claim is an input to this path, and producing one from a real second node would mean two
+// gossip sockets, an announcement, and a wait — moving the assertion away from *which range this node
+// decides to warm* and onto internal/distributed's delivery, which its own tests cover. The metadata
+// cache is deliberately real, because the ETag every decision here turns on comes from it.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// warmFixture is a coordFixture whose prefetch queue nothing drains.
+//
+// ConcurrentReads: 0 is what makes the tests below deterministic: schedulePrefetch fills the queue and
+// no worker empties it, so every request in it was put there by the read under test and can be read back
+// as a fact rather than caught in flight.
+type warmFixture struct {
+	*coordFixture
+}
+
+func newWarmFixture(t *testing.T) *warmFixture {
+	t.Helper()
+
+	f := newCoordFixture(t)
+
+	f.fs.readAhead = NewReadAheadManager(t.Context(), f.fs, &ReadAheadConfig{
+		Enabled:         true,
+		WindowSize:      64 << 10,
+		MinSequential:   3,
+		ConcurrentReads: 0,
+		TTL:             time.Minute,
+	})
+
+	return &warmFixture{coordFixture: f}
+}
+
+// queued drains the prefetch queue and returns what was in it.
+func (f *warmFixture) queued() []PrefetchRequest {
+	var reqs []PrefetchRequest
+
+	for {
+		select {
+		case req := <-f.fs.readAhead.prefetchQueue:
+			reqs = append(reqs, *req)
+		default:
+			return reqs
+		}
+	}
+}
+
+// warmed returns the single queued request, failing if there is not exactly one.
+//
+// Exactly one, because a read that queues two prefetches for one miss is the failure mode this feature
+// could plausibly have: warmFromPeers and the read pattern both feed the same queue, and a test that
+// picked the first matching entry would not notice the detector's own prefetch being counted as the warm.
+// Every test here reads at offset 0 of a fresh pattern, where sequentialHits reaches 1 against a
+// MinSequential of 3, so the detector queues nothing and the warm is the only entry there should be.
+func (f *warmFixture) warmed(t *testing.T) PrefetchRequest {
+	t.Helper()
+
+	reqs := f.queued()
+	if len(reqs) != 1 {
+		t.Fatalf("the read queued %d prefetch requests, want exactly 1 (the warm): %+v", len(reqs), reqs)
+	}
+
+	return reqs[0]
+}
+
+// holder builds a peer's claim to hold [off, off+length) of key at etag.
+func holder(key, etag string, size, off, length int64) types.KeyAnnouncement {
+	return types.KeyAnnouncement{
+		Key:      key,
+		NodeID:   "peer-1",
+		ETag:     etag,
+		Size:     size,
+		CachedAt: time.Now(),
+		Offset:   off,
+		Length:   length,
+	}
+}
+
+// etagOf returns the version the store holds for key, which is the version the metadata cache will carry
+// once the object has been stat'ed.
+func etagOf(t *testing.T, f *coordFixture, key string) string {
+	t.Helper()
+
+	info, err := f.fs.backend.HeadObject(t.Context(), key)
+	if err != nil {
+		t.Fatalf("HeadObject(%q): %v", key, err)
+	}
+
+	if info.ETag == "" {
+		t.Fatalf("the store reports no ETag for %q, so no claim about it can match", key)
+	}
+
+	return info.ETag
+}
+
+// TestReadWarmsPastWhatAPeerHolds is #142's headline: a miss on a key some peer already caches reads
+// further than the application asked for, up to the end of the range that peer claims.
+//
+// The arithmetic is the assertion. The warm starts where the read ended — not at the read's own offset,
+// which would re-fetch bytes just cached — and ends where the holder's range does, because that is the
+// extent of the evidence. Both halves have a plausible wrong answer: starting at `off` duplicates the
+// read, and taking the holder's Length as the size ignores where its range begins.
+func TestReadWarmsPastWhatAPeerHolds(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key      = "hot.dat"
+		size     = 1 << 20
+		readSize = 128 << 10
+		peerEnd  = 512 << 10
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{holder(key, etagOf(t, f.coordFixture, key), size, 0, peerEnd)}
+
+	if got := f.read(t, f.open(key), 0, readSize); len(got) != readSize {
+		t.Fatalf("read %d bytes, want %d", len(got), readSize)
+	}
+
+	if queries := f.coord.queries(); len(queries) == 0 {
+		t.Fatal("a cache miss asked no peer who holds the key, so a cold node can never learn what is hot " +
+			"in the cluster")
+	}
+
+	req := f.warmed(t)
+
+	if req.path != key {
+		t.Errorf("warmed path %q, want %q", req.path, key)
+	}
+
+	if req.offset != readSize {
+		t.Errorf("warmed from offset %d, want %d — the bytes below that were just read and cached, so a "+
+			"warm starting at the read's own offset pays for them a second time", req.offset, readSize)
+	}
+
+	if want := int64(peerEnd - readSize); req.size != want {
+		t.Errorf("warmed %d bytes, want %d: the evidence is a peer's range ending at %d, and the read "+
+			"already covered up to %d. A size of %d would be the holder's Length, which ignores where its "+
+			"range starts", req.size, want, peerEnd, readSize, peerEnd)
+	}
+}
+
+// TestWarmingDoesNotDisturbTheReadPattern is the separation [ReadAheadManager.warm] promises.
+//
+// The pattern models *this* process's sequential behavior and decides whether it looks sequential
+// enough to prefetch for. A warm folded into it would let another node's reads move this reader's
+// predicted-next offset, and the visible consequence would be the detector prefetching from the wrong
+// place for the rest of the traversal — a wrong offset for reasons nothing in the read history explains.
+func TestWarmingDoesNotDisturbTheReadPattern(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key      = "pattern.dat"
+		size     = 1 << 20
+		readSize = 128 << 10
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{
+		holder(key, etagOf(t, f.coordFixture, key), size, 0, 512<<10),
+	}
+
+	f.read(t, f.open(key), 0, readSize)
+
+	if req := f.warmed(t); req.size == 0 {
+		t.Fatal("nothing was warmed, so this test is not measuring what a warm does to the pattern")
+	}
+
+	f.fs.readAhead.mu.RLock()
+	pattern := f.fs.readAhead.activeReads[key]
+	f.fs.readAhead.mu.RUnlock()
+
+	if pattern == nil {
+		t.Fatal("the read left no pattern at all")
+	}
+
+	if pattern.predictedNext != readSize {
+		t.Errorf("after one %d-byte read the detector predicts the reader is at %d, want %d. A warm has "+
+			"moved the prediction, so the next prefetch is aimed at a range chosen by another node's reads",
+			readSize, pattern.predictedNext, readSize)
+	}
+
+	if pattern.sequentialHits != 1 {
+		t.Errorf("sequentialHits is %d after one read, want 1: a warm counted as a read makes this reader "+
+			"look sequential on another node's evidence", pattern.sequentialHits)
+	}
+}
+
+// TestWarmingIgnoresAClaimAboutAnotherVersion is the fail-closed rule, and it is the assertion that
+// matters most here.
+//
+// A holder's range describes the version *it* cached. If that is not the version this node is reading,
+// the range says nothing about the object in hand — an overwrite can change its length entirely — so
+// warming on it fetches bytes chosen by a claim about something else. Skipping costs exactly the read
+// the application asked for, which is what a single-node mount pays.
+func TestWarmingIgnoresAClaimAboutAnotherVersion(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key  = "stale-claim.dat"
+		size = 1 << 20
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{
+		holder(key, `"0000000000000000000000000000000a"`, size, 0, 512<<10),
+	}
+
+	f.read(t, f.open(key), 0, 128<<10)
+
+	if reqs := f.queued(); len(reqs) != 0 {
+		t.Errorf("warmed %+v on a claim about a different version of the object. The holder's range "+
+			"describes the bytes it cached; against a version this node is not reading, it does not even "+
+			"establish that the object is that long", reqs)
+	}
+}
+
+// TestWarmingNeedsAVersionOfItsOwn is the same rule from the other side: this node not knowing what it is
+// reading.
+//
+// [FileHandle.Read] does not stat, and a handle outlives its metadata cache entry — the two entries have
+// separate TTLs — so a read with no cached version is ordinary rather than contrived. With nothing to
+// compare a claim against, every claim is unverifiable, and the honest answer is to warm nothing.
+func TestWarmingNeedsAVersionOfItsOwn(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key  = "unstatted-warm.dat"
+		size = 1 << 20
+	)
+
+	f.srv.SeedRandom(key, size)
+
+	// The peer's claim carries the real version. What is missing is this node's, since nothing has stat'ed
+	// the object — so a match cannot be established even though one exists.
+	f.coord.queryResults = []types.KeyAnnouncement{
+		holder(key, etagOf(t, f.coordFixture, key), size, 0, 512<<10),
+	}
+
+	f.read(t, f.open(key), 0, 128<<10)
+
+	if reqs := f.queued(); len(reqs) != 0 {
+		t.Errorf("warmed %+v with no version known for the object this node is reading; a claim that "+
+			"cannot be checked is not evidence", reqs)
+	}
+}
+
+// TestWarmingTakesTheFurthestHolderOfTheRightVersion covers the loop over holders rather than its first
+// entry.
+//
+// Holders arrive freshest first, and freshest is not furthest: the most recent claim can be a 4 KiB range
+// while an older one covers the whole object. So every claim at the matching version is considered and
+// the one reaching furthest wins. An implementation that stopped at holders[0] would pass every other
+// test in this file.
+//
+// The wrong-version claim reaching furthest of all is in the list on purpose: it is what a first-match
+// implementation, or one that checked the ETag only after choosing, would act on.
+func TestWarmingTakesTheFurthestHolderOfTheRightVersion(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key      = "many-holders.dat"
+		size     = 4 << 20
+		readSize = 128 << 10
+		furthest = 1 << 20
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	etag := etagOf(t, f.coordFixture, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{
+		holder(key, etag, size, 0, 256<<10),                               // freshest, and short
+		holder(key, `"ffffffffffffffffffffffffffffffff"`, size, 0, 3<<20), // furthest, wrong version
+		holder(key, etag, size, 512<<10, furthest-(512<<10)),              // the furthest right version
+		holder(key, etag, size, 0, 300<<10),                               // middling
+	}
+
+	f.read(t, f.open(key), 0, readSize)
+
+	req := f.warmed(t)
+
+	if want := int64(furthest - readSize); req.size != want {
+		t.Errorf("warmed %d bytes, want %d. The furthest claim at the version being read reaches %d; a "+
+			"size of %d means only the first holder was considered, and one reaching %d means a claim "+
+			"about another version was acted on",
+			req.size, want, furthest, (256<<10)-readSize, (3<<20)-readSize)
+	}
+}
+
+// TestWarmingTreatsLengthZeroAsTheWholeObject pins the convention [types.KeyAnnouncement] documents.
+//
+// A Length of 0 means the full object from Offset, and it is not a rare shape: an unranged GET announces
+// it. Read literally as a length it is an empty range, so a holder of the entire object would look like a
+// holder of nothing — the strongest possible claim silently producing no warm at all.
+func TestWarmingTreatsLengthZeroAsTheWholeObject(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key      = "whole-object.dat"
+		size     = 1 << 20
+		readSize = 128 << 10
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{
+		holder(key, etagOf(t, f.coordFixture, key), size, 0, 0),
+	}
+
+	f.read(t, f.open(key), 0, readSize)
+
+	req := f.warmed(t)
+
+	if want := int64(size - readSize); req.size != want {
+		t.Errorf("a holder claiming the whole %d-byte object produced a warm of %d bytes, want %d. Length "+
+			"0 means the object's full extent from Offset; read as a literal length it is an empty range, "+
+			"so the strongest claim there is would warm nothing", size, req.size, want)
+	}
+}
+
+// TestWarmingIsCappedAtMaxPeerWarmBytes bounds the wasted egress.
+//
+// Warming reads bytes no application asked for, so the worst case is the whole warm being paid for and
+// none of it read. A peer holding a 64 MiB object end to end is a claim that would otherwise pull all of
+// it on one 128 KiB miss.
+func TestWarmingIsCappedAtMaxPeerWarmBytes(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key      = "huge.dat"
+		size     = 64 << 20
+		readSize = 128 << 10
+	)
+
+	// Not seeded with 64 MiB of random bytes: nothing here reads them. The metadata cache decides the
+	// object's extent for this path, and cacheInfo is how the size gets there.
+	f.srv.SeedRandom(key, 8<<10)
+
+	etag := etagOf(t, f.coordFixture, key)
+	f.fs.cacheInfo(key, &types.ObjectInfo{Key: key, Size: size, ETag: etag})
+
+	f.coord.queryResults = []types.KeyAnnouncement{holder(key, etag, size, 0, 0)}
+
+	f.fs.warmFromPeers(t.Context(), key, 0, readSize)
+
+	if req := f.warmed(t); req.size != maxPeerWarmBytes {
+		t.Errorf("a peer claiming the whole %d-byte object produced a warm of %d bytes, want the "+
+			"%d-byte cap. Unbounded, one cache miss transfers the rest of the object on speculation",
+			size, req.size, maxPeerWarmBytes)
+	}
+}
+
+// TestNoWarmWhenNoPeerReachesPastTheRead is the ordinary case, and it is also why warming cannot loop.
+//
+// A peer that read the same range as this node holds exactly what was just read, so there is nothing
+// further to fetch. That is what stops a warm's own GET from producing another: the bytes a warm fetches
+// are cached, so the next miss is past them or does not happen.
+func TestNoWarmWhenNoPeerReachesPastTheRead(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const (
+		key      = "same-range.dat"
+		size     = 1 << 20
+		readSize = 128 << 10
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	etag := etagOf(t, f.coordFixture, key)
+
+	for _, tc := range []struct {
+		name   string
+		holder types.KeyAnnouncement
+	}{
+		{"exactly the range that was read", holder(key, etag, size, 0, readSize)},
+		{"less than was read", holder(key, etag, size, 0, 64<<10)},
+		{"a range entirely behind the read", holder(key, etag, size, 0, 4<<10)},
+	} {
+		f.coord.queryResults = []types.KeyAnnouncement{tc.holder}
+
+		f.fs.warmFromPeers(t.Context(), key, 0, readSize)
+
+		if reqs := f.queued(); len(reqs) != 0 {
+			t.Errorf("%s: warmed %+v, want nothing. There are no bytes past the read to fetch, and a warm "+
+				"of a range already cached is the loop this design avoids", tc.name, reqs)
+		}
+	}
+}
+
+// TestNoPeersMeansNoWarm covers the empty answer, which is every mount whose peers have not read the key.
+func TestNoPeersMeansNoWarm(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	const key = "unheld.dat"
+
+	f.srv.SeedRandom(key, 1<<20)
+	f.stat(t, key)
+
+	f.read(t, f.open(key), 0, 128<<10)
+
+	if reqs := f.queued(); len(reqs) != 0 {
+		t.Errorf("warmed %+v with no peer claiming to hold anything; there is no evidence here, and read-"+
+			"ahead's own prediction is what a solitary reader gets", reqs)
+	}
+}
+
+// TestNoCoordinatorAsksNoPeers is the single-node path.
+//
+// Nearly every mount takes it. The assertion is on the *query*, not only on the warm: a nil coordinator
+// cannot be called at all, so a guard missing here is a nil dereference on the read path rather than a
+// missed optimization.
+func TestNoCoordinatorAsksNoPeers(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+	f.fs.coordinator = nil
+
+	const key = "solo-warm.dat"
+
+	content := f.srv.SeedRandom(key, 1<<20)
+	f.stat(t, key)
+
+	got := f.read(t, f.open(key), 0, 128<<10)
+	if string(got) != string(content[:128<<10]) {
+		t.Error("a read on a mount with no coordinator returned different bytes")
+	}
+
+	if queries := f.coord.queries(); len(queries) != 0 {
+		t.Errorf("queried %v after the coordinator was set to nil", queries)
+	}
+
+	if reqs := f.queued(); len(reqs) != 0 {
+		t.Errorf("queued %+v on a mount with no cluster", reqs)
+	}
+}
+
+// TestReadAheadDisabledAsksNoPeers is an operator's setting being honored, and the query is the half
+// worth asserting.
+//
+// [ReadAheadManager.warm] refuses to queue when read-ahead is off, which is the guarantee. But reaching
+// that refusal costs a gossip broadcast per cache miss whose answer is then discarded — invisible in any
+// assertion about warming, and visible in production as unexplained cluster traffic on a mount whose
+// operator turned the feature off.
+func TestReadAheadDisabledAsksNoPeers(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+
+	f.fs.readAhead = NewReadAheadManager(t.Context(), f.fs, &ReadAheadConfig{
+		Enabled:         false,
+		WindowSize:      64 << 10,
+		MinSequential:   3,
+		ConcurrentReads: 0,
+		TTL:             time.Minute,
+	})
+
+	const (
+		key  = "no-readahead.dat"
+		size = 1 << 20
+	)
+
+	f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{
+		holder(key, etagOf(t, f.coordFixture, key), size, 0, 512<<10),
+	}
+
+	f.read(t, f.open(key), 0, 128<<10)
+
+	if queries := f.coord.queries(); len(queries) != 0 {
+		t.Errorf("a mount with read-ahead disabled queried peer ownership for %v. The answer cannot be "+
+			"acted on, so this is one gossip round trip per cache miss in exchange for nothing", queries)
+	}
+
+	if reqs := f.queued(); len(reqs) != 0 {
+		t.Errorf("queued %+v with read-ahead disabled; an operator who turned it off has said not to read "+
+			"bytes nobody asked for, and a peer's claim is not an exception", reqs)
+	}
+
+	// And warm itself refuses, which is the guard that keeps the promise rather than the one that saves the
+	// round trip. Asserted directly because nothing else reaches it: with warmFromPeers returning early,
+	// removing the check inside warm changes no observable behavior today — and it is the check that would
+	// matter the moment a second caller appears.
+	f.fs.readAhead.warm(key, 128<<10, 64<<10)
+
+	if reqs := f.queued(); len(reqs) != 0 {
+		t.Errorf("warm queued %+v with read-ahead disabled when called directly", reqs)
+	}
+}
+
+// TestNilReadAheadManagerIsSafe covers the other nil on this path.
+//
+// Three tests in this package set `readAhead` to nil to take the prefetcher out of the way, and
+// [ReadAheadManager.warm] tolerates a nil receiver for that reason. warmFromPeers now calls a second
+// method on the same receiver before the query, so the nil case has to hold there too — otherwise those
+// tests, and any mount that ever leaves the field unset, panic inside a read.
+func TestNilReadAheadManagerIsSafe(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+	f.fs.readAhead = nil
+
+	const key = "nil-manager.dat"
+
+	content := f.srv.SeedRandom(key, 64<<10)
+	f.stat(t, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{
+		holder(key, etagOf(t, f.coordFixture, key), 64<<10, 0, 64<<10),
+	}
+
+	got := f.read(t, f.open(key), 0, 8<<10)
+	if string(got) != string(content[:8<<10]) {
+		t.Error("a read with no read-ahead manager returned different bytes")
+	}
+}
+
+// TestReadSucceedsWhenTheOwnershipQueryFails is the fire-and-forget property for this direction.
+//
+// The read has already succeeded by the time this runs — the bytes are fetched and the buffer is filled —
+// so a failed query costs a warm that would have been speculative anyway. Surfacing it would fail a
+// read(2) that has its data.
+func TestReadSucceedsWhenTheOwnershipQueryFails(t *testing.T) {
+	t.Parallel()
+
+	f := newWarmFixture(t)
+	f.coord.queryErr = errors.New("no peer answered")
+
+	const key = "query-fails.dat"
+
+	content := f.srv.SeedRandom(key, 1<<20)
+	f.stat(t, key)
+
+	got := f.read(t, f.open(key), 0, 128<<10)
+	if string(got) != string(content[:128<<10]) {
+		t.Errorf("a read whose ownership query failed returned %d wrong bytes", len(got))
+	}
+
+	if queries := f.coord.queries(); len(queries) == 0 {
+		t.Error("the query was not attempted, so this test asserts nothing about its failure")
+	}
+
+	if reqs := f.queued(); len(reqs) != 0 {
+		t.Errorf("queued %+v from a failed query; there is no evidence to act on", reqs)
+	}
+}
+
+// TestWarmingReallyFetchesTheRange is the one test here that lets a worker run, and it is what makes the
+// queue assertions above worth anything.
+//
+// Every other test in this file asserts a decision. A decision is not an effect: `warm` could queue onto
+// a channel no worker drains, or performPrefetch could discard the request, and all of them would still
+// pass. So this one asserts where the bytes ended up — in this node's cache, fetched from S3, which is
+// #142's rescope in one sentence.
+//
+// It polls rather than sleeping, so it neither races the worker nor waits for a fixed interval that is
+// too short on a loaded machine and wasted on an idle one.
+func TestWarmingReallyFetchesTheRange(t *testing.T) {
+	t.Parallel()
+
+	f := newCoordFixture(t)
+
+	// One worker, so the queued warm is actually performed. Not four: a single worker makes the sequence
+	// deterministic, and there is exactly one request to serve.
+	f.fs.readAhead = NewReadAheadManager(t.Context(), f.fs, &ReadAheadConfig{
+		Enabled:         true,
+		WindowSize:      64 << 10,
+		MinSequential:   3,
+		ConcurrentReads: 1,
+		TTL:             time.Minute,
+	})
+
+	const (
+		key      = "warm-for-real.dat"
+		size     = 1 << 20
+		readSize = 128 << 10
+		peerEnd  = 512 << 10
+	)
+
+	content := f.srv.SeedRandom(key, size)
+	f.stat(t, key)
+
+	f.coord.queryResults = []types.KeyAnnouncement{holder(key, etagOf(t, f, key), size, 0, peerEnd)}
+
+	if got := f.read(t, f.open(key), 0, readSize); string(got) != string(content[:readSize]) {
+		t.Fatal("the read itself returned the wrong bytes")
+	}
+
+	// The warmed range, held in full. Get answers only for a range it holds entirely, so this is the whole
+	// property in one call: a warm that fetched a prefix, or nothing, cannot satisfy it.
+	deadline := time.Now().Add(30 * time.Second)
+
+	var held []byte
+	for time.Now().Before(deadline) {
+		if held = f.fs.cache.Get(key, readSize, peerEnd-readSize); held != nil {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if held == nil {
+		t.Fatalf("%d bytes from offset %d are not cached after a peer claimed to hold through %d. The warm "+
+			"was decided but nothing fetched it, so #142 costs a gossip round trip and buys nothing. GETs: %d",
+			peerEnd-readSize, readSize, peerEnd, len(f.srv.GETs(key)))
+	}
+
+	if string(held) != string(content[readSize:peerEnd]) {
+		t.Error("the warmed range holds the wrong bytes: a warm fetches [read end, holder end) of this " +
+			"object, and holding some other range under that key would serve them to a reader as file " +
+			"content")
+	}
+
+	// And the bytes came from S3 rather than from the peer, which is the rescope. A gossip datagram carries
+	// 5802 bytes of object at the default limit, so a transport that tried to serve 384 KiB over it would
+	// fail as a 30-second timeout on this host (#399); the GET is the evidence it was never attempted.
+	if gets := len(f.srv.GETs(key)); gets < 2 {
+		t.Errorf("the object was fetched in %d GET(s); the read is one and the warm is another, so fewer "+
+			"than two means the warmed bytes did not come from the object store", gets)
+	}
+
+	// Bounded: the warm is one fetch of one range, not a walk of the object. A warm whose own GET queried
+	// ownership and queued another would show up here as a GET count climbing with the object's size.
+	if got := f.srv.BytesRead(key); got > peerEnd {
+		t.Errorf("a %d-byte read plus a warm through %d transferred %d bytes. Warming must not warm from "+
+			"its own output: it is queued on the application's read alone, and a warm feeding itself walks "+
+			"the whole object one window at a time", readSize, peerEnd, got)
+	}
+}


### PR DESCRIPTION
Closes #142, closes #143. The last two issues in the v0.13.0 warming chain.

## What this does

A cache miss asks the cluster who holds the key. If a peer holds a range reaching past what was just read, this node reads ahead to the end of that range — **from S3**, capped at 4 MiB per miss. And a node answering a join follows the membership sync with a `cache_warmup` message listing the keys it holds, which the joiner records as ownership claims.

## Both issues specified something the transport cannot do

**#142 planned to fetch the bytes from the peer** via `ExecuteOperation(&types.ReadOp{...})`. A gossip datagram carries 5802 bytes of object at the default limit, so a 128 KiB kernel read is 21× over and fails as a 30-second timeout on the requesting host (#399 made that failure honest, which is what made this rescope possible). What a peer's claim is *actually* evidence of is that the key is hot in this cluster — the one thing a cold node cannot learn on its own — and that is worth acting on even when the bytes still cost an S3 read. `PeerFetchTimeout` is deliberately not added: it would describe a code path that does not exist.

**#143 specified "max 256 entries per warmup message"** and `cache.Warmup(keys)` on receipt. Neither works:

- Measured against the real seal path, 256 announcements with 52-character keys seal to **65631 bytes against the 8192-byte default — 8× over**. Every warmup datagram would be refused at the socket and a joiner would warm nothing at all. 31 fit. And 31 is not a constant to write down instead, because it moves with key length — so the chunk is grown one entry at a time and the whole message sealed to check, reusing `syncChunkFits`'s shape. A count cannot bound a byte limit.
- `MultiLevelCache.Warmup` is one `GetObject` per key, so calling it on a warmup message turns cold-start into an egress burst. The criterion "100% hit rate **before any S3 request**" cannot pass against it under any bound — `Warmup` *is* the S3 request. Recording the announcements delivers what that criterion was reaching for, and costs nothing.

Both issue bodies have been rewritten to match.

## Design notes worth a reviewer's attention

**A claim is acted on only at the version this node is reading.** A holder's range describes the object *it* cached; against another version the object may have a different length entirely, so warming on it fetches bytes chosen by a claim about something else. A mismatch — or no known version on either side — warms nothing, which costs exactly the read the application asked for. Same fail-closed rule `announceCached` applies in the other direction.

**`selfAnnounced` is a second map beside `announcements`, and the separation is load-bearing.** `announcements` answers `QueryKeyOwnership`, which is asked *because this node's cache missed*, so a self-claim there is a holder guaranteed not to hold, returned in place of a peer that does. And the cache cannot be enumerated instead: `types.Cache` stores bytes with no version beside them, so the only record of what this node holds *and at which version* is what it announced. The existing sweep now covers both maps — the second is the half that would have leaked silently, since `recentHoldings` filters expired entries on read.

**The warm goes through the prefetch queue**, so it inherits EOF clamping, skipping what is cached, standing off in-flight reads, and flight-sharing. It does not touch the read pattern: another node's reads must not decide whether this reader looks sequential. It is called from `FileHandle.Read` and never from `fetchUncached`, so a warm's own GET cannot query ownership and queue another — a warm cannot feed itself and walk the object.

**`read_ahead.enabled: false` suppresses the warm and the ownership query both**, rather than asking peers once per cache miss and discarding the answer.

## Verification

- `go test -race ./...` — clean, whole repo, not `-short`
- `go test -race -tags=distributed ./internal/distributed/...` — clean
- `go build ./...`, `gofmt -l`, `go vet ./internal/...`, `golangci-lint run --new-from-merge-base=origin/main` — clean
- 30 new tests: 16 in `internal/distributed/cache_warmup_test.go`, 14 in `internal/fuse/warm_test.go`

**Mutation-verified, thirteen guards, each breakage failing a named test.** Two initially survived and both were test defects, now fixed:

- `TestJoinWarmsTheJoiner` cleared the joiner's ownership map *after* announcing. Delivery is asynchronous on the joiner's receive goroutine, so a broadcast still in flight lands after the clear — that version passed with `recordSelfHolding` deleted entirely. The joiner is now removed from the sender's memberlist *before* anything is announced, and the test asserts zero announcements arrived, so the join is provably the only channel. It also surfaced that `testConfig` advertises `127.0.0.1:0`, which is a request for a free port rather than an address anything can reply to.
- A separate empty-holdings guard in `sendCacheWarmup` duplicated the send loop's own `break`, so no test could distinguish them. Removed, with the reasoning recorded where the remaining check lives.

The #142 assertions are on decisions *and* on effects: most read the prefetch queue with no workers draining it (deterministic, per `read_path_test.go`'s hard-won precedent), but `TestWarmingReallyFetchesTheRange` runs a real worker and asserts the warmed range lands in the cache with the right bytes and came from S3 — queue assertions alone would pass against a `warm` that queued onto a channel nothing read.