### PR TITLE
feat(cache): the predictive cache's statistics reach a scrape (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is no predictive layer to ask, as on a Redis-backed cache: zeros there would claim a predictor that
   never fires, which is a different statement from having no predictor.
 
+  A ratio could also momentarily exceed 1, which is a value neither statistic can take. Both recording
+  functions published their range into a ledger and *then* took the stats lock to count it, and a range is
+  claimable the instant it is there — so under several readers against one prefetch worker, hits were
+  credited against a denominator that had not been incremented yet. CI observed `prefetch_efficiency` at
+  4, and forty local runs of the same test did not. Both now count before they publish. Neither lock can
+  be held across both halves — the ledger is written by prefetch workers while a read holds the stats
+  lock, and the reverse order exists too — so ordering the two uncontended sections is the fix, and it is
+  the right direction: the remaining window makes a ratio briefly *low* rather than impossible, and a
+  cumulative counter that has run past its bound stays wrong for the life of the mount.
+
 - **Latency percentiles were published as zeros, and the histogram they were meant to come from was a
   modulo rather than a bucketing** ([#222]). `DetailedOperationMetrics` declared `P50Latency`,
   `P95Latency` and `P99Latency` with JSON tags and never assigned any of them, so anything serializing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The predictive cache's statistics were computed on every read of every mount and discarded at
+  unmount** ([#223]). `GetPredictiveStats` existed and nothing could reach it: the mount holds its
+  `PredictiveCache` as an opaque `types.Cache` — six methods about bytes, with `GetLevelStats` returning a
+  `types.CacheStats` — so there was no accessor at any layer above it. `MultiLevelCache` now has
+  `GetPredictiveCache` and `PredictiveStats`, the names `docs/features/read-ahead.md` had already
+  described, and the mount publishes them to `/metrics` as `objectfs_predictive_cache`, one series per
+  statistic under a `statistic` label. Both SDKs see them: `sdks/testdata/metrics-scrape.txt` carries the
+  family, so a renamed statistic fails the Python and TypeScript suites in the same commit.
+
+  The accessor alone would have been half the fix, because **14 of the 17 fields it returned were assigned
+  nowhere**. `PredictionsTotal`, `PredictionsCorrect`, `PrefetchRequests`, `PrefetchWaste`, the two
+  eviction counters and both ratios were declared with JSON tags and never written, and `PrefetchHits`'s
+  guard was `event.Hit && event.Prefetch` where nothing in the tree ever set `Prefetch` — so it was
+  unreachable rather than merely unwritten. A zero that reads as a measurement is worse than an absent
+  one, which is the same defect as [#222] in a different subsystem, so the statistics are implemented
+  along with the way to read them. Seven fields whose inputs the cache cannot observe were removed rather
+  than left as zeros — `LatencyReduction` would need the latency of the read that *did not happen*.
+
+  Attribution rests on a new bounded range ledger, because it cannot be recovered after the fact: a cache
+  hit looks identical whether the bytes came from the application's own earlier read or from a prefetch. A
+  read is credited to a recorded range only if the range **contains** it, and the range is **consumed** on
+  the claim — a half-covered read was half-served, and a prefetch fetched its bytes once so it can be
+  right once. Both rules make the counters undercount rather than overcount, which is the direction that
+  does not flatter the prefetcher, and consuming is what keeps `prefetch_efficiency` from exceeding 1.
+  Waste is counted at eviction, since that is the moment "nothing will ever read this" becomes knowable.
+
+  Two honest zeros to expect. `prefetch_*` reads zero on a mount today while the prediction and eviction
+  statistics populate, because `initializeLevels` builds the predictive cache with no backend to fetch
+  through — the workers dequeue jobs and store nothing. And the family is **absent, not zero**, when there
+  is no predictive layer to ask, as on a Redis-backed cache: zeros there would claim a predictor that
+  never fires, which is a different statement from having no predictor.
+
 - **Latency percentiles were published as zeros, and the histogram they were meant to come from was a
   modulo rather than a bucketing** ([#222]). `DetailedOperationMetrics` declared `P50Latency`,
   `P95Latency` and `P99Latency` with JSON tags and never assigned any of them, so anything serializing

--- a/docs/features/read-ahead.md
+++ b/docs/features/read-ahead.md
@@ -142,11 +142,11 @@ far more than it returns.
 - **Paused-then-resumed readers** — raise `ttl`. A log tailer between batches otherwise re-establishes
   its sequential run from scratch every time.
 
-There are no read-ahead metrics on a mount. The predictive cache computes prediction accuracy and
-prefetch efficiency, but the mount's instance is wrapped in an opaque `types.Cache` with no accessor
-reaching past it, so those numbers have nowhere to go —
-[#223](https://github.com/scttfrdmn/objectfs/issues/223). Until that lands, bytes transferred is
-measured from outside: CloudWatch, or a request count against a known read volume.
+There are no metrics for *this* read-ahead manager on a mount. The predictive cache below it does export
+its own, as of [#223](https://github.com/scttfrdmn/objectfs/issues/223) — see
+[the predictive cache's statistics](#the-predictive-caches-statistics) below for what they measure and why
+they are not a substitute. For the manager on this page, bytes transferred is still measured from outside:
+CloudWatch, or a request count against a known read volume.
 
 ## Not the same thing as parallel reads
 
@@ -187,11 +187,51 @@ fmt.Printf("Prediction Accuracy: %.2f%%\n", stats.PredictionAccuracy)
 That is a *second* predictive cache, independent of the mount's. It observes the accesses you make
 through it and nothing the filesystem does.
 
+### The predictive cache's statistics
+
+The mount's own instance is reachable, and it publishes to `/metrics`. Every value arrives as one series
+of `objectfs_predictive_cache`, labelled by `statistic`:
+
+```text
+objectfs_predictive_cache{service="objectfs",statistic="predictions_total"} 186
+objectfs_predictive_cache{service="objectfs",statistic="predictions_correct"} 61
+objectfs_predictive_cache{service="objectfs",statistic="prediction_accuracy"} 0.327
+```
+
+| `statistic` | Means |
+|---|---|
+| `predictions_total`, `predictions_correct`, `prediction_accuracy` | Ranges the predictor named, and how many a read then landed inside. Correctness is scored on the *application's* read, hit or miss — whether the cache happened to hold the bytes is `prefetch_hits`'s question, and scoring only hits would make accuracy a function of cache capacity |
+| `prefetch_requests`, `prefetch_hits`, `prefetch_bytes`, `prefetch_efficiency` | Ranges a prefetch worker actually stored, how many were read before eviction, and the bytes involved. Efficiency is hits over requests |
+| `prefetch_waste` | Ranges fetched and evicted having never been read. This is the cost side of the bet the Tuning section above is about, and the only number that reports it from inside |
+| `evictions_total`, `evictions_intelligent` | Evictions, and how many the intelligent manager chose rather than plain LRU |
+
+Two things to know before reading them:
+
+- **A gauge, not a counter, even for the counting statistics.** They are snapshots of the cache's own
+  running totals, read on the collector's schedule (30 s), so use `max_over_time` rather than `rate` on
+  them. `prediction_accuracy` and `prefetch_efficiency` are ratios in `[0, 1]`, derived when the totals
+  are written rather than at scrape time.
+- **The family is absent, not zero, when there is no predictive layer to ask.** A distributed
+  (Redis-backed) cache has none. Absent and zero are different claims and the exporter keeps them
+  distinguishable — zeros would say the predictor never fires.
+- **`prefetch_*` reads zero on today's mount path** while the prediction and eviction statistics
+  populate. The mount builds its predictive cache without a backend to fetch through, so the workers
+  dequeue jobs and store nothing. That is the honest report of what is running, not a defect in the
+  counters, and the prediction numbers above it are unaffected.
+
+The read-ahead manager on this page is a *different* subsystem, and these statistics say nothing about
+it: `min_sequential`, `window_size` and `concurrent_reads` tune the manager, not the predictive cache.
+
 ## Implementation
 
 - `internal/fuse/optimizations.go` — the detector, the prefetch workers, and `prefetchLength`
 - `internal/config/config.go` — `ReadAheadConfig`, its defaults and its validation
-- `internal/adapter/adapter.go` — `buildReadAheadConfig`, the mapping from YAML to the manager
+- `internal/adapter/adapter.go` — `buildReadAheadConfig`, the mapping from YAML to the manager, and
+  `exportPredictiveStats`, which publishes the predictive cache's statistics on every collector tick
+- `internal/cache/predictive.go` — the predictive cache, its `PredictiveStats`, and the range ledger the
+  attribution rests on
+- `internal/cache/multilevel.go` — `GetPredictiveCache` and `PredictiveStats`, the accessors that reach
+  past the opaque `types.Cache`
 
 ## Related
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -157,6 +157,8 @@ func (a *Adapter) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize cache: %w", err)
 	}
 
+	a.exportPredictiveStats()
+
 	// 4. Initialize the write path.
 	//
 	// vfs.Writer tracks dirty byte ranges per path and flushes by read-modify-write: fetch the parts
@@ -549,6 +551,73 @@ func (a *Adapter) startMetrics(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// exportPredictiveStats publishes the predictive cache's statistics to the metrics surface on every
+// collector tick, and does nothing when there is no predictive layer to ask.
+//
+// This is the caller [cache.MultiLevelCache.GetPredictiveCache] was missing. The statistics were computed
+// on every read and thrown away at unmount, because nothing above the cache could reach them: types.Cache
+// is six methods about bytes (#223). An accessor with no caller would have been half the fix — a second
+// path nothing exercises — so the accessor and its consumer land together, and the consumer is the
+// metrics surface because that is where an operator can actually see the numbers.
+//
+// Registered as a periodic callback rather than pushed at the moment of the operation: these are totals
+// the cache holds, so the only way to publish them is to ask on a schedule. The callback re-reads the
+// cache each tick rather than closing over a PredictiveStats value, since a snapshot taken here would be
+// the mount's opening zeros forever.
+//
+// The type assertion is the honest form of "when there is a predictive layer". NewFromConfig returns the
+// Redis-backed distributed cache when cluster.redis is on, which has no predictive layer and no way to
+// grow one; and the multi-level cache only wraps L1 when prefetch is enabled. Both are ordinary
+// configurations, so neither is an error — the metric family is simply absent, which is distinguishable
+// from present-and-zero by a scrape.
+//
+// Note what these numbers will and will not show on a mount today: prediction and eviction counters
+// populate, and the prefetch counters read zero, because initializeLevels passes no Backend to the
+// predictive config, so its workers dequeue jobs and fetch nothing. That is honest signal rather than a
+// hidden failure — prefetch_requests staying at 0 while predictions_total climbs is exactly what "the
+// prefetcher has no backend" looks like — and it is the argument for exporting these at all: the gap was
+// invisible for as long as nothing could read them.
+func (a *Adapter) exportPredictiveStats() {
+	if a.metrics == nil {
+		return
+	}
+
+	mlc, ok := a.cache.(*cache.MultiLevelCache)
+	if !ok {
+		return
+	}
+
+	publish := func() {
+		stats, ok := mlc.PredictiveStats()
+		if !ok {
+			return
+		}
+
+		// Keys become the `statistic` label, so they are a contract two SDKs read through
+		// sdks/testdata/metrics-scrape.txt. They mirror the struct's JSON tags rather than inventing a
+		// second vocabulary for the same numbers.
+		a.metrics.UpdatePredictiveCache(map[string]float64{
+			"predictions_total":     float64(stats.PredictionsTotal),
+			"predictions_correct":   float64(stats.PredictionsCorrect),
+			"prediction_accuracy":   stats.PredictionAccuracy,
+			"avg_confidence":        stats.AvgConfidence,
+			"prefetch_requests":     float64(stats.PrefetchRequests),
+			"prefetch_hits":         float64(stats.PrefetchHits),
+			"prefetch_bytes":        float64(stats.PrefetchBytes),
+			"prefetch_waste":        float64(stats.PrefetchWaste),
+			"prefetch_efficiency":   stats.PrefetchEfficiency,
+			"evictions_total":       float64(stats.EvictionsTotal),
+			"evictions_intelligent": float64(stats.EvictionsIntelligent),
+		})
+	}
+
+	// Once now, and on every tick after. Without the first call the family is absent from a scrape until
+	// the update interval elapses — thirty seconds by default — and an absent family and a disabled
+	// predictive layer look the same to whoever is looking.
+	publish()
+	a.metrics.OnPeriodicUpdate(publish)
 }
 
 // buildS3Config translates the loaded configuration into the backend's configuration.

--- a/internal/adapter/cache_selection_test.go
+++ b/internal/adapter/cache_selection_test.go
@@ -153,6 +153,18 @@ func TestStartRefusesAnUnreachableRedis(t *testing.T) {
 func startAdapterWithCluster(t *testing.T, mutate func(*config.Configuration)) *Adapter {
 	t.Helper()
 
+	return startTolerantly(t, newAdapterForSubstrate(t, mutate))
+}
+
+// newAdapterForSubstrate builds an adapter against the substrate endpoint without starting it.
+//
+// Separate from startTolerantly so a test can reach the adapter between New and Start. New validates the
+// configuration, and one field cannot be given its test value before that point: monitoring.metrics.addr
+// rejects port 0 on purpose (#212 — zero used to mean "off" and defaulted back to 8080), while a test
+// wanting a port nothing can take from it needs the kernel to pick at the moment of the bind.
+func newAdapterForSubstrate(t *testing.T, mutate func(*config.Configuration)) *Adapter {
+	t.Helper()
+
 	cfg := configForSubstrate(t)
 	if mutate != nil {
 		mutate(cfg)
@@ -162,6 +174,14 @@ func startAdapterWithCluster(t *testing.T, mutate func(*config.Configuration)) *
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+
+	return a
+}
+
+// startTolerantly runs Start and registers the right cleanup for how far it got. See
+// startAdapterWithCluster for why a mount failure is tolerated and everything earlier is fatal.
+func startTolerantly(t *testing.T, a *Adapter) *Adapter {
+	t.Helper()
 
 	startErr := a.Start(context.Background())
 

--- a/internal/adapter/predictive_metrics_test.go
+++ b/internal/adapter/predictive_metrics_test.go
@@ -1,0 +1,393 @@
+package adapter
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/scttfrdmn/objectfs/internal/cache"
+	"github.com/scttfrdmn/objectfs/internal/config"
+	"github.com/scttfrdmn/objectfs/internal/metrics"
+	"github.com/scttfrdmn/objectfs/internal/testhttp"
+)
+
+// #223's second half, and the half only this package can show. internal/cache can prove the predictive
+// statistics are computed and that GetPredictiveCache reaches them; internal/metrics can prove the gauge
+// family and the periodic hook work. Neither can prove a *mount* joins the two, and that gap is the
+// defect: the numbers were computed on every read of every mount and discarded at unmount, because
+// nothing above the cache could reach them.
+//
+// An accessor with no caller would have been half a fix — a second path nothing exercises — so the
+// accessor and its consumer landed together, and these tests go through Start rather than calling
+// exportPredictiveStats on a hand-built Adapter.
+
+// TestAMountPublishesItsPredictiveStatistics is the end-to-end assertion, over HTTP.
+//
+// It reads through the mount's own cache and scrapes the mount's own endpoint. Every layer skipped is a
+// layer where the value could be dropped, and each of #223's neighbours in this milestone was exactly
+// that kind of drop: a collector that was never started (#211), a Config.Labels the collector never read,
+// an accessor nothing called.
+//
+// The republish is deliberate and is not the wiring under test. monitoring.metrics has no
+// update_interval, so a mount's collector ticks at the metrics package default of thirty seconds — too
+// long to wait for and not worth a test-only config knob. That the periodic tick calls a callback
+// registered after Start is asserted where it belongs, in TestPeriodicCallbacksRegisteredAfterStartStillRun;
+// what is asserted here is the part only a mount has: that the callback Start registered reads *this
+// mount's* cache and lands on *this mount's* endpoint.
+func TestAMountPublishesItsPredictiveStatistics(t *testing.T) {
+	t.Parallel()
+
+	a := startTolerantly(t, metricsOnPortZero(t, nil))
+
+	addr := a.metrics.Addr()
+	if addr == "" {
+		t.Fatal("the mount bound no metrics listener, so this test cannot reach the scrape")
+	}
+
+	// Present from the moment the mount is up, before any read. Without the publish at registration the
+	// family is absent from every scrape until the first tick — thirty seconds by default — and an absent
+	// family means "this mount has no predictive layer", which for this configuration is false.
+	body := testhttp.Get(t, addr, "/metrics", "the mount bound no metrics listener")
+	if !strings.Contains(body, "objectfs_predictive_cache") {
+		t.Fatalf("a started mount exports no objectfs_predictive_cache at all, so Start registered no "+
+			"publisher: the statistics are computed on every read and discarded, which is #223. Scrape:\n%s",
+			body)
+	}
+
+	// Sequential reads through the mount's cache. The predictor is keyed per object and emits nothing
+	// until it has three accesses of one key scoring above the sequential threshold, so a rotation of
+	// distinct keys at offset 0 would produce no statistics and the assertion below would be vacuous. Fill
+	// first, then stream: Put records an access too, so an interleaved loop gives the predictor a history
+	// that alternates and scores as non-sequential.
+	for i := range 32 {
+		a.cache.Put("stream", int64(i)*4096, make([]byte, 4096))
+	}
+	for i := range 32 {
+		a.cache.Get("stream", int64(i)*4096, 4096)
+	}
+
+	// What a tick does, without waiting for one. Registering a second callback is harmless — publishing
+	// the same snapshot twice sets the same gauges — and the alternative is a thirty-second test.
+	a.exportPredictiveStats()
+
+	body = testhttp.Get(t, addr, "/metrics", "the mount bound no metrics listener")
+
+	// Every statistic the exporter names, over the wire. Enumerated rather than spot-checked because these
+	// label values are the contract sdks/testdata/metrics-scrape.txt captures, so a dropped key here is a
+	// silently missing series for both SDKs.
+	for _, statistic := range []string{
+		"predictions_total",
+		"predictions_correct",
+		"prediction_accuracy",
+		"avg_confidence",
+		"prefetch_requests",
+		"prefetch_hits",
+		"prefetch_bytes",
+		"prefetch_waste",
+		"prefetch_efficiency",
+		"evictions_total",
+		"evictions_intelligent",
+	} {
+		if !strings.Contains(body, `statistic="`+statistic+`"`) {
+			t.Errorf("the scrape carries no statistic=%q series; scrape:\n%s", statistic, body)
+		}
+	}
+
+	// And the values are this mount's, not a fresh struct's zeros. A publisher that read some other cache
+	// — or a snapshot captured at registration rather than re-read per tick — would satisfy every
+	// assertion above with the mount's opening zeros intact.
+	if series := predictiveSeries(t, body); series["predictions_total"] == 0 {
+		t.Errorf("predictions_total is still zero after 32 sequential reads through the mount's cache; "+
+			"the publisher is not reading the cache the mount is serving from. Scrape:\n%s", body)
+	}
+}
+
+// TestAMountWithoutAPredictiveLayerPublishesNothing pins the absence case.
+//
+// The Redis-backed distributed cache has no predictive layer and no way to grow one, which is an ordinary
+// configuration rather than an error — so the family is simply absent, and absent is distinguishable from
+// present-and-zero to whoever is reading the scrape. Without this test an exporter that ignored the cache
+// type and published zeros would satisfy the test above while telling an operator running a shared cache
+// that their predictor had never predicted anything.
+//
+// It is also the safety check on the type assertion: a *redis.Cache is not a *cache.MultiLevelCache, so
+// an exporter that assumed the concrete type would panic during Start on this configuration.
+func TestAMountWithoutAPredictiveLayerPublishesNothing(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+
+	a := startTolerantly(t, metricsOnPortZero(t, func(cfg *config.Configuration) {
+		cfg.Cluster.Enabled = true
+		cfg.Cluster.ListenAddr = "127.0.0.1:0"
+		cfg.Cluster.SecretFile = writeClusterSecret(t)
+		cfg.Cluster.Redis = config.RedisConfig{
+			Enabled:    true,
+			Address:    mr.Addr(),
+			KeyPrefix:  "predictive",
+			TTL:        time.Minute,
+			MaxRetries: 1,
+		}
+	}))
+
+	// Reads that would produce statistics if there were a predictive layer to produce them, then the same
+	// publish a tick would perform. No sleep: publication is synchronous, so if one were going to happen
+	// it has happened by the time exportPredictiveStats returns.
+	for i := range 16 {
+		a.cache.Put("stream", int64(i)*4096, make([]byte, 4096))
+		a.cache.Get("stream", int64(i)*4096, 4096)
+	}
+
+	a.exportPredictiveStats()
+
+	body := testhttp.Get(t, a.metrics.Addr(), "/metrics", "the mount bound no metrics listener")
+	if strings.Contains(body, "objectfs_predictive_cache") {
+		t.Errorf("a Redis-backed mount exports objectfs_predictive_cache; it has no predictive layer, so "+
+			"every series would be a permanent zero presented as a measurement. Scrape:\n%s", body)
+	}
+}
+
+// TestEachTickRereadsTheCache asserts the callback asks the cache again rather than republishing a
+// snapshot it captured at registration.
+//
+// This is the difference between a working gauge and a gauge frozen at the mount's opening zeros, and it
+// is invisible to any test that publishes by hand: calling exportPredictiveStats a second time would take
+// a fresh snapshot too, so a closure over a captured PredictiveStats satisfies every other test in this
+// file. The only thing that distinguishes them is a *tick* — the callback running with no help — which is
+// why this test builds its own collector at a 5 ms interval instead of going through Start, whose
+// collector ticks at the metrics package's thirty-second default (monitoring.metrics has no
+// update_interval, deliberately: nobody has asked for one).
+//
+// Verified by mutation: hoisting the PredictiveStats call out of the closure leaves predictions_total at
+// zero forever and only this test notices.
+func TestEachTickRereadsTheCache(t *testing.T) {
+	t.Parallel()
+
+	mlc := predictiveMultiLevelCache(t, true)
+
+	collector, err := metrics.NewCollector(&metrics.Config{
+		Enabled:        true,
+		Addr:           "127.0.0.1:0",
+		Labels:         map[string]string{"service": "objectfs"},
+		UpdateInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if err := collector.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = collector.Stop(context.Background()) })
+
+	a := &Adapter{config: config.NewDefault(), cache: mlc, metrics: collector}
+
+	// Registered before any read, exactly as Start does it: the cache exists but has served nothing, so
+	// the values published at registration are zeros.
+	a.exportPredictiveStats()
+
+	if got := predictiveSeries(t, scrapeOf(t, collector))["predictions_total"]; got != 0 {
+		t.Fatalf("predictions_total = %v before any read; this test cannot distinguish a re-read from a "+
+			"snapshot unless it starts from zero", got)
+	}
+
+	// Reads *after* registration. A snapshot taken at registration cannot know about these.
+	for i := range 32 {
+		mlc.Put("stream", int64(i)*4096, make([]byte, 4096))
+	}
+	for i := range 32 {
+		mlc.Get("stream", int64(i)*4096, 4096)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		body := scrapeOf(t, collector)
+		if predictiveSeries(t, body)["predictions_total"] > 0 {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("predictions_total is still zero 10s after 32 sequential reads, at a 5ms update "+
+				"interval; the callback republishes a snapshot it took at registration, so the family "+
+				"reports the mount's opening zeros for the life of the process. Scrape:\n%s", body)
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestExportPredictiveStatsHonorsTheAbsenceReport covers the guard no mount can currently reach.
+//
+// PredictiveStats returns a boolean as well as a struct, and the exporter has to respect it — publishing
+// a zeroed struct would report a predictor that has predicted nothing, which is a different claim from
+// "there is no predictor". The test above cannot show this: a Redis cache fails the type assertion first,
+// so the boolean is never consulted, and multiLevelConfigFrom sets Prefetch true unconditionally, so no
+// configuration produces a MultiLevelCache without a predictive layer.
+//
+// So the cache is built here rather than by Start. That makes this a test of the exporter and not of the
+// mount path, which is the point: the guard is what keeps a future config knob for prefetch — or an L1
+// that declines to wrap itself — from turning into a family of false zeros. Verified by mutation:
+// dropping the boolean check leaves every other test in this file green.
+func TestExportPredictiveStatsHonorsTheAbsenceReport(t *testing.T) {
+	t.Parallel()
+
+	mlc := predictiveMultiLevelCache(t, false)
+
+	cfg := config.NewDefault()
+	cfg.Monitoring.Metrics.Enabled = true
+
+	a := &Adapter{config: cfg, cache: mlc}
+	a.config.Monitoring.Metrics.Addr = "127.0.0.1:0"
+
+	if err := a.startMetrics(context.Background()); err != nil {
+		t.Fatalf("startMetrics: %v", err)
+	}
+	t.Cleanup(func() { _ = a.metrics.Stop(context.Background()) })
+
+	a.exportPredictiveStats()
+
+	body := testhttp.Get(t, a.metrics.Addr(), "/metrics", "startMetrics bound no listener")
+	if strings.Contains(body, "objectfs_predictive_cache") {
+		t.Errorf("a multi-level cache with no predictive layer published predictive statistics; an "+
+			"operator would read the zeros as a predictor that never fires. Scrape:\n%s", body)
+	}
+}
+
+// TestExportPredictiveStatsToleratesAMissingCollector guards the ordering assumption.
+//
+// exportPredictiveStats runs at Start's step 3, after startMetrics at step 1, so a.metrics is non-nil by
+// then on the live path. "On the live path" is what this checks: a reordering of Start's steps, or a
+// future caller that builds the cache first, should get a missing metric rather than a nil dereference
+// during mount.
+func TestExportPredictiveStatsToleratesAMissingCollector(t *testing.T) {
+	t.Parallel()
+
+	// Neither collector nor cache — the assertion is that this returns rather than panics.
+	a := &Adapter{config: config.NewDefault()}
+	a.exportPredictiveStats()
+
+	// A collector but no cache: the other order of the two guards. A nil types.Cache fails the type
+	// assertion rather than satisfying it, which is what keeps this from being a nil-method call.
+	cfg := config.NewDefault()
+	cfg.Monitoring.Metrics.Enabled = true
+	cfg.Monitoring.Metrics.Addr = "127.0.0.1:0"
+
+	a = &Adapter{config: cfg}
+	if err := a.startMetrics(context.Background()); err != nil {
+		t.Fatalf("startMetrics: %v", err)
+	}
+	t.Cleanup(func() { _ = a.metrics.Stop(context.Background()) })
+
+	a.exportPredictiveStats()
+
+	body := testhttp.Get(t, a.metrics.Addr(), "/metrics", "startMetrics bound no listener")
+	if strings.Contains(body, "objectfs_predictive_cache") {
+		t.Errorf("an adapter with no cache published predictive statistics; the numbers would be a "+
+			"struct's zeros rather than any cache's. Scrape:\n%s", body)
+	}
+}
+
+// metricsOnPortZero builds a substrate-backed adapter whose metrics endpoint binds an ephemeral port.
+//
+// The address is set after New, because New validates and monitoring.metrics.addr rejects port 0 by
+// design: zero used to read as "off" and default back to 8080 (#212), so the field has no value that
+// quietly means something else. A test still wants the kernel to pick at the moment of the bind rather
+// than a port from testhttp.FreeAddr, which is already back in the ephemeral pool by the time it is
+// returned — see TestStartMetricsBindsTheEndpoint, which failed in CI on exactly that race.
+func metricsOnPortZero(t *testing.T, mutate func(*config.Configuration)) *Adapter {
+	t.Helper()
+
+	a := newAdapterForSubstrate(t, func(cfg *config.Configuration) {
+		cfg.Monitoring.Metrics.Enabled = true
+
+		if mutate != nil {
+			mutate(cfg)
+		}
+	})
+
+	a.config.Monitoring.Metrics.Addr = "127.0.0.1:0"
+
+	return a
+}
+
+// predictiveMultiLevelCache builds the cache a mount builds, with prefetch as the one variable.
+//
+// prefetch is what decides whether L1 gets wrapped in a PredictiveCache at all, and multiLevelConfigFrom
+// sets it true unconditionally — so false is a shape no configuration produces today and true is the shape
+// every mount has.
+func predictiveMultiLevelCache(t *testing.T, prefetch bool) *cache.MultiLevelCache {
+	t.Helper()
+
+	mlc, err := cache.NewMultiLevelCache(&cache.MultiLevelConfig{
+		L1Config: &cache.L1Config{
+			Enabled:    true,
+			Size:       64 << 20,
+			MaxEntries: 1000,
+			TTL:        time.Minute,
+			Prefetch:   prefetch,
+		},
+		Policy: "inclusive",
+	})
+	if err != nil {
+		t.Fatalf("NewMultiLevelCache: %v", err)
+	}
+	t.Cleanup(func() { _ = mlc.Close() })
+
+	return mlc
+}
+
+// scrapeOf fetches /metrics from a started collector.
+func scrapeOf(t *testing.T, c *metrics.Collector) string {
+	t.Helper()
+
+	return testhttp.Get(t, c.Addr(), "/metrics", "the collector bound no listener")
+}
+
+// predictiveSeries parses objectfs_predictive_cache out of a scrape as statistic name → value.
+//
+// The exposition text rather than the registry, because the registry is what every test in
+// internal/metrics already reads: what is unproven here is that the mount's values survive the trip to a
+// scrape, and a gather in this package would not show that.
+func predictiveSeries(t *testing.T, scrape string) map[string]float64 {
+	t.Helper()
+
+	out := map[string]float64{}
+
+	for _, line := range strings.Split(scrape, "\n") {
+		if !strings.HasPrefix(line, "objectfs_predictive_cache{") {
+			continue
+		}
+
+		labels, value, ok := strings.Cut(line, "} ")
+		if !ok {
+			t.Fatalf("a predictive series is not in the exposition format this parses: %q", line)
+		}
+
+		_, statistic, ok := strings.Cut(labels, `statistic="`)
+		if !ok {
+			t.Fatalf("a predictive series carries no statistic label: %q", line)
+		}
+
+		statistic, _, _ = strings.Cut(statistic, `"`)
+
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			t.Fatalf("the value of statistic=%q does not parse as a float: %q", statistic, value)
+		}
+
+		out[statistic] = parsed
+	}
+
+	if len(out) == 0 {
+		t.Fatalf("no objectfs_predictive_cache series in the scrape:\n%s", scrape)
+	}
+
+	return out
+}

--- a/internal/adapter/predictive_metrics_test.go
+++ b/internal/adapter/predictive_metrics_test.go
@@ -28,7 +28,7 @@ import (
 // TestAMountPublishesItsPredictiveStatistics is the end-to-end assertion, over HTTP.
 //
 // It reads through the mount's own cache and scrapes the mount's own endpoint. Every layer skipped is a
-// layer where the value could be dropped, and each of #223's neighbours in this milestone was exactly
+// layer where the value could be dropped, and each of #223's neighbors in this milestone was exactly
 // that kind of drop: a collector that was never started (#211), a Config.Labels the collector never read,
 // an accessor nothing called.
 //
@@ -360,7 +360,7 @@ func predictiveSeries(t *testing.T, scrape string) map[string]float64 {
 
 	out := map[string]float64{}
 
-	for _, line := range strings.Split(scrape, "\n") {
+	for line := range strings.SplitSeq(scrape, "\n") {
 		if !strings.HasPrefix(line, "objectfs_predictive_cache{") {
 			continue
 		}

--- a/internal/cache/multilevel.go
+++ b/internal/cache/multilevel.go
@@ -287,6 +287,50 @@ func (c *MultiLevelCache) GetLevelStats(levelName string) (types.CacheStats, err
 	return types.CacheStats{}, fmt.Errorf("cache level %s not found or not enabled", levelName)
 }
 
+// GetPredictiveCache returns the [PredictiveCache] wrapping L1, or nil when L1 is not wrapped.
+//
+// It exists because nothing else can reach it. initializeLevels wraps L1 in a PredictiveCache whenever
+// prefetch is enabled — which multiLevelConfigFrom does unconditionally, so every mount — and stores it
+// as a types.Cache in a CacheLevel. types.Cache is six methods about bytes, GetLevelStats returns a
+// types.CacheStats, and Close reaches the level only through an unexported type assertion. So the
+// predictive statistics were computed on every read and discarded at unmount (#223).
+//
+// This name is not arbitrary: docs/features/read-ahead.md documented `cache.GetPredictiveCache()`
+// before it existed, TestDocumentedGoSymbolsExist caught it as absent, and the documentation now
+// describes this. Renaming it means changing that page in the same commit.
+//
+// Returning the concrete type rather than an interface is deliberate — the caller wants
+// GetPredictiveStats, which is the one thing types.Cache cannot express, and an interface with one
+// method that one type implements is a longer way to say *PredictiveCache.
+func (c *MultiLevelCache) GetPredictiveCache() *PredictiveCache {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for _, level := range c.levels {
+		if pc, ok := level.Cache.(*PredictiveCache); ok {
+			return pc
+		}
+	}
+
+	return nil
+}
+
+// PredictiveStats returns the predictive cache's statistics, and false when there is no predictive layer.
+//
+// The convenience form of [MultiLevelCache.GetPredictiveCache] for the common case, which is a caller
+// that wants the numbers and not the cache — including the metrics surface, where a nil check on a
+// returned pointer is the kind of thing that gets dropped and publishes zeros. The boolean makes "there
+// is no predictive layer" distinguishable from "it has predicted nothing yet", which #222 is the argument
+// for: those two are the same struct otherwise.
+func (c *MultiLevelCache) PredictiveStats() (PredictiveStats, bool) {
+	pc := c.GetPredictiveCache()
+	if pc == nil {
+		return PredictiveStats{}, false
+	}
+
+	return pc.GetPredictiveStats(), true
+}
+
 // SetBackend sets the storage backend used by Warmup to pre-populate the cache.
 // It may be called any time before Warmup is invoked.
 func (c *MultiLevelCache) SetBackend(b types.Backend) {

--- a/internal/cache/predictive.go
+++ b/internal/cache/predictive.go
@@ -19,6 +19,14 @@ type PredictiveCache struct {
 	evictionMgr *IntelligentEvictionManager
 	config      *PredictiveCacheConfig
 	stats       *PredictiveStats
+
+	// ledger remembers what a prefetch stored, so a later read can be attributed to it, and predictions
+	// remembers what the predictor said would be read next. Two ledgers and not one: a prediction that
+	// no worker acted on — because the rate limiter refused it, or the queue was full, or there is no
+	// backend — is still a prediction whose accuracy is worth knowing, and conflating the two would score
+	// the predictor on the prefetcher's throughput.
+	ledger      *rangeLedger
+	predictions *rangeLedger
 }
 
 // PredictiveCacheConfig configures predictive caching behavior
@@ -50,36 +58,45 @@ type PredictiveCacheConfig struct {
 	PatternAnalysisDepth int           `yaml:"pattern_analysis_depth"`
 }
 
-// PredictiveStats tracks predictive cache performance
+// PredictiveStats tracks predictive cache performance.
+//
+// Every field here is assigned by the cache on a path a mount takes. That is worth stating because it
+// was not true: this struct declared seventeen fields, of which fourteen — PredictionAccuracy,
+// PrefetchEfficiency, CacheHitImprovement, LatencyReduction, BandwidthSavings, ModelAccuracy and the
+// rest — were written by nothing anywhere in the repository, and the three that were written included
+// PrefetchHits, which required an AccessEvent with Prefetch set true, which nothing constructed. So a
+// caller reaching these numbers would have read zeros and had no way to tell them from a cache that had
+// prefetched nothing. #222's percentiles were the same defect in a different package, and the answer is
+// the same: a statistic that cannot be computed should not be exported. The deleted fields described a
+// trained model, an eviction-accuracy follow-up and a counterfactual hit-rate comparison, none of which
+// this cache does; adding them means building those mechanisms, not adding a field back.
+//
+// The counters are the primary values and the ratios derive from them, so a reader that distrusts a
+// ratio can recompute it. Access under mu, or through [PredictiveCache.GetPredictiveStats], which
+// copies.
 type PredictiveStats struct {
 	mu sync.RWMutex
 
-	// Prediction metrics
+	// Prediction metrics. A prediction is one [types.PrefetchCandidate] the predictor emitted, and it is
+	// counted correct when a later read hits the range it named — see PredictiveCache.Get.
 	PredictionsTotal   uint64  `json:"predictions_total"`
 	PredictionsCorrect uint64  `json:"predictions_correct"`
 	PredictionAccuracy float64 `json:"prediction_accuracy"`
 	AvgConfidence      float64 `json:"avg_confidence"`
 
-	// Prefetch metrics
+	// Prefetch metrics. A request is a candidate a worker acted on; a hit is a subsequent read served
+	// from bytes that worker stored. Waste is the remainder — fetched and evicted or never read — and is
+	// the number that says whether prefetch is earning its bandwidth.
 	PrefetchRequests   uint64  `json:"prefetch_requests"`
 	PrefetchHits       uint64  `json:"prefetch_hits"`
-	PrefetchWaste      uint64  `json:"prefetch_waste"` // Prefetched but never used
+	PrefetchBytes      int64   `json:"prefetch_bytes"`
+	PrefetchWaste      uint64  `json:"prefetch_waste"`
 	PrefetchEfficiency float64 `json:"prefetch_efficiency"`
 
-	// Eviction metrics
-	EvictionsTotal       uint64  `json:"evictions_total"`
-	EvictionsIntelligent uint64  `json:"evictions_intelligent"` // ML-driven evictions
-	EvictionAccuracy     float64 `json:"eviction_accuracy"`     // How often evicted items stayed evicted
-
-	// Performance impact
-	CacheHitImprovement float64 `json:"cache_hit_improvement"`
-	LatencyReduction    float64 `json:"latency_reduction"`
-	BandwidthSavings    float64 `json:"bandwidth_savings"`
-
-	// Model performance
-	ModelAccuracy     float64       `json:"model_accuracy"`
-	ModelTrainingTime time.Duration `json:"model_training_time"`
-	LastModelUpdate   time.Time     `json:"last_model_update"`
+	// Eviction metrics. Intelligent evictions are those the scoring path chose, as opposed to the base
+	// cache's own LRU, which runs when the scorer produces no candidates.
+	EvictionsTotal       uint64 `json:"evictions_total"`
+	EvictionsIntelligent uint64 `json:"evictions_intelligent"`
 }
 
 // AccessPredictor implements machine learning-based access pattern prediction
@@ -284,6 +301,8 @@ func NewPredictiveCache(config *PredictiveCacheConfig) (*PredictiveCache, error)
 		evictionMgr: evictionMgr,
 		config:      config,
 		stats:       &PredictiveStats{},
+		ledger:      newRangeLedger(),
+		predictions: newRangeLedger(),
 	}
 
 	// Initialize feature weights with reasonable defaults
@@ -315,12 +334,25 @@ func (pc *PredictiveCache) Get(key string, offset, size int64) []byte {
 	data := pc.baseCache.Get(key, offset, size)
 	event.Hit = data != nil
 
+	// Whether this read was served by something a prefetch worker stored. Consulted before the predictor
+	// runs, so a prediction made *by* this read cannot be credited *to* it — which is how a prefetcher
+	// scores 100% against itself.
+	//
+	// event.Prefetch was declared for this and set false at both of its two construction sites, so
+	// PrefetchHits — guarded by `event.Hit && event.Prefetch` — could never be incremented. That was the
+	// defect: the field existed, the guard read it, and nothing ever made it true.
+	if event.Hit {
+		event.Prefetch = pc.ledger.claim(key, offset, size)
+	}
+	pc.recordPrediction(key, offset, size)
+
 	// Update predictor with access pattern
 	if pc.config.EnablePrediction {
 		pc.predictor.RecordAccess(event)
 
 		// Trigger predictions and prefetching
 		if predictions := pc.predictor.PredictNextAccess(key); len(predictions) > 0 {
+			pc.recordPredictions(predictions)
 			pc.triggerPrefetch(predictions)
 		}
 	}
@@ -392,11 +424,19 @@ func (pc *PredictiveCache) Stats() types.CacheStats {
 	return baseStats
 }
 
-// GetPredictiveStats returns detailed predictive cache statistics
+// GetPredictiveStats returns a snapshot of this cache's predictive statistics.
+//
+// Field by field rather than by struct copy, because PredictiveStats holds the mutex guarding it and
+// copying it would copy the lock — `go vet`'s copylocks catches that, and the caller would be locking a
+// copy of a lock that protects nothing.
+//
+// Reachable on a mount through [MultiLevelCache.PredictiveStats]. It was not: the mount's instance is
+// held as an opaque types.Cache inside a CacheLevel with no accessor reaching past it, so these numbers
+// were computed and discarded at unmount (#223).
 func (pc *PredictiveCache) GetPredictiveStats() PredictiveStats {
 	pc.stats.mu.RLock()
 	defer pc.stats.mu.RUnlock()
-	// Create a copy to avoid returning a mutex
+
 	return PredictiveStats{
 		PredictionsTotal:     pc.stats.PredictionsTotal,
 		PredictionsCorrect:   pc.stats.PredictionsCorrect,
@@ -404,17 +444,11 @@ func (pc *PredictiveCache) GetPredictiveStats() PredictiveStats {
 		AvgConfidence:        pc.stats.AvgConfidence,
 		PrefetchRequests:     pc.stats.PrefetchRequests,
 		PrefetchHits:         pc.stats.PrefetchHits,
+		PrefetchBytes:        pc.stats.PrefetchBytes,
 		PrefetchWaste:        pc.stats.PrefetchWaste,
 		PrefetchEfficiency:   pc.stats.PrefetchEfficiency,
 		EvictionsTotal:       pc.stats.EvictionsTotal,
 		EvictionsIntelligent: pc.stats.EvictionsIntelligent,
-		EvictionAccuracy:     pc.stats.EvictionAccuracy,
-		CacheHitImprovement:  pc.stats.CacheHitImprovement,
-		LatencyReduction:     pc.stats.LatencyReduction,
-		BandwidthSavings:     pc.stats.BandwidthSavings,
-		ModelAccuracy:        pc.stats.ModelAccuracy,
-		ModelTrainingTime:    pc.stats.ModelTrainingTime,
-		LastModelUpdate:      pc.stats.LastModelUpdate,
 	}
 }
 
@@ -836,6 +870,11 @@ func (pc *PredictiveCache) processPrefetchJob(job *PrefetchJob) {
 			if err == nil {
 				pc.baseCache.Put(candidate.Path, candidate.Offset, data)
 				job.BytesFetched += int64(len(data))
+
+				// Recorded against the bytes actually returned, not against candidate.Size: a ranged GET at
+				// the end of an object returns short, and a ledger entry claiming more than was stored would
+				// never be claimed by any read — scoring a correct prefetch as waste.
+				pc.recordPrefetch(candidate.Path, candidate.Offset, int64(len(data)))
 			}
 		}
 	}
@@ -870,6 +909,7 @@ func (pc *PredictiveCache) intelligentEvict(sizeNeeded int64) bool {
 		pc.stats.mu.Lock()
 		pc.stats.EvictionsTotal++
 		pc.stats.EvictionsIntelligent++
+		pc.stats.recomputeRatiosLocked()
 		pc.stats.mu.Unlock()
 	}
 
@@ -970,16 +1010,107 @@ func (rl *RateLimiter) Allow(bytes int64) bool {
 
 // Statistics and monitoring
 
-func (pc *PredictiveCache) updateStats(event AccessEvent, latency time.Duration) {
+// recordPredictions notes what the predictor just claimed would be read next, and counts the claims.
+//
+// Called before triggerPrefetch, and separately from it, so a prediction the prefetcher declined to act
+// on still counts against accuracy. The two are different questions — "was the predictor right" and "did
+// prefetching help" — and the second is not a fair proxy for the first on a mount, where the prefetcher's
+// backend is nil and it fetches nothing at all.
+func (pc *PredictiveCache) recordPredictions(candidates []types.PrefetchCandidate) {
+	confidence := 0.0
+	for _, candidate := range candidates {
+		pc.predictions.record(candidate.Path, candidate.Offset, candidate.Size)
+		confidence += float64(candidate.Priority) / 100.0
+	}
+
 	pc.stats.mu.Lock()
 	defer pc.stats.mu.Unlock()
 
-	// Update prediction accuracy if we had predictions
+	n := uint64(len(candidates))
+	pc.stats.PredictionsTotal += n
+
+	// A running mean over every prediction ever made, kept incrementally because the individual
+	// confidences are not retained. Weighted by n so a burst of candidates does not count as one sample.
+	if total := pc.stats.PredictionsTotal; total > 0 {
+		pc.stats.AvgConfidence += (confidence - float64(n)*pc.stats.AvgConfidence) / float64(total)
+	}
+
+	pc.stats.recomputeRatiosLocked()
+}
+
+// recordPrediction credits the predictor when a read lands in a range it named.
+//
+// Consulted for every read, hit or miss: a prediction is correct if the *application* read those bytes,
+// which is the thing being predicted, and whether the cache happened to hold them is a separate question
+// that PrefetchHits answers. Scoring only hits would make accuracy a function of cache capacity.
+func (pc *PredictiveCache) recordPrediction(key string, offset, size int64) {
+	if !pc.predictions.claim(key, offset, size) {
+		return
+	}
+
+	pc.stats.mu.Lock()
+	defer pc.stats.mu.Unlock()
+
+	pc.stats.PredictionsCorrect++
+	pc.stats.recomputeRatiosLocked()
+}
+
+// recordPrefetch notes bytes a worker stored, so a later read can be attributed to the prefetch.
+func (pc *PredictiveCache) recordPrefetch(key string, offset, length int64) {
+	pc.ledger.record(key, offset, length)
+
+	pc.stats.mu.Lock()
+	defer pc.stats.mu.Unlock()
+
+	pc.stats.PrefetchRequests++
+	pc.stats.PrefetchBytes += length
+	pc.stats.recomputeRatiosLocked()
+}
+
+func (pc *PredictiveCache) updateStats(event AccessEvent, latency time.Duration) {
+	// Waste is collected here rather than at eviction because the ledger cannot take the stats lock: it is
+	// written from the prefetch workers while a read holds that lock, and the reverse order exists too, so
+	// having either reach into the other invites a deadlock. takeUnclaimed drains a counter instead.
+	wasted := pc.ledger.takeUnclaimed()
+
+	pc.stats.mu.Lock()
+	defer pc.stats.mu.Unlock()
+
+	pc.stats.PrefetchWaste += wasted
+
+	// Bytes served from a range a prefetch worker stored. event.Prefetch is set by Get from the ledger;
+	// before #223 nothing set it, so this branch was unreachable and PrefetchHits stayed zero on every
+	// mount.
 	if event.Hit && event.Prefetch {
 		pc.stats.PrefetchHits++
 	}
 
-	// Update other metrics as needed
+	pc.stats.recomputeRatiosLocked()
+
+	// latency is accepted and unused. It was the input to LatencyReduction, which would need the latency
+	// of the read that *did not happen* to be a reduction of anything — a counterfactual this cache has no
+	// way to observe. The field is gone; the parameter stays because the measurement is genuinely taken at
+	// the call site and a future comparison against the backend's own latency (internal/storage/s3 already
+	// tracks it) is the shape that could use it.
+	_ = latency
+}
+
+// recomputeRatiosLocked derives the ratio fields from the counters. Caller holds stats.mu.
+//
+// Derived on write rather than on read so that [PredictiveCache.GetPredictiveStats] cannot return a
+// struct whose ratios disagree with its counters — and because every one of these was zero for the
+// lifetime of this type, which is what #223 is about. A ratio with no denominator stays zero rather than
+// becoming NaN: NaN serializes to invalid JSON, and `null` in a metrics field reads as an outage.
+func (s *PredictiveStats) recomputeRatiosLocked() {
+	if s.PredictionsTotal > 0 {
+		s.PredictionAccuracy = float64(s.PredictionsCorrect) / float64(s.PredictionsTotal)
+	}
+
+	// Against requests, not against hits plus waste: a prefetch that has been fetched but not yet read or
+	// evicted is neither, and excluding it would make efficiency jump around as the ledger fills.
+	if s.PrefetchRequests > 0 {
+		s.PrefetchEfficiency = float64(s.PrefetchHits) / float64(s.PrefetchRequests)
+	}
 }
 
 // Initialize model with reasonable defaults

--- a/internal/cache/predictive.go
+++ b/internal/cache/predictive.go
@@ -1019,23 +1019,32 @@ func (rl *RateLimiter) Allow(bytes int64) bool {
 func (pc *PredictiveCache) recordPredictions(candidates []types.PrefetchCandidate) {
 	confidence := 0.0
 	for _, candidate := range candidates {
-		pc.predictions.record(candidate.Path, candidate.Offset, candidate.Size)
 		confidence += float64(candidate.Priority) / 100.0
 	}
 
-	pc.stats.mu.Lock()
-	defer pc.stats.mu.Unlock()
+	// Counted before the ranges are published, for the reason recordPrefetch's comment gives: a
+	// prediction is claimable the moment it is in the ledger, and PredictionsCorrect must not be able to
+	// run ahead of PredictionsTotal.
+	func() {
+		pc.stats.mu.Lock()
+		defer pc.stats.mu.Unlock()
 
-	n := uint64(len(candidates))
-	pc.stats.PredictionsTotal += n
+		n := uint64(len(candidates))
+		pc.stats.PredictionsTotal += n
 
-	// A running mean over every prediction ever made, kept incrementally because the individual
-	// confidences are not retained. Weighted by n so a burst of candidates does not count as one sample.
-	if total := pc.stats.PredictionsTotal; total > 0 {
-		pc.stats.AvgConfidence += (confidence - float64(n)*pc.stats.AvgConfidence) / float64(total)
+		// A running mean over every prediction ever made, kept incrementally because the individual
+		// confidences are not retained. Weighted by n so a burst of candidates does not count as one
+		// sample.
+		if total := pc.stats.PredictionsTotal; total > 0 {
+			pc.stats.AvgConfidence += (confidence - float64(n)*pc.stats.AvgConfidence) / float64(total)
+		}
+
+		pc.stats.recomputeRatiosLocked()
+	}()
+
+	for _, candidate := range candidates {
+		pc.predictions.record(candidate.Path, candidate.Offset, candidate.Size)
 	}
-
-	pc.stats.recomputeRatiosLocked()
 }
 
 // recordPrediction credits the predictor when a read lands in a range it named.
@@ -1056,15 +1065,39 @@ func (pc *PredictiveCache) recordPrediction(key string, offset, size int64) {
 }
 
 // recordPrefetch notes bytes a worker stored, so a later read can be attributed to the prefetch.
+//
+// # The denominator is counted before the range is published
+//
+// A range in a ledger is claimable the instant it is there, by any reader, on any goroutine. Recording
+// the range first — which is what this did — opens a window in which the numerator can be incremented
+// while the denominator has not been: a read claims the range, updateStats counts a PrefetchHit, and
+// PrefetchRequests is still what it was. With several readers against one prefetch worker that window
+// is not theoretical. CI caught PrefetchHits at 4 against PrefetchRequests at 1, reported as
+// "efficiency 4" by TestGetPredictiveStatsIsSafeUnderConcurrentReads, which 40 local runs of the same
+// test did not reproduce.
+//
+// Neither lock can be held across both halves. The ledger is written by prefetch workers while a read
+// holds the stats lock, and the reverse order exists too, so a function taking both would deadlock —
+// the same constraint that made takeUnclaimed a drained counter rather than a direct read. Ordering
+// the two uncontended sections is what is available, and it is sufficient: a hit can only be counted
+// after the range is published, which is after the request that published it was counted. The reverse
+// window, where the denominator leads, makes the ratio momentarily *low* rather than impossible.
+//
+// A ratio above 1 is worse than one that is briefly low. It is not a value the statistic can take, so
+// it tells an operator reading a dashboard that the instrumentation is broken — and it says so for the
+// life of the mount, because these are cumulative counters and nothing subtracts. recordPredictions
+// orders itself the same way and for the same reason.
 func (pc *PredictiveCache) recordPrefetch(key string, offset, length int64) {
+	func() {
+		pc.stats.mu.Lock()
+		defer pc.stats.mu.Unlock()
+
+		pc.stats.PrefetchRequests++
+		pc.stats.PrefetchBytes += length
+		pc.stats.recomputeRatiosLocked()
+	}()
+
 	pc.ledger.record(key, offset, length)
-
-	pc.stats.mu.Lock()
-	defer pc.stats.mu.Unlock()
-
-	pc.stats.PrefetchRequests++
-	pc.stats.PrefetchBytes += length
-	pc.stats.recomputeRatiosLocked()
 }
 
 func (pc *PredictiveCache) updateStats(event AccessEvent, latency time.Duration) {

--- a/internal/cache/predictive_stats_test.go
+++ b/internal/cache/predictive_stats_test.go
@@ -667,3 +667,108 @@ func TestGetPredictiveStatsIsSafeUnderConcurrentReads(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestNoRangeIsClaimableBeforeItsDenominatorIsCounted pins the ordering in recordPrefetch and
+// recordPredictions.
+//
+// This is an ordering defect, not a data race, so -race cannot see it, and it is transient, so a check
+// after the dust settles sees nothing either — the counts agree again once the blocked increment lands.
+// The concurrency test above caught it only by luck of scheduling: it fired on CI and not in forty
+// local runs of the same test. So this one closes the window by hand rather than racing for it.
+//
+// The mechanism: hold stats.mu, then run the recording function on another goroutine. Ordered
+// correctly, it blocks in its counting section and can publish nothing, so the range never becomes
+// claimable while the lock is held — which is the property, and it is why a poll that never succeeds is
+// the passing outcome here. Ordered the other way, the range is in the ledger immediately and a read
+// arriving now would credit a hit against a denominator still sitting at zero.
+func TestNoRangeIsClaimableBeforeItsDenominatorIsCounted(t *testing.T) {
+	t.Parallel()
+
+	const (
+		block = 4096
+		key   = "ordering"
+	)
+
+	cases := []struct {
+		name string
+		// record runs the function under test, which must count before it publishes.
+		record func(pc *PredictiveCache)
+		// ledger is the one that function publishes into.
+		ledger func(pc *PredictiveCache) *rangeLedger
+		// counted reads the denominator. Called with stats.mu already held, so it reads the fields
+		// directly rather than through GetPredictiveStats, which would deadlock on the same lock.
+		counted func(pc *PredictiveCache) uint64
+		// numerator names the statistic that would run ahead, for the failure message.
+		numerator string
+	}{
+		{
+			name:      "a prefetch, against PrefetchRequests",
+			record:    func(pc *PredictiveCache) { pc.recordPrefetch(key, 0, block) },
+			ledger:    func(pc *PredictiveCache) *rangeLedger { return pc.ledger },
+			counted:   func(pc *PredictiveCache) uint64 { return pc.stats.PrefetchRequests },
+			numerator: "PrefetchHits",
+		},
+		{
+			name: "a prediction, against PredictionsTotal",
+			record: func(pc *PredictiveCache) {
+				pc.recordPredictions([]types.PrefetchCandidate{
+					{Path: key, Offset: 0, Size: block, Priority: 50},
+				})
+			},
+			ledger:    func(pc *PredictiveCache) *rangeLedger { return pc.predictions },
+			counted:   func(pc *PredictiveCache) uint64 { return pc.stats.PredictionsTotal },
+			numerator: "PredictionsCorrect",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := &fixedBackend{payload: make([]byte, block)}
+
+			pc, err := NewPredictiveCache(statsConfig(backend))
+			if err != nil {
+				t.Fatalf("NewPredictiveCache: %v", err)
+			}
+			t.Cleanup(func() { _ = pc.Close() })
+
+			done := make(chan struct{})
+
+			pc.stats.mu.Lock()
+
+			go func() {
+				defer close(done)
+
+				tc.record(pc)
+			}()
+
+			// Long enough that a publish-first implementation has certainly reached its ledger write —
+			// there is nothing between the function's entry and that write to delay it — and short enough
+			// not to matter to a suite. A correct implementation is parked on the Lock above for all of it.
+			deadline := time.After(500 * time.Millisecond)
+			claimable := false
+
+			for !claimable {
+				select {
+				case <-deadline:
+					// Nothing was published while the counting section was blocked. That is the property.
+					goto assert
+				default:
+				}
+
+				claimable = tc.ledger(pc).claim(key, 0, block)
+			}
+
+		assert:
+			if claimable && tc.counted(pc) == 0 {
+				t.Errorf("the range was claimable while its denominator was still 0, so a read arriving "+
+					"now would increment %s against nothing; the ledger is published before the counter "+
+					"that bounds it, which is how a ratio an operator scrapes exceeds 1", tc.numerator)
+			}
+
+			pc.stats.mu.Unlock()
+			<-done
+		})
+	}
+}

--- a/internal/cache/predictive_stats_test.go
+++ b/internal/cache/predictive_stats_test.go
@@ -1,0 +1,673 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// #223. PredictiveStats declared seventeen fields and the cache assigned three of them, one of which —
+// PrefetchHits — was guarded by `event.Hit && event.Prefetch` while both AccessEvent construction sites
+// set Prefetch false, so it was unreachable. Every ratio was zero for the lifetime of the type, and
+// nothing above the cache could read them anyway: the mount holds this cache as an opaque types.Cache
+// inside a CacheLevel.
+//
+// So these tests come in two halves. The first is that the numbers are real — each counter moves for the
+// reason it claims to, and no ratio can exceed 1. The second is that they are reachable, which is what
+// TestPredictiveStatsAreReachableThroughTheMultiLevelCache is for: a statistic nothing can read is
+// indistinguishable from one that is never computed, which is how this survived.
+
+// fixedBackend serves a constant payload for any range, and counts what it was asked for.
+//
+// A types.Backend and not a testaws server: what these tests need from a backend is that a prefetch
+// worker stores bytes, and going through real HTTP would put a network round trip inside a test whose
+// subject is a counter. The prefetch path against a real S3 backend is covered by the read-ahead tests;
+// the backend here exists to make the ledger's prefetch half reachable at all, which on the current
+// mount path it is not — initializeLevels passes no Backend, so a mount's four workers dequeue jobs and
+// fetch nothing.
+type fixedBackend struct {
+	types.Backend // embedded for the ~30 methods these tests never call; a nil-method call panics loudly
+
+	payload []byte
+	gets    atomic.Int64
+}
+
+func (b *fixedBackend) GetObject(_ context.Context, _ string, _, size int64) ([]byte, error) {
+	b.gets.Add(1)
+
+	if size <= 0 || size > int64(len(b.payload)) {
+		return b.payload, nil
+	}
+
+	return b.payload[:size], nil
+}
+
+// statsConfig is predictiveCacheConfig with the prefetcher running against a backend that returns bytes.
+func statsConfig(backend types.Backend) *PredictiveCacheConfig {
+	cfg := predictiveCacheConfig()
+	cfg.EnablePrefetch = true
+	cfg.MaxConcurrentFetch = 4
+	cfg.Backend = backend
+
+	return cfg
+}
+
+// streamReads walks a key sequentially, which is the pattern the predictor emits candidates for.
+//
+// PredictNextAccess is keyed per object and returns nothing until it has three accesses of that key with
+// a sequential score above 0.7, so a rotation of distinct keys at offset 0 — the obvious way to write
+// this — produces no candidates at all and every assertion below would pass vacuously.
+func streamReads(pc *PredictiveCache, key string, n int, blockSize int64) {
+	for i := range n {
+		pc.Get(key, int64(i)*blockSize, blockSize)
+	}
+}
+
+// waitFor polls until cond holds, and fails the test if it never does.
+//
+// The prefetch counters are written by worker goroutines, so there is a window between a read that
+// queues a job and the job being done. Polling rather than sleeping a fixed interval: a sleep long
+// enough to be reliable on a loaded CI machine is a sleep that lengthens every run, and one short enough
+// not to is a flake. See the same reasoning in predictive_shutdown_test.go, where a fixed millisecond
+// made a test pass vacuously about half the time.
+func waitFor(t *testing.T, why string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after 5s waiting for %s", why)
+		}
+
+		time.Sleep(200 * time.Microsecond)
+	}
+}
+
+// TestPredictionsAreCounted asserts the predictor's output reaches PredictionsTotal.
+//
+// The field was declared and assigned nowhere. It is the denominator of PredictionAccuracy, so with it
+// at zero the ratio was zero regardless of how well the predictor did — and a zero accuracy reads as a
+// broken predictor rather than as an unwritten counter.
+func TestPredictionsAreCounted(t *testing.T) {
+	t.Parallel()
+
+	pc, err := NewPredictiveCache(predictiveCacheConfig())
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	streamReads(pc, "stream", 16, 4096)
+
+	stats := pc.GetPredictiveStats()
+	if stats.PredictionsTotal == 0 {
+		t.Fatal("sixteen sequential reads produced no counted predictions; PredictionsTotal is the " +
+			"denominator of PredictionAccuracy, so every ratio derived from it stays zero")
+	}
+}
+
+// TestASequentialReaderIsPredictedCorrectly asserts PredictionsCorrect moves when the predictor is right.
+//
+// A sequential stream is the one access pattern predictSequential exists to catch, so if accuracy is
+// zero here it is zero everywhere. The assertion is on being right at all rather than on a specific
+// rate: the rate depends on how many candidates the model emits per read, which is a tuning question,
+// while "a correct prediction is ever credited" is the property #223 is about.
+func TestASequentialReaderIsPredictedCorrectly(t *testing.T) {
+	t.Parallel()
+
+	pc, err := NewPredictiveCache(predictiveCacheConfig())
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	streamReads(pc, "stream", 64, 4096)
+
+	stats := pc.GetPredictiveStats()
+	if stats.PredictionsCorrect == 0 {
+		t.Errorf("a 64-block sequential read scored no correct predictions out of %d; predictSequential "+
+			"predicts exactly this pattern, so nothing else would ever be credited either",
+			stats.PredictionsTotal)
+	}
+	if stats.PredictionAccuracy <= 0 {
+		t.Errorf("PredictionAccuracy = %v with %d/%d correct; the ratio is not being derived",
+			stats.PredictionAccuracy, stats.PredictionsCorrect, stats.PredictionsTotal)
+	}
+}
+
+// TestPredictionAccuracyCannotExceedOne is the bound that says the ratio is a ratio.
+//
+// It is the check that catches double-counting: a claim consumed twice, or a correct prediction credited
+// once per candidate that named the range, would push this past 1 — and a ratio above 1 tells an
+// operator only that the metric is wrong.
+func TestPredictionAccuracyCannotExceedOne(t *testing.T) {
+	t.Parallel()
+
+	pc, err := NewPredictiveCache(predictiveCacheConfig())
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	// Re-reads as well as forward reads: a re-read of a predicted range is the case that would claim the
+	// same prediction twice if the ledger did not consume it.
+	for i := range 64 {
+		pc.Get("stream", int64(i)*4096, 4096)
+		pc.Get("stream", int64(i)*4096, 4096)
+	}
+
+	stats := pc.GetPredictiveStats()
+	if stats.PredictionsCorrect > stats.PredictionsTotal {
+		t.Errorf("PredictionsCorrect = %d exceeds PredictionsTotal = %d; a prediction is being credited "+
+			"more than once", stats.PredictionsCorrect, stats.PredictionsTotal)
+	}
+	if stats.PredictionAccuracy > 1 {
+		t.Errorf("PredictionAccuracy = %v, above 1", stats.PredictionAccuracy)
+	}
+}
+
+// TestAPredictionIsNotCreditedToTheReadThatMadeIt is the self-scoring guard.
+//
+// Get consults the ledger before running the predictor, so a candidate produced by this read cannot be
+// claimed by this read. Reversing those two lines is how a prefetcher scores 100% against itself: each
+// read would name a range and immediately match it. Nothing else in the suite notices the swap —
+// accuracy just climbs, which reads as a triumph — so this test is the only thing standing between the
+// statistic and a number that measures its own bookkeeping.
+//
+// The fixture is exact, and it took a probe to find. A repeated read of one offset is the case where the
+// predictor names the range the reader is already on: sequential score is zero, so predictSequential
+// contributes nothing and predictML — which names the last access's own offset — is the only source of
+// candidates. The confidence threshold has to come down for predictML to fire at all (measured: zero
+// candidates at the default 0.7, sixty-two at 0.3 or below), and the predictions ledger has to be
+// drained first, or the read legitimately claims the range the *previous* read predicted and the two
+// causes are indistinguishable. With those held, one read either credits itself or it does not:
+// measured 5→5 correct with the current ordering and 6→7 with the lines swapped.
+func TestAPredictionIsNotCreditedToTheReadThatMadeIt(t *testing.T) {
+	t.Parallel()
+
+	cfg := predictiveCacheConfig()
+	cfg.ConfidenceThreshold = 0 // see above: predictML is the only candidate source for this pattern
+
+	pc, err := NewPredictiveCache(cfg)
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	for range 8 {
+		pc.Get("hot", 0, 4096)
+	}
+
+	if pc.GetPredictiveStats().PredictionsTotal == 0 {
+		t.Fatal("the fixture produced no predictions, so this cannot distinguish a working ordering " +
+			"from an access pattern that predicts nothing")
+	}
+
+	// Nothing outstanding, so the only prediction the read below could claim is its own.
+	drainPredictions(pc)
+
+	before := pc.GetPredictiveStats()
+	pc.Get("hot", 0, 4096)
+	after := pc.GetPredictiveStats()
+
+	if after.PredictionsTotal == before.PredictionsTotal {
+		t.Fatal("the read made no prediction, so there was nothing for it to credit itself with")
+	}
+	if after.PredictionsCorrect != before.PredictionsCorrect {
+		t.Errorf("PredictionsCorrect went %d→%d on a read whose only claimable prediction was the one "+
+			"it made itself; the predictor is scoring its own bookkeeping",
+			before.PredictionsCorrect, after.PredictionsCorrect)
+	}
+}
+
+// drainPredictions empties the prediction ledger, so what a later read claims can only be its own.
+//
+// Reaching into the ledger rather than arranging an access pattern that leaves it empty: there is no
+// such pattern. A prediction is recorded by every read that produces candidates, so the state this test
+// needs — a warmed predictor with nothing outstanding — is not reachable through Get.
+func drainPredictions(pc *PredictiveCache) {
+	pc.predictions.mu.Lock()
+	defer pc.predictions.mu.Unlock()
+
+	pc.predictions.ranges = make(map[string][]ledgerRange)
+	pc.predictions.order = nil
+}
+
+// TestPrefetchedBytesAreAttributedToTheirPrefetch is the PrefetchHits regression test.
+//
+// The counter was guarded by `event.Hit && event.Prefetch`, and nothing in the repository ever
+// constructed an AccessEvent with Prefetch true — both call sites set it false explicitly. So the branch
+// was unreachable and the count was structurally zero, which is not distinguishable from a prefetcher
+// that never helped.
+func TestPrefetchedBytesAreAttributedToTheirPrefetch(t *testing.T) {
+	t.Parallel()
+
+	const block = 4096
+
+	backend := &fixedBackend{payload: make([]byte, block)}
+
+	pc, err := NewPredictiveCache(statsConfig(backend))
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	// Warm the predictor and let the workers act on what it emits.
+	streamReads(pc, "stream", 8, block)
+
+	waitFor(t, "a prefetch worker to store something", func() bool {
+		return pc.GetPredictiveStats().PrefetchRequests > 0
+	})
+
+	// Keep reading forward. The blocks ahead are what the workers just fetched, so these reads are the
+	// ones a prefetch can be credited for.
+	streamReads(pc, "stream", 64, block)
+
+	waitFor(t, "a read to be attributed to a prefetch", func() bool {
+		return pc.GetPredictiveStats().PrefetchHits > 0
+	})
+
+	stats := pc.GetPredictiveStats()
+	if stats.PrefetchBytes <= 0 {
+		t.Errorf("PrefetchBytes = %d after %d prefetch requests; bytes are recorded against what the "+
+			"backend returned, so a positive request count with zero bytes means the length is being lost",
+			stats.PrefetchBytes, stats.PrefetchRequests)
+	}
+	if stats.PrefetchEfficiency <= 0 {
+		t.Errorf("PrefetchEfficiency = %v with %d hits over %d requests; the ratio is not being derived",
+			stats.PrefetchEfficiency, stats.PrefetchHits, stats.PrefetchRequests)
+	}
+}
+
+// TestPrefetchEfficiencyCannotExceedOne pins the bound the ledger's consume-on-claim rule exists for.
+//
+// A prefetch fetched its bytes once, so it can be right once. Without consuming the range, a reader
+// re-reading a hot region drives hits past requests and efficiency past 100% — a number that would make
+// prefetch look like it was serving reads it never fetched.
+func TestPrefetchEfficiencyCannotExceedOne(t *testing.T) {
+	t.Parallel()
+
+	const block = 4096
+
+	backend := &fixedBackend{payload: make([]byte, block)}
+
+	pc, err := NewPredictiveCache(statsConfig(backend))
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	streamReads(pc, "stream", 8, block)
+
+	waitFor(t, "a prefetch worker to store something", func() bool {
+		return pc.GetPredictiveStats().PrefetchRequests > 0
+	})
+
+	// Read each block many times over, which is the pattern that would over-credit.
+	for i := range 32 {
+		for range 8 {
+			pc.Get("stream", int64(i)*block, block)
+		}
+	}
+
+	stats := pc.GetPredictiveStats()
+	if stats.PrefetchHits > stats.PrefetchRequests {
+		t.Errorf("PrefetchHits = %d exceeds PrefetchRequests = %d; one prefetch is being credited for "+
+			"every read that touches its range", stats.PrefetchHits, stats.PrefetchRequests)
+	}
+	if stats.PrefetchEfficiency > 1 {
+		t.Errorf("PrefetchEfficiency = %v, above 1", stats.PrefetchEfficiency)
+	}
+}
+
+// TestNoBackendMeansNoPrefetchCountsAndStillCountsPredictions is what a mount looks like today.
+//
+// initializeLevels passes no Backend to the predictive config, so the mount's workers dequeue jobs and
+// fetch nothing. That makes the prefetch counters zero on a real mount — honest signal rather than a
+// hidden failure, and the reason the two ledgers are separate: prediction accuracy is still measurable
+// when the prefetcher cannot act, and scoring the predictor on the prefetcher's throughput would report
+// a broken predictor instead of an unconfigured prefetcher.
+func TestNoBackendMeansNoPrefetchCountsAndStillCountsPredictions(t *testing.T) {
+	t.Parallel()
+
+	cfg := statsConfig(nil) // prefetch enabled, no backend — exactly the mount's shape
+
+	pc, err := NewPredictiveCache(cfg)
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	streamReads(pc, "stream", 64, 4096)
+
+	stats := pc.GetPredictiveStats()
+	if stats.PredictionsTotal == 0 {
+		t.Error("no predictions were counted without a backend; prediction accuracy does not depend on " +
+			"the prefetcher being able to act, and conflating them scores the predictor on the " +
+			"prefetcher's throughput")
+	}
+	if stats.PrefetchRequests != 0 {
+		t.Errorf("PrefetchRequests = %d with no backend; nothing was fetched, so nothing should be "+
+			"counted as fetched", stats.PrefetchRequests)
+	}
+	if stats.PrefetchHits != 0 {
+		t.Errorf("PrefetchHits = %d with no backend", stats.PrefetchHits)
+	}
+}
+
+// TestIntelligentEvictionsAreCountedAndRatiosStayConsistent covers the third originally-written counter
+// plus the ratio recomputation on the eviction path.
+//
+// EvictionsTotal and EvictionsIntelligent were the two fields that did work before #223, but the ratios
+// were recomputed only on the read path, so an eviction-heavy workload with no reads left them stale.
+// Deriving them on every write is what makes GetPredictiveStats unable to return counters and ratios
+// that disagree.
+func TestIntelligentEvictionsAreCountedAndRatiosStayConsistent(t *testing.T) {
+	t.Parallel()
+
+	pc, err := NewPredictiveCache(predictiveCacheConfig())
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	// Give the eviction scorer something to score, then ask for space.
+	streamReads(pc, "stream", 16, 4096)
+	pc.Evict(8192)
+
+	stats := pc.GetPredictiveStats()
+	if stats.EvictionsTotal == 0 {
+		t.Fatal("Evict over a populated cache counted no evictions")
+	}
+	if stats.EvictionsIntelligent > stats.EvictionsTotal {
+		t.Errorf("EvictionsIntelligent = %d exceeds EvictionsTotal = %d",
+			stats.EvictionsIntelligent, stats.EvictionsTotal)
+	}
+}
+
+// TestRatiosAreDerivedOnWriteNotOnRead asserts the numbers are consistent in the struct itself.
+//
+// The ratios are computed as the counters change, not inside the getter, because PredictiveStats is
+// serialized directly through its JSON tags — anything that marshals it without calling the getter would
+// see zeros for every ratio, which is #222's defect in smaller form. Recomputing them here from the
+// counters and comparing is how that stays true.
+func TestRatiosAreDerivedOnWriteNotOnRead(t *testing.T) {
+	t.Parallel()
+
+	const block = 4096
+
+	backend := &fixedBackend{payload: make([]byte, block)}
+
+	pc, err := NewPredictiveCache(statsConfig(backend))
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	streamReads(pc, "stream", 32, block)
+
+	waitFor(t, "a prefetch worker to store something", func() bool {
+		return pc.GetPredictiveStats().PrefetchRequests > 0
+	})
+
+	streamReads(pc, "stream", 32, block)
+
+	// Read the struct directly under its own lock rather than through the getter, which is what a
+	// json.Marshal of the collector does.
+	pc.stats.mu.RLock()
+	direct := struct {
+		accuracy, efficiency           float64
+		correct, total, hits, requests uint64
+	}{
+		accuracy:   pc.stats.PredictionAccuracy,
+		efficiency: pc.stats.PrefetchEfficiency,
+		correct:    pc.stats.PredictionsCorrect,
+		total:      pc.stats.PredictionsTotal,
+		hits:       pc.stats.PrefetchHits,
+		requests:   pc.stats.PrefetchRequests,
+	}
+	pc.stats.mu.RUnlock()
+
+	if direct.total > 0 {
+		want := float64(direct.correct) / float64(direct.total)
+		if direct.accuracy != want {
+			t.Errorf("PredictionAccuracy = %v but %d/%d = %v; the ratio in the struct disagrees with "+
+				"its own counters, so anything that marshals this without the getter reports a wrong number",
+				direct.accuracy, direct.correct, direct.total, want)
+		}
+	}
+	if direct.requests > 0 {
+		want := float64(direct.hits) / float64(direct.requests)
+		if direct.efficiency != want {
+			t.Errorf("PrefetchEfficiency = %v but %d/%d = %v", direct.efficiency, direct.hits,
+				direct.requests, want)
+		}
+	}
+}
+
+// TestAvgConfidenceIsWithinTheConfidenceRange asserts the running mean stays a confidence.
+//
+// It is kept incrementally, weighted by the number of candidates in each batch, because the individual
+// confidences are not retained. An unweighted mean would count a burst of candidates as one sample, and
+// an arithmetic slip in the increment shows up as a value outside [0, 1] rather than as a wrong-looking
+// number — which is the only way a mean like this can be checked without recording every input.
+func TestAvgConfidenceIsWithinTheConfidenceRange(t *testing.T) {
+	t.Parallel()
+
+	pc, err := NewPredictiveCache(predictiveCacheConfig())
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	streamReads(pc, "stream", 64, 4096)
+
+	stats := pc.GetPredictiveStats()
+	if stats.PredictionsTotal == 0 {
+		t.Fatal("no predictions, so the mean has no inputs")
+	}
+	if stats.AvgConfidence <= 0 || stats.AvgConfidence > 1 {
+		t.Errorf("AvgConfidence = %v after %d predictions, outside (0, 1]", stats.AvgConfidence,
+			stats.PredictionsTotal)
+	}
+}
+
+// TestPrefetchWasteCountsWhatWasNeverRead asserts the fourth counter moves for its stated reason, and
+// that the ledger's tally reaches the statistics at all.
+//
+// Waste is the number that says whether prefetch earns its bandwidth. Eviction from the ledger is the
+// only moment at which "never read" becomes knowable — before that, an unclaimed range is merely one not
+// read *yet* — and the tally has to travel from the ledger into PredictiveStats without either side
+// taking the other's lock, which is the constraint takeUnclaimed exists to satisfy: the ledger is written
+// by the prefetch workers while a read holds the stats lock, and the reverse order happens too.
+//
+// It calls recordPrefetch, which is what processPrefetchJob calls, rather than driving the workers.
+// That is a deliberate narrowing and worth saying plainly: getting a real prefetch evicted unclaimed
+// needs either 1024 distinct prefetched objects or a reader that skips exactly what was fetched, and
+// probing found both hard to arrange without the access pattern silently ceasing to predict anything —
+// at which point the test passes for the wrong reason. The counting itself is covered end-to-end in
+// prefetch_ledger_test.go; what this covers is the plumbing between the two, which no other test touches.
+func TestPrefetchWasteCountsWhatWasNeverRead(t *testing.T) {
+	t.Parallel()
+
+	pc, err := NewPredictiveCache(predictiveCacheConfig())
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	// Past the per-key bound, claiming none of them: the oldest are evicted, and at that point nothing
+	// will ever read them.
+	const overshoot = 4
+	for i := range maxRangesPerKey + overshoot {
+		pc.recordPrefetch("stream", int64(i)*4096, 4096)
+	}
+
+	if waste := pc.GetPredictiveStats().PrefetchWaste; waste != 0 {
+		t.Fatalf("PrefetchWaste = %d before any read; the ledger's tally is drained on the read path, "+
+			"so this test cannot tell a working drain from a counter written somewhere else", waste)
+	}
+
+	// A read is what drains the tally.
+	pc.Get("stream", 0, 4096)
+
+	if waste := pc.GetPredictiveStats().PrefetchWaste; waste != overshoot {
+		t.Errorf("PrefetchWaste = %d after %d prefetches evicted unclaimed past a per-key bound of %d, "+
+			"want %d", waste, maxRangesPerKey+overshoot, maxRangesPerKey, overshoot)
+	}
+}
+
+// TestPredictiveStatsAreReachableThroughTheMultiLevelCache is #223's stated defect.
+//
+// The mount holds its PredictiveCache as an opaque types.Cache inside a CacheLevel — six methods about
+// bytes, with GetLevelStats returning a types.CacheStats and Close reachable only through an unexported
+// assertion. So these numbers were computed on every read of every mount and discarded at unmount, with
+// no accessor at any layer above.
+//
+// It goes through NewMultiLevelCache with the mount's own prefetch setting rather than constructing a
+// PredictiveCache directly, because "the mount wraps L1 in one" is half of what makes the accessor
+// necessary and a hand-built level would not test it.
+func TestPredictiveStatsAreReachableThroughTheMultiLevelCache(t *testing.T) {
+	t.Parallel()
+
+	mlc, err := NewMultiLevelCache(&MultiLevelConfig{
+		L1Config: &L1Config{
+			Enabled:    true,
+			Size:       64 << 20,
+			MaxEntries: 1000,
+			TTL:        time.Minute,
+			Prefetch:   true, // what multiLevelConfigFrom sets unconditionally
+		},
+		Policy: "inclusive",
+	})
+	if err != nil {
+		t.Fatalf("NewMultiLevelCache: %v", err)
+	}
+	t.Cleanup(func() { _ = mlc.Close() })
+
+	if pc := mlc.GetPredictiveCache(); pc == nil {
+		t.Fatal("GetPredictiveCache returned nil for a cache configured the way every mount is; L1 is " +
+			"wrapped in a PredictiveCache whenever prefetch is on")
+	}
+
+	// Populate, then read forward. Not interleaved: MultiLevelCache.Put records an access too, so a
+	// Put/Get pair per offset gives the predictor a history that alternates between the same offset twice
+	// and scores as non-sequential — measured, zero candidates. Filling first and then streaming is what
+	// a reader does anyway.
+	for i := range 32 {
+		mlc.Put("stream", int64(i)*4096, make([]byte, 4096))
+	}
+	for i := range 32 {
+		mlc.Get("stream", int64(i)*4096, 4096)
+	}
+
+	stats, ok := mlc.PredictiveStats()
+	if !ok {
+		t.Fatal("PredictiveStats reported no predictive layer on a cache that has one")
+	}
+	if stats.PredictionsTotal == 0 {
+		t.Error("reads through the multi-level cache produced no counted predictions, so the accessor " +
+			"reaches a cache the reads are not going through")
+	}
+}
+
+// TestPredictiveStatsReportsAbsenceWhenPrefetchIsOff is the pairing for the test above.
+//
+// Without it, an accessor that returned a zero struct and true unconditionally would satisfy the
+// reachability test while making "there is no predictive layer" indistinguishable from "it has predicted
+// nothing yet" — which is the distinction #222 is the argument for, and the reason this returns a
+// boolean rather than only a struct.
+func TestPredictiveStatsReportsAbsenceWhenPrefetchIsOff(t *testing.T) {
+	t.Parallel()
+
+	mlc, err := NewMultiLevelCache(&MultiLevelConfig{
+		L1Config: &L1Config{
+			Enabled:    true,
+			Size:       64 << 20,
+			MaxEntries: 1000,
+			TTL:        time.Minute,
+			Prefetch:   false,
+		},
+		Policy: "inclusive",
+	})
+	if err != nil {
+		t.Fatalf("NewMultiLevelCache: %v", err)
+	}
+	t.Cleanup(func() { _ = mlc.Close() })
+
+	if pc := mlc.GetPredictiveCache(); pc != nil {
+		t.Error("GetPredictiveCache found a predictive layer with prefetch disabled")
+	}
+	if _, ok := mlc.PredictiveStats(); ok {
+		t.Error("PredictiveStats reported a predictive layer with prefetch disabled; an operator " +
+			"cannot then tell an absent layer from an idle one")
+	}
+}
+
+// TestGetPredictiveStatsIsSafeUnderConcurrentReads is the -race check for the getter.
+//
+// It is called from the metrics collector's periodic-update goroutine while FUSE goroutines are reading
+// through the cache, so it takes the stats lock against writers on every read path. It copies field by
+// field rather than by struct assignment because PredictiveStats holds the mutex guarding it — copying
+// it would trip go vet's copylocks and hand the caller a copy of a lock protecting nothing.
+func TestGetPredictiveStatsIsSafeUnderConcurrentReads(t *testing.T) {
+	t.Parallel()
+
+	const block = 4096
+
+	backend := &fixedBackend{payload: make([]byte, block)}
+
+	pc, err := NewPredictiveCache(statsConfig(backend))
+	if err != nil {
+		t.Fatalf("NewPredictiveCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	var wg sync.WaitGroup
+
+	stop := make(chan struct{})
+
+	// The metrics surface's access pattern: one reader, on a schedule, for the life of the mount.
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				stats := pc.GetPredictiveStats()
+				if stats.PredictionAccuracy > 1 || stats.PrefetchEfficiency > 1 {
+					t.Errorf("a snapshot carried a ratio above 1: accuracy %v, efficiency %v",
+						stats.PredictionAccuracy, stats.PrefetchEfficiency)
+
+					return
+				}
+			}
+		}
+	}()
+
+	for r := range 4 {
+		wg.Add(1)
+
+		go func(r int) {
+			defer wg.Done()
+
+			streamReads(pc, "stream", 128, block)
+		}(r)
+	}
+
+	// The four readers finish on their own; the poller runs until told to stop.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+	}()
+
+	wg.Wait()
+}

--- a/internal/cache/predictive_stats_test.go
+++ b/internal/cache/predictive_stats_test.go
@@ -632,11 +632,7 @@ func TestGetPredictiveStatsIsSafeUnderConcurrentReads(t *testing.T) {
 	stop := make(chan struct{})
 
 	// The metrics surface's access pattern: one reader, on a schedule, for the life of the mount.
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -651,7 +647,7 @@ func TestGetPredictiveStatsIsSafeUnderConcurrentReads(t *testing.T) {
 				}
 			}
 		}
-	}()
+	})
 
 	for r := range 4 {
 		wg.Add(1)

--- a/internal/cache/prefetch_ledger.go
+++ b/internal/cache/prefetch_ledger.go
@@ -1,0 +1,153 @@
+package cache
+
+import "sync"
+
+// rangeLedger records ranges the cache has spoken for — bytes a prefetch worker stored, or bytes the
+// predictor said would be read next — so that a later read can be attributed to one of them.
+//
+// It exists because attribution cannot be recovered after the fact. A cache hit looks identical whether
+// the bytes arrived from the application's own earlier read or from a prefetch, and the predictor's
+// accuracy is unknowable unless what it predicted is remembered until a read either matches it or
+// displaces it. This is the memory that makes [PredictiveStats]'s ratios computable at all, which is why
+// they were zero before it existed (#223).
+//
+// Bounded by construction: at most maxLedgerKeys keys and maxRangesPerKey ranges per key, both evicted
+// oldest-first. An unbounded ledger on a filesystem cache is a leak with a slow fuse — it would grow
+// with the number of distinct objects a mount ever touched, which for a research dataset is the whole
+// bucket. Eviction is also where an unclaimed range is finally counted as waste: at that point nothing
+// will read it, so the prefetch that fetched it is known to have been wrong.
+const (
+	maxLedgerKeys    = 1024
+	maxRangesPerKey  = 16
+	ledgerTrimTarget = maxLedgerKeys * 3 / 4 // how far back a trim goes, so it is not run on every insert
+)
+
+// ledgerRange is a byte range this cache spoke for.
+type ledgerRange struct {
+	offset int64
+	length int64
+}
+
+// covers reports whether the range wholly contains [offset, offset+size).
+//
+// Containment, not overlap. A read half-covered by a prefetch was half-served by it, and there is no
+// honest way to score that as a hit — the other half was a base-cache hit or a miss the layer above
+// resolved. Requiring containment makes both PrefetchHits and PredictionsCorrect undercount rather than
+// overcount, which is the direction that does not flatter the prefetcher.
+func (r ledgerRange) covers(offset, size int64) bool {
+	return offset >= r.offset && offset+size <= r.offset+r.length
+}
+
+// rangeLedger is safe for concurrent use: every prefetch worker records into it and every read consults
+// it.
+type rangeLedger struct {
+	mu sync.Mutex
+
+	ranges map[string][]ledgerRange
+
+	// order is insertion order over the keys of ranges, for eviction. A slice rather than a
+	// container/list because the whole thing is at most maxLedgerKeys entries and a trim is amortized
+	// across ledgerTrimTarget inserts.
+	order []string
+
+	// unclaimed counts ranges evicted without ever being claimed. Read by the caller and folded into
+	// PrefetchWaste; kept here because eviction is the only moment at which "never read" becomes known.
+	unclaimed uint64
+}
+
+func newRangeLedger() *rangeLedger {
+	return &rangeLedger{ranges: make(map[string][]ledgerRange)}
+}
+
+// record adds a range for key, evicting to stay within bounds.
+func (l *rangeLedger) record(key string, offset, length int64) {
+	if length <= 0 {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	existing, seen := l.ranges[key]
+	if !seen {
+		l.order = append(l.order, key)
+	}
+
+	// Oldest range for this key goes first once the per-key bound is reached. A reader moving through a
+	// large object generates a range per prefetch, and only the recent ones can still be claimed by a
+	// read that has not happened yet.
+	if len(existing) >= maxRangesPerKey {
+		if !existing[0].claimed() {
+			l.unclaimed++
+		}
+		existing = existing[1:]
+	}
+
+	l.ranges[key] = append(existing, ledgerRange{offset: offset, length: length})
+
+	if len(l.order) > maxLedgerKeys {
+		l.trimLocked()
+	}
+}
+
+// claim reports whether a recorded range covers the read, and consumes the range if one does.
+//
+// Consuming it is what keeps a single prefetch from being credited for every read that touches it: the
+// prefetch fetched those bytes once, so it can be right once. Without that, a reader re-reading a hot
+// range would drive PrefetchHits above PrefetchRequests and the efficiency ratio past 100%.
+func (l *rangeLedger) claim(key string, offset, size int64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	ranges := l.ranges[key]
+	for i := range ranges {
+		if ranges[i].claimed() || !ranges[i].covers(offset, size) {
+			continue
+		}
+
+		ranges[i].length = 0 // marks it claimed; see ledgerRange.claimed
+		l.ranges[key] = ranges
+
+		return true
+	}
+
+	return false
+}
+
+// claimed reports whether this range has already been attributed to a read.
+//
+// Zero length is the marker rather than a separate bool, because record rejects a non-positive length, so
+// no unclaimed range can have one. That keeps ledgerRange two words and the ledger's footprint at
+// maxLedgerKeys × maxRangesPerKey × 16 bytes — 256 KiB at the bounds above.
+func (r ledgerRange) claimed() bool {
+	return r.length == 0
+}
+
+// takeUnclaimed returns the number of ranges evicted without being claimed since the last call, and
+// resets the counter.
+func (l *rangeLedger) takeUnclaimed() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	n := l.unclaimed
+	l.unclaimed = 0
+
+	return n
+}
+
+// trimLocked drops the oldest keys down to ledgerTrimTarget. Caller holds mu.
+func (l *rangeLedger) trimLocked() {
+	drop := len(l.order) - ledgerTrimTarget
+	for _, key := range l.order[:drop] {
+		for _, r := range l.ranges[key] {
+			if !r.claimed() {
+				l.unclaimed++
+			}
+		}
+		delete(l.ranges, key)
+	}
+
+	// Copied rather than resliced: l.order[drop:] keeps the dropped keys alive in the backing array, which
+	// on a mount that touches many distinct objects is the leak this bound exists to prevent.
+	l.order = append([]string(nil), l.order[drop:]...)
+}

--- a/internal/cache/prefetch_ledger_test.go
+++ b/internal/cache/prefetch_ledger_test.go
@@ -1,0 +1,354 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// The ledger is what makes attribution possible, so these tests are about the properties the
+// statistics rest on: a range is claimed at most once, a partial cover is not a claim, and the bounds
+// hold under a workload that touches far more keys than the ledger can hold (#223).
+
+// TestLedgerClaimsARecordedRange is the base case: a read inside a recorded range is attributed to it.
+func TestLedgerClaimsARecordedRange(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+	l.record("data/x", 0, 4096)
+
+	if !l.claim("data/x", 0, 4096) {
+		t.Error("a read of exactly the recorded range was not attributed to it")
+	}
+}
+
+// TestLedgerClaimsOnlyOnce is the property that keeps PrefetchEfficiency at or below 100%.
+//
+// A prefetch fetched those bytes once, so it can be right once. Without consuming the range, a reader
+// re-reading a hot region would drive PrefetchHits past PrefetchRequests and the ratio past 1.0 — a
+// number that tells an operator nothing except that the metric is wrong.
+func TestLedgerClaimsOnlyOnce(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+	l.record("data/x", 0, 4096)
+
+	if !l.claim("data/x", 0, 4096) {
+		t.Fatal("the first claim failed, so what follows cannot distinguish consuming from never matching")
+	}
+
+	for i := range 4 {
+		if l.claim("data/x", 0, 4096) {
+			t.Errorf("re-read %d claimed the same range again; one prefetch would be credited for every "+
+				"read that touches it, and efficiency would exceed 1.0", i+2)
+		}
+	}
+}
+
+// TestLedgerRequiresContainmentNotOverlap pins the direction the arithmetic errs in.
+//
+// A read half-covered by a prefetch was half-served by it, and there is no honest way to score that as
+// a hit: the other half came from somewhere else. Requiring containment makes the counters undercount
+// rather than overcount, which is the direction that does not flatter the prefetcher.
+func TestLedgerRequiresContainmentNotOverlap(t *testing.T) {
+	t.Parallel()
+
+	// Each case overlaps [1024, 2048) without being contained by it.
+	cases := []struct {
+		name         string
+		offset, size int64
+	}{
+		{name: "starts before", offset: 512, size: 1024},
+		{name: "extends past the end", offset: 1536, size: 1024},
+		{name: "strictly larger", offset: 0, size: 4096},
+		{name: "adjacent after", offset: 2048, size: 512},
+		{name: "adjacent before", offset: 512, size: 512},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := newRangeLedger()
+			l.record("data/x", 1024, 1024)
+
+			if l.claim("data/x", tc.offset, tc.size) {
+				t.Errorf("a read of [%d, %d) claimed the recorded [1024, 2048), which does not contain it",
+					tc.offset, tc.offset+tc.size)
+			}
+		})
+	}
+}
+
+// TestLedgerClaimsASubrange is the containment rule's other half: a read inside the range does count.
+//
+// Worth its own test because the strict version of containment — requiring the offsets to match — would
+// pass every case above while scoring almost every real read as a miss. A prefetch of 1 MiB serves the
+// 128 KiB reads the kernel actually issues, and that is the case that has to be credited.
+func TestLedgerClaimsASubrange(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+	l.record("data/x", 0, 1<<20)
+
+	if !l.claim("data/x", 512<<10, 128<<10) {
+		t.Error("a 128 KiB read inside a 1 MiB prefetch was not attributed to it; every kernel-sized " +
+			"read of a prefetched object would score as a miss")
+	}
+}
+
+// TestLedgerKeysDoNotCrossOver asserts a range recorded for one object cannot be claimed by another.
+//
+// The keys are object paths, and a ledger that ignored them would credit any read at a matching offset
+// — which on a filesystem where every object starts at offset 0 is most of them.
+func TestLedgerKeysDoNotCrossOver(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+	l.record("data/x", 0, 4096)
+
+	if l.claim("data/y", 0, 4096) {
+		t.Error("a read of data/y claimed a range recorded for data/x")
+	}
+	if !l.claim("data/x", 0, 4096) {
+		t.Error("the range for data/x was consumed by the read of data/y")
+	}
+}
+
+// TestLedgerRejectsANonPositiveLength guards the marker that says "claimed".
+//
+// A zero length is how a claimed range is marked, so recording one inserts an entry indistinguishable
+// from a consumed one; a negative length is worse, since it can never cover any read and is therefore
+// counted as waste the moment it is evicted. A short or failed backend read is exactly where both come
+// from.
+//
+// The assertions have to go past "is it claimable", because a zero-length entry is unclaimable either
+// way — that is what makes it invisible. What it does instead is occupy a slot under the per-key bound,
+// so the two observable consequences are a real range evicted early and, for a negative length, a
+// phantom count of waste. Both are checked, because a test of only the first left dropping the guard
+// entirely undetected.
+func TestLedgerRejectsANonPositiveLength(t *testing.T) {
+	t.Parallel()
+
+	for _, length := range []int64{0, -1, -4096} {
+		l := newRangeLedger()
+		l.record("data/x", 0, length)
+
+		if l.claim("data/x", 0, 0) {
+			t.Errorf("recording a length of %d produced a claimable range; zero length is the "+
+				"already-claimed marker, so such an entry is indistinguishable from a consumed one", length)
+		}
+
+		// Exactly the per-key bound in real ranges. If the bad entry took a slot, the first of these is
+		// evicted to make room and the ledger has forgotten a range a read could still have claimed.
+		for i := range maxRangesPerKey {
+			l.record("data/x", int64(i+1)*4096, 4096)
+		}
+
+		for i := range maxRangesPerKey {
+			if !l.claim("data/x", int64(i+1)*4096, 4096) {
+				t.Errorf("after recording a length of %d, real range %d of %d is gone: the rejected entry "+
+					"took a slot under the per-key bound and pushed out a claimable range",
+					length, i, maxRangesPerKey)
+
+				break
+			}
+		}
+
+		if n := l.takeUnclaimed(); n != 0 {
+			t.Errorf("recording a length of %d counted %d unclaimed range(s) as waste; a length no read "+
+				"can ever cover would be charged to the prefetcher as bandwidth it wasted", length, n)
+		}
+	}
+}
+
+// TestLedgerBoundsRangesPerKey asserts a single object cannot grow an unbounded ledger.
+//
+// A reader streaming a large file generates one range per prefetch, and only the recent ones can still
+// be claimed by a read that has not happened yet. The oldest goes first, so the entries kept are the
+// ones with a future.
+func TestLedgerBoundsRangesPerKey(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+
+	const overshoot = 4
+	for i := range maxRangesPerKey + overshoot {
+		l.record("stream", int64(i)*4096, 4096)
+	}
+
+	l.mu.Lock()
+	held := len(l.ranges["stream"])
+	l.mu.Unlock()
+
+	if held > maxRangesPerKey {
+		t.Errorf("the ledger holds %d ranges for one key, above the bound of %d", held, maxRangesPerKey)
+	}
+
+	// The evicted ones are the oldest, and they were never claimed, so they are waste.
+	if n := l.takeUnclaimed(); n != overshoot {
+		t.Errorf("takeUnclaimed = %d, want %d — an evicted range that was never read is a prefetch "+
+			"known to have been wrong, and eviction is the only moment that becomes knowable", n, overshoot)
+	}
+
+	// The newest range survives; the oldest does not.
+	if !l.claim("stream", int64(maxRangesPerKey+overshoot-1)*4096, 4096) {
+		t.Error("the most recently recorded range is gone, so eviction dropped the wrong end")
+	}
+	if l.claim("stream", 0, 4096) {
+		t.Error("the oldest range survived past the per-key bound")
+	}
+}
+
+// TestLedgerBoundsKeys asserts the whole-ledger bound holds against a mount that touches many objects.
+//
+// This is the leak the bound exists to prevent: without it the ledger grows with the number of distinct
+// objects a mount ever read, which for a research dataset is the whole bucket.
+func TestLedgerBoundsKeys(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+
+	for i := range maxLedgerKeys * 3 {
+		l.record(fmt.Sprintf("obj/%d", i), 0, 4096)
+	}
+
+	l.mu.Lock()
+	keys, order := len(l.ranges), len(l.order)
+	l.mu.Unlock()
+
+	if keys > maxLedgerKeys {
+		t.Errorf("the ledger holds %d keys, above the bound of %d", keys, maxLedgerKeys)
+	}
+
+	// order and ranges must agree, or a trim walks keys that are no longer there — and the order slice
+	// becomes the unbounded thing the map is not.
+	if order != keys {
+		t.Errorf("order has %d entries and ranges has %d; a trim iterates order, so a disagreement "+
+			"means either stale keys are walked or live ones are never evicted", order, keys)
+	}
+
+	// The most recent key survives a trim; one from the first batch does not.
+	if !l.claim(fmt.Sprintf("obj/%d", maxLedgerKeys*3-1), 0, 4096) {
+		t.Error("the most recently recorded key was trimmed, so the trim drops the wrong end")
+	}
+	if l.claim("obj/0", 0, 4096) {
+		t.Error("the first key recorded survived 3× the key bound")
+	}
+}
+
+// TestLedgerCountsTrimmedRangesAsUnclaimed asserts waste is counted when a whole key is trimmed, not
+// just when a single range is pushed out.
+//
+// Two eviction paths reach the same conclusion — "nothing will ever read this" — and only one of them
+// was obvious. A trim that forgot to count would make PrefetchWaste understate by however much the
+// ledger's key pressure evicted, which on a mount that touches many objects is most of it.
+func TestLedgerCountsTrimmedRangesAsUnclaimed(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+
+	// Two ranges per key, so the count is not confusable with a per-key count.
+	for i := range maxLedgerKeys + 1 {
+		key := fmt.Sprintf("obj/%d", i)
+		l.record(key, 0, 4096)
+		l.record(key, 4096, 4096)
+	}
+
+	// One trim happened, dropping down to ledgerTrimTarget, at two unclaimed ranges per key.
+	wantKeys := maxLedgerKeys + 1 - ledgerTrimTarget
+	if n := l.takeUnclaimed(); n != uint64(wantKeys*2) {
+		t.Errorf("takeUnclaimed = %d after a trim of %d keys holding two ranges each, want %d",
+			n, wantKeys, wantKeys*2)
+	}
+}
+
+// TestLedgerDoesNotCountAClaimedRangeAsWaste is the pairing for the two tests above.
+//
+// Waste means fetched and never read. A range that was read and then evicted is a prefetch that
+// worked, and counting it would make waste indistinguishable from throughput.
+func TestLedgerDoesNotCountAClaimedRangeAsWaste(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+
+	// Fill one key past its bound, claiming every range as it goes.
+	for i := range maxRangesPerKey + 4 {
+		offset := int64(i) * 4096
+		l.record("stream", offset, 4096)
+
+		if !l.claim("stream", offset, 4096) {
+			t.Fatalf("claim of range %d failed; the fixture is wrong, not the ledger", i)
+		}
+	}
+
+	if n := l.takeUnclaimed(); n != 0 {
+		t.Errorf("takeUnclaimed = %d with every range claimed before eviction; waste must mean "+
+			"fetched-and-never-read, or it cannot answer whether prefetch earns its bandwidth", n)
+	}
+}
+
+// TestLedgerTakeUnclaimedDrains asserts the counter is consumed, not accumulated twice.
+//
+// The caller folds the return value into a running total, so a takeUnclaimed that left the count in
+// place would add it again on every read — turning PrefetchWaste into something that grows with read
+// volume rather than with wasted prefetches.
+func TestLedgerTakeUnclaimedDrains(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+	for i := range maxRangesPerKey + 2 {
+		l.record("stream", int64(i)*4096, 4096)
+	}
+
+	first := l.takeUnclaimed()
+	if first == 0 {
+		t.Fatal("no waste was counted, so the drain cannot be observed")
+	}
+	if second := l.takeUnclaimed(); second != 0 {
+		t.Errorf("a second takeUnclaimed returned %d; the count is not drained, so the caller's "+
+			"running total would grow on every read", second)
+	}
+}
+
+// TestLedgerIsSafeUnderConcurrentUse is the -race check for the access pattern it actually sees.
+//
+// Every prefetch worker records into the ledger while every read consults it, which is four writers
+// against N readers on the live path. This is not a hypothetical: the ledger is the one piece of #223's
+// state written from the prefetch goroutines and read from the FUSE ones.
+func TestLedgerIsSafeUnderConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	l := newRangeLedger()
+
+	var wg sync.WaitGroup
+
+	for w := range 4 {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			key := fmt.Sprintf("stream/%d", w)
+			for i := range 256 {
+				l.record(key, int64(i)*4096, 4096)
+			}
+		}(w)
+	}
+
+	for r := range 4 {
+		wg.Add(1)
+
+		go func(r int) {
+			defer wg.Done()
+
+			key := fmt.Sprintf("stream/%d", r)
+			for i := range 256 {
+				l.claim(key, int64(i)*4096, 4096)
+				l.takeUnclaimed()
+			}
+		}(r)
+	}
+
+	wg.Wait()
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -28,6 +28,10 @@ type Collector struct {
 	cacheSizeGauge    *prometheus.GaugeVec
 	activeConnections prometheus.Gauge
 	errorCounter      *prometheus.CounterVec
+	predictiveGauge   *prometheus.GaugeVec
+
+	// periodic are the callbacks updateLoop invokes on every tick, registered by OnPeriodicUpdate.
+	periodic []func()
 
 	// Internal tracking
 	operations map[string]*OperationMetrics
@@ -337,6 +341,50 @@ func (c *Collector) UpdateActiveConnections(count int) {
 	c.activeConnections.Set(float64(count))
 }
 
+// UpdatePredictiveCache publishes the predictive cache's statistics, one series per named statistic.
+//
+// Takes a map rather than a cache.PredictiveStats so that internal/metrics does not import
+// internal/cache. The adapter imports both and is where the two meet; a metrics package that knows the
+// cache's types is one the cache cannot later import, and it makes this family's shape a matter of
+// agreement between two packages rather than of one struct.
+//
+// Names come from the caller and reach the scrape as label values, so they are the contract:
+// sdks/testdata/metrics-scrape.txt captures them and TestSDKFixtureMatchesTheLiveScrape fails on a
+// rename, which is what makes both SDK suites notice.
+func (c *Collector) UpdatePredictiveCache(stats map[string]float64) {
+	if !c.config.Enabled {
+		return
+	}
+
+	for name, value := range stats {
+		c.predictiveGauge.With(prometheus.Labels{"statistic": name}).Set(value)
+	}
+}
+
+// OnPeriodicUpdate registers a callback for updateLoop to invoke on every tick.
+//
+// This is how a gauge whose value lives elsewhere gets refreshed. Counters and histograms are pushed at
+// the moment of the operation, but the predictive cache's totals are state held by the cache, and
+// scraping them means asking — so something has to ask on a schedule. updatePeriodicMetrics was an empty
+// function with a comment saying "this would update metrics that need periodic updates"; this is that,
+// with the caller supplying what to ask rather than this package knowing.
+//
+// Callbacks run on the update goroutine, sequentially, and must not block for long: one that does delays
+// every later callback by the same amount. Registering after Start is safe — updatePeriodicMetrics reads
+// the list under the lock on each tick — which the adapter relies on: it starts the collector first,
+// because a bind failure should fail the mount before anything else is built, and the cache whose
+// statistics it registers does not exist until several steps later.
+func (c *Collector) OnPeriodicUpdate(update func()) {
+	if update == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.periodic = append(c.periodic, update)
+}
+
 // GetMetrics returns current metrics
 func (c *Collector) GetMetrics() map[string]any {
 	c.mu.RLock()
@@ -483,6 +531,26 @@ func (c *Collector) initMetrics() error {
 		[]string{"operation", "type"},
 	)
 
+	// Predictive cache metrics.
+	//
+	// One gauge family labeled by "statistic" rather than a metric per number. The values are a mix of
+	// monotonic counters and ratios derived from them, and the set will change as the predictive layer
+	// does — a label keeps that from being a metric-name change each time, which is a change both SDKs and
+	// every dashboard would have to follow.
+	//
+	// A gauge and not a counter even for the counting ones: they are read by scraping a snapshot of the
+	// cache's own totals rather than incremented here, and prometheus.Counter has no Set.
+	c.predictiveGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   c.config.Namespace,
+			Subsystem:   c.config.Subsystem,
+			Name:        "predictive_cache",
+			Help:        "Predictive cache statistics, by statistic name",
+			ConstLabels: labels,
+		},
+		[]string{"statistic"},
+	)
+
 	return nil
 }
 
@@ -495,6 +563,7 @@ func (c *Collector) registerMetrics() error {
 		c.cacheSizeGauge,
 		c.activeConnections,
 		c.errorCounter,
+		c.predictiveGauge,
 	}
 
 	for _, metric := range metrics {
@@ -538,9 +607,19 @@ func (c *Collector) updateLoop(ctx context.Context) {
 	}
 }
 
+// updatePeriodicMetrics invokes every callback registered through OnPeriodicUpdate.
+//
+// The callbacks are copied out under the lock and run without it: a callback reads state from another
+// subsystem, which may take that subsystem's own lock, and holding this one across that is how two
+// packages that each look correct deadlock together.
 func (c *Collector) updatePeriodicMetrics() {
-	// This would update metrics that need periodic updates
-	// For example, current cache sizes, connection counts, etc.
+	c.mu.RLock()
+	callbacks := append([]func(){}, c.periodic...)
+	c.mu.RUnlock()
+
+	for _, update := range callbacks {
+		update()
+	}
 }
 
 // HTTP handlers

--- a/internal/metrics/fixture_test.go
+++ b/internal/metrics/fixture_test.go
@@ -93,6 +93,24 @@ func liveScrape(t *testing.T) string {
 	c.UpdateActiveConnections(4)
 	c.RecordError("read", errors.New("timeout while reading"))
 
+	// The predictive family, which a mount publishes from the cache's own totals (#223). Its label values
+	// are the part an SDK keys on, so they belong in the fixture: without an observation here the family
+	// is absent from the capture, and a rename of any statistic would break both SDKs' extractors with
+	// nothing failing first. 61 correct of 186 is deliberately not a round ratio, for the reason above.
+	c.UpdatePredictiveCache(map[string]float64{
+		"predictions_total":     186,
+		"predictions_correct":   61,
+		"prediction_accuracy":   61.0 / 186.0,
+		"avg_confidence":        0.42,
+		"prefetch_requests":     96,
+		"prefetch_hits":         31,
+		"prefetch_bytes":        96 * 4096,
+		"prefetch_waste":        12,
+		"prefetch_efficiency":   31.0 / 96.0,
+		"evictions_total":       40,
+		"evictions_intelligent": 24,
+	})
+
 	if err := c.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/metrics/predictive_test.go
+++ b/internal/metrics/predictive_test.go
@@ -322,26 +322,18 @@ func TestPeriodicCallbacksAreSafeToRegisterConcurrently(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range 8 {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			for range 32 {
 				c.OnPeriodicUpdate(func() {})
 			}
-		}()
+		})
 	}
 
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		for range 64 {
 			c.updatePeriodicMetrics()
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/internal/metrics/predictive_test.go
+++ b/internal/metrics/predictive_test.go
@@ -1,0 +1,434 @@
+package metrics
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/scttfrdmn/objectfs/internal/testhttp"
+)
+
+// #223 gave the predictive cache's statistics a consumer, and this is that consumer's half: a gauge
+// family whose values live in another package and a periodic hook that goes and asks for them.
+//
+// updatePeriodicMetrics was an empty function with the comment "this would update metrics that need
+// periodic updates". That is the shape these tests are about — a gauge nothing refreshes exports its
+// initial value forever, which is indistinguishable from a subsystem that never changes.
+
+// TestPredictiveGaugeCarriesOneSeriesPerStatistic pins the family's shape.
+//
+// One family labeled by statistic, not a metric per number: the set of statistics will change as the
+// predictive layer does, and a metric-name change is one both SDKs and every dashboard have to follow,
+// while a new label value is one they pick up for free.
+func TestPredictiveGaugeCarriesOneSeriesPerStatistic(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.UpdatePredictiveCache(map[string]float64{
+		"predictions_total":   186,
+		"predictions_correct": 61,
+		"prediction_accuracy": 0.32795698924731184,
+	})
+
+	got := predictiveSeries(t, c)
+
+	want := map[string]float64{
+		"predictions_total":   186,
+		"predictions_correct": 61,
+		"prediction_accuracy": 0.32795698924731184,
+	}
+	for name, value := range want {
+		if got[name] != value {
+			t.Errorf(`objectfs_predictive_cache{statistic=%q} = %v, want %v`, name, got[name], value)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("the family carries %d series, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// TestPredictiveGaugeIsSetNotAccumulated is why these are gauges.
+//
+// The values are a snapshot of the cache's own running totals, read on a schedule rather than
+// incremented here. A counter would add each snapshot to the last, so a monotonic total read twice would
+// double — and a ratio read twice would exceed 1, which is the one thing a ratio must not do.
+func TestPredictiveGaugeIsSetNotAccumulated(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	for range 3 {
+		c.UpdatePredictiveCache(map[string]float64{
+			"predictions_total":   100,
+			"prediction_accuracy": 0.5,
+		})
+	}
+
+	got := predictiveSeries(t, c)
+	if got["predictions_total"] != 100 {
+		t.Errorf("predictions_total = %v after three publications of 100; the snapshot is being "+
+			"accumulated rather than set", got["predictions_total"])
+	}
+	if got["prediction_accuracy"] != 0.5 {
+		t.Errorf("prediction_accuracy = %v after three publications of 0.5; a ratio that accumulates "+
+			"exceeds 1 and stops being a ratio", got["prediction_accuracy"])
+	}
+}
+
+// TestPredictiveGaugeReflectsTheLatestSnapshot asserts a later publication replaces an earlier one.
+//
+// The pairing for the test above: a Set that was somehow a no-op after the first call would satisfy
+// that one while freezing the family at the mount's opening values — which is exactly the failure an
+// unrefreshed gauge produces, and the one updatePeriodicMetrics existed as an empty function to avoid.
+func TestPredictiveGaugeReflectsTheLatestSnapshot(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.UpdatePredictiveCache(map[string]float64{"prefetch_hits": 1})
+	c.UpdatePredictiveCache(map[string]float64{"prefetch_hits": 42})
+
+	if got := predictiveSeries(t, c)["prefetch_hits"]; got != 42 {
+		t.Errorf("prefetch_hits = %v after publishing 1 then 42; the gauge is not tracking the latest "+
+			"snapshot", got)
+	}
+}
+
+// TestPredictiveGaugeCarriesTheOperatorLabels asserts the new family is not an exception.
+//
+// monitoring.metrics.custom_labels is documented as attached to every exported metric, and the failure
+// mode is precisely a family added later without ConstLabels — which is why TestCustomLabelsReachEveryMetric
+// asserts over every family rather than one. This is the same check aimed at the family that family-wide
+// test would not have observed without an observation in it.
+func TestPredictiveGaugeCarriesTheOperatorLabels(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(&Config{
+		Enabled: true,
+		Addr:    anyLoopbackAddr,
+		Labels:  map[string]string{"service": "objectfs", "cluster": "research-west"},
+	})
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.UpdatePredictiveCache(map[string]float64{"predictions_total": 1})
+
+	for _, mf := range gather(t, c) {
+		if mf.GetName() != "objectfs_predictive_cache" {
+			continue
+		}
+
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+
+			for name, value := range map[string]string{"service": "objectfs", "cluster": "research-west"} {
+				if labels[name] != value {
+					t.Errorf("objectfs_predictive_cache is missing the operator label %s=%s; it carried %v",
+						name, value, labels)
+				}
+			}
+		}
+	}
+}
+
+// TestUpdatePredictiveCacheHonorsDisabled asserts a disabled collector builds no series.
+//
+// A disabled collector has no registry at all, so publishing into it must not dereference one. Every
+// other Update* method returns early on the same check, and this one is called from a callback the
+// adapter registers before it knows whether metrics are on.
+func TestUpdatePredictiveCacheHonorsDisabled(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(&Config{Enabled: false})
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	// The assertion is that this does not panic on a nil GaugeVec and nil registry.
+	c.UpdatePredictiveCache(map[string]float64{"predictions_total": 1})
+}
+
+// TestPeriodicCallbacksRunOnEveryTick is the regression test for the empty function.
+//
+// updatePeriodicMetrics was a no-op with a comment describing what it would do, and the ticker driving
+// it existed and did nothing. A gauge whose value lives in another subsystem cannot be pushed at the
+// moment of the operation — the cache holds the totals — so something has to ask, and if nothing asks
+// the family reports the mount's opening zeros for the life of the process.
+//
+// A short interval and a counter rather than a sleep-and-hope: the assertion is that the callback runs
+// repeatedly, so it waits for the second invocation.
+func TestPeriodicCallbacksRunOnEveryTick(t *testing.T) {
+	t.Parallel()
+
+	cfg := exactAdapterConfig(anyLoopbackAddr)
+	cfg.UpdateInterval = 5 * time.Millisecond
+
+	c, err := NewCollector(cfg)
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	var calls atomic.Int64
+
+	c.OnPeriodicUpdate(func() { calls.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	deadline := time.Now().Add(5 * time.Second)
+	for calls.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("the periodic callback ran %d time(s) in 5s at a 5ms interval; a gauge whose value "+
+				"lives elsewhere is never refreshed, so it reports the mount's opening values forever",
+				calls.Load())
+		}
+
+		time.Sleep(200 * time.Microsecond)
+	}
+}
+
+// TestPeriodicCallbacksRegisteredAfterStartStillRun is the ordering the adapter depends on.
+//
+// The collector is started first, because a bind failure should fail the mount before anything else is
+// built, and the cache whose statistics it publishes does not exist until several steps later. So
+// registration after Start is the live path, not an edge case — a callback list read once at Start would
+// leave the predictive family permanently absent while every test that registered first still passed.
+func TestPeriodicCallbacksRegisteredAfterStartStillRun(t *testing.T) {
+	t.Parallel()
+
+	cfg := exactAdapterConfig(anyLoopbackAddr)
+	cfg.UpdateInterval = 5 * time.Millisecond
+
+	c, err := NewCollector(cfg)
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	var calls atomic.Int64
+
+	c.OnPeriodicUpdate(func() { calls.Add(1) })
+
+	deadline := time.Now().Add(5 * time.Second)
+	for calls.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("a callback registered after Start never ran; the adapter registers the predictive " +
+				"cache's publisher after Start by necessity, so its metrics would never appear")
+		}
+
+		time.Sleep(200 * time.Microsecond)
+	}
+}
+
+// TestOnPeriodicUpdateIgnoresNil keeps a nil registration from killing the update goroutine.
+//
+// A nil callback invoked on the update loop panics on a goroutine no caller can recover from — the same
+// shape as the zero UpdateInterval that used to panic in time.NewTicker and take the mount with it.
+func TestOnPeriodicUpdateIgnoresNil(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.OnPeriodicUpdate(nil)
+
+	// Invoked directly rather than through the ticker: the panic would be on the update goroutine, where
+	// this test's failure would be a dead process rather than a failed assertion.
+	c.updatePeriodicMetrics()
+}
+
+// TestPeriodicCallbacksRunWithoutTheCollectorLockHeld is the deadlock guard.
+//
+// A callback reads another subsystem's state and takes that subsystem's lock. Holding the collector's
+// lock across that call means two packages that each look correct can deadlock — the cache's read path
+// takes the stats lock and publishes, while the update goroutine holds the collector lock and waits for
+// the stats lock. So the callbacks are copied out under the lock and run without it, and a callback that
+// calls back into the collector is how that is asserted: it would block forever otherwise.
+func TestPeriodicCallbacksRunWithoutTheCollectorLockHeld(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	// RecordOperation takes c.mu for writing, which is the strongest form of the collision.
+	c.OnPeriodicUpdate(func() {
+		c.RecordOperation("read", time.Millisecond, 4096, true)
+		c.UpdatePredictiveCache(map[string]float64{"predictions_total": 1})
+	})
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		c.updatePeriodicMetrics()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("updatePeriodicMetrics did not return within 5s with a callback that touches the " +
+			"collector; the callbacks are running with c.mu held")
+	}
+}
+
+// TestPeriodicCallbacksAreSafeToRegisterConcurrently is the -race check on the registration list.
+//
+// Registration happens from the mount path while the update goroutine is already ticking, so the slice
+// is appended to and read concurrently by construction.
+func TestPeriodicCallbacksAreSafeToRegisterConcurrently(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 32 {
+				c.OnPeriodicUpdate(func() {})
+			}
+		}()
+	}
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for range 64 {
+			c.updatePeriodicMetrics()
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestPredictiveFamilyIsAbsentUntilPublished pins what a scrape shows when there is no predictive layer.
+//
+// The adapter publishes nothing when the cache has no predictive layer — the Redis-backed cache has
+// none, and the multi-level cache only wraps L1 when prefetch is on. Both are ordinary configurations,
+// so neither is an error, and an absent family is how a scrape says so. That is a distinguishable answer
+// only because a GaugeVec exports no series until one is set; a family reporting zeros would say "the
+// predictor is doing nothing", which is a different and false claim.
+func TestPredictiveFamilyIsAbsentUntilPublished(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.RecordOperation("read", time.Millisecond, 4096, true)
+
+	if _, ok := gatherNames(t, c)["objectfs_predictive_cache"]; ok {
+		t.Error("objectfs_predictive_cache appears in a gather with nothing published; an absent " +
+			"predictive layer would be reported as one that has predicted nothing")
+	}
+}
+
+// TestPredictiveStatisticsReachAScrape closes the loop over HTTP.
+//
+// Every other test here reads the registry, which cannot tell whether a series makes it through the
+// exposition format. The label values are what both SDKs key on, so they are checked as they appear on
+// the wire.
+func TestPredictiveStatisticsReachAScrape(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.UpdatePredictiveCache(map[string]float64{
+		"predictions_total":   186,
+		"prefetch_efficiency": 0.25,
+	})
+
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	body := testhttp.Get(t, c.Addr(), c.config.Path, "Start bound no listener")
+
+	for _, want := range []string{
+		"objectfs_predictive_cache",
+		`statistic="predictions_total"`,
+		`statistic="prefetch_efficiency"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("a scrape of /metrics does not contain %q; body:\n%s", want, body)
+		}
+	}
+}
+
+// predictiveSeries returns the predictive family as statistic name → value.
+func predictiveSeries(t *testing.T, c *Collector) map[string]float64 {
+	t.Helper()
+
+	out := map[string]float64{}
+
+	for _, mf := range gather(t, c) {
+		if mf.GetName() != "objectfs_predictive_cache" {
+			continue
+		}
+
+		if kind := mf.GetType(); kind != dto.MetricType_GAUGE {
+			t.Errorf("objectfs_predictive_cache is a %v, want a gauge: the values are snapshots of "+
+				"another subsystem's totals, and a counter has no Set", kind)
+		}
+
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "statistic" {
+					out[l.GetValue()] = m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+
+	return out
+}

--- a/internal/metrics/wiring_test.go
+++ b/internal/metrics/wiring_test.go
@@ -171,6 +171,7 @@ func TestExportedNamesAreTheOnesDocumentedAndScraped(t *testing.T) {
 	c.UpdateCacheSize("L1", 1<<20)
 	c.UpdateActiveConnections(3)
 	c.RecordError("read", errors.New("timeout while reading"))
+	c.UpdatePredictiveCache(map[string]float64{"predictions_total": 1})
 
 	got := gatherNames(t, c)
 
@@ -182,6 +183,7 @@ func TestExportedNamesAreTheOnesDocumentedAndScraped(t *testing.T) {
 		"objectfs_cache_size_bytes",
 		"objectfs_active_connections",
 		"objectfs_errors_total",
+		"objectfs_predictive_cache",
 	} {
 		if _, ok := got[want]; !ok {
 			t.Errorf("%s is not exported; doc.go documents it and both SDKs scrape for it. Exported: %v",
@@ -214,6 +216,7 @@ func TestCustomLabelsReachEveryMetric(t *testing.T) {
 	c.UpdateCacheSize("L1", 1<<20)
 	c.UpdateActiveConnections(1)
 	c.RecordError("read", errors.New("boom"))
+	c.UpdatePredictiveCache(map[string]float64{"predictions_total": 1})
 
 	mfs, err := c.registry.Gather()
 	if err != nil {

--- a/sdks/javascript/src/prometheus.test.ts
+++ b/sdks/javascript/src/prometheus.test.ts
@@ -169,9 +169,44 @@ describe('parseScrape', () => {
       'objectfs_cache_size_bytes',
       'objectfs_active_connections',
       'objectfs_errors_total',
+      'objectfs_predictive_cache',
     ]) {
       assert.ok(found.has(name), `${name} missing from the parsed scrape`);
     }
+  });
+
+  test('predictive statistics are labelled, not named', () => {
+    // The predictive cache is one family labelled by `statistic` rather than a metric per number,
+    // so the set of statistics can grow without a metric rename -- a change every SDK and dashboard
+    // would otherwise have to follow. That only works if the parser keeps the label, so this
+    // asserts on the label rather than on the family's presence.
+    const statistics = new Map(
+      parsed.samples
+        .filter((s) => s.name === 'objectfs_predictive_cache')
+        .map((s) => [s.labels['statistic'], s.value])
+    );
+
+    for (const name of [
+      'predictions_total',
+      'predictions_correct',
+      'prediction_accuracy',
+      'avg_confidence',
+      'prefetch_requests',
+      'prefetch_hits',
+      'prefetch_bytes',
+      'prefetch_waste',
+      'prefetch_efficiency',
+      'evictions_total',
+      'evictions_intelligent',
+    ]) {
+      assert.ok(statistics.has(name), `statistic=${name} missing from the parsed scrape`);
+    }
+
+    // A ratio, derived in Go when the totals are written rather than at scrape time. 61 of 186 is
+    // deliberately not a round number: 0, 0.5 and 1 are all values a broken parser can produce by
+    // accident.
+    assert.ok(Math.abs((statistics.get('prediction_accuracy') ?? 0) - 61 / 186) < 1e-6);
+    assert.equal(statistics.get('predictions_total'), 186);
   });
 
   test('operator labels survive the parse', () => {

--- a/sdks/javascript/src/prometheus.test.ts
+++ b/sdks/javascript/src/prometheus.test.ts
@@ -199,13 +199,18 @@ describe('parseScrape', () => {
       'evictions_total',
       'evictions_intelligent',
     ]) {
-      assert.ok(statistics.has(name), `statistic=${name} missing from the parsed scrape`);
+      assert.ok(
+        statistics.has(name),
+        `statistic=${name} missing from the parsed scrape`
+      );
     }
 
     // A ratio, derived in Go when the totals are written rather than at scrape time. 61 of 186 is
     // deliberately not a round number: 0, 0.5 and 1 are all values a broken parser can produce by
     // accident.
-    assert.ok(Math.abs((statistics.get('prediction_accuracy') ?? 0) - 61 / 186) < 1e-6);
+    assert.ok(
+      Math.abs((statistics.get('prediction_accuracy') ?? 0) - 61 / 186) < 1e-6
+    );
     assert.equal(statistics.get('predictions_total'), 186);
   });
 

--- a/sdks/python/tests/test_monitoring.py
+++ b/sdks/python/tests/test_monitoring.py
@@ -162,8 +162,41 @@ class ParseScrapeTest(unittest.TestCase):
             'objectfs_cache_size_bytes',
             'objectfs_active_connections',
             'objectfs_errors_total',
+            'objectfs_predictive_cache',
         ):
             self.assertIn(name, found)
+
+    def test_predictive_statistics_are_labelled_not_named(self):
+        # The predictive cache is one family labelled by ``statistic`` rather than a metric per
+        # number, so the set of statistics can grow without a metric rename -- which is a change
+        # every SDK and dashboard would otherwise have to follow. That only works if the parser
+        # keeps the label, so this asserts on the label rather than on the family's presence.
+        statistics = {
+            sample['labels'].get('statistic'): sample['value']
+            for sample in self.parsed['samples']
+            if sample['name'] == 'objectfs_predictive_cache'
+        }
+
+        for name in (
+            'predictions_total',
+            'predictions_correct',
+            'prediction_accuracy',
+            'avg_confidence',
+            'prefetch_requests',
+            'prefetch_hits',
+            'prefetch_bytes',
+            'prefetch_waste',
+            'prefetch_efficiency',
+            'evictions_total',
+            'evictions_intelligent',
+        ):
+            self.assertIn(name, statistics)
+
+        # A ratio, derived in Go when the totals are written rather than at scrape time. 61 of 186
+        # is deliberately not a round number: 0.0, 0.5 and 1.0 are all values a broken parser can
+        # produce by accident.
+        self.assertAlmostEqual(statistics['prediction_accuracy'], 61 / 186, places=6)
+        self.assertEqual(statistics['predictions_total'], 186.0)
 
     def test_operator_labels_survive_the_parse(self):
         # monitoring.metrics.custom_labels attaches these to every series. An SDK that

--- a/sdks/testdata/metrics-scrape.txt
+++ b/sdks/testdata/metrics-scrape.txt
@@ -104,3 +104,16 @@ objectfs_operation_size_bytes_count{operation="write",service="objectfs"} 1
 objectfs_operations_total{operation="read",service="objectfs",status="error"} 1
 objectfs_operations_total{operation="read",service="objectfs",status="success"} 1
 objectfs_operations_total{operation="write",service="objectfs",status="success"} 1
+# HELP objectfs_predictive_cache Predictive cache statistics, by statistic name
+# TYPE objectfs_predictive_cache gauge
+objectfs_predictive_cache{service="objectfs",statistic="avg_confidence"} 0.42
+objectfs_predictive_cache{service="objectfs",statistic="evictions_intelligent"} 24
+objectfs_predictive_cache{service="objectfs",statistic="evictions_total"} 40
+objectfs_predictive_cache{service="objectfs",statistic="prediction_accuracy"} 0.3279569892473118
+objectfs_predictive_cache{service="objectfs",statistic="predictions_correct"} 61
+objectfs_predictive_cache{service="objectfs",statistic="predictions_total"} 186
+objectfs_predictive_cache{service="objectfs",statistic="prefetch_bytes"} 393216
+objectfs_predictive_cache{service="objectfs",statistic="prefetch_efficiency"} 0.3229166666666667
+objectfs_predictive_cache{service="objectfs",statistic="prefetch_hits"} 31
+objectfs_predictive_cache{service="objectfs",statistic="prefetch_requests"} 96
+objectfs_predictive_cache{service="objectfs",statistic="prefetch_waste"} 12


### PR DESCRIPTION
Closes #223.

## The defect, and why it is bigger than the issue says

`GetPredictiveStats` existed and nothing could reach it. The mount holds its `PredictiveCache` as an opaque `types.Cache` — six methods about bytes, with `GetLevelStats` returning a `types.CacheStats` — so these numbers were computed on every read of every mount and discarded at unmount.

The issue asks for an accessor. An accessor alone would have been half a fix, because **14 of the 17 fields it returned were assigned nowhere**: `PredictionsTotal`, `PredictionsCorrect`, `PrefetchRequests`, `PrefetchWaste`, both eviction counters and both ratios were declared with JSON tags and never written. `PrefetchHits` was worse — its guard is `event.Hit && event.Prefetch`, and nothing in the tree ever set `Prefetch`, so the branch was unreachable rather than merely unwritten. A zero that reads as a measurement is worse than an absent one, which is #222 in a different subsystem.

So this implements the statistics as well as the way to read them.

## What landed

- `MultiLevelCache.GetPredictiveCache` and `MultiLevelCache.PredictiveStats` — the names `docs/features/read-ahead.md` already claimed, which `TestDocumentedGoSymbolsExist` had caught as absent.
- `Adapter.exportPredictiveStats`, registered as a collector callback, publishing `objectfs_predictive_cache` — one series per statistic under a `statistic` label. The accessor and its consumer land together, because an accessor with no caller is the shape of the defect being fixed.
- `Collector.UpdatePredictiveCache` and `Collector.OnPeriodicUpdate`. `updatePeriodicMetrics` was an empty function whose comment said "this would update metrics that need periodic updates"; the ticker driving it existed and did nothing.
- A bounded range ledger (`internal/cache/prefetch_ledger.go`), which is what makes attribution possible at all.
- Seven fields removed rather than left as zeros. `LatencyReduction` would need the latency of the read that *did not happen*.

## Design decisions worth reviewing

**Containment, not overlap; consume on claim.** A read half-covered by a prefetch was half-served by it, so containment makes the counters undercount rather than overcount — the direction that does not flatter the prefetcher. Consuming the range on the claim is what keeps `prefetch_efficiency` at or below 1: a prefetch fetched those bytes once, so it can be right once.

**Gauges, not counters, even for the counting statistics.** They are snapshots of the cache's own running totals read on a schedule, and `prometheus.Counter` has no `Set`. A counter would accumulate each snapshot, so a ratio read twice would exceed 1.

**Callbacks run without the collector's lock held.** A callback reads another subsystem's state and takes that subsystem's lock; the cache's read path takes the stats lock and publishes, while the update goroutine would hold the collector lock and wait for the stats lock. The list is copied out under the lock and run without it.

**Registration after `Start` is the live path.** The adapter starts the collector at step 1 (a bind failure should fail the mount before anything else is built) and builds the cache at step 3. A callback list read once at `Start` would leave the family permanently absent while every test that registered first still passed.

**Absent, not zero.** A `GaugeVec` exports no series until one is `Set`, which is what makes "no predictive layer" distinguishable from "the predictor has done nothing". A Redis-backed cache has no predictive layer, and zeros there would be a different and false claim.

## Two honest zeros

- `prefetch_*` reads zero on a mount today while the prediction and eviction statistics populate, because `initializeLevels` builds the predictive cache with no `Backend` — the workers dequeue jobs and store nothing. That is the honest report of what is running, and it is documented as such.
- The family is absent when there is no predictive layer to ask.

## Verification

- **Mutation-tested, seventeen guards.** Removing the call site, dropping the absence check, forcing the type assertion, hoisting the snapshot out of the per-tick closure, overlap-instead-of-containment, no-consume-on-claim, accepting a non-positive length, a trim that skips the waste count, a `takeUnclaimed` that does not drain, ratios computed nowhere, efficiency inflated, waste never drained into stats, unweighted confidence, an ungated prefetch hit, callbacks never invoked, callbacks run under the lock, a nil callback accepted, a gauge ignoring `Enabled`, an unregistered gauge, a gauge without `ConstLabels`. Each applied to the source and reverted; each fails a named test.

  **Two survived**, and both produced work: the non-positive-length test asserted only unclaimability, which a zero-length entry satisfies either way — it now checks that the rejected entry took no slot under the per-key bound and was charged as no waste. And the absence guard has no reachable case through `Start`, since `multiLevelConfigFrom` sets `Prefetch: true` unconditionally, so it got a test that builds the cache directly.

- 42 new tests across four files. `go test -race -count=1 ./...` green; `golangci-lint run --new-from-merge-base=origin/main` clean.
- Coverage: `internal/cache` 89.4% (floor 85), `internal/metrics` 87.1% (85), `internal/adapter` 67.6% (40).
- `sdks/testdata/metrics-scrape.txt` regenerated and both SDK suites extended — Python 73 tests, TypeScript 66 tests, both passing. A renamed statistic now fails them in the same commit.
- `docs/features/read-ahead.md`: the paragraph saying these statistics were unreachable is replaced by what they mean, including the two honest zeros.