### PR TITLE
feat(s3): a way back from a Transfer Acceleration fallback, and a way to see it (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pre-release: the row says what that build did on 2026-08-08, and the mount-time probe is what
   protects a deployment if a later beta regresses.
 
+- **`objectfs_s3_acceleration`, so an operator can see whether Transfer Acceleration is in effect**
+  ([#204]). One gauge family with a `statistic` label, matching `objectfs_predictive_cache`, carrying
+  `configured`, `active`, `requests`, `bytes`, `fallbacks`, `avg_latency_seconds` and
+  `retry_period_seconds`. `configured` and `active` are separate series and the difference between them
+  is the point: **1 and 0 is a mount that was asked to accelerate and is not**, and neither series alone
+  can say that. Before this, `BackendMetrics.AccelerationEnabled` — whose only writer was `NewBackend`,
+  passing the config flag, behind a `GetMetrics` with no caller outside its own package — reported
+  acceleration enabled on a mount that had been serving every byte over the standard endpoint since its
+  first request.
+
+  Registered whether or not acceleration is configured, unlike `objectfs_predictive_cache`, whose absence
+  is meaningful. `configured 0` says the operator asked for the standard endpoint; an absent family says
+  this build does not report acceleration — and which of those they are looking at is the first question
+  an operator investigating slow reads has to answer. `sdks/testdata/metrics-scrape.txt` carries the
+  family with `configured 1, active 0`, so both SDK suites parse the state worth alerting on rather than a
+  healthy one.
+
+- **`storage.s3.acceleration_retry`** ([#204]). How long a Transfer Acceleration fallback lasts before one
+  request is allowed to try the accelerate endpoint again; default 5 minutes, ignored unless
+  `use_acceleration` is true. It must carry a unit — the loader rejects a bare number, because yaml.v2
+  reads `300` into a `time.Duration` as 300 *nanoseconds* with no error, which would put one request per
+  300 ns against the accelerate endpoint.
+
 ### Changed
 
 - **BREAKING: `cluster.enabled: true` now requires a gossip secret, including for a Redis-only
@@ -230,6 +253,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reading the output that matters.
 
 ### Fixed
+
+- **A Transfer Acceleration fallback was permanent for the life of the mount** ([#204]).
+  `DisableAcceleration` fired on the first acceleration error and `EnableAcceleration` had no caller
+  anywhere in the tree, so every later request took the standard endpoint until ObjectFS restarted. A
+  thirty-second DNS failure reaching the accelerate endpoint therefore cost a long-lived mount its
+  acceleration for weeks, and nothing reported that it had happened.
+
+  One request may now try the accelerate endpoint again after `storage.s3.acceleration_retry`. The
+  mechanism is `internal/circuit`'s breaker rather than a second bespoke recovery: withdrawn is its open
+  state, probing is half-open with `MaxRequests: 1`, so **exactly one probe is in flight at a time** and a
+  permanently broken endpoint costs one failed request per period rather than one per read — which is the
+  cost that justified making the fallback one-way in the first place. The bound is what a mutex around two
+  fields could not have expressed, and it is verified by mutation: raising `MaxRequests` to 64 fails
+  `TestOnlyOneProbeIsInFlightAtATime` and nothing else.
+
+- **`use_acceleration: true` together with any `endpoint:` failed every read and write, permanently.**
+  The AWS SDK refuses the combination before a request leaves the process — `A custom endpoint cannot be
+  combined with S3 Accelerate` — and that refusal is not a `smithy.APIError`, so it was not classified as
+  an acceleration error and never triggered the fallback. Every `GetObject` and `PutObject` returned
+  `STORAGE_READ`/`STORAGE_WRITE` for the life of the mount on every MinIO, Ceph, RustFS or Wasabi
+  deployment that copied the acceleration example. It now falls back and keeps serving, silently, because
+  acceleration is a performance capability and slower is a correct outcome.
+
+  The first fix for this did not work, and the end-to-end test is what caught it: `isAccelerationError`
+  matched against `err.Error()`, but the backend's `translateError` wraps the SDK error in an
+  `*errors.ObjectFSError` whose `Error()` renders its own code and message and deliberately **omits its
+  cause** — so what the classifier saw was `[s3-backend:GetObject] STORAGE_READ: GetObject operation
+  failed`, with no trace of the ruleset message anywhere in it. It now walks the whole `Unwrap` chain.
+  Two wrapping styles in this codebase behave differently under `Error()`, and a matcher over service
+  prose silently stops matching the moment its input is wrapped by the second kind — which is every error
+  the S3 backend returns.
+
+  `testaws.Fault` grew a `Message` field for this. A fault could produce an S3 error *code* and not a
+  message, so no injected fault could express a condition S3 reports only in prose, and the fallback
+  branch was reachable only by calling the classifier directly — which proves the classifier and not the
+  behavior.
 
 - **The predictive cache's statistics were computed on every read of every mount and discarded at
   unmount** ([#223]). `GetPredictiveStats` existed and nothing could reach it: the mount holds its
@@ -2814,6 +2873,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#399]: https://github.com/scttfrdmn/objectfs/issues/399
 [#223]: https://github.com/scttfrdmn/objectfs/issues/223
 [#222]: https://github.com/scttfrdmn/objectfs/issues/222
+[#204]: https://github.com/scttfrdmn/objectfs/issues/204
 [#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#390]: https://github.com/scttfrdmn/objectfs/issues/390
 [#378]: https://github.com/scttfrdmn/objectfs/issues/378

--- a/docs/s3-acceleration.md
+++ b/docs/s3-acceleration.md
@@ -85,35 +85,84 @@ standard S3 endpoints:
 
 **Detected Errors:**
 
-- `InvalidRequest` - Acceleration not enabled on bucket
-- `AccelerateNotSupported` - Bucket doesn't support acceleration
-- Acceleration endpoint connection failures
-- S3-accelerate endpoint errors
+S3 has no acceleration-specific error code — it reports every one of these as `InvalidRequest` and
+distinguishes them only by the message — so the classifier is a conjunction of the two. An
+`InvalidRequest` for an unrelated reason, such as `Invalid Range header` or an oversized single-part
+copy, is *not* an acceleration error and must not withdraw the endpoint.
+
+- `InvalidRequest` whose message names transfer acceleration or transfer accelerate: not configured
+  on the bucket, disabled, unsupported on the bucket, or a bucket name that is not DNS-compliant
+- Any error whose text names the `s3-accelerate` endpoint, such as a DNS failure resolving it. These
+  carry no API error at all, so the code half of the conjunction cannot see them
+- The AWS SDK's refusal to combine acceleration with a custom endpoint (see below)
 
 **Fallback Behavior:**
 
 1. Attempt operation with accelerated endpoint
 2. Detect acceleration error
-3. Log fallback event
+3. Log fallback event and increment `objectfs_s3_acceleration{statistic="fallbacks"}`
 4. Retry operation with standard endpoint
-5. Temporarily disable acceleration to avoid repeated failures
+5. Withdraw the accelerate endpoint until the retry period elapses
 
 **Re-enabling:**
 
-There is none. The fallback is one-way for the life of the mount: once an acceleration error is
-seen, every later request uses the standard endpoint until ObjectFS restarts. This section used to
-promise an "automatic re-enable after successful standard operations" and a manual
-`backend.GetClientManager().EnableAcceleration()`; nothing calls the re-enable path, and `Backend`
-has no `GetClientManager` accessor to reach it with.
+One request is allowed to try the accelerate endpoint again after `storage.s3.acceleration_retry`
+(default 5 minutes). If it succeeds, acceleration resumes for everything; if it fails, the endpoint
+is withdrawn for another period. Exactly one probe is in flight at a time, so a permanently broken
+endpoint costs one failed request per period rather than one per read.
 
-That is a deliberate trade rather than an oversight worth working around. The error that triggers
-fallback — a bucket without the Transfer Acceleration configuration — does not resolve on its own,
-so retrying it would mean paying a failed round-trip per request forever. Restart after fixing the
-bucket configuration.
+The mechanism is `internal/circuit`'s breaker, not a bespoke timer: withdrawn is its open state,
+probing is half-open with `MaxRequests: 1`. Reusing it is why the single-probe bound holds under
+concurrent load, which a mutex around two fields cannot express.
+
+Through v0.12.x there was no way back. The fallback was one-way for the life of the mount, so a
+thirty-second DNS failure reaching the accelerate endpoint cost a long-lived mount its acceleration
+until restart, and nothing reported that it had happened (#204). The trade that justified it — that a
+bucket without the acceleration configuration does not fix itself, so retrying forever costs a failed
+round-trip per request — is real, and the retry period is the answer to it: the cost of a permanent
+failure is bounded by the period rather than by the request rate.
+
+**Acceleration and a custom endpoint are mutually exclusive.**
+
+The AWS SDK refuses the pair outright — `A custom endpoint cannot be combined with S3 Accelerate` —
+before any request leaves the process. So `use_acceleration: true` together with `endpoint:` set for
+MinIO, Ceph, RustFS or Wasabi means every request attempts the accelerate client, is refused locally,
+and is served by the standard endpoint instead. Reads and writes work; the acceleration does nothing.
+
+That is a silent degradation on purpose, because acceleration is a performance capability and slower
+is a correct outcome (see the thesis in `CLAUDE.md`). It is also why the classifier has to match this
+particular error: unmatched, the refusal is not recognized as an acceleration problem and every GET
+and PUT fails permanently. Note that the SDK's refusal is not a `smithy.APIError` and the backend
+wraps it in an `*errors.ObjectFSError`, whose `Error()` deliberately omits its cause — so the
+classifier walks the whole `Unwrap` chain rather than matching the top-level string.
 
 ### Metrics Tracking
 
-Monitor acceleration performance with built-in metrics:
+A mount publishes acceleration state to its Prometheus endpoint as one gauge family,
+`objectfs_s3_acceleration`, with a `statistic` label:
+
+```text
+objectfs_s3_acceleration{statistic="configured"} 1
+objectfs_s3_acceleration{statistic="active"} 0
+objectfs_s3_acceleration{statistic="requests"} 412
+objectfs_s3_acceleration{statistic="bytes"} 1687552
+objectfs_s3_acceleration{statistic="fallbacks"} 1
+objectfs_s3_acceleration{statistic="avg_latency_seconds"} 0.0184
+objectfs_s3_acceleration{statistic="retry_period_seconds"} 300
+```
+
+`configured` against `active` is the pair to alert on, and the scrape above is the state worth
+alerting on: this mount was asked to accelerate and is not. Neither series alone can say that, which
+is why both are exported. `configured 0` is present rather than absent for the same reason — an absent
+family means "this build does not report acceleration", which is a different fact from "this mount was
+not asked to accelerate".
+
+The values are a snapshot the adapter re-reads from the backend on each collector tick, so they are
+gauges even where the underlying number is a running total. `fallbacks` is *set* to the backend's
+count, not incremented, and a fallback followed by a recovery shows as `active` returning to 1 with
+`fallbacks` staying where it is.
+
+In-process, the same numbers are available from the backend:
 
 ```go
 metrics := backend.GetMetrics()
@@ -241,22 +290,44 @@ if m.Requests > 0 {
 
 Acceleration events are logged automatically:
 
-```
-INFO  S3 Transfer Acceleration enabled    component=s3-backend bucket=my-bucket
+```text
+INFO  S3 Transfer Acceleration enabled    bucket=my-bucket endpoint=""
 WARN  S3 Transfer Acceleration error detected, falling back to standard endpoint
-      operation=GetObject error=InvalidRequest
-INFO  Re-enabling S3 Transfer Acceleration    component=s3-client
+      operation=GetObject retry_after=5m0s error="..."
+WARN  Disabling S3 Transfer Acceleration    reason="..."
+INFO  Retrying S3 Transfer Acceleration after backoff    breaker=s3-acceleration
+INFO  Re-enabling S3 Transfer Acceleration
+INFO  S3 Transfer Acceleration restored    breaker=s3-acceleration
 ```
+
+The last three are the recovery, and they are the sequence to look for when deciding whether a
+fallback was transient. "Retrying ... after backoff" without a following "restored" means the probe
+failed and the endpoint was withdrawn for another period.
 
 ### Metrics Integration
 
-Export metrics to monitoring systems:
+Nothing to write. A mount with `monitoring.metrics.enabled: true` exports
+`objectfs_s3_acceleration` on its own endpoint — see "Metrics Tracking" above for the series — and
+re-reads the backend on every collector tick. This section used to show two hand-rolled Prometheus
+collectors, which is what an operator had to do when the state was reachable only from inside the
+`s3` package.
 
-```go
-// Prometheus example
-accelerationGauge.Set(float64(metrics.AcceleratedRequests))
-fallbackCounter.Add(float64(metrics.FallbackEvents))
+An alert on the state that matters:
+
+```yaml
+- alert: ObjectFSAccelerationFallenBack
+  expr: |
+    objectfs_s3_acceleration{statistic="configured"} == 1
+      unless on(instance)
+    objectfs_s3_acceleration{statistic="active"} == 1
+  for: 15m
+  annotations:
+    summary: "{{ $labels.instance }} was configured to accelerate and is not"
 ```
+
+`for: 15m` rather than a shorter window because a single fallback is expected to resolve on its own
+after `storage.s3.acceleration_retry` — the default is 5 minutes, so alert on longer than a couple of
+retry periods, not on the first one.
 
 ## Troubleshooting
 
@@ -377,6 +448,10 @@ type Config struct {
     // Enable S3 Transfer Acceleration
     UseAccelerate bool `yaml:"use_accelerate"`
 
+    // How long a fallback lasts before one request may try the accelerate endpoint
+    // again. Zero takes the 5-minute default.
+    AccelerationRetry time.Duration `yaml:"acceleration_retry"`
+
     // Other S3 settings
     Region         string        `yaml:"region"`
     PoolSize       int           `yaml:"pool_size"`
@@ -384,13 +459,17 @@ type Config struct {
 }
 ```
 
+The operator-facing keys are `storage.s3.use_acceleration` and `storage.s3.acceleration_retry`; the
+struct above is what the adapter maps them onto.
+
 ### Client Manager Methods
 
 ```go
 // Check acceleration status
 IsAccelerationActive() bool
 
-// Manually control acceleration
+// Withdraw and restore the endpoint. Both are the gate's to call, not a caller's:
+// the gate decides when, and the retry has to be bounded to one in-flight probe.
 EnableAcceleration()
 DisableAcceleration(reason string)
 
@@ -401,7 +480,24 @@ GetStandardClient() *s3.Client
 
 ### Metrics Methods
 
+`AccelerationStats` is what an exporter should read. It answers "is acceleration in effect" —
+`BackendMetrics.AccelerationEnabled` answers only "was it configured", which is why a mount that had
+fallen back reported acceleration enabled for the life of the process.
+
 ```go
+type AccelerationStats struct {
+    Configured  bool          // what the operator asked for
+    Active      bool          // whether requests are taking the accelerate endpoint now
+    GateState   circuit.State // closed, open (withdrawn), or half-open (probing)
+    Requests    int64
+    Bytes       int64
+    Fallbacks   int64
+    AvgLatency  time.Duration
+    RetryPeriod time.Duration
+}
+
+stats := backend.AccelerationStats()
+
 type BackendMetrics struct {
     AccelerationEnabled  bool
     AcceleratedRequests  int64

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -31,6 +31,24 @@ storage:
     use_acceleration: false           # S3 Transfer Acceleration (bucket must have it enabled)
     force_path_style: false           # true for most S3-compatible servers
 
+    # How long a Transfer Acceleration fallback lasts before one request is allowed to try the
+    # accelerate endpoint again. Ignored unless use_acceleration is true; 0 means the default of 5m.
+    #
+    # Must carry a unit. `acceleration_retry: 300` is read as 300 *nanoseconds*, which would put one
+    # request per 300ns against the accelerate endpoint — so the loader rejects a bare number here.
+    #
+    # The fallback used to be permanent for the life of the mount (#204): a thirty-second DNS failure
+    # reaching the accelerate endpoint cost a long-lived mount its acceleration until restart, and
+    # nothing reported it. Exactly one request probes at a time, so a still-broken endpoint costs one
+    # request per period and not a retry per read. Watch
+    # objectfs_s3_acceleration{statistic="configured"} against statistic="active": 1 and 0 is a mount
+    # that was asked to accelerate and is not.
+    #
+    # Note that acceleration cannot be combined with `endpoint` above — the AWS SDK refuses the pair —
+    # so on a non-AWS store setting both means every request falls back. That is a silent slowdown
+    # rather than an error, deliberately, since acceleration is a performance capability.
+    acceleration_retry: 5m
+
     # S3 storage class for written objects. Validated at load: an unrecognized class used to be
     # silently replaced with STANDARD, so `STANDARD_1A` — digit one for capital I — was billed as
     # STANDARD with nothing reporting a problem.

--- a/internal/adapter/acceleration_metrics_test.go
+++ b/internal/adapter/acceleration_metrics_test.go
@@ -142,19 +142,26 @@ func TestAMountWithAccelerationConfiguredSaysSo(t *testing.T) {
 func TestEachTickRereadsTheBackend(t *testing.T) {
 	t.Parallel()
 
-	a := newAdapterForSubstrate(t, func(cfg *config.Configuration) {
+	// startTolerantly rather than a hand-rolled Start, because which cleanup is correct depends on how far
+	// Start got and only it knows: this test first called closePartialStart unconditionally, which never
+	// unmounts. On a host that *can* mount — CI's Linux runner can, the developer laptop this was written on
+	// could not — that left a live FUSE mount over t.TempDir(), and the failure surfaced as the framework's
+	// own `TempDir RemoveAll cleanup: readdirent: input/output error` rather than as anything about
+	// acceleration.
+	a := startTolerantly(t, newAdapterForSubstrate(t, func(cfg *config.Configuration) {
 		cfg.Storage.S3.UseAcceleration = true
 		cfg.Storage.S3.AccelerationRetry = 25 * time.Millisecond
-	})
-
-	if err := a.Start(context.Background()); err != nil &&
-		!strings.Contains(err.Error(), "failed to mount filesystem") {
-		t.Fatalf("Start failed before reaching the mount: %v", err)
-	}
-	t.Cleanup(func() { closePartialStart(t, a) })
+	}))
 
 	if a.backend == nil {
 		t.Fatal("Start left no backend on the adapter, so there is nothing for a publisher to read")
+	}
+
+	// The collector Start built, which the swap below displaces. Stopped by hand because Stop stops
+	// whatever a.metrics holds at teardown, which by then is the fast one — so without this the mount's own
+	// metrics listener outlives the test.
+	if started := a.metrics; started != nil {
+		t.Cleanup(func() { _ = started.Stop(context.Background()) })
 	}
 
 	collector, err := metrics.NewCollector(&metrics.Config{

--- a/internal/adapter/acceleration_metrics_test.go
+++ b/internal/adapter/acceleration_metrics_test.go
@@ -1,0 +1,284 @@
+package adapter
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/config"
+	"github.com/scttfrdmn/objectfs/internal/metrics"
+	"github.com/scttfrdmn/objectfs/internal/testhttp"
+)
+
+// #204's exporter half, at the only layer that can show it. internal/storage/s3 can prove the gate falls
+// back and comes back and that AccelerationStats reports it; internal/metrics can prove the gauge family
+// and the periodic hook work. Neither can prove a *mount* joins the two, and that join is the defect:
+// s3.Backend tracked the fallback accurately in a struct whose accessor had no caller outside its own
+// package, so a mount serving every byte over the standard endpoint reported acceleration enabled and the
+// throughput loss appeared in no scrape.
+//
+// These go through Start rather than calling exportAccelerationStats on a hand-built Adapter, for the same
+// reason predictive_metrics_test.go does: an accessor with a test-only caller is half a fix.
+
+// TestAMountPublishesItsAccelerationState is the end-to-end assertion, over HTTP.
+//
+// Acceleration is off in this mount's config, which is the case that matters most and the one an absent
+// family would misreport. `configured 0` says the operator asked for the standard endpoint; an absent
+// objectfs_s3_acceleration says this build does not report acceleration at all — and "which of those am I
+// looking at" is the first question an operator investigating slow reads has to answer.
+func TestAMountPublishesItsAccelerationState(t *testing.T) {
+	t.Parallel()
+
+	a := startTolerantly(t, metricsOnPortZero(t, nil))
+
+	addr := a.metrics.Addr()
+	if addr == "" {
+		t.Fatal("the mount bound no metrics listener, so this test cannot reach the scrape")
+	}
+
+	// Present from the moment the mount is up, before any read and before the first tick — thirty seconds
+	// by default, which is a long time to be unable to tell "not reporting" from "not accelerating".
+	body := testhttp.Get(t, addr, "/metrics", "the mount bound no metrics listener")
+	if !strings.Contains(body, "objectfs_s3_acceleration") {
+		t.Fatalf("a started mount exports no objectfs_s3_acceleration at all, so Start registered no "+
+			"publisher: the acceleration state is tracked by the backend and readable by nobody, which is "+
+			"#204. Scrape:\n%s", body)
+	}
+
+	series := accelerationSeriesFromScrape(t, body)
+
+	// Every statistic the exporter names, over the wire. Enumerated rather than spot-checked because these
+	// label values are the contract sdks/testdata/metrics-scrape.txt captures, so a dropped key here is a
+	// silently missing series for both SDKs.
+	for _, statistic := range []string{
+		"configured",
+		"active",
+		"requests",
+		"bytes",
+		"fallbacks",
+		"avg_latency_seconds",
+		"retry_period_seconds",
+	} {
+		if _, ok := series[statistic]; !ok {
+			t.Errorf("the scrape carries no statistic=%q series; scrape:\n%s", statistic, body)
+		}
+	}
+
+	// Present and zero, not absent. This is the assertion the family exists for.
+	if series["configured"] != 0 {
+		t.Errorf(`statistic="configured" = %v on a mount with use_acceleration unset; the publisher is `+
+			`reporting something other than this mount's config`, series["configured"])
+	}
+	if series["active"] != 0 {
+		t.Errorf(`statistic="active" = %v with acceleration unconfigured; nothing is going to the `+
+			`accelerate endpoint, so this would tell an operator the opposite of the truth`, series["active"])
+	}
+
+	// The retry period is a real configured value rather than a zero, which is what distinguishes a
+	// publisher reading the backend from one publishing a zeroed struct: storage.s3.acceleration_retry
+	// defaults to five minutes, and no field of AccelerationStats{} does.
+	if series["retry_period_seconds"] <= 0 {
+		t.Errorf(`statistic="retry_period_seconds" = %v, want the configured default; a zero means the `+
+			`publisher is not reading the backend's gate`, series["retry_period_seconds"])
+	}
+}
+
+// TestAMountWithAccelerationConfiguredSaysSo pins the other half of the distinction.
+//
+// The mount runs against substrate, so `configured 1` with `active` reporting whatever the backend
+// currently believes is exactly the shape of the state #204 is about — and asserting `configured` follows
+// the config is what keeps the exporter from hardcoding the answer. Without this test a publisher that
+// wrote 0 for both fields unconditionally would satisfy every assertion above.
+//
+// `active` is deliberately not asserted: the substrate endpoint is a custom BaseEndpoint, which the AWS
+// SDK refuses to combine with UseAccelerate, so the first request falls back — and *when* that happens
+// relative to this scrape is the gate's business and is covered by
+// TestAnAccelerationErrorFallsBackAndStillServesTheRead in internal/storage/s3. What matters here is that
+// the pair is published at all.
+func TestAMountWithAccelerationConfiguredSaysSo(t *testing.T) {
+	t.Parallel()
+
+	a := startTolerantly(t, metricsOnPortZero(t, func(cfg *config.Configuration) {
+		cfg.Storage.S3.UseAcceleration = true
+		cfg.Storage.S3.AccelerationRetry = 90 * time.Second
+	}))
+
+	series := accelerationSeriesFromScrape(t,
+		testhttp.Get(t, a.metrics.Addr(), "/metrics", "the mount bound no metrics listener"))
+
+	if series["configured"] != 1 {
+		t.Errorf(`statistic="configured" = %v with use_acceleration: true; the publisher is not reading `+
+			`this mount's config, so the scrape cannot distinguish "asked for and not happening" from `+
+			`"not asked for"`, series["configured"])
+	}
+
+	// The configured retry, not the default. This is the value an operator would use to decide how long to
+	// wait before concluding a fallback is permanent, so a publisher reporting the package default while
+	// the gate used something else would mislead them by more than a rounding.
+	if series["retry_period_seconds"] != 90 {
+		t.Errorf(`statistic="retry_period_seconds" = %v, want 90 from storage.s3.acceleration_retry; the `+
+			`publisher reports a period the gate is not using`, series["retry_period_seconds"])
+	}
+}
+
+// TestEachTickRereadsTheBackend asserts the callback asks the backend again rather than republishing a
+// snapshot it captured at registration.
+//
+// This is the whole point of the family. The state at registration is always the healthy one — a mount
+// begins believing it accelerates — so a publisher that closed over a snapshot would report `active 1`
+// forever and the fallback would be exactly as invisible as it was before #204. Every other test in this
+// file is blind to it: calling exportAccelerationStats a second time takes a fresh snapshot too.
+//
+// So this one builds a collector at a 5 ms interval, lets a *tick* do the work, and moves the backend's
+// numbers in between by making it fall back for real: substrate is a custom BaseEndpoint, which the AWS SDK
+// refuses to combine with UseAccelerate, so every attempt on the accelerate client is an acceleration
+// error. A 25 ms retry period means the gate keeps going half-open and probing, so a fallback event is
+// available on demand however many happened during Start.
+//
+// Verified by mutation: hoisting the AccelerationStats call out of the closure leaves fallbacks at its
+// opening value and only this test notices.
+func TestEachTickRereadsTheBackend(t *testing.T) {
+	t.Parallel()
+
+	a := newAdapterForSubstrate(t, func(cfg *config.Configuration) {
+		cfg.Storage.S3.UseAcceleration = true
+		cfg.Storage.S3.AccelerationRetry = 25 * time.Millisecond
+	})
+
+	if err := a.Start(context.Background()); err != nil &&
+		!strings.Contains(err.Error(), "failed to mount filesystem") {
+		t.Fatalf("Start failed before reaching the mount: %v", err)
+	}
+	t.Cleanup(func() { closePartialStart(t, a) })
+
+	if a.backend == nil {
+		t.Fatal("Start left no backend on the adapter, so there is nothing for a publisher to read")
+	}
+
+	collector, err := metrics.NewCollector(&metrics.Config{
+		Enabled:        true,
+		Addr:           "127.0.0.1:0",
+		Labels:         map[string]string{"service": "objectfs"},
+		UpdateInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if err := collector.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = collector.Stop(context.Background()) })
+
+	// Swap in the fast-ticking collector and register the publisher, exactly as Start does.
+	a.metrics = collector
+	a.exportAccelerationStats()
+
+	before := accelerationSeriesFromScrape(t, scrapeOf(t, collector))["fallbacks"]
+
+	// Writes *after* registration, each of which attempts the accelerate client, fails, and falls back. A
+	// snapshot taken at registration cannot know about them. The loop keeps writing rather than writing once
+	// and waiting, because the gate may be open at any given moment — in which case nothing is attempted and
+	// no fallback is recorded — and it goes half-open again 25 ms later.
+	deadline := time.Now().Add(10 * time.Second)
+	for i := 0; ; i++ {
+		if err := a.backend.PutObject(context.Background(),
+			"tick/"+strconv.Itoa(i), []byte("x"), nil); err != nil {
+			t.Fatalf("PutObject %d: %v — the fallback is supposed to keep the write serving", i, err)
+		}
+
+		body := scrapeOf(t, collector)
+		if accelerationSeriesFromScrape(t, body)["fallbacks"] > before {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("fallbacks is still %v 10s and %d writes after registration, at a 5ms update interval "+
+				"and a 25ms gate retry; the callback republishes a snapshot it took at registration, so the "+
+				"family reports the mount's opening state — acceleration healthy — for the life of the "+
+				"process, which is the exact invisibility #204 is about. Scrape:\n%s", before, i, body)
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestExportAccelerationStatsToleratesAMissingCollectorOrBackend guards the ordering assumption.
+//
+// exportAccelerationStats runs at Start's step 3, after startMetrics at step 1 and after the backend is
+// built, so both fields are non-nil by then on the live path. "On the live path" is what this checks: a
+// reordering of Start's steps should produce a missing metric rather than a nil dereference during mount.
+func TestExportAccelerationStatsToleratesAMissingCollectorOrBackend(t *testing.T) {
+	t.Parallel()
+
+	// Neither collector nor backend — the assertion is that this returns rather than panics.
+	a := &Adapter{config: config.NewDefault()}
+	a.exportAccelerationStats()
+
+	// A collector but no backend: the other order of the two guards.
+	cfg := config.NewDefault()
+	cfg.Monitoring.Metrics.Enabled = true
+	cfg.Monitoring.Metrics.Addr = "127.0.0.1:0"
+
+	a = &Adapter{config: cfg}
+	if err := a.startMetrics(context.Background()); err != nil {
+		t.Fatalf("startMetrics: %v", err)
+	}
+	t.Cleanup(func() { _ = a.metrics.Stop(context.Background()) })
+
+	a.exportAccelerationStats()
+
+	body := testhttp.Get(t, a.metrics.Addr(), "/metrics", "startMetrics bound no listener")
+	if strings.Contains(body, "objectfs_s3_acceleration") {
+		t.Errorf("an adapter with no backend published acceleration statistics; the numbers would be a "+
+			"struct's zeros presented as a mount's state, and `active 0` in particular would read as a "+
+			"fallback in effect. Scrape:\n%s", body)
+	}
+}
+
+// accelerationSeriesFromScrape parses objectfs_s3_acceleration out of a scrape as statistic name → value.
+//
+// The exposition text rather than the registry, for the reason predictiveSeries gives: the registry is
+// what internal/metrics already reads, and what is unproven here is that a mount's values survive the trip
+// to a scrape.
+func accelerationSeriesFromScrape(t *testing.T, scrape string) map[string]float64 {
+	t.Helper()
+
+	out := map[string]float64{}
+
+	for line := range strings.SplitSeq(scrape, "\n") {
+		if !strings.HasPrefix(line, "objectfs_s3_acceleration{") {
+			continue
+		}
+
+		labels, value, ok := strings.Cut(line, "} ")
+		if !ok {
+			t.Fatalf("an acceleration series is not in the exposition format this parses: %q", line)
+		}
+
+		_, statistic, ok := strings.Cut(labels, `statistic="`)
+		if !ok {
+			t.Fatalf("an acceleration series carries no statistic label: %q", line)
+		}
+
+		statistic, _, _ = strings.Cut(statistic, `"`)
+
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			t.Fatalf("the value of statistic=%q does not parse as a float: %q", statistic, value)
+		}
+
+		out[statistic] = parsed
+	}
+
+	if len(out) == 0 {
+		t.Fatalf("no objectfs_s3_acceleration series in the scrape:\n%s", scrape)
+	}
+
+	return out
+}

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -158,6 +158,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 	}
 
 	a.exportPredictiveStats()
+	a.exportAccelerationStats()
 
 	// 4. Initialize the write path.
 	//
@@ -620,6 +621,68 @@ func (a *Adapter) exportPredictiveStats() {
 	a.metrics.OnPeriodicUpdate(publish)
 }
 
+// exportAccelerationStats publishes the S3 Transfer Acceleration state to the metrics surface on every
+// collector tick.
+//
+// This is the "surface the state" half of #204, and the state it surfaces is one an operator could not
+// previously obtain by any means. Acceleration fell back on the first acceleration error and stayed
+// fallen back for the life of the mount; s3.Backend tracked that accurately, in
+// BackendMetrics.AccelerationEnabled — a field whose only writer was NewBackend, passing the config flag
+// — behind s3.Backend.GetMetrics, which had no caller outside its own package. So a mount serving every
+// byte over the standard endpoint reported acceleration enabled, and the throughput loss showed up
+// nowhere but in a throughput graph nobody had reason to compare against.
+//
+// Registered unconditionally, including when acceleration is not configured, and that is deliberate.
+// `configured 0` is a different fact from an absent metric family — the first says the mount was asked
+// not to accelerate, the second says this build does not report it — and the question an operator asks
+// when investigating slow reads is exactly which of those they are looking at.
+//
+// A periodic callback rather than a push at the moment of the fallback, for two reasons. The gate's
+// transitions happen inside the s3 package under a breaker lock, so a push would mean handing that lock
+// a metrics dependency; and `active` is a gauge whose value is the state of another subsystem, which is
+// the shape OnPeriodicUpdate exists for. Reading it on a tick also advances the gate's open→half-open
+// transition, which is harmless: it recovers a few seconds earlier than the next request would.
+func (a *Adapter) exportAccelerationStats() {
+	if a.metrics == nil || a.backend == nil {
+		return
+	}
+
+	publish := func() {
+		stats := a.backend.AccelerationStats()
+
+		// Keys become the `statistic` label, so they are the contract two SDKs read through
+		// sdks/testdata/metrics-scrape.txt.
+		//
+		// `configured` and `active` are both here because they answer different questions and the
+		// difference between them *is* the fallback: configured 1 with active 0 means this mount was
+		// asked to accelerate and is not. Neither one alone can say that.
+		a.metrics.UpdateS3Acceleration(map[string]float64{
+			"configured":           boolGauge(stats.Configured),
+			"active":               boolGauge(stats.Active),
+			"requests":             float64(stats.Requests),
+			"bytes":                float64(stats.Bytes),
+			"fallbacks":            float64(stats.Fallbacks),
+			"avg_latency_seconds":  stats.AvgLatency.Seconds(),
+			"retry_period_seconds": stats.RetryPeriod.Seconds(),
+		})
+	}
+
+	publish()
+	a.metrics.OnPeriodicUpdate(publish)
+}
+
+// boolGauge renders a boolean as the 1/0 Prometheus convention for state.
+//
+// Named rather than inlined as a conditional expression per field, because the two callers above are the
+// two halves of one distinction and writing them the same way is what keeps them comparable.
+func boolGauge(b bool) float64 {
+	if b {
+		return 1
+	}
+
+	return 0
+}
+
 // buildS3Config translates the loaded configuration into the backend's configuration.
 //
 // This function is audit finding D12, and the finding was not that it was wrong — it was that it was
@@ -670,6 +733,10 @@ func (a *Adapter) buildS3Config() *s3.Config {
 		},
 
 		UseAccelerate: s3cfg.UseAcceleration,
+
+		// Zero passes through to newAccelerationGate's default rather than being substituted here, so
+		// there is one place that decides the period.
+		AccelerationRetry: s3cfg.AccelerationRetry,
 
 		MultipartThreshold: a.sizeOrDefault("storage.s3.multipart.threshold",
 			s3cfg.Multipart.Threshold, defaults.MultipartThreshold),

--- a/internal/adapter/config_mapping_test.go
+++ b/internal/adapter/config_mapping_test.go
@@ -46,6 +46,7 @@ func TestBuildS3ConfigMapsEveryConfiguredValue(t *testing.T) {
 	cfg.Storage.S3.Endpoint = "https://s3.example.invalid"
 	cfg.Storage.S3.ForcePathStyle = true
 	cfg.Storage.S3.UseAcceleration = true
+	cfg.Storage.S3.AccelerationRetry = 90 * time.Second
 	cfg.Storage.S3.StorageTier = "GLACIER_IR"
 	cfg.Storage.S3.MaxRetries = 7
 	cfg.Storage.S3.Multipart = config.MultipartConfig{
@@ -114,6 +115,15 @@ func TestBuildS3ConfigMapsEveryConfiguredValue(t *testing.T) {
 		{field: "Endpoint", got: got.Endpoint, want: "https://s3.example.invalid"},
 		{field: "ForcePathStyle", got: got.ForcePathStyle, want: true},
 		{field: "UseAccelerate", got: got.UseAccelerate, want: true},
+
+		{
+			field: "AccelerationRetry",
+			got:   got.AccelerationRetry,
+			want:  90 * time.Second,
+			why: "90s is neither zero nor the gate's 5-minute default, so a mapping that dropped this " +
+				"field would still produce a working fallback at the wrong period — and the period is how " +
+				"long a mount stays un-accelerated after one error (#204)",
+		},
 
 		{
 			field: "StorageTier",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -576,6 +576,14 @@ type S3Config struct {
 	UseAcceleration bool   `yaml:"use_acceleration"`
 	ForcePathStyle  bool   `yaml:"force_path_style"`
 
+	// AccelerationRetry is how long a Transfer Acceleration fallback lasts before one request is
+	// allowed to try the accelerate endpoint again. Zero means the backend's default of 5 minutes.
+	//
+	// Ignored unless use_acceleration is true. It exists because the fallback used to be permanent for
+	// the life of the mount (#204): a thirty-second DNS failure reaching the accelerate endpoint cost a
+	// mount its acceleration until it was restarted, and nothing reported that it had happened.
+	AccelerationRetry time.Duration `yaml:"acceleration_retry"`
+
 	// StorageTier is the S3 storage class objects are written with: STANDARD, STANDARD_IA,
 	// ONEZONE_IA, GLACIER_IR, GLACIER, DEEP_ARCHIVE, INTELLIGENT_TIERING or REDUCED_REDUNDANCY.
 	// Empty means STANDARD, which is also what S3 applies to a PUT that names no class.
@@ -1626,6 +1634,13 @@ func (c *Configuration) validateDurations() error {
 		{"monitoring.health_checks.timeout", c.Monitoring.HealthChecks.Timeout},
 		{"cache.ttl", c.Cache.TTL},
 		{"cluster.redis.ttl", c.Cluster.Redis.TTL},
+
+		// Checked whether or not use_acceleration is set, on the same reasoning as
+		// performance.read_ahead.ttl below: `acceleration_retry: 300` is a mistake in a file where
+		// acceleration is off too, and it becomes a live 300-nanosecond retry period the day someone
+		// turns the flag on. A period that short would put one request per 300ns against the accelerate
+		// endpoint — the per-request retry the backoff exists to avoid.
+		{"storage.s3.acceleration_retry", c.Storage.S3.AccelerationRetry},
 
 		// Checked here and not in validateReadAheadConfig, even though that function checks the other
 		// four read-ahead keys, because that one returns early on a disabled block and this trap does

--- a/internal/metrics/acceleration_test.go
+++ b/internal/metrics/acceleration_test.go
@@ -1,0 +1,214 @@
+package metrics
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/scttfrdmn/objectfs/internal/testhttp"
+)
+
+// #204's exporter half. The S3 backend tracked whether Transfer Acceleration was in effect and nothing
+// outside its own package could read it, so a mount that had silently dropped to the standard endpoint
+// reported acceleration enabled and the throughput loss appeared in no scrape, log, or health check.
+//
+// The tests here are about this family's shape rather than about the fallback: that the booleans survive
+// the trip as 0 and 1, that a gauge is what these are, and that the family is present even when
+// acceleration is off — which is the deliberate difference from objectfs_predictive_cache, whose absence
+// is meaningful.
+
+// TestAccelerationGaugeCarriesOneSeriesPerStatistic pins the shape.
+//
+// One family labeled by statistic, matching objectfs_predictive_cache: the set of statistics will grow,
+// and a new label value is something dashboards and SDKs pick up for free while a new metric name is a
+// change every consumer has to follow.
+func TestAccelerationGaugeCarriesOneSeriesPerStatistic(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	want := map[string]float64{
+		"configured":           1,
+		"active":               0,
+		"requests":             412,
+		"bytes":                1 << 24,
+		"fallbacks":            1,
+		"avg_latency_seconds":  0.0184,
+		"retry_period_seconds": 300,
+	}
+
+	c.UpdateS3Acceleration(want)
+
+	got := accelerationSeries(t, c)
+
+	for name, value := range want {
+		if got[name] != value {
+			t.Errorf(`objectfs_s3_acceleration{statistic=%q} = %v, want %v`, name, got[name], value)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("the family carries %d series, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// TestAccelerationGaugeTracksTheLatestSnapshot is what makes the fallback and the recovery visible.
+//
+// These values are a snapshot of another package's state, read on a tick. A gauge that accumulated
+// would make `active` climb past 1 and stop being a boolean; one that ignored later publications would
+// freeze at the mount's opening state — which is the exact failure #204 is about, since the opening
+// state is "acceleration enabled" and the interesting state is the one it changes to.
+func TestAccelerationGaugeTracksTheLatestSnapshot(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	// A mount that starts accelerating, falls back, and recovers.
+	c.UpdateS3Acceleration(map[string]float64{"active": 1, "fallbacks": 0})
+	c.UpdateS3Acceleration(map[string]float64{"active": 0, "fallbacks": 1})
+	c.UpdateS3Acceleration(map[string]float64{"active": 1, "fallbacks": 1})
+
+	got := accelerationSeries(t, c)
+
+	if got["active"] != 1 {
+		t.Errorf("active = %v after 1 → 0 → 1; the gauge does not track the latest snapshot, so a "+
+			"recovery would never appear in a scrape", got["active"])
+	}
+	if got["fallbacks"] != 1 {
+		t.Errorf("fallbacks = %v after publishing 0, 1, 1; a snapshot of a running total is being "+
+			"accumulated rather than set", got["fallbacks"])
+	}
+}
+
+// TestAccelerationGaugeCarriesTheOperatorLabels asserts the new family is not an exception to
+// monitoring.metrics.custom_labels, which is documented as attached to every exported metric.
+//
+// TestCustomLabelsReachEveryMetric asserts over every family, but only over families that have been
+// observed — so a family added without ConstLabels and without an observation there passes it.
+func TestAccelerationGaugeCarriesTheOperatorLabels(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(&Config{
+		Enabled: true,
+		Addr:    anyLoopbackAddr,
+		Labels:  map[string]string{"service": "objectfs", "cluster": "research-west"},
+	})
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.UpdateS3Acceleration(map[string]float64{"configured": 1})
+
+	for _, mf := range gather(t, c) {
+		if mf.GetName() != "objectfs_s3_acceleration" {
+			continue
+		}
+
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+
+			for name, value := range map[string]string{"service": "objectfs", "cluster": "research-west"} {
+				if labels[name] != value {
+					t.Errorf("objectfs_s3_acceleration is missing the operator label %s=%s; it carried %v",
+						name, value, labels)
+				}
+			}
+		}
+	}
+}
+
+// TestUpdateS3AccelerationHonorsDisabled asserts a disabled collector builds no series.
+//
+// A disabled collector has no registry, so publishing into it must not dereference one — and the adapter
+// registers this publisher unconditionally, before consulting whether metrics are on.
+func TestUpdateS3AccelerationHonorsDisabled(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(&Config{Enabled: false})
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	// The assertion is that this does not panic on a nil GaugeVec and nil registry.
+	c.UpdateS3Acceleration(map[string]float64{"configured": 0})
+}
+
+// TestAccelerationStatisticsReachAScrape closes the loop over HTTP.
+//
+// Every other test here reads the registry, which cannot show whether a series survives the exposition
+// format. The label values are what an SDK and a dashboard key on, so they are checked as they appear on
+// the wire.
+func TestAccelerationStatisticsReachAScrape(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCollector(exactAdapterConfig(anyLoopbackAddr))
+	if err != nil {
+		t.Fatalf("NewCollector: %v", err)
+	}
+
+	c.UpdateS3Acceleration(map[string]float64{
+		"configured": 1,
+		"active":     0,
+		"fallbacks":  3,
+	})
+
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	body := testhttp.Get(t, c.Addr(), c.config.Path, "Start bound no listener")
+
+	for _, want := range []string{
+		"objectfs_s3_acceleration",
+		`statistic="configured"`,
+		`statistic="active"`,
+		`statistic="fallbacks"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("a scrape of /metrics does not contain %q; body:\n%s", want, body)
+		}
+	}
+}
+
+// accelerationSeries returns the acceleration family as statistic name → value.
+func accelerationSeries(t *testing.T, c *Collector) map[string]float64 {
+	t.Helper()
+
+	out := map[string]float64{}
+
+	for _, mf := range gather(t, c) {
+		if mf.GetName() != "objectfs_s3_acceleration" {
+			continue
+		}
+
+		if kind := mf.GetType(); kind != dto.MetricType_GAUGE {
+			t.Errorf("objectfs_s3_acceleration is a %v, want a gauge: the values are a snapshot of the "+
+				"backend's state, including two booleans, and a counter has no Set", kind)
+		}
+
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "statistic" {
+					out[l.GetValue()] = m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		t.Fatalf("no objectfs_s3_acceleration series in the registry")
+	}
+
+	return out
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -29,6 +29,7 @@ type Collector struct {
 	activeConnections prometheus.Gauge
 	errorCounter      *prometheus.CounterVec
 	predictiveGauge   *prometheus.GaugeVec
+	accelerationGauge *prometheus.GaugeVec
 
 	// periodic are the callbacks updateLoop invokes on every tick, registered by OnPeriodicUpdate.
 	periodic []func()
@@ -361,6 +362,23 @@ func (c *Collector) UpdatePredictiveCache(stats map[string]float64) {
 	}
 }
 
+// UpdateS3Acceleration publishes the S3 Transfer Acceleration state, one series per named statistic.
+//
+// A map for the same reason UpdatePredictiveCache takes one: internal/metrics must not import
+// internal/storage/s3. The adapter imports both and is where they meet.
+//
+// The names are the contract, captured in sdks/testdata/metrics-scrape.txt and asserted by
+// TestSDKFixtureMatchesTheLiveScrape, so both SDK suites fail on a rename.
+func (c *Collector) UpdateS3Acceleration(stats map[string]float64) {
+	if !c.config.Enabled {
+		return
+	}
+
+	for name, value := range stats {
+		c.accelerationGauge.With(prometheus.Labels{"statistic": name}).Set(value)
+	}
+}
+
 // OnPeriodicUpdate registers a callback for updateLoop to invoke on every tick.
 //
 // This is how a gauge whose value lives elsewhere gets refreshed. Counters and histograms are pushed at
@@ -551,6 +569,27 @@ func (c *Collector) initMetrics() error {
 		[]string{"statistic"},
 	)
 
+	// S3 Transfer Acceleration metrics.
+	//
+	// Same shape as the predictive family above and for the same reasons: one gauge labeled by
+	// "statistic", so the set can grow without a metric-name change that both SDKs and every dashboard
+	// would have to follow.
+	//
+	// The family exists because the acceleration state was reachable by nothing outside the s3 package
+	// (#204). A mount could fall back to the standard endpoint on its first request and serve everything
+	// after that at standard throughput, and no scrape, log line, or health check said so — so the
+	// series that matters most here is `active`, which is 0 exactly when the fallback is in effect.
+	c.accelerationGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   c.config.Namespace,
+			Subsystem:   c.config.Subsystem,
+			Name:        "s3_acceleration",
+			Help:        "S3 Transfer Acceleration state and counters, by statistic name",
+			ConstLabels: labels,
+		},
+		[]string{"statistic"},
+	)
+
 	return nil
 }
 
@@ -564,6 +603,7 @@ func (c *Collector) registerMetrics() error {
 		c.activeConnections,
 		c.errorCounter,
 		c.predictiveGauge,
+		c.accelerationGauge,
 	}
 
 	for _, metric := range metrics {

--- a/internal/metrics/doc.go
+++ b/internal/metrics/doc.go
@@ -94,6 +94,19 @@ Histograms:
 Gauges:
   - objectfs_cache_size_bytes{level}: Current cache size per level
   - objectfs_active_connections: Current active S3 connections
+  - objectfs_predictive_cache{statistic}: Read-ahead statistics, by statistic name
+  - objectfs_s3_acceleration{statistic}: Transfer Acceleration state and counters, by statistic name
+
+The last two are one family each with a statistic label rather than a metric per statistic, because
+both sets grow: a new label value is something a dashboard and both SDKs pick up for free, where a
+new name is a change every consumer has to follow. Their values are a snapshot the adapter re-reads
+on each update tick, so they are gauges even where the underlying number is a running total —
+objectfs_s3_acceleration{statistic="fallbacks"} is set to the backend's count, not incremented.
+
+objectfs_s3_acceleration carries statistic="configured" and statistic="active" separately, and the
+difference between them is the point (#204): configured 1 with active 0 is a mount that was asked to
+accelerate and is not, which before this family existed was reported nowhere. Alert on the pair, not
+on either alone.
 
 Every series additionally carries the operator's monitoring.metrics.custom_labels as constant
 labels — service="objectfs" by default. Consumers must parse the label block: a name identifies a

--- a/internal/metrics/fixture_test.go
+++ b/internal/metrics/fixture_test.go
@@ -111,6 +111,20 @@ func liveScrape(t *testing.T) string {
 		"evictions_intelligent": 24,
 	})
 
+	// The Transfer Acceleration family, published by a mount from the S3 backend's own state (#204).
+	// `configured` 1 with `active` 0 is the state that used to be unreportable and is the reason this
+	// family exists: acceleration was asked for and is not happening. Capturing it in that state rather
+	// than a healthy one means an SDK extractor that reads the two as one value fails here.
+	c.UpdateS3Acceleration(map[string]float64{
+		"configured":           1,
+		"active":               0,
+		"requests":             412,
+		"bytes":                412 * 4096,
+		"fallbacks":            1,
+		"avg_latency_seconds":  0.0184,
+		"retry_period_seconds": 300,
+	})
+
 	if err := c.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/metrics/wiring_test.go
+++ b/internal/metrics/wiring_test.go
@@ -172,6 +172,7 @@ func TestExportedNamesAreTheOnesDocumentedAndScraped(t *testing.T) {
 	c.UpdateActiveConnections(3)
 	c.RecordError("read", errors.New("timeout while reading"))
 	c.UpdatePredictiveCache(map[string]float64{"predictions_total": 1})
+	c.UpdateS3Acceleration(map[string]float64{"configured": 1})
 
 	got := gatherNames(t, c)
 
@@ -184,6 +185,7 @@ func TestExportedNamesAreTheOnesDocumentedAndScraped(t *testing.T) {
 		"objectfs_active_connections",
 		"objectfs_errors_total",
 		"objectfs_predictive_cache",
+		"objectfs_s3_acceleration",
 	} {
 		if _, ok := got[want]; !ok {
 			t.Errorf("%s is not exported; doc.go documents it and both SDKs scrape for it. Exported: %v",
@@ -217,6 +219,7 @@ func TestCustomLabelsReachEveryMetric(t *testing.T) {
 	c.UpdateActiveConnections(1)
 	c.RecordError("read", errors.New("boom"))
 	c.UpdatePredictiveCache(map[string]float64{"predictions_total": 1})
+	c.UpdateS3Acceleration(map[string]float64{"configured": 1})
 
 	mfs, err := c.registry.Gather()
 	if err != nil {

--- a/internal/storage/s3/acceleration_bench_test.go
+++ b/internal/storage/s3/acceleration_bench_test.go
@@ -132,8 +132,6 @@ func BenchmarkFallback(b *testing.B) {
 
 // BenchmarkAccelerationOverhead benchmarks the overhead of acceleration detection
 func BenchmarkAccelerationOverhead(b *testing.B) {
-	backend := &Backend{}
-
 	// One error per path through the classifier: the InvalidRequest-plus-message conjunction that
 	// matches, an InvalidRequest that fails the message half (the most expensive path — it pays for
 	// the unwrap, the code comparison, and the ToLower), a different code that short-circuits after
@@ -151,7 +149,7 @@ func BenchmarkAccelerationOverhead(b *testing.B) {
 	b.ResetTimer()
 	for range b.N {
 		for _, err := range testErrors {
-			_ = backend.isAccelerationError(err)
+			_ = isAccelerationError(err)
 		}
 	}
 }

--- a/internal/storage/s3/acceleration_gate.go
+++ b/internal/storage/s3/acceleration_gate.go
@@ -1,0 +1,190 @@
+package s3
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/circuit"
+)
+
+// defaultAccelerationRetry is how long the accelerate endpoint stays out of service after a
+// fallback, when Config.AccelerationRetry says nothing.
+//
+// Five minutes is chosen against the unrecoverable case, because that is the one that pays for the
+// probe rather than benefiting from it: a bucket with no Transfer Acceleration configuration will
+// fail one request per period forever. At 5m that is 288 failed requests a day, each of which
+// immediately succeeds on the standard endpoint — invisible against any mount whose traffic
+// justified turning acceleration on, and a bounded cost rather than the unbounded one a per-request
+// retry would be.
+//
+// The recoverable case wants it shorter and tolerates this: a mount that lost acceleration to a
+// transient DNS failure gets it back within five minutes instead of at the next restart, which was
+// the previous answer.
+const defaultAccelerationRetry = 5 * time.Minute
+
+// accelerationGate decides whether a request may use the accelerate endpoint.
+//
+// # Why a circuit breaker and not a timestamp
+//
+// The shape wanted here — a capability that is withdrawn on failure, restored after a delay, and
+// withdrawn again if the one probe that tests it fails — is a circuit breaker's half-open cycle
+// exactly. [circuit.CircuitBreaker] already implements it, is already imported by this package for
+// the operation breakers, and has its own tests for the parts that are easy to get subtly wrong:
+// MaxRequests caps how many probes run at once, so a burst of concurrent requests at the moment the
+// window opens sends *one* to the accelerate endpoint rather than all of them, and the trial ends on
+// the first result rather than on a second timer.
+//
+// A bespoke `lastFailure time.Time` plus a comparison would have been about six lines, and every one
+// of those properties would have been absent from it. #204 said as much when it was filed, and it is
+// the reason this reuses rather than reimplements.
+//
+// # The mapping onto the breaker's vocabulary
+//
+// One "request" through this breaker is one *acceleration attempt*, and the only failure it counts is
+// an acceleration error — [Backend.isAccelerationError]. Everything else is a success as far as this
+// breaker is concerned, including a NoSuchKey and a 500: those say nothing about whether the
+// accelerate endpoint is usable, and counting them would withdraw acceleration for reasons that have
+// nothing to do with it. That is the same distinction circuit.defaultIsSuccessful draws for the
+// operation breakers, drawn against a different question.
+//
+// ReadyToTrip is `ConsecutiveFailures >= 1` rather than a proportional default, and deliberately:
+// unlike a flaky service, an unusable accelerate endpoint is unusable for every request, so there is
+// no threshold to reach and nothing to be gained by sampling further. One acceleration error is the
+// whole evidence there is going to be.
+type accelerationGate struct {
+	breaker *circuit.CircuitBreaker
+
+	// retry is the resolved backoff, kept because circuit.Config is not readable back off the breaker
+	// and AccelerationStats reports it: an operator looking at a mount in fallback wants to know when
+	// it will try again, and the configured value may be the default rather than anything they set.
+	retry time.Duration
+}
+
+// newAccelerationGate builds the gate and wires its state transitions to the client manager.
+//
+// The wiring direction matters. The breaker is the authority on whether acceleration is available,
+// and cm.accelerationActive is a projection of it — kept in step through OnStateChange rather than
+// written by whoever noticed the error. That is what makes the recovery observable: the same hook
+// that flips the client also logs the transition and is where a metric hangs off, so an operator
+// sees "acceleration withdrawn" and "acceleration restored" as events rather than having to infer
+// them from a throughput graph. Before this, nothing anywhere reported that acceleration was off.
+//
+// retry of zero takes defaultAccelerationRetry; a negative value takes it too, since a negative
+// timeout would put the breaker permanently half-open, which is the one state that must not be
+// reachable from configuration.
+func newAccelerationGate(
+	cm *ClientManager,
+	mc *MetricsCollector,
+	retry time.Duration,
+	logger *slog.Logger,
+) *accelerationGate {
+	if retry <= 0 {
+		retry = defaultAccelerationRetry
+	}
+
+	return &accelerationGate{
+		retry: retry,
+		breaker: circuit.NewCircuitBreaker("s3-acceleration", circuit.Config{
+			// One probe when the window opens, not one per in-flight request. A mount under load has
+			// dozens of requests arriving in the millisecond the breaker half-opens, and every one of
+			// them would otherwise pay the failed round trip that only the first needed to pay.
+			MaxRequests: 1,
+
+			// Interval clears the closed-state counts periodically, which for this breaker only means
+			// forgetting successes it has no use for. It is set well above Timeout so it cannot
+			// interact with the trip decision, which is about consecutive failures.
+			Interval: time.Hour,
+			Timeout:  retry,
+
+			ReadyToTrip: func(counts circuit.Counts) bool {
+				return counts.ConsecutiveFailures >= 1
+			},
+
+			// Only an acceleration error is a failure here. See the type comment: a missing object or
+			// an S3 500 arriving over the accelerate endpoint is not evidence about the endpoint.
+			IsSuccessful: func(err error) bool {
+				return !isAccelerationError(err)
+			},
+
+			// Every state change is applied here and reported here, which is the "surface the state"
+			// half of #204. It must not call back into the breaker: this runs under the breaker's own
+			// lock, and both ClientManager methods take only cm.accelMu.
+			OnStateChange: func(name string, from, to circuit.State) {
+				switch to {
+				case circuit.StateOpen:
+					cm.DisableAcceleration("acceleration error; retrying in " + retry.String())
+					mc.SetAccelerationEnabled(false)
+
+				case circuit.StateHalfOpen:
+					cm.EnableAcceleration()
+					mc.SetAccelerationEnabled(true)
+					logger.Info("Retrying S3 Transfer Acceleration after backoff",
+						"breaker", name,
+						"backoff", retry)
+
+				case circuit.StateClosed:
+					// Reached from half-open on a probe that did not fail — acceleration works again.
+					// EnableAcceleration already ran on the half-open transition, so this is the
+					// report rather than the change.
+					if from == circuit.StateHalfOpen {
+						logger.Info("S3 Transfer Acceleration restored", "breaker", name)
+					}
+				}
+			},
+		}),
+	}
+}
+
+// attempt runs fn against the accelerate endpoint if the gate permits it, and reports whether it ran.
+//
+// attempted false means the gate is open or its single half-open probe slot is taken, so the caller
+// must use the standard endpoint; err is nil in that case and nothing has been sent. attempted true
+// means fn ran and err is its result, already counted — an acceleration error has tripped the gate by
+// the time this returns, so the caller's job is only to retry on the standard endpoint.
+//
+// Going through [circuit.CircuitBreaker.Execute] rather than a permission/report pair is what keeps
+// the accounting correct without a rule for the caller to follow. Execute counts the request in and
+// the result out under the breaker's own lock; a caller that took permission and forgot to report
+// would hold the half-open slot forever, and MaxRequests is 1, so that is every later probe blocked
+// for the life of the mount.
+//
+// The distinction is drawn by observing whether fn ran, not by classifying the returned error, and that
+// is not fussiness. Execute reports its own refusal as [circuit.ErrOpenState] or
+// [circuit.ErrTooManyRequests], and testing for those would be indistinguishable from fn returning one
+// — which an S3 call wrapped in the operation breaker can do. Misreading that as "the gate said no"
+// sends a second request for an answer the caller already has.
+func (g *accelerationGate) attempt(fn func() error) (err error, attempted bool) {
+	var fnErr error
+
+	// The gate's own verdict is discarded: when fn ran, its error is fn's, and when it did not, the
+	// verdict is exactly what `attempted` reports.
+	_ = g.breaker.Execute(func() error {
+		attempted = true
+		fnErr = fn()
+
+		return fnErr
+	})
+
+	if !attempted {
+		return nil, false
+	}
+
+	return fnErr, true
+}
+
+// state reports the gate's state, for metrics and for tests.
+//
+// It calls through to the breaker rather than caching, because reading the state is also what
+// advances it: circuit.CircuitBreaker.GetState performs the open→half-open transition when the
+// timeout has passed. A gate nothing asks about therefore stays open until the next request, which is
+// correct — there is nothing to recover for — and a mount that scrapes metrics recovers on the scrape
+// rather than on the next request, which is harmless and slightly earlier.
+func (g *accelerationGate) state() circuit.State {
+	return g.breaker.GetState()
+}
+
+// retryPeriod is the resolved backoff — the configured value, or defaultAccelerationRetry when the
+// configuration named none.
+func (g *accelerationGate) retryPeriod() time.Duration {
+	return g.retry
+}

--- a/internal/storage/s3/acceleration_gate_test.go
+++ b/internal/storage/s3/acceleration_gate_test.go
@@ -1,0 +1,306 @@
+package s3
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// #204: the acceleration fallback was a one-way latch. One acceleration error — including a DNS
+// failure lasting seconds — sent every later request in the mount's life to the standard endpoint,
+// and nothing reported it had happened.
+//
+// These tests drive the gate directly, with a ClientManager built by hand as
+// TestAccelerationFallbackIsRaceFree does. What that buys over the end-to-end tests in
+// acceleration_recovery_test.go is control of the clock-shaped parts: the backoff can be milliseconds,
+// and the half-open probe can be held open while a second attempt is made, which is the property that
+// decides whether a mount under load sends one probe or hundreds.
+//
+// What it does not buy is any evidence that the backend calls the gate, or that a fallback returns
+// correct bytes. That is what the external tests are for, and neither set is sufficient alone.
+
+// gateFixture builds a gate over a ClientManager with acceleration active, and returns both plus the
+// metrics collector the gate reports through.
+func gateFixture(t *testing.T, retry time.Duration) (*accelerationGate, *ClientManager, *MetricsCollector) {
+	t.Helper()
+
+	cm := &ClientManager{
+		client:             &s3.Client{},
+		acceleratedClient:  &s3.Client{},
+		standardClient:     &s3.Client{},
+		accelerationActive: true,
+		config:             &Config{UseAccelerate: true},
+		logger:             slog.New(slog.DiscardHandler),
+	}
+
+	mc := NewMetricsCollector()
+	mc.SetAccelerationEnabled(true)
+
+	return newAccelerationGate(cm, mc, retry, slog.New(slog.DiscardHandler)), cm, mc
+}
+
+// accelErr is the error S3 returns for the common acceleration failure: an InvalidRequest whose
+// message is the only thing distinguishing it from a bad Range or an oversized copy source.
+func accelErr() error {
+	return apiErr("InvalidRequest", "S3 Transfer Acceleration is not configured on this bucket")
+}
+
+// TestOneAccelerationErrorWithdrawsTheEndpoint is the first half of the latch — the half that was
+// never in doubt. It is here because the second half is only meaningful if this one holds.
+func TestOneAccelerationErrorWithdrawsTheEndpoint(t *testing.T) {
+	t.Parallel()
+
+	gate, cm, mc := gateFixture(t, time.Hour)
+
+	err, attempted := gate.attempt(accelErr)
+	if !attempted {
+		t.Fatal("the first attempt through a fresh gate was refused; the gate starts closed")
+	}
+	if !isAccelerationError(err) {
+		t.Fatalf("attempt returned %v, want the acceleration error fn produced", err)
+	}
+
+	// One error, not a threshold. An unusable accelerate endpoint is unusable for every request, so
+	// sampling further only spends failed round trips to learn what the first one established.
+	if _, attempted := gate.attempt(func() error { return nil }); attempted {
+		t.Error("a second request was sent to the accelerate endpoint after an acceleration error; the " +
+			"gate did not withdraw it")
+	}
+
+	if cm.IsAccelerationActive() {
+		t.Error("the client manager still reports acceleration active, so requests keep being built " +
+			"against an endpoint the gate has withdrawn")
+	}
+	if mc.GetMetrics().AccelerationEnabled {
+		t.Error("BackendMetrics reports acceleration enabled while the gate holds it withdrawn; this is " +
+			"the field that used to be a copy of the config flag, and reporting the flag is #204")
+	}
+}
+
+// TestANonAccelerationErrorLeavesTheEndpointInService is the classifier's half of the decision, seen
+// through the gate.
+//
+// A NoSuchKey or a 500 arriving over the accelerate endpoint is evidence the endpoint *works* — it
+// reached S3, which answered. Counting those would withdraw acceleration for reasons that have
+// nothing to do with acceleration, which is the false-positive direction that costs a mount its
+// throughput for the backoff period on every unrelated error.
+func TestANonAccelerationErrorLeavesTheEndpointInService(t *testing.T) {
+	t.Parallel()
+
+	gate, cm, _ := gateFixture(t, time.Hour)
+
+	for _, err := range []error{
+		apiErr("NoSuchKey", "The specified key does not exist"),
+		apiErr("InternalError", "We encountered an internal error. Please try again."),
+		apiErr("InvalidRequest", "Invalid Range header"),
+		errors.New("connection timeout"),
+	} {
+		if _, attempted := gate.attempt(func() error { return err }); !attempted {
+			t.Fatalf("the gate refused an attempt after %v; only an acceleration error should withdraw "+
+				"the endpoint", err)
+		}
+	}
+
+	if !cm.IsAccelerationActive() {
+		t.Error("acceleration was withdrawn by errors that say nothing about the accelerate endpoint")
+	}
+}
+
+// TestTheEndpointComesBackAfterTheBackoff is #204 itself.
+//
+// Verified by mutation: reverting executeWithAccelerationFallback to call DisableAcceleration
+// directly — the shape this replaced — leaves this test failing at the recovery poll and every other
+// acceleration test green.
+func TestTheEndpointComesBackAfterTheBackoff(t *testing.T) {
+	t.Parallel()
+
+	const retry = 25 * time.Millisecond
+
+	gate, cm, mc := gateFixture(t, retry)
+
+	if _, attempted := gate.attempt(accelErr); !attempted {
+		t.Fatal("the first attempt through a fresh gate was refused")
+	}
+
+	// Polled rather than slept-and-asserted: the assertion is that a probe becomes available, and a
+	// single sleep of exactly the backoff races the breaker's own comparison.
+	deadline := time.Now().Add(10 * time.Second)
+
+	var probed bool
+	for !probed {
+		if time.Now().After(deadline) {
+			t.Fatalf("no request reached the accelerate endpoint in 10s at a %v backoff; the fallback is "+
+				"still one-way, which is #204", retry)
+		}
+
+		_, probed = gate.attempt(func() error { return nil })
+		if !probed {
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// The probe succeeded, so the gate closes and acceleration is in service again — not merely
+	// permitted for one request.
+	if _, attempted := gate.attempt(func() error { return nil }); !attempted {
+		t.Error("the request after a successful probe was refused; the gate did not close, so acceleration " +
+			"would be rationed to one request per backoff period forever")
+	}
+
+	if !cm.IsAccelerationActive() {
+		t.Error("the client manager still reports acceleration inactive after recovery, so requests would " +
+			"keep going to the standard endpoint while the gate believes the accelerate endpoint is in use")
+	}
+	if !mc.GetMetrics().AccelerationEnabled {
+		t.Error("BackendMetrics reports acceleration disabled after recovery; an operator watching the " +
+			"metric would not see the recovery, which is the observability half of #204")
+	}
+}
+
+// TestAFailedProbeWithdrawsTheEndpointAgain pins the unrecoverable case.
+//
+// A bucket with no Transfer Acceleration configuration fails every probe forever, and the cost of the
+// mechanism is bounded by exactly this: the failed probe must reopen the gate for another full backoff
+// rather than leaving it half-open, where every subsequent request would pay a failed round trip.
+func TestAFailedProbeWithdrawsTheEndpointAgain(t *testing.T) {
+	t.Parallel()
+
+	const retry = 25 * time.Millisecond
+
+	gate, cm, _ := gateFixture(t, retry)
+
+	if _, attempted := gate.attempt(accelErr); !attempted {
+		t.Fatal("the first attempt through a fresh gate was refused")
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+
+	var probed bool
+	for !probed {
+		if time.Now().After(deadline) {
+			t.Fatalf("no probe reached the accelerate endpoint in 10s at a %v backoff", retry)
+		}
+
+		// The probe fails the same way the original request did, which is the real behavior of a
+		// bucket that cannot be accelerated at all.
+		_, probed = gate.attempt(accelErr)
+		if !probed {
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	if _, attempted := gate.attempt(func() error { return nil }); attempted {
+		t.Error("a request immediately after a failed probe was sent to the accelerate endpoint; the gate " +
+			"stayed half-open, so every request on an unacceleratable bucket pays a failed round trip")
+	}
+
+	if cm.IsAccelerationActive() {
+		t.Error("acceleration reports active after the probe failed")
+	}
+}
+
+// TestOnlyOneProbeIsInFlightAtATime is the property that makes the retry affordable under load.
+//
+// A mount serving concurrent reads has dozens of requests arriving in the millisecond the backoff
+// expires. Without MaxRequests: 1 every one of them is sent to an endpoint the gate has no reason yet
+// to believe works, and on an unacceleratable bucket every one pays the failed round trip that only
+// the first needed to pay — turning a bounded 288-failures-a-day cost into a per-request one.
+//
+// The first probe is held inside fn until the second attempt has been made, so the interleaving is a
+// fixture rather than a race: a version of this test that launched two goroutines and hoped would pass
+// against a gate with no cap at all.
+func TestOnlyOneProbeIsInFlightAtATime(t *testing.T) {
+	t.Parallel()
+
+	const retry = 25 * time.Millisecond
+
+	gate, _, _ := gateFixture(t, retry)
+
+	if _, attempted := gate.attempt(accelErr); !attempted {
+		t.Fatal("the first attempt through a fresh gate was refused")
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	probeAttempted := make(chan bool, 1)
+
+	// Retried until the backoff has expired: before then the gate refuses without running fn, so
+	// `entered` would never be closed and the test would deadlock on a condition that is simply not
+	// yet true.
+	go func() {
+		deadline := time.Now().Add(10 * time.Second)
+
+		for {
+			_, attempted := gate.attempt(func() error {
+				close(entered)
+				<-release
+
+				return nil
+			})
+			if attempted {
+				probeAttempted <- true
+
+				return
+			}
+
+			if time.Now().After(deadline) {
+				probeAttempted <- false
+
+				return
+			}
+
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	select {
+	case <-entered:
+	case ok := <-probeAttempted:
+		t.Fatalf("no probe ran within 10s at a %v backoff (attempted=%v)", retry, ok)
+	}
+
+	// The probe is inside fn and has not reported. A second request must not be sent.
+	if _, attempted := gate.attempt(func() error { return nil }); attempted {
+		close(release)
+		t.Fatal("a second request was sent to the accelerate endpoint while the half-open probe was still " +
+			"in flight; under load that is one failed round trip per concurrent request rather than one")
+	}
+
+	close(release)
+
+	if ok := <-probeAttempted; !ok {
+		t.Fatal("the probe goroutine gave up")
+	}
+}
+
+// TestAZeroRetryTakesTheDefault covers the value every existing configuration has.
+//
+// storage.s3.acceleration_retry is new, so every config file written before it — and every embedder
+// building an s3.Config by hand — leaves it zero. Zero must mean the default and not "retry
+// immediately", which would send one request per acceleration error to an endpoint that just failed;
+// and a negative value must not reach circuit.Config.Timeout, where it would leave the breaker
+// permanently half-open, the one state configuration must not be able to produce.
+func TestAZeroRetryTakesTheDefault(t *testing.T) {
+	t.Parallel()
+
+	for _, retry := range []time.Duration{0, -time.Second} {
+		gate, _, _ := gateFixture(t, retry)
+
+		if got := gate.retryPeriod(); got != defaultAccelerationRetry {
+			t.Errorf("a gate built with retry=%v reports a period of %v, want the default %v",
+				retry, got, defaultAccelerationRetry)
+		}
+
+		// And the resulting breaker is genuinely open rather than half-open: one error, then no
+		// further request.
+		if _, attempted := gate.attempt(accelErr); !attempted {
+			t.Fatalf("retry=%v: the first attempt through a fresh gate was refused", retry)
+		}
+		if _, attempted := gate.attempt(func() error { return nil }); attempted {
+			t.Errorf("retry=%v: a request was sent immediately after an acceleration error, so the "+
+				"backoff is zero", retry)
+		}
+	}
+}

--- a/internal/storage/s3/acceleration_recovery_test.go
+++ b/internal/storage/s3/acceleration_recovery_test.go
@@ -1,0 +1,259 @@
+package s3_test
+
+// #204's end-to-end half: an acceleration error withdraws the accelerate endpoint, the read still
+// returns correct bytes over the standard endpoint, and the endpoint comes back on its own.
+//
+// The gate's own tests (acceleration_gate_test.go) drive it directly and can hold a probe open to
+// check the concurrency cap. What only this file can show is that the *backend* consults it — that
+// GetObject and PutObject route through executeWithAccelerationFallback, that a withdrawn endpoint
+// still serves the caller's request rather than failing it, and that the state reaches
+// Backend.AccelerationStats, which is the accessor the metrics surface reads. Before #204 that
+// accessor did not exist and GetMetrics had no caller outside the package, so the whole condition was
+// unobservable from anywhere a user could look.
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/circuit"
+	"github.com/scttfrdmn/objectfs/internal/storage/s3"
+	"github.com/scttfrdmn/objectfs/internal/testaws"
+)
+
+// accelerationFault is the failure S3 produces for a bucket that has not enabled Transfer
+// Acceleration. The message is the load-bearing half: S3 gives every acceleration failure the
+// InvalidRequest code, which it shares with a bad Range and an oversized copy source, so a fault
+// carrying only the code would exercise the classifier's *rejecting* branch and prove nothing about
+// the fallback.
+//
+// 400 rather than 500 so the SDK does not retry it: a retried fault would spend the Times budget on
+// one logical request and the standard-endpoint attempt would fail too.
+func accelerationFault(method string, times int) testaws.Fault {
+	return testaws.Fault{
+		Method:  method,
+		Status:  400,
+		Code:    "InvalidRequest",
+		Message: "S3 Transfer Acceleration is not configured on this bucket",
+		Times:   times,
+	}
+}
+
+// TestAnAccelerationErrorFallsBackAndStillServesTheRead is the fallback, seen from the caller.
+//
+// The bytes are the assertion. A read that reached the accelerate endpoint, got an unusable answer, and
+// returned an error to the caller would be a worse outcome than not accelerating at all — and the
+// project's degradation rule for a performance capability is to fall back silently and keep serving.
+func TestAnAccelerationErrorFallsBackAndStillServesTheRead(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	backend := ts.Backend(func(cfg *s3.Config) {
+		cfg.AccelerationRetry = time.Hour
+	})
+	s3.RouteAccelerationThroughTheTestEndpoint(backend)
+
+	ctx := context.Background()
+
+	want := []byte("the read must still return these bytes")
+	ts.PutObject("accelerated.bin", want)
+
+	ts.InjectFault(accelerationFault("GET", 1))
+
+	got, err := backend.GetObject(ctx, "accelerated.bin", 0, -1)
+	if err != nil {
+		t.Fatalf("a read that met an acceleration error failed instead of falling back: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("the fallback returned %q, want %q", got, want)
+	}
+
+	if ts.FaultsFired() != 1 {
+		t.Fatalf("the injected fault fired %d times, want 1; without it firing this test proves nothing "+
+			"— a read that never met an acceleration error succeeds trivially", ts.FaultsFired())
+	}
+
+	stats := backend.AccelerationStats()
+	if stats.Active {
+		t.Error("AccelerationStats reports acceleration active after an acceleration error; this is the " +
+			"field an operator reads to find out their mount stopped accelerating")
+	}
+	if !stats.Configured {
+		t.Error("Configured is false; it reports what the operator asked for and must survive a fallback, " +
+			"since Configured-and-not-Active is precisely the state #204 made reportable")
+	}
+	if stats.GateState != circuit.StateOpen {
+		t.Errorf("the gate is %v after an acceleration error, want OPEN", stats.GateState)
+	}
+	if stats.Fallbacks != 1 {
+		t.Errorf("Fallbacks = %d, want 1", stats.Fallbacks)
+	}
+	if stats.RetryPeriod != time.Hour {
+		t.Errorf("RetryPeriod = %v, want the configured 1h; an operator looking at a mount in fallback "+
+			"is asking when it will try again", stats.RetryPeriod)
+	}
+}
+
+// TestSubsequentReadsSkipTheWithdrawnEndpoint asserts the withdrawal costs nothing per request.
+//
+// The point of withdrawing rather than retrying is that later requests do not pay the failed round
+// trip. Counted at the wire: after the fallback, a read must produce exactly one request — the
+// standard-endpoint one — and not two.
+func TestSubsequentReadsSkipTheWithdrawnEndpoint(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+	backend := ts.Backend(func(cfg *s3.Config) {
+		cfg.AccelerationRetry = time.Hour
+	})
+	s3.RouteAccelerationThroughTheTestEndpoint(backend)
+
+	ctx := context.Background()
+
+	ts.PutObject("hot.bin", []byte("payload"))
+	ts.InjectFault(accelerationFault("GET", 1))
+
+	if _, err := backend.GetObject(ctx, "hot.bin", 0, -1); err != nil {
+		t.Fatalf("the read that triggers the fallback failed: %v", err)
+	}
+
+	ts.ResetRequests()
+
+	for i := range 3 {
+		if _, err := backend.GetObject(ctx, "hot.bin", 0, -1); err != nil {
+			t.Fatalf("read %d after the fallback failed: %v", i, err)
+		}
+	}
+
+	if got := len(ts.GETs("hot.bin")); got != 3 {
+		t.Errorf("3 reads after the fallback issued %d GETs, want 3; a request per read is being sent to "+
+			"an endpoint the gate has withdrawn, which is the per-request cost the backoff exists to avoid",
+			got)
+	}
+}
+
+// TestTheAccelerateEndpointComesBackWithinTheBackoff is #204 as a user would state it.
+//
+// The recovery is asserted through AccelerationStats rather than through a log line or the gate's
+// internals, because the issue is half about the state being *reachable*: a recovery visible only
+// inside the s3 package is the same invisibility the fallback had.
+//
+// Verified by mutation: freezing circuit.Config.Timeout at an hour instead of the configured retry
+// leaves this test failing at the poll and the rest of the file green.
+func TestTheAccelerateEndpointComesBackWithinTheBackoff(t *testing.T) {
+	t.Parallel()
+
+	const retry = 25 * time.Millisecond
+
+	ts := testaws.Start(t)
+	backend := ts.Backend(func(cfg *s3.Config) {
+		cfg.AccelerationRetry = retry
+	})
+	s3.RouteAccelerationThroughTheTestEndpoint(backend)
+
+	ctx := context.Background()
+
+	ts.PutObject("recovered.bin", []byte("payload"))
+
+	// Exactly one fire: the condition is transient, which is the case the permanent latch got wrong.
+	ts.InjectFault(accelerationFault("GET", 1))
+
+	if _, err := backend.GetObject(ctx, "recovered.bin", 0, -1); err != nil {
+		t.Fatalf("the read that triggers the fallback failed: %v", err)
+	}
+	if backend.AccelerationStats().Active {
+		t.Fatal("acceleration is still active, so nothing was withdrawn and this test cannot observe a " +
+			"recovery")
+	}
+
+	// Reads until acceleration is in effect again. Each read is a request that would have gone to the
+	// accelerate endpoint had the gate permitted it, which is how a mount actually recovers.
+	deadline := time.Now().Add(10 * time.Second)
+	for !backend.AccelerationStats().Active {
+		if time.Now().After(deadline) {
+			t.Fatalf("acceleration is still withdrawn 10s after a %v backoff, over repeated reads; the "+
+				"fallback is one-way for the life of the mount, which is #204", retry)
+		}
+
+		if _, err := backend.GetObject(ctx, "recovered.bin", 0, -1); err != nil {
+			t.Fatalf("a read during the backoff failed: %v", err)
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	stats := backend.AccelerationStats()
+	if stats.GateState != circuit.StateClosed {
+		t.Errorf("the gate is %v after a successful probe, want CLOSED: a gate left half-open rations "+
+			"acceleration to one request per backoff period", stats.GateState)
+	}
+	if stats.Requests == 0 {
+		t.Error("Requests is zero after recovery, so no request has been recorded against the accelerate " +
+			"endpoint and the recovery is not visible as traffic")
+	}
+}
+
+// TestAccelerationOnACustomEndpointFallsBackRatherThanFailing is a second defect, found by probing
+// while #204 was being fixed and not named in it.
+//
+// The AWS SDK's endpoint ruleset refuses UseAccelerate together with a BaseEndpoint:
+//
+//	operation error S3: GetObject, resolve auth scheme: resolve endpoint: endpoint rule error,
+//	A custom endpoint cannot be combined with S3 Accelerate
+//
+// It never reaches the network, so it is not a smithy.APIError, so isAccelerationError did not match it
+// and the fallback never fired. `use_acceleration: true` with any `endpoint:` set therefore failed
+// *every* GET and PUT with STORAGE_READ / STORAGE_WRITE, permanently — on every MinIO, Ceph, RustFS or
+// Wasabi deployment that copied the acceleration example from the docs.
+//
+// This test is the one place the real combination is exercised, so it deliberately does not use
+// RouteAccelerationThroughTheTestEndpoint: the substituted client is what makes every other test in this
+// file possible and is also exactly the thing whose absence caused this defect.
+//
+// Refusing the combination at config load is the other candidate fix and is deliberately not taken. Per
+// the project thesis, acceleration is a performance capability, so it degrades silently; failing the
+// mount would apply the correctness rule to the wrong kind of capability, and would take down mounts
+// that are working today.
+func TestAccelerationOnACustomEndpointFallsBackRatherThanFailing(t *testing.T) {
+	t.Parallel()
+
+	ts := testaws.Start(t)
+
+	// The real configuration: acceleration on, endpoint set. No test hook.
+	backend := ts.Backend(func(cfg *s3.Config) {
+		cfg.UseAccelerate = true
+		cfg.AccelerationRetry = time.Hour
+	})
+
+	ctx := context.Background()
+
+	want := []byte("this object was unreadable on every S3-compatible deployment")
+	ts.PutObject("compat.bin", want)
+
+	got, err := backend.GetObject(ctx, "compat.bin", 0, -1)
+	if err != nil {
+		t.Fatalf("a read with use_accelerate and a custom endpoint failed: %v\n\nThe SDK refuses the "+
+			"combination before sending anything, and the error carries no API code, so it was not "+
+			"classified as an acceleration error and no fallback ran. Every GET and PUT on such a mount "+
+			"failed for its whole life.", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("the fallback returned %q, want %q", got, want)
+	}
+
+	// The write side independently: PutObject goes through the same helper, and a mount that can read
+	// but not write is not a working mount.
+	if err := backend.PutObject(ctx, "compat-write.bin", want, nil); err != nil {
+		t.Fatalf("a write with use_accelerate and a custom endpoint failed: %v", err)
+	}
+	if roundTripped := ts.GetObject("compat-write.bin"); !bytes.Equal(roundTripped, want) {
+		t.Errorf("the written object reads back as %q, want %q", roundTripped, want)
+	}
+
+	if stats := backend.AccelerationStats(); stats.Active {
+		t.Error("acceleration still reports active, so the ruleset refusal was not classified as an " +
+			"acceleration error and every request is still being built against a combination the SDK " +
+			"rejects")
+	}
+}

--- a/internal/storage/s3/acceleration_test.go
+++ b/internal/storage/s3/acceleration_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
+
+	objerrors "github.com/scttfrdmn/objectfs/pkg/errors"
 )
 
 // apiErr builds the shape the AWS SDK actually hands back for an S3 error response: a
@@ -25,8 +27,6 @@ func apiErr(code, message string) error {
 
 func TestBackend_isAccelerationError(t *testing.T) {
 	t.Parallel()
-
-	b := &Backend{}
 
 	tests := []struct {
 		name     string
@@ -85,6 +85,26 @@ func TestBackend_isAccelerationError(t *testing.T) {
 			expected: true,
 			why:      "no API error to inspect, but the accelerate endpoint is unmistakably what failed",
 		},
+		{
+			name: "the SDK refusing accelerate together with a custom endpoint",
+			err: errors.New("operation error S3: GetObject, resolve auth scheme: resolve endpoint: " +
+				"endpoint rule error, A custom endpoint cannot be combined with S3 Accelerate"),
+			expected: true,
+			why: "never reaches the network, so it carries no API error; unmatched, it failed every GET " +
+				"and PUT on every S3-compatible deployment that set both",
+		},
+		{
+			name: "the same refusal behind an ObjectFSError, which is how the backend sees it",
+			err: objerrors.NewError(objerrors.ErrCodeStorageRead, "GetObject operation failed").
+				WithComponent("s3-backend").
+				WithOperation("GetObject").
+				WithCause(errors.New("operation error S3: GetObject, resolve auth scheme: resolve " +
+					"endpoint: endpoint rule error, A custom endpoint cannot be combined with S3 Accelerate")),
+			expected: true,
+			why: "ObjectFSError.Error() renders its own code and message and not its cause, so a matcher " +
+				"over err.Error() alone sees no acceleration text at all — and this is the shape " +
+				"translateError hands the classifier for every request",
+		},
 
 		// Audit finding L27. Each of these was classified as an acceleration error by the substring
 		// matcher this replaced, and each false positive disables acceleration for the remaining life
@@ -141,7 +161,7 @@ func TestBackend_isAccelerationError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := b.isAccelerationError(tt.err)
+			result := isAccelerationError(tt.err)
 			if result != tt.expected {
 				t.Errorf("isAccelerationError(%v) = %v, want %v\nwhy: %s", tt.err, result, tt.expected, tt.why)
 			}
@@ -156,11 +176,10 @@ func TestBackend_isAccelerationError(t *testing.T) {
 func TestBackend_isAccelerationError_WrappedInvalidRequestStillMatches(t *testing.T) {
 	t.Parallel()
 
-	b := &Backend{}
 	inner := apiErr("InvalidRequest", "S3 Transfer Acceleration is not configured on this bucket")
 
 	for depth, err := 0, inner; depth < 4; depth++ {
-		if !b.isAccelerationError(err) {
+		if !isAccelerationError(err) {
 			t.Errorf("wrapped %d deep: isAccelerationError = false, want true (%v)", depth, err)
 		}
 		err = fmt.Errorf("layer %d: %w", depth, err)

--- a/internal/storage/s3/backend.go
+++ b/internal/storage/s3/backend.go
@@ -67,6 +67,12 @@ type Backend struct {
 	// Circuit breaker for resilience
 	circuitManager *circuit.Manager
 
+	// accelerationGate decides whether a request may use the accelerate endpoint, and is what gives the
+	// fallback a way back (#204). Always non-nil on a constructed backend, including when acceleration
+	// is off — an always-closed gate in front of a nil accelerated client costs nothing and is one path
+	// instead of two.
+	accelerationGate *accelerationGate
+
 	// Retry logic for error recovery
 	retryer *retry.Retryer
 
@@ -194,7 +200,13 @@ func NewBackend(ctx context.Context, bucket string, cfg *Config) (*Backend, erro
 		return nil, fmt.Errorf("failed to create client manager: %w", err)
 	}
 
-	// Initialize metrics collector
+	// Initialize metrics collector.
+	//
+	// SetAccelerationEnabled here is the *initial* state and nothing else. It used to be the only call
+	// to it, which made BackendMetrics.AccelerationEnabled a copy of the config flag: a mount could
+	// report acceleration enabled, have fallen back on its first request, and have served everything
+	// since over the standard endpoint. The gate below re-sets it on every transition, so the field
+	// reports what is happening rather than what was asked for (#204).
 	metricsCollector := NewMetricsCollector()
 	metricsCollector.SetAccelerationEnabled(cfg.UseAccelerate)
 
@@ -219,6 +231,7 @@ func NewBackend(ctx context.Context, bucket string, cfg *Config) (*Backend, erro
 		tierValidator:       tierValidator,
 		singlePartCopyLimit: maxSinglePartCopy,
 		copyPartSize:        defaultCopyPartSize,
+		accelerationGate:    newAccelerationGate(clientManager, metricsCollector, cfg.AccelerationRetry, logger),
 	}
 
 	backend.pricingManager = pricingManager
@@ -1729,6 +1742,51 @@ func (b *Backend) GetMetrics() BackendMetrics {
 	return b.metricsCollector.GetMetrics()
 }
 
+// AccelerationStats reports the Transfer Acceleration state and its counters, for whoever is exporting
+// them.
+//
+// This exists because GetMetrics had no caller outside this package, which was the other half of #204:
+// the fallback state was tracked accurately and reachable by nothing, so an operator whose mount had
+// silently dropped to the standard endpoint had no scrape, log line, or health check that said so. The
+// throughput loss was invisible.
+//
+// A purpose-built struct rather than returning BackendMetrics, because the consumer is the metrics
+// surface and the mapping it needs is a set of numbers with settled names. BackendMetrics carries
+// twenty-odd fields on four unrelated subjects and a time.Duration that a gauge cannot take; handing
+// that to internal/adapter would put the choice of what to export, and the unit conversions, in the
+// caller.
+func (b *Backend) AccelerationStats() AccelerationStats {
+	m := b.metricsCollector.GetMetrics()
+
+	return AccelerationStats{
+		Configured:  b.config.UseAccelerate,
+		Active:      b.clientManager.IsAccelerationActive(),
+		GateState:   b.accelerationGate.state(),
+		Requests:    m.AcceleratedRequests,
+		Bytes:       m.AcceleratedBytes,
+		Fallbacks:   m.FallbackEvents,
+		AvgLatency:  m.AccelerationLatency,
+		RetryPeriod: b.accelerationGate.retryPeriod(),
+	}
+}
+
+// AccelerationStats is the Transfer Acceleration state as an exporter sees it.
+//
+// Configured and Active are both here and they are different questions — which is the distinction #204
+// turned on. Configured is what the operator asked for and never changes; Active is whether requests are
+// going to the accelerate endpoint right now. Configured true with Active false is the fallback in
+// effect, and it is the state that used to be unreportable.
+type AccelerationStats struct {
+	Configured  bool          `json:"configured"`
+	Active      bool          `json:"active"`
+	GateState   circuit.State `json:"gate_state"`
+	Requests    int64         `json:"requests"`
+	Bytes       int64         `json:"bytes"`
+	Fallbacks   int64         `json:"fallbacks"`
+	AvgLatency  time.Duration `json:"avg_latency"`
+	RetryPeriod time.Duration `json:"retry_period"`
+}
+
 // Close closes the backend and releases resources
 func (b *Backend) Close() error {
 	return b.clientManager.Close()
@@ -2679,11 +2737,32 @@ func (b *Backend) IsFullyHealthy() bool {
 // "BucketAlreadyExists" is gone with no replacement. Its comment claimed it was "sometimes returned
 // for acceleration errors"; it is CreateBucket's name collision, and ObjectFS does not create buckets.
 //
-// The remaining message-only check is for a failure with no API error at all: reaching
-// <bucket>.s3-accelerate.amazonaws.com can fail in DNS or TLS before S3 answers. That is genuinely an
-// acceleration failure and genuinely needs the fallback. It matches the endpoint hostname label rather
-// than the word "acceleration", because a hostname cannot appear in a standard-endpoint error.
-func (b *Backend) isAccelerationError(err error) bool {
+// The remaining message-only checks are for failures with no API error at all, of which there are two
+// kinds and only one was handled.
+//
+// The first: reaching <bucket>.s3-accelerate.amazonaws.com can fail in DNS or TLS before S3 answers.
+// That is genuinely an acceleration failure and genuinely needs the fallback. It matches the endpoint
+// hostname label rather than the word "acceleration", because a hostname cannot appear in a
+// standard-endpoint error.
+//
+// The second is the AWS SDK refusing to build the request at all, and it is the one this function used
+// to miss entirely:
+//
+//	operation error S3: GetObject, resolve auth scheme: resolve endpoint: endpoint rule error,
+//	A custom endpoint cannot be combined with S3 Accelerate
+//
+// The SDK's endpoint ruleset rejects UseAccelerate together with a BaseEndpoint, so it never reaches
+// the network and never produces an APIError. `use_acceleration: true` with any `endpoint:` set — which
+// is every MinIO, Ceph, RustFS or Wasabi deployment that copies the acceleration example — therefore
+// failed *every* GET and PUT with STORAGE_READ / STORAGE_WRITE, with no fallback, for the life of the
+// mount. Verified by probe against the substrate endpoint, which is also where
+// TestAccelerationOnACustomEndpointFallsBackRatherThanFailing now keeps it verified.
+//
+// Whether that combination should be refused at config load instead is a fair question and the answer
+// is no, for the reason the project thesis gives: acceleration is a performance capability, so the
+// degradation rule is to fall back silently and keep serving. Failing the mount would be the
+// correctness rule applied to the wrong kind of capability.
+func isAccelerationError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -2706,12 +2785,65 @@ func (b *Backend) isAccelerationError(err error) bool {
 		return false
 	}
 
-	// No API error: a transport failure reaching the accelerate endpoint itself, which carries the
-	// hostname and no code.
-	return strings.Contains(err.Error(), "s3-accelerate")
+	// No API error. Two shapes, per the comment above: a transport failure reaching the accelerate
+	// endpoint, which carries the hostname; and the SDK's endpoint ruleset refusing to build the
+	// request, which carries the ruleset's own wording and never touches the network.
+	//
+	// Both matched on lowercase, because "S3 Accelerate" in the ruleset message and "s3-accelerate" in
+	// a hostname differ in case as well as in punctuation.
+	//
+	// Over the whole chain rather than err.Error(), and that is not belt-and-braces — it is the
+	// difference between this working and not. Both of these arrive here already translated:
+	// executeWithAccelerationFallback's fn calls b.translateError before returning, so what this sees is
+	// an *errors.ObjectFSError whose Cause is the SDK error. ObjectFSError.Error() renders its own code
+	// and message and deliberately does not include the cause, so the top-level string is
+	// "[s3-backend:GetObject] STORAGE_READ: GetObject operation failed" — with no trace of the ruleset
+	// message anywhere in it. Matching on err.Error() alone therefore classified nothing, which is how the
+	// custom-endpoint defect survived the first attempt at fixing it.
+	return errMessageChainContains(err, "s3-accelerate") ||
+		errMessageChainContains(err, "cannot be combined with s3 accelerate")
 }
 
-// executeWithAccelerationFallback executes an S3 operation with automatic fallback
+// errMessageChainContains reports whether needle appears, case-insensitively, in the text of err or of
+// any error it wraps.
+//
+// It exists because two of the wrapping styles in this codebase behave differently under Error():
+// fmt.Errorf("%w") includes the wrapped text, so the top-level string carries everything, while
+// [errors.ObjectFSError] renders only its own code and message and keeps its cause reachable solely via
+// Unwrap. A matcher over service prose has to look at every level or it silently stops matching the
+// moment its input is wrapped by the second kind — which is every error the S3 backend returns.
+//
+// needle must be lowercase; each level is lowered before comparison.
+func errMessageChainContains(err error, needle string) bool {
+	for e := err; e != nil; e = stderr.Unwrap(e) {
+		if strings.Contains(strings.ToLower(e.Error()), needle) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// executeWithAccelerationFallback runs fn against the accelerate endpoint when it is available, and
+// against the standard endpoint when it is not.
+//
+// # The fallback is no longer for the life of the mount
+//
+// It was, and that was #204: one acceleration error and every later request in the mount's life used
+// the standard endpoint, with nothing anywhere reporting it — so the throughput loss was invisible and
+// the only cure was a restart. The gate ([accelerationGate]) withdraws the endpoint on an acceleration
+// error, holds it out for Config.AccelerationRetry, then lets exactly one request try again. See
+// newAccelerationGate for why that is a circuit breaker rather than a timestamp comparison.
+//
+// The reason the old behavior was defensible and still wrong: its trigger case — a bucket with no
+// Transfer Acceleration configuration — really does not resolve on its own, but it is not the only
+// trigger. A DNS or TLS failure reaching the accelerate endpoint matches too, and so does a transient
+// InvalidRequest. Those resolve in seconds, and a mount that hit one lost acceleration until it was
+// restarted.
+//
+// A request that arrives while the gate is open pays nothing: gate.attempt returns without sending, and
+// this falls straight through to the standard endpoint, which is the same cost the old permanent
+// fallback had.
 func (b *Backend) executeWithAccelerationFallback(
 	ctx context.Context,
 	operation string,
@@ -2723,40 +2855,62 @@ func (b *Backend) executeWithAccelerationFallback(
 	// gets "active, and here it is" as one answer under one lock.
 	acceleratedClient := b.clientManager.GetAcceleratedClient()
 	if acceleratedClient == nil {
-		client, err := b.clientManager.GetPooledClient()
-		if err != nil {
-			return fmt.Errorf("%s: %w", operation, err)
-		}
-		defer b.clientManager.ReturnPooledClient(client)
-
-		return fn(client)
+		return b.executeOnStandardEndpoint(operation, fn)
 	}
 
 	start := time.Now()
-	err := fn(acceleratedClient)
+
+	// The gate both permits the attempt and records its outcome. An acceleration error inside here has
+	// already tripped it — and therefore already called DisableAcceleration, through OnStateChange — by
+	// the time attempt returns.
+	err, attempted := b.accelerationGate.attempt(func() error { return fn(acceleratedClient) })
+
+	if !attempted {
+		// The gate is open, or its single half-open probe is already in flight on another goroutine.
+		// Either way nothing was sent, so this is not a retry.
+		return b.executeOnStandardEndpoint(operation, fn)
+	}
+
 	duration := time.Since(start)
 
 	if err == nil {
-		// Success with acceleration
 		b.metricsCollector.RecordAcceleratedRequest(0, duration)
 
 		return nil
 	}
 
-	// Not an acceleration error: the caller's retry and circuit-breaker wrappers own it.
-	if !b.isAccelerationError(err) {
+	// Not an acceleration error: the caller's retry and circuit-breaker wrappers own it. The gate
+	// counted it as a success, which is correct — a NoSuchKey over the accelerate endpoint is evidence
+	// the endpoint works.
+	if !isAccelerationError(err) {
 		return err
 	}
 
 	b.logger.Warn("S3 Transfer Acceleration error detected, falling back to standard endpoint",
 		"operation", operation,
+		"retry_after", b.config.AccelerationRetry,
 		"error", err.Error())
 	b.metricsCollector.RecordFallbackEvent()
-	b.clientManager.DisableAcceleration(fmt.Sprintf("acceleration error: %v", err))
 
-	// Retry with the standard client. This fallback is for the life of the mount — nothing
-	// re-enables acceleration afterwards.
-	return fn(b.clientManager.GetStandardClient())
+	return b.executeOnStandardEndpoint(operation, fn)
+}
+
+// executeOnStandardEndpoint runs fn on a pooled client.
+//
+// The pool rather than clientManager.standardClient, and this is a fix rather than a refactor: the
+// fallback retry used GetStandardClient while the "acceleration was never on" path used the pool, so
+// which client served a request depended on whether acceleration had ever been tried. They are
+// configured identically — clientOptions is applied to both — so nothing observable diverged, but two
+// paths through the same operation is how they come to diverge later, and one of them bypassed the pool
+// entirely, which is what bounds concurrent connections.
+func (b *Backend) executeOnStandardEndpoint(operation string, fn func(client *s3.Client) error) error {
+	client, err := b.clientManager.GetPooledClient()
+	if err != nil {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+	defer b.clientManager.ReturnPooledClient(client)
+
+	return fn(client)
 }
 
 // putObjectMultipart performs a multipart upload for large objects with parallel

--- a/internal/storage/s3/client.go
+++ b/internal/storage/s3/client.go
@@ -348,12 +348,15 @@ func (cm *ClientManager) DisableAcceleration(reason string) {
 
 // EnableAcceleration re-enables Transfer Acceleration if configured.
 //
-// Nothing in ObjectFS calls this. The fallback is one-way for the life of the mount: once an
-// acceleration error is seen, every subsequent request uses the standard endpoint until restart.
-// docs/s3-acceleration.md claimed an "automatic re-enable after successful standard operations";
-// there is no such path, and the doc now says so. Kept as the supported way to re-enable for an
-// embedder that wants to retry periodically, since the alternative — deleting it — leaves callers
-// with no way to undo a fallback at all.
+// Called by accelerationGate when its breaker goes half-open, which is the one path back from a
+// fallback (#204). Until then nothing called it and the fallback was one-way for the life of the
+// mount: one acceleration error, whatever its cause, sent every subsequent request to the standard
+// endpoint until restart. A thirty-second DNS failure reaching the accelerate endpoint therefore cost
+// a long-lived mount its acceleration permanently, and nothing reported it had happened.
+//
+// The gate, not this method, decides *when*. Re-enabling on any schedule of its own would put this
+// method in the business of retry policy, and the retry has to be capped to one in-flight probe —
+// which is the breaker's MaxRequests, not something a mutex around two fields can express.
 func (cm *ClientManager) EnableAcceleration() {
 	cm.accelMu.Lock()
 	defer cm.accelMu.Unlock()

--- a/internal/storage/s3/config.go
+++ b/internal/storage/s3/config.go
@@ -54,6 +54,25 @@ type Config struct {
 	UseAccelerate bool `yaml:"use_accelerate"`
 	UseDualStack  bool `yaml:"use_dual_stack"`
 
+	// AccelerationRetry is how long the fallback stays in effect before one request is allowed to
+	// try the accelerate endpoint again. Zero means the default below.
+	//
+	// The fallback used to be permanent — one acceleration error and every later request in the
+	// mount's life used the standard endpoint (#204). The argument for that was sound as far as it
+	// went: the usual trigger is a bucket without the Transfer Acceleration configuration, which
+	// does not resolve on its own, so retrying it per request would pay a failed round trip forever.
+	// What it missed is that the trigger set is not only that one. A DNS or TLS failure reaching
+	// <bucket>.s3-accelerate.amazonaws.com matches too, and so does a transient InvalidRequest; those
+	// do resolve, and a mount that lost acceleration to a thirty-second network fault kept paying for
+	// it for weeks.
+	//
+	// A period rather than a per-request retry is what makes both cases affordable. At the default,
+	// the unrecoverable case costs one failed request every five minutes — a rounding error against
+	// the request rate of any mount doing enough traffic to want acceleration — and the recoverable
+	// case comes back on its own within one period. See newAccelerationGate for the state machine;
+	// it is [circuit.CircuitBreaker], not a second bespoke one.
+	AccelerationRetry time.Duration `yaml:"acceleration_retry"`
+
 	// Multipart upload configuration
 	MultipartThreshold   int64 `yaml:"multipart_threshold"`   // Size threshold for multipart uploads (bytes)
 	MultipartChunkSize   int64 `yaml:"multipart_chunk_size"`  // Chunk size for multipart uploads (bytes)
@@ -468,6 +487,10 @@ func NewDefaultConfig() *Config {
 			FailureThreshold: 0,
 			Timeout:          30 * time.Second,
 		},
+		// Not UseAccelerate — that stays false — but the period that governs it once an operator turns
+		// it on. Named here rather than left to newAccelerationGate's fallback so that a backend built
+		// from this config reports the period it will actually use.
+		AccelerationRetry:       defaultAccelerationRetry,
 		MultipartThreshold:      32 * 1024 * 1024, // 32MB - trigger multipart for larger files
 		MultipartChunkSize:      16 * 1024 * 1024, // 16MB - optimal chunk size for performance
 		MultipartConcurrency:    8,                // Match pool size for concurrent uploads

--- a/internal/storage/s3/export_test.go
+++ b/internal/storage/s3/export_test.go
@@ -67,6 +67,40 @@ func ReadyToTripForTest(cfg CircuitBreakerConfig) func(circuit.Counts) bool {
 	return readyToTrip(cfg)
 }
 
+// RouteAccelerationThroughTheTestEndpoint makes the accelerated client an ordinary client against the
+// same endpoint, so the acceleration path can be driven end-to-end against a test server.
+//
+// It exists because UseAccelerate and a custom BaseEndpoint are mutually exclusive in the AWS SDK: the
+// endpoint ruleset refuses to build the request at all ("A custom endpoint cannot be combined with S3
+// Accelerate"), so against any emulator an accelerated request never reaches the network. That is a real
+// defect and it has its own test — TestAccelerationOnACustomEndpointFallsBackRatherThanFailing — but it
+// also means the *recovery* half of #204 has no end-to-end path: the probe can never succeed, because no
+// probe is ever sent.
+//
+// So this substitutes the one thing that cannot work for the one thing that can, and changes nothing
+// else. The accelerated client becomes the standard client, which is a real HTTP client against the test
+// endpoint; the gate, the classifier, the fallback, the metrics and the client-manager state are all the
+// production article. What the resulting test cannot show is that the accelerate *hostname* is used —
+// nothing without a real AWS bucket can — and TestAcceleratedClientKeepsTheConfiguredEndpoint covers the
+// client construction separately.
+//
+// Config.UseAccelerate is set as well, because EnableAcceleration checks it: without that the gate's
+// half-open transition would decline to re-enable and the recovery would be untestable for a reason that
+// has nothing to do with the recovery.
+func RouteAccelerationThroughTheTestEndpoint(b *Backend) {
+	b.config.UseAccelerate = true
+
+	cm := b.clientManager
+	cm.config.UseAccelerate = true
+
+	cm.accelMu.Lock()
+	defer cm.accelMu.Unlock()
+
+	cm.acceleratedClient = cm.standardClient
+	cm.client = cm.standardClient
+	cm.accelerationActive = true
+}
+
 // CapabilityProbeKeyForTest is the key the conditional-write probe asserts against.
 //
 // A test asserting the probe left nothing behind has to name the key, and hardcoding the literal in the

--- a/internal/storage/s3/metrics.go
+++ b/internal/storage/s3/metrics.go
@@ -165,7 +165,13 @@ func (mc *MetricsCollector) RecordFallbackEvent() {
 	mc.metrics.FallbackEvents++
 }
 
-// SetAccelerationEnabled sets whether acceleration is enabled
+// SetAccelerationEnabled records whether acceleration is currently in effect.
+//
+// "Currently in effect", not "configured". Until #204 this was called once, from NewBackend, with
+// cfg.UseAccelerate — so the field reported the operator's request and never the outcome: a mount could
+// say acceleration was enabled, have fallen back on its first request, and have used the standard
+// endpoint ever since. The gate's OnStateChange now calls this on every transition, which is what makes
+// AccelerationEnabled a fact about the mount.
 func (mc *MetricsCollector) SetAccelerationEnabled(enabled bool) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()

--- a/internal/testaws/recorder.go
+++ b/internal/testaws/recorder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"io"
 	"net/http"
@@ -140,6 +141,20 @@ type Fault struct {
 	// consider retryable produces a request that fails once and stays failed.
 	Code string
 
+	// Message is the S3 error message in the XML body. Defaults to "injected by testaws".
+	//
+	// It exists because ObjectFS has a classifier that a code alone cannot drive: S3 reports every
+	// Transfer Acceleration failure as InvalidRequest and distinguishes it only by the message, so
+	// isAccelerationError is a conjunction of the two. With a fixed message a Fault could produce
+	// the code and never the condition, and the acceleration fallback — the path deciding whether a
+	// mount keeps serving when the accelerate endpoint is unusable — had no way to be exercised
+	// against a real endpoint.
+	//
+	// The general form: a matcher over service prose is a matcher the harness has to be able to
+	// feed, or the branch behind it is reachable only by calling the classifier directly, which
+	// proves the classifier and not the behavior.
+	Message string
+
 	// Times is how many matching requests to fail. Zero means one — a Fault that fails nothing is
 	// never what a caller meant, and reading `Times: 0` as "unlimited" would turn a typo into a
 	// test that hangs on the retry budget.
@@ -226,6 +241,9 @@ func (ts *TestServer) InjectFault(f Fault) {
 	}
 	if f.Code == "" {
 		f.Code = "InternalError"
+	}
+	if f.Message == "" {
+		f.Message = "injected by testaws"
 	}
 
 	ts.rec.mu.Lock()
@@ -332,17 +350,32 @@ func (ts *TestServer) controlPlane(method, path string, body []byte) {
 
 // serveFault writes an S3-shaped error response. The body matters: the AWS SDK parses the Code out
 // of it to decide whether the error is retryable, and a bare status with an empty body classifies
-// differently from the same status with an InternalError body.
+// differently from the same status with an InternalError body. The Message matters for the same kind
+// of reason on ObjectFS's side — see [Fault.Message].
 func serveFault(w http.ResponseWriter, spec Fault) {
 	body := `<?xml version="1.0" encoding="UTF-8"?>` +
 		`<Error><Code>` + spec.Code + `</Code>` +
-		`<Message>injected by testaws</Message>` +
+		`<Message>` + xmlEscape(spec.Message) + `</Message>` +
 		`<RequestId>testaws-injected</RequestId></Error>`
 
 	w.Header().Set("Content-Type", "application/xml")
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(spec.Status)
 	_, _ = w.Write([]byte(body))
+}
+
+// xmlEscape escapes a fault message for the XML body.
+//
+// [Fault.Message] is caller-supplied, and an unescaped "&" or "<" in it produces a body the SDK's XML
+// decoder rejects — which surfaces as a deserialization failure carrying no error code at all, so the
+// test sees neither the code it injected nor the message. Escaping keeps a mistyped message a wrong
+// message rather than a broken response.
+func xmlEscape(s string) string {
+	var b strings.Builder
+
+	_ = xml.EscapeText(&b, []byte(s))
+
+	return b.String()
 }
 
 // countingBody wraps a response body to count the bytes that pass through it.

--- a/sdks/testdata/metrics-scrape.txt
+++ b/sdks/testdata/metrics-scrape.txt
@@ -117,3 +117,12 @@ objectfs_predictive_cache{service="objectfs",statistic="prefetch_efficiency"} 0.
 objectfs_predictive_cache{service="objectfs",statistic="prefetch_hits"} 31
 objectfs_predictive_cache{service="objectfs",statistic="prefetch_requests"} 96
 objectfs_predictive_cache{service="objectfs",statistic="prefetch_waste"} 12
+# HELP objectfs_s3_acceleration S3 Transfer Acceleration state and counters, by statistic name
+# TYPE objectfs_s3_acceleration gauge
+objectfs_s3_acceleration{service="objectfs",statistic="active"} 0
+objectfs_s3_acceleration{service="objectfs",statistic="avg_latency_seconds"} 0.0184
+objectfs_s3_acceleration{service="objectfs",statistic="bytes"} 1.687552e+06
+objectfs_s3_acceleration{service="objectfs",statistic="configured"} 1
+objectfs_s3_acceleration{service="objectfs",statistic="fallbacks"} 1
+objectfs_s3_acceleration{service="objectfs",statistic="requests"} 412
+objectfs_s3_acceleration{service="objectfs",statistic="retry_period_seconds"} 300


### PR DESCRIPTION
Closes #204.

## The latch

`DisableAcceleration` fired on the first acceleration error and `EnableAcceleration` had no caller anywhere in the tree, so the fallback was permanent for the life of the mount. A thirty-second DNS failure reaching the accelerate endpoint cost a long-lived mount its acceleration until restart, and nothing reported that it had happened.

One request may now try the accelerate endpoint again after `storage.s3.acceleration_retry` (new key, default 5m). The mechanism is **`internal/circuit`'s breaker**, not a second bespoke recovery: withdrawn is its open state, probing is half-open with `MaxRequests: 1`. So exactly one probe is in flight at a time, and a permanently broken endpoint costs one failed request per period rather than one per read — which is the cost that justified making the fallback one-way in the first place. That bound is what a mutex around two fields could not express.

## The observability half

New gauge family `objectfs_s3_acceleration`, one series per statistic under a `statistic` label, matching `objectfs_predictive_cache`: `configured`, `active`, `requests`, `bytes`, `fallbacks`, `avg_latency_seconds`, `retry_period_seconds`.

`configured` and `active` are separate series because **the difference between them is the point**: 1 and 0 is a mount that was asked to accelerate and is not, and neither series alone can say that. Before this, `BackendMetrics.AccelerationEnabled` — whose only writer was `NewBackend`, passing the config flag, behind a `GetMetrics` with no caller outside its own package — reported acceleration enabled on a mount that had been serving every byte over the standard endpoint since its first request.

Registered whether or not acceleration is configured, unlike `objectfs_predictive_cache` whose absence is meaningful: `configured 0` says the operator asked for the standard endpoint, an absent family says this build does not report acceleration, and which of those you are looking at is the first question when investigating slow reads.

## A defect the issue does not mention

The AWS SDK refuses `UseAccelerate` together with a custom `BaseEndpoint` before a request leaves the process — `A custom endpoint cannot be combined with S3 Accelerate` — and that refusal is **not a `smithy.APIError`**, so it was never classified as an acceleration error and never triggered the fallback. `use_acceleration: true` plus any `endpoint:` therefore failed *every* GET and PUT permanently, on every MinIO/Ceph/RustFS/Wasabi deployment that copied the acceleration example. It falls back and keeps serving now, silently, because acceleration is a performance capability and slower is a correct outcome.

**The first fix for that did not work, and the end-to-end test is what caught it.** `isAccelerationError` matched `err.Error()`, but `translateError` wraps the SDK error in an `*errors.ObjectFSError` whose `Error()` renders its own code and message and deliberately omits its cause — so the classifier saw `[s3-backend:GetObject] STORAGE_READ: GetObject operation failed`, with no trace of the ruleset message. It walks the whole `Unwrap` chain now. Two wrapping styles in this codebase behave differently under `Error()`, and a matcher over service prose stops matching the moment its input is wrapped by the second kind — which is every error the S3 backend returns.

## Harness

`testaws.Fault` grew a `Message` field. A fault could produce an S3 error *code* and not a message, so no injected fault could express a condition S3 reports only in prose, and the fallback branch was reachable only by calling the classifier directly — which proves the classifier and not the behavior. XML-escaped, because an unescaped `&` produces a body the SDK's decoder rejects, which surfaces as a deserialization failure carrying no code at all.

## Verification

`go build ./...`, `gofmt -l .`, `go vet ./...`, `go test -race ./...` all clean. `golangci-lint run --new-from-merge-base=origin/main`: 0 issues. Both SDK suites green against the regenerated fixture — 73 Python, 66 TypeScript.

Mutation-verified, each producing exactly one failing test and no others:

| mutation | fails |
| --- | --- |
| `Timeout: retry` → `time.Hour` | `TestTheEndpointComesBackAfterTheBackoff` |
| `MaxRequests: 1` → `64` | `TestOnlyOneProbeIsInFlightAtATime` |
| drop `EnableAcceleration()` from the half-open arm | `TestTheEndpointComesBackAfterTheBackoff` |
| hoist `AccelerationStats()` out of the publisher closure | `TestEachTickRereadsTheBackend` |
| revert the `Unwrap` chain walk | the `ObjectFSError` table case + the custom-endpoint end-to-end test |

New tests: 6 gate tests (in-package), 4 end-to-end recovery tests against substrate (external `s3_test`), 5 metrics-family tests, 4 adapter-level tests, 2 classifier table cases.

## Docs

`docs/s3-acceleration.md`'s "Re-enabling: There is none" section is now false and rewritten; the log sample matches the lines the code actually emits; the API reference gains `AccelerationStats`; "Metrics Integration" no longer shows hand-rolled collectors an operator had to write when the state was unreachable, and carries an alert rule on the `configured`/`active` pair instead. `acceleration_retry` documented in `examples/config.yaml`, including that it must carry a unit and that acceleration and `endpoint:` are mutually exclusive.