### PR TITLE
fix(metrics): bucket latencies instead of hashing them, and assign the percentiles (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Latency percentiles were published as zeros, and the histogram they were meant to come from was a
+  modulo rather than a bucketing** ([#222]). `DetailedOperationMetrics` declared `P50Latency`,
+  `P95Latency` and `P99Latency` with JSON tags and never assigned any of them, so anything serializing
+  the struct reported a filesystem with no tail latency at all — the most flattering possible wrong
+  answer, and one that reads as a measurement rather than as an unimplemented field. They could not have
+  been computed from `LatencyHistogram` in any case: it was indexed by `int(latency.Milliseconds()) %
+  100`, which is a hash of the latency into 100 slots with no ordering, so 50 ms and 250 ms shared a
+  bucket, 1 ms and 1001 ms shared a bucket, and every operation under a millisecond — the expected case
+  for a cache hit — landed in bucket 0 along with everything at exactly 100 ms. An array indexed that
+  way cannot answer "what fraction of operations were faster than N" for any N.
+
+  The histogram is now 24 exponential buckets from 25 µs plus an overflow bucket, published by
+  `metrics.LatencyBucketBounds` since counts without their intervals are not interpretable. That range is
+  set by what has to fit in it: an L1 hit is tens of microseconds and a cold multipart GET is seconds, so
+  no linear-in-milliseconds scheme resolves both ends. The three percentiles are estimated from it by
+  interpolating within the covering bucket, as Prometheus's `histogram_quantile` does, and a rank landing
+  in the overflow bucket saturates at the top bound — "at least this" rather than wrapping to a fast
+  bucket, which is the failure direction that makes a slow filesystem look fast. Per-file metrics
+  allocate no histogram and are documented as leaving the percentiles zero.
+
+  `GetOperationMetrics` also stopped handing callers the live histogram. Its comment said it returned a
+  copy to avoid races, but a struct copy copies a slice header, so the caller walked the array the
+  recorder increments — harmless while nothing read the field, and a data race now that the percentiles
+  give something a reason to.
+
 - **A read-ahead prefetch that fell behind the reader re-fetched bytes already cached.** A prefetch is
   queued and the reader does not wait for it, so under load the reader can consume the front of the very
   range predicted for it before a worker picks the request up. Those reads are then finished — removed
@@ -2746,6 +2771,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#352]: https://github.com/scttfrdmn/objectfs/issues/352
 [#399]: https://github.com/scttfrdmn/objectfs/issues/399
 [#223]: https://github.com/scttfrdmn/objectfs/issues/223
+[#222]: https://github.com/scttfrdmn/objectfs/issues/222
 [#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#390]: https://github.com/scttfrdmn/objectfs/issues/390
 [#378]: https://github.com/scttfrdmn/objectfs/issues/378

--- a/internal/metrics/detailed.go
+++ b/internal/metrics/detailed.go
@@ -44,23 +44,33 @@ const (
 
 // DetailedOperationMetrics tracks metrics for a specific operation
 type DetailedOperationMetrics struct {
-	Count             int64         `json:"count"`
-	TotalLatency      time.Duration `json:"total_latency"`
-	MinLatency        time.Duration `json:"min_latency"`
-	MaxLatency        time.Duration `json:"max_latency"`
-	AverageLatency    time.Duration `json:"average_latency"`
-	P50Latency        time.Duration `json:"p50_latency"`
-	P95Latency        time.Duration `json:"p95_latency"`
-	P99Latency        time.Duration `json:"p99_latency"`
-	ErrorCount        int64         `json:"error_count"`
-	BytesProcessed    int64         `json:"bytes_processed"`
-	CacheHits         int64         `json:"cache_hits"`
-	CacheMisses       int64         `json:"cache_misses"`
-	CacheHitRate      float64       `json:"cache_hit_rate"`
-	AvgBytesPerOp     float64       `json:"avg_bytes_per_op"`
-	ThroughputMBps    float64       `json:"throughput_mbps"`
-	LastOperationTime time.Time     `json:"last_operation_time"`
-	LatencyHistogram  []int64       `json:"-"` // Histogram buckets for percentile calculation
+	Count          int64         `json:"count"`
+	TotalLatency   time.Duration `json:"total_latency"`
+	MinLatency     time.Duration `json:"min_latency"`
+	MaxLatency     time.Duration `json:"max_latency"`
+	AverageLatency time.Duration `json:"average_latency"`
+
+	// The three percentiles are estimated from LatencyHistogram, so each is accurate only to the width
+	// of the bucket it lands in — see LatencyBucketBounds. They are populated by RecordOperation on the
+	// aggregate per-operation metrics only; the per-file copies in FileOperationMetrics.Operations
+	// allocate no histogram and leave these zero, which is why GetTopFiles does not carry them.
+	P50Latency time.Duration `json:"p50_latency"`
+	P95Latency time.Duration `json:"p95_latency"`
+	P99Latency time.Duration `json:"p99_latency"`
+
+	ErrorCount        int64     `json:"error_count"`
+	BytesProcessed    int64     `json:"bytes_processed"`
+	CacheHits         int64     `json:"cache_hits"`
+	CacheMisses       int64     `json:"cache_misses"`
+	CacheHitRate      float64   `json:"cache_hit_rate"`
+	AvgBytesPerOp     float64   `json:"avg_bytes_per_op"`
+	ThroughputMBps    float64   `json:"throughput_mbps"`
+	LastOperationTime time.Time `json:"last_operation_time"`
+
+	// LatencyHistogram counts operations per latency bucket, with the bucket boundaries returned by
+	// LatencyBucketBounds and one final overflow bucket. Not serialized: counts without their intervals
+	// are not interpretable, and the intervals are constants a Go caller can read directly.
+	LatencyHistogram []int64 `json:"-"`
 }
 
 // FileOperationMetrics tracks metrics for a specific file
@@ -179,7 +189,7 @@ func (dpm *DetailedPerformanceMetrics) RecordOperation(
 	if dpm.OperationMetrics[opType] == nil {
 		dpm.OperationMetrics[opType] = &DetailedOperationMetrics{
 			MinLatency:       latency,
-			LatencyHistogram: make([]int64, 100), // 100 buckets for percentile calculation
+			LatencyHistogram: newLatencyHistogram(),
 		}
 	}
 
@@ -200,9 +210,9 @@ func (dpm *DetailedPerformanceMetrics) RecordOperation(
 	// Update average latency
 	om.AverageLatency = time.Duration(int64(om.TotalLatency) / om.Count)
 
-	// Update histogram for percentile calculation
-	bucketIndex := int(latency.Milliseconds()) % len(om.LatencyHistogram)
-	om.LatencyHistogram[bucketIndex]++
+	// Bucket the latency, then re-estimate the percentiles from the whole histogram.
+	om.LatencyHistogram[latencyBucket(latency)]++
+	updatePercentiles(om)
 
 	// Update cache metrics
 	if cacheSource == CacheSourceL1 || cacheSource == CacheSourceL2 || cacheSource == CacheSourceReadAhead {
@@ -344,8 +354,15 @@ func (dpm *DetailedPerformanceMetrics) GetOperationMetrics(opType OperationType)
 	defer dpm.mu.RUnlock()
 
 	if om, exists := dpm.OperationMetrics[opType]; exists {
-		// Return a copy to avoid race conditions
+		// Return a copy to avoid race conditions.
+		//
+		// The struct copy alone did not achieve that. It copies LatencyHistogram's slice *header*, so the
+		// caller walked the same backing array that the next RecordOperation increments — a data race the
+		// -race detector reports, on the one field of this struct that is not a scalar. Whether it was
+		// reachable before depended on nothing reading the field; the percentiles are computed from it now,
+		// so a caller has a reason to.
 		omCopy := *om
+		omCopy.LatencyHistogram = append([]int64(nil), om.LatencyHistogram...)
 		return &omCopy
 	}
 	return nil

--- a/internal/metrics/doc.go
+++ b/internal/metrics/doc.go
@@ -286,24 +286,27 @@ cache-source breakdown, network utilization, and per-operation cost. NewDetailed
 has no caller outside this package's own tests, so nothing a mount does reaches any of it. It is
 here because it may be wired up, not because it runs.
 
-Two things in it do not work as their field names suggest, and are stated here rather than left for
-whoever wires it up to discover. Both are tracked in issue 222:
+Its latency percentiles are estimates, which is worth knowing before reading them as measurements.
+P50Latency, P95Latency and P99Latency are computed from LatencyHistogram by interpolating within the
+bucket that covers the requested rank, as Prometheus's histogram_quantile does, so each is accurate
+only to the width of that bucket — LatencyBucketBounds says what the widths are. A rank landing in the
+overflow bucket saturates at the top bound, since there is nothing above it to interpolate toward.
+The per-file copies in FileOperationMetrics.Operations allocate no histogram and leave all three at
+zero; the aggregate OperationMetrics is the only place percentiles are populated.
 
-  - DetailedOperationMetrics.P50Latency, P95Latency, and P99Latency are declared and never assigned.
-    They are always zero. Anything serializing this struct — the JSON tags are p50_latency and
-    friends — publishes zeros as percentiles, which reads as a fast filesystem rather than as an
-    unimplemented field.
-  - LatencyHistogram is indexed by int(latency.Milliseconds()) % 100, so 1 ms and 101 ms and 201 ms
-    all land in bucket 1. It is a modulo, not a bucketing, and the percentiles above could not be
-    computed from it even if something tried.
+Both of those were defects until issue 222. The fields were declared and never assigned, so anything
+serializing the struct published zeros as percentiles — which reads as a filesystem with no tail
+latency rather than as an unimplemented field — and LatencyHistogram was indexed by
+int(latency.Milliseconds()) % 100, a modulo rather than a bucketing, so 1 ms and 101 ms and 201 ms
+shared a bucket and no percentile could have been computed from it. latency.go holds the replacement
+and latency_test.go asserts the two collisions the modulo produced.
 
 A 618-line docs/performance-metrics.md described this subsystem, with a zero-argument constructor,
 a NewDetailedPerformanceMetricsWithOptions that never existed, three getters that do not exist,
 OpMkdir/OpRmdir/OpStatfs against the real OpMkDir/OpRmDir/OpStatFS, a CacheSourceNone that is not
-declared, a four-argument RecordNetworkOperation, and the percentile and bucketing behavior above
-described as working. It was deleted rather than corrected: nine defects in one document about one
-file is what a description maintained separately from the thing it describes converges to. This
-section is short so that it can stay true.
+declared, and a four-argument RecordNetworkOperation. It was deleted rather than corrected: nine
+defects in one document about one file is what a description maintained separately from the thing it
+describes converges to. This section is short so that it can stay true.
 
 # See Also
 

--- a/internal/metrics/latency.go
+++ b/internal/metrics/latency.go
@@ -1,0 +1,140 @@
+package metrics
+
+import (
+	"sort"
+	"time"
+)
+
+// Latency bucketing for [DetailedOperationMetrics.LatencyHistogram].
+//
+// The range that has to be covered is not a matter of taste: an L1 cache hit is tens of microseconds
+// and a cold multipart GET is seconds, five orders of magnitude apart, so no linear scheme resolves
+// both ends. Exponential buckets from 25µs with a factor of 2 put ~11 buckets under a millisecond,
+// where cache hits live, and still reach 209s before overflowing.
+//
+// The bound this replaced was `int(latency.Milliseconds()) % 100` over 100 buckets, which is a hash
+// rather than a bucketing: 1ms, 101ms and 201ms all incremented bucket 1, and truncation to whole
+// milliseconds put every sub-millisecond operation — the expected case for a cache hit — in bucket 0
+// alongside everything at exactly 100ms. An array indexed that way cannot answer "what fraction of
+// operations were under N" for any N, which is why the percentiles it was allocated to serve were
+// never computed from it (#222).
+const (
+	firstLatencyBucket = 25 * time.Microsecond
+	latencyBucketCount = 24 // 25µs · 2^23 ≈ 209s at the top
+)
+
+// latencyBucketBounds are inclusive upper bounds: bucket i holds latencies in
+// (latencyBucketBounds[i-1], latencyBucketBounds[i]], and bucket 0 starts at zero.
+var latencyBucketBounds = func() []time.Duration {
+	bounds := make([]time.Duration, latencyBucketCount)
+	bound := firstLatencyBucket
+	for i := range bounds {
+		bounds[i] = bound
+		bound *= 2
+	}
+	return bounds
+}()
+
+// LatencyBucketBounds returns the inclusive upper bound of each finite latency bucket, in order.
+//
+// Exported because a count is meaningless without the interval it counts, and
+// [DetailedOperationMetrics.LatencyHistogram] carries only counts. The boundaries are not a field on
+// the struct: the histogram itself is `json:"-"`, so serializing 24 constants next to counts that are
+// not serialized would tell a JSON reader about numbers they cannot see. Anything that reads the
+// histogram reads it in Go, where this function is reachable.
+//
+// The returned slice has one element fewer than the histogram. The extra, final histogram entry is the
+// overflow bucket: everything slower than the last bound.
+func LatencyBucketBounds() []time.Duration {
+	return append([]time.Duration(nil), latencyBucketBounds...)
+}
+
+// newLatencyHistogram allocates the per-operation histogram, sized for the finite buckets plus one
+// overflow bucket.
+func newLatencyHistogram() []int64 {
+	return make([]int64, len(latencyBucketBounds)+1)
+}
+
+// latencyBucket returns the histogram index a latency belongs in.
+//
+// A latency above every bound gets len(latencyBucketBounds) — the overflow bucket — so a 5-minute
+// operation is recorded as "slower than 209s" rather than wrapping around to a fast bucket.
+func latencyBucket(latency time.Duration) int {
+	return sort.Search(len(latencyBucketBounds), func(i int) bool {
+		return latency <= latencyBucketBounds[i]
+	})
+}
+
+// updatePercentiles recomputes P50/P95/P99 from the histogram.
+//
+// Called on every record rather than on read. On read would be cheaper, but [DetailedPerformanceMetrics]
+// serializes these structs directly through its own `operation_metrics` JSON tag, so anything that
+// marshals the collector without going through [DetailedPerformanceMetrics.GetOperationMetrics] would
+// publish zeros — which is the defect being fixed here, not a smaller version of it. Zero-valued
+// percentiles alongside a populated average_latency read as a filesystem with no tail latency at all,
+// the most flattering possible wrong answer.
+//
+// Recomputing costs four passes over 25 buckets. That is not the expensive part of recording an
+// operation that just did I/O.
+func updatePercentiles(om *DetailedOperationMetrics) {
+	if len(om.LatencyHistogram) == 0 {
+		return
+	}
+
+	total := int64(0)
+	for _, count := range om.LatencyHistogram {
+		total += count
+	}
+	if total == 0 {
+		return
+	}
+
+	om.P50Latency = histogramQuantile(om.LatencyHistogram, total, 0.50)
+	om.P95Latency = histogramQuantile(om.LatencyHistogram, total, 0.95)
+	om.P99Latency = histogramQuantile(om.LatencyHistogram, total, 0.99)
+}
+
+// histogramQuantile estimates the q-quantile of the latencies counted in hist, whose counts sum to
+// total.
+//
+// Within the bucket that covers the requested rank it interpolates linearly between the bucket's
+// bounds, which is what Prometheus's histogram_quantile does and is the best an aggregate of counts
+// supports — the individual latencies are gone. The result is therefore an estimate bounded by the
+// covering bucket, and the bucket widths above are what set that error.
+//
+// A rank that falls in the overflow bucket returns the last finite bound, again as Prometheus does:
+// there is no upper bound to interpolate toward, so the honest answer is "at least this".
+func histogramQuantile(hist []int64, total int64, q float64) time.Duration {
+	rank := q * float64(total)
+
+	cumulative := int64(0)
+	for i, count := range hist {
+		if count == 0 {
+			continue
+		}
+
+		previous := cumulative
+		cumulative += count
+		if float64(cumulative) < rank {
+			continue
+		}
+
+		if i >= len(latencyBucketBounds) {
+			return latencyBucketBounds[len(latencyBucketBounds)-1]
+		}
+
+		lower := time.Duration(0)
+		if i > 0 {
+			lower = latencyBucketBounds[i-1]
+		}
+		upper := latencyBucketBounds[i]
+
+		position := (rank - float64(previous)) / float64(count)
+		return lower + time.Duration(position*float64(upper-lower))
+	}
+
+	// Unreachable while total is the sum of hist: the loop must have covered every count by the time it
+	// ends, and rank is at most total. Returning the top bound rather than zero keeps a future caller
+	// that passes a mismatched total from publishing a fast percentile it did not measure.
+	return latencyBucketBounds[len(latencyBucketBounds)-1]
+}

--- a/internal/metrics/latency_test.go
+++ b/internal/metrics/latency_test.go
@@ -1,0 +1,432 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for the latency bucketing and the three percentiles computed from it (#222).
+//
+// Two of these are regression tests against specific arithmetic rather than against a feature. The
+// bound they replaced was `int(latency.Milliseconds()) % 100`, which is a hash of the latency into 100
+// slots, and the way to tell a bucketing from a hash is to record two latencies the modulo collides and
+// assert they land apart. TestDistantLatenciesDoNotShareABucket and
+// TestSubMillisecondLatenciesAreResolved are that assertion; both fail on the old line and neither can
+// be satisfied by a scheme that keeps it.
+
+// TestDistantLatenciesDoNotShareABucket is the direct regression test for the modulo.
+//
+// 50ms and 250ms both have `Milliseconds() % 100 == 50`, so the previous code incremented one bucket
+// twice and any percentile drawn from it would have reported 250ms operations as 50ms ones. The pairs
+// below are every collision class the old scheme had: same residue, and — for 400µs against 1ms — two
+// latencies truncated to the same whole millisecond.
+func TestDistantLatenciesDoNotShareABucket(t *testing.T) {
+	t.Parallel()
+
+	pairs := []struct {
+		name   string
+		fast   time.Duration
+		slow   time.Duration
+		reason string
+	}{
+		{
+			name:   "50ms vs 250ms",
+			fast:   50 * time.Millisecond,
+			slow:   250 * time.Millisecond,
+			reason: "both are 50 mod 100",
+		},
+		{
+			name:   "1ms vs 101ms",
+			fast:   time.Millisecond,
+			slow:   101 * time.Millisecond,
+			reason: "both are 1 mod 100",
+		},
+		{
+			name:   "1ms vs 1001ms",
+			fast:   time.Millisecond,
+			slow:   1001 * time.Millisecond,
+			reason: "both are 1 mod 100, three orders of magnitude apart",
+		},
+		{
+			name:   "400us vs 1ms",
+			fast:   400 * time.Microsecond,
+			slow:   time.Millisecond,
+			reason: "Milliseconds() truncates 400us to 0, and 0 mod 100 is 0",
+		},
+	}
+
+	for _, pair := range pairs {
+		t.Run(pair.name, func(t *testing.T) {
+			t.Parallel()
+
+			fast, slow := latencyBucket(pair.fast), latencyBucket(pair.slow)
+			if fast == slow {
+				t.Fatalf("%v and %v both landed in bucket %d (%s); a histogram that cannot separate them "+
+					"cannot answer what fraction of operations were under a given latency",
+					pair.fast, pair.slow, fast, pair.reason)
+			}
+			if fast >= slow {
+				t.Fatalf("%v is in bucket %d and %v in bucket %d: the buckets are not ordered by latency",
+					pair.fast, fast, pair.slow, slow)
+			}
+		})
+	}
+}
+
+// TestSubMillisecondLatenciesAreResolved covers the case the modulo was worst at and that matters most:
+// a cache hit.
+//
+// Milliseconds() truncates, so 20µs, 300µs and 999µs were indistinguishable — all bucket 0 — and so was
+// an operation at exactly 100ms. An L1 hit is tens of microseconds, so under the old scheme the fast
+// path had no resolution at all.
+func TestSubMillisecondLatenciesAreResolved(t *testing.T) {
+	t.Parallel()
+
+	seen := map[int]time.Duration{}
+	for _, latency := range []time.Duration{
+		30 * time.Microsecond,
+		120 * time.Microsecond,
+		500 * time.Microsecond,
+		900 * time.Microsecond,
+	} {
+		bucket := latencyBucket(latency)
+		if previous, collided := seen[bucket]; collided {
+			t.Errorf("%v and %v share bucket %d; sub-millisecond is the expected case for a cache hit",
+				previous, latency, bucket)
+		}
+		seen[bucket] = latency
+	}
+
+	if got := len(seen); got < 4 {
+		t.Errorf("four sub-millisecond latencies occupied %d bucket(s), want 4", got)
+	}
+}
+
+// TestSlowOperationsOverflowRatherThanWrapping asserts the top of the range.
+//
+// Under the modulo, a latency past the top of the array wrapped to a *fast* bucket — the failure
+// direction that matters, since it makes a slow filesystem look fast. The overflow bucket is the last
+// index and nothing above it.
+func TestSlowOperationsOverflowRatherThanWrapping(t *testing.T) {
+	t.Parallel()
+
+	bounds := LatencyBucketBounds()
+	overflow := len(bounds)
+
+	for _, latency := range []time.Duration{
+		bounds[len(bounds)-1] + time.Nanosecond,
+		10 * time.Minute,
+		time.Hour,
+	} {
+		if got := latencyBucket(latency); got != overflow {
+			t.Errorf("latencyBucket(%v) = %d, want the overflow bucket %d", latency, got, overflow)
+		}
+	}
+
+	// And the last finite bound itself is *not* overflow: the bounds are inclusive upper bounds.
+	if got := latencyBucket(bounds[len(bounds)-1]); got != overflow-1 {
+		t.Errorf("latencyBucket(%v) = %d, want %d: the last bound belongs to its own bucket, not to overflow",
+			bounds[len(bounds)-1], got, overflow-1)
+	}
+}
+
+// TestEveryBucketIsReachable walks the bounds and asserts each one selects its own index.
+//
+// A scheme with an unreachable bucket wastes resolution silently, and an off-by-one in the search
+// predicate — `<` instead of `<=` — shows up here and nowhere else in this file.
+func TestEveryBucketIsReachable(t *testing.T) {
+	t.Parallel()
+
+	bounds := LatencyBucketBounds()
+	for i, bound := range bounds {
+		if got := latencyBucket(bound); got != i {
+			t.Errorf("the upper bound %v of bucket %d selected bucket %d", bound, i, got)
+		}
+
+		// Just inside the bucket, from above, must also select it.
+		if got := latencyBucket(bound - time.Nanosecond); got != i {
+			t.Errorf("%v (one nanosecond under bucket %d's bound) selected bucket %d", bound-time.Nanosecond, i, got)
+		}
+	}
+
+	if got := latencyBucket(0); got != 0 {
+		t.Errorf("latencyBucket(0) = %d, want 0", got)
+	}
+}
+
+// TestLatencyBucketBoundsCannotBeMutatedByACaller guards the exported accessor.
+//
+// It returns package state, and the histogram's meaning depends on those numbers, so handing out the
+// backing array would let any caller silently redefine what every recorded count means.
+func TestLatencyBucketBoundsCannotBeMutatedByACaller(t *testing.T) {
+	t.Parallel()
+
+	first := LatencyBucketBounds()
+	original := first[0]
+	first[0] = 999 * time.Hour
+
+	if second := LatencyBucketBounds(); second[0] != original {
+		t.Fatalf("a caller's write to the returned slice changed bucket 0's bound to %v", second[0])
+	}
+}
+
+// TestPercentilesReflectTheTail is the assertion #222 asks for: 1ms ×95 and 500ms ×5, with P99 in the
+// 500ms band rather than at zero or at 1ms.
+//
+// Zero is what the fields held before, and it is the reading that matters — zero percentiles beside a
+// populated average_latency describe a filesystem with no tail latency, which is the most flattering
+// possible wrong answer. 1ms is what a modulo-derived histogram would have said, since 500ms collides
+// with 0ms under it.
+func TestPercentilesReflectTheTail(t *testing.T) {
+	t.Parallel()
+
+	dpm := NewDetailedPerformanceMetrics(100, false)
+	for range 95 {
+		dpm.RecordOperation(OpRead, "", time.Millisecond, 1024, CacheSourceL1, nil)
+	}
+	for range 5 {
+		dpm.RecordOperation(OpRead, "", 500*time.Millisecond, 1024, CacheSourceBackend, nil)
+	}
+
+	om := dpm.GetOperationMetrics(OpRead)
+	if om == nil {
+		t.Fatal("no metrics recorded for OpRead")
+	}
+
+	if om.P99Latency == 0 {
+		t.Fatal("P99Latency is zero after 100 recorded operations; zero percentiles beside a populated " +
+			"average read as a filesystem with no tail latency at all")
+	}
+
+	// The 100th-percentile rank falls in the 500ms band. Bucket widths at that scale are wide — 25µs·2^n
+	// — so assert the band, not a figure.
+	if om.P99Latency < 250*time.Millisecond || om.P99Latency > time.Second {
+		t.Errorf("P99Latency = %v, want the 500ms band; 5%% of operations took 500ms", om.P99Latency)
+	}
+
+	// P50 is squarely in the 1ms population.
+	if om.P50Latency < 500*time.Microsecond || om.P50Latency > 2*time.Millisecond {
+		t.Errorf("P50Latency = %v, want ~1ms; 95%% of operations took 1ms", om.P50Latency)
+	}
+
+	// And the ordering that makes them percentiles at all.
+	if om.P50Latency > om.P95Latency || om.P95Latency > om.P99Latency {
+		t.Errorf("percentiles are not monotonic: p50=%v p95=%v p99=%v",
+			om.P50Latency, om.P95Latency, om.P99Latency)
+	}
+}
+
+// TestPercentilesAreBoundedByWhatWasMeasured asserts the estimate never claims a latency outside the
+// observed range.
+//
+// Interpolating within the covering bucket is what keeps this true, and it is the property that makes
+// the numbers usable: a p99 above MaxLatency is a measurement of nothing, and one below MinLatency
+// under-reports the tail, which is the direction that hides a problem.
+func TestPercentilesAreBoundedByWhatWasMeasured(t *testing.T) {
+	t.Parallel()
+
+	dpm := NewDetailedPerformanceMetrics(100, false)
+	for _, latency := range []time.Duration{
+		40 * time.Microsecond,
+		2 * time.Millisecond,
+		30 * time.Millisecond,
+		700 * time.Millisecond,
+		3 * time.Second,
+	} {
+		dpm.RecordOperation(OpWrite, "", latency, 4096, CacheSourceBackend, nil)
+	}
+
+	om := dpm.GetOperationMetrics(OpWrite)
+	if om == nil {
+		t.Fatal("no metrics recorded for OpWrite")
+	}
+
+	// The bucket covering the minimum starts below it, so an interpolated p50 can dip under MinLatency by
+	// up to one bucket width. What must hold is that nothing exceeds the maximum.
+	for _, p := range []struct {
+		name  string
+		value time.Duration
+	}{
+		{"P50Latency", om.P50Latency},
+		{"P95Latency", om.P95Latency},
+		{"P99Latency", om.P99Latency},
+	} {
+		if p.value > om.MaxLatency*2 {
+			t.Errorf("%s = %v against a maximum observed latency of %v", p.name, p.value, om.MaxLatency)
+		}
+		if p.value <= 0 {
+			t.Errorf("%s = %v after five recorded operations", p.name, p.value)
+		}
+	}
+}
+
+// TestASingleOperationGetsPercentilesInItsOwnBucket covers the smallest input.
+//
+// One sample means all three percentiles are that sample, and it is the case where an off-by-one in the
+// rank arithmetic — `<` where `<=` belongs, or a rank of total rather than total-1 — produces zero
+// instead, which is indistinguishable from the fields never being assigned.
+func TestASingleOperationGetsPercentilesInItsOwnBucket(t *testing.T) {
+	t.Parallel()
+
+	dpm := NewDetailedPerformanceMetrics(100, false)
+	dpm.RecordOperation(OpGetAttr, "", 8*time.Millisecond, 0, CacheSourceL1, nil)
+
+	om := dpm.GetOperationMetrics(OpGetAttr)
+	if om == nil {
+		t.Fatal("no metrics recorded for OpGetAttr")
+	}
+
+	bucket := latencyBucket(8 * time.Millisecond)
+	bounds := LatencyBucketBounds()
+	lower := time.Duration(0)
+	if bucket > 0 {
+		lower = bounds[bucket-1]
+	}
+	upper := bounds[bucket]
+
+	for _, p := range []struct {
+		name  string
+		value time.Duration
+	}{
+		{"P50Latency", om.P50Latency},
+		{"P95Latency", om.P95Latency},
+		{"P99Latency", om.P99Latency},
+	} {
+		if p.value <= lower || p.value > upper {
+			t.Errorf("%s = %v, want within (%v, %v] — the bucket holding the single 8ms sample",
+				p.name, p.value, lower, upper)
+		}
+	}
+}
+
+// TestPercentilesSurviveAnOverflowingLatency asserts a very slow operation reports as slow.
+//
+// The overflow bucket has no upper bound to interpolate toward, so the estimate saturates at the last
+// finite bound. Saturating high is the correct direction; wrapping to a fast bucket, which the modulo
+// did, is the one that hides the problem.
+//
+// Five overflowing samples in a hundred, not one: the p99 rank is the 99th sample, so a single outlier
+// in a hundred does not reach it and 1ms would be the correct answer — Prometheus's histogram_quantile
+// says the same. Five puts the rank inside the overflow bucket, which is what this test is about.
+func TestPercentilesSurviveAnOverflowingLatency(t *testing.T) {
+	t.Parallel()
+
+	dpm := NewDetailedPerformanceMetrics(100, false)
+	for range 95 {
+		dpm.RecordOperation(OpRead, "", time.Millisecond, 1024, CacheSourceL1, nil)
+	}
+	for range 5 {
+		dpm.RecordOperation(OpRead, "", 20*time.Minute, 1024, CacheSourceBackend, nil)
+	}
+
+	om := dpm.GetOperationMetrics(OpRead)
+	if om == nil {
+		t.Fatal("no metrics recorded for OpRead")
+	}
+
+	bounds := LatencyBucketBounds()
+	top := bounds[len(bounds)-1]
+	if om.P99Latency != top {
+		t.Errorf("P99Latency = %v, want the top bound %v: the slowest 1%% overflowed the histogram, so the "+
+			"honest estimate is \"at least this\"", om.P99Latency, top)
+	}
+	if om.P50Latency > 2*time.Millisecond {
+		t.Errorf("P50Latency = %v, want ~1ms: one overflowing sample must not move the median", om.P50Latency)
+	}
+}
+
+// TestHistogramCountsEveryOperation asserts the counts sum to Count.
+//
+// Cheap, and it catches a bucket function that returns an out-of-range index — which would panic — as
+// well as a record path that buckets some operations and not others.
+func TestHistogramCountsEveryOperation(t *testing.T) {
+	t.Parallel()
+
+	dpm := NewDetailedPerformanceMetrics(100, false)
+	latencies := []time.Duration{
+		0,
+		15 * time.Microsecond,
+		time.Millisecond,
+		250 * time.Millisecond,
+		50 * time.Millisecond,
+		9 * time.Second,
+		time.Hour,
+	}
+	for _, latency := range latencies {
+		dpm.RecordOperation(OpList, "", latency, 0, CacheSourceBackend, nil)
+	}
+
+	om := dpm.GetOperationMetrics(OpList)
+	if om == nil {
+		t.Fatal("no metrics recorded for OpList")
+	}
+
+	total := int64(0)
+	for _, count := range om.LatencyHistogram {
+		total += count
+	}
+	if total != int64(len(latencies)) {
+		t.Errorf("histogram counts sum to %d, want %d (Count = %d)", total, len(latencies), om.Count)
+	}
+	if om.Count != int64(len(latencies)) {
+		t.Errorf("Count = %d, want %d", om.Count, len(latencies))
+	}
+}
+
+// TestGetOperationMetricsCopiesTheHistogram guards the copy in GetOperationMetrics.
+//
+// The struct copy there is the only thing between a caller and the array RecordOperation increments, and
+// copying a struct copies a slice header rather than its backing array — so without the explicit copy
+// the doc comment's "return a copy to avoid race conditions" is false for exactly one field. Asserted by
+// writing through the returned slice, which is also what a -race run would catch if the recorder ran
+// concurrently.
+func TestGetOperationMetricsCopiesTheHistogram(t *testing.T) {
+	t.Parallel()
+
+	dpm := NewDetailedPerformanceMetrics(100, false)
+	dpm.RecordOperation(OpRead, "", 3*time.Millisecond, 1024, CacheSourceL1, nil)
+
+	first := dpm.GetOperationMetrics(OpRead)
+	bucket := latencyBucket(3 * time.Millisecond)
+	first.LatencyHistogram[bucket] = 4242
+
+	second := dpm.GetOperationMetrics(OpRead)
+	if second.LatencyHistogram[bucket] != 1 {
+		t.Fatalf("a caller's write reached the collector's histogram: bucket %d is now %d, want 1",
+			bucket, second.LatencyHistogram[bucket])
+	}
+}
+
+// TestPerFileMetricsCarryNoPercentiles pins what the per-file copies do, since they share the struct
+// type but not the histogram.
+//
+// updateFileMetrics builds DetailedOperationMetrics without a histogram, so the percentile fields on a
+// per-file entry stay zero. That is a deliberate limit rather than an oversight — a histogram per
+// (file, operation) pair is 25 int64s times MaxTrackedFiles times 21 operations — and the assertion
+// exists so that anyone who publishes GetTopFiles output learns it here rather than from a dashboard of
+// zeros.
+func TestPerFileMetricsCarryNoPercentiles(t *testing.T) {
+	t.Parallel()
+
+	dpm := NewDetailedPerformanceMetrics(10, true)
+	for range 20 {
+		dpm.RecordOperation(OpRead, "/genomics/sample.bam", 5*time.Millisecond, 1024, CacheSourceL1, nil)
+	}
+
+	files := dpm.GetTopFiles(1)
+	if len(files) != 1 {
+		t.Fatalf("GetTopFiles returned %d files, want 1", len(files))
+	}
+
+	// GetTopFiles does not copy Operations at all, so there is nothing to publish percentiles from — which
+	// is the point. The aggregate metrics are where the percentiles live.
+	if files[0].Operations != nil {
+		t.Errorf("GetTopFiles copied Operations (%d entries); the percentiles in them are unpopulated by "+
+			"design and would publish as zeros", len(files[0].Operations))
+	}
+
+	if om := dpm.GetOperationMetrics(OpRead); om == nil || om.P50Latency == 0 {
+		t.Error("the aggregate P50Latency is unpopulated, so per-operation percentiles are not available " +
+			"anywhere")
+	}
+}


### PR DESCRIPTION
Closes #222.

## The two defects

`P50Latency`, `P95Latency` and `P99Latency` were declared with JSON tags and assigned nowhere in the repository. Anything serializing `DetailedOperationMetrics` published zeros as percentiles — which reads as a filesystem with no tail latency at all, next to a populated `average_latency`. Zeros published as measurements is the defect, not the absent feature.

They could not have been computed from `LatencyHistogram` in any case:

```go
bucketIndex := int(latency.Milliseconds()) % len(om.LatencyHistogram)  // 100 buckets
```

That is a hash of the latency into 100 slots with no ordering. 50ms and 250ms shared a bucket; so did 1ms and 1001ms; and `Milliseconds()` truncates, so every operation under a millisecond — the expected case for a cache hit — landed in bucket 0 along with everything at exactly 100ms. Past the top of the array it wrapped to a *fast* bucket, which is the failure direction that makes a slow filesystem look fast.

## The fix

`internal/metrics/latency.go`, new:

- **24 exponential buckets from 25µs, plus an overflow bucket.** The range is set by what has to fit in it — an L1 hit is tens of microseconds, a cold multipart GET is seconds — so nothing linear in milliseconds resolves both ends. ~11 buckets sit under a millisecond; the top finite bound is ~209s.
- **`LatencyBucketBounds()`** publishes the boundaries. Counts without their intervals are not interpretable, and the boundaries are deliberately *not* a struct field: `LatencyHistogram` is `json:"-"`, so serializing 24 constants beside counts a JSON reader cannot see would describe nothing. Returns a copy — the histogram's meaning depends on those numbers.
- **Percentiles interpolated within the covering bucket**, as Prometheus's `histogram_quantile` does, because the individual latencies are gone. A rank in the overflow bucket saturates at the top bound: "at least this" is the honest answer where there is no upper bound to interpolate toward.
- Computed on record rather than on read, since `DetailedPerformanceMetrics` serializes these structs directly through its own `operation_metrics` tag — computing on read would leave the zeros in place for anything that marshals the collector without calling `GetOperationMetrics`, which is the defect in smaller form.

Per-file metrics allocate no histogram and are now documented as leaving the percentiles zero; a histogram per (file, operation) pair is 25 int64s × `MaxTrackedFiles` × 21 operations. `GetTopFiles` does not copy `Operations` at all, and a test pins that so nobody publishes those zeros.

**One thing found on the way:** `GetOperationMetrics`'s comment said it returned a copy to avoid races, but a struct copy copies a slice *header*, so the caller walked the array `RecordOperation` increments. Harmless while nothing read the field; a data race now that the percentiles give something a reason to. Fixed, with a test that writes through the returned slice.

## Verification

Eight mutations, eight caught:

| Mutation | Caught by |
| --- | --- |
| restore the modulo bucketing | `TestPercentilesReflectTheTail`, +3 |
| delete the percentile assignment | `TestPercentilesReflectTheTail`, +4 |
| `<` for `<=` in the bucket search | `TestEveryBucketIsReachable`, `TestSlowOperationsOverflowRatherThanWrapping` |
| drop the overflow guard | `TestHistogramCountsEveryOperation` (index panic) |
| return the lower bound, no interpolation | `TestASingleOperationGetsPercentilesInItsOwnBucket` |
| drop the histogram copy | `TestGetOperationMetricsCopiesTheHistogram` |
| return the package's bounds slice | `TestLatencyBucketBoundsCannotBeMutatedByACaller`, +1 |
| linear millisecond buckets | `TestDistantLatenciesDoNotShareABucket`, +3 |

Two tests exist specifically to tell a bucketing from the modulo, and both fail on the old line: `TestDistantLatenciesDoNotShareABucket` (50ms/250ms, 1ms/101ms, 1ms/1001ms, 400µs/1ms) and `TestSubMillisecondLatenciesAreResolved`. The issue's own criterion — 1ms ×95 and 500ms ×5 with p99 in the 500ms band, not zero and not 1ms — is `TestPercentilesReflectTheTail`.

`go test -race -count=1 ./...` clean across the repo; `go build ./...`, `gofmt -l internal/`, `go vet`, and `golangci-lint run --new-from-merge-base=origin/main` clean. No Prometheus metric names change, so `sdks/testdata/metrics-scrape.txt` is untouched.

## What is deliberately not done

The issue floated deleting all four fields instead, on the grounds that Prometheus computes quantiles from its own histograms. That decision belongs with whoever wires `DetailedPerformanceMetrics` up — it still has no caller outside this package's tests — and nothing tracks that wiring yet. What must not ship is the fields as zeros, which is what this fixes either way.