### PR TITLE
perf(compression): skip data that arrived compressed, and measure what that is worth (#184)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -171,7 +171,11 @@ internal/circuit         96
 # disagreeing with the parser the mount used. The 32 statements still uncovered are the codec-table
 # construction failures in buildDecoders and NewCompressor, unreachable without breaking
 # SupportedAlgorithms itself.
-internal/compression     87
+#
+# 87 → 90 with #184's skip. Ratcheted because the new statements arrived covered rather than because a
+# suite was widened over old ones: AlreadyCompressed is three statements and the table test drives all
+# of them, so the floor follows the code up. The 32 uncovered statements above are still the same 32.
+internal/compression     90
 # internal/config goes from 83 to 86 with the validation the config plumbing added. The two points
 # that raise is worth are in what the new tests assert rather than in the number: each case checks
 # that the rejection message names the YAML path, because the failure being prevented is not "a bad

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Data that arrived compressed is no longer compressed again** ([#184]). With compression enabled, a
+  write above `min_size` whose leading bytes name a compressed format — gzip, zstd, bzip2, lz4, xz, zip,
+  PNG, JPEG, GIF, WebP, MP4, Matroska, Ogg, MP3, PDF — is stored as-is and the codec is never entered.
+  These are the formats a research bucket is mostly made of, and a BAM counts: BGZF is gzip per block, so
+  its first bytes are gzip's.
+
+  Measured on an Apple M4 Max at zstd level 3, six runs per case compared with `benchstat`: an 8 MiB zstd
+  frame goes from **1.85 ms and 33 MiB of allocation** to **3 ns and none**, 1 MiB from 237 µs to 3 ns,
+  64 KiB from 7.4 µs to 3 ns. Data the skip does not apply to is unchanged — 1 MiB of compressible text is
+  91.5 µs against 90.4 µs, which is the row that says the check pays for itself, since a gate that taxes
+  the compressible path is not a win. Reproduce with `BenchmarkCompressAlreadyCompressed`,
+  `BenchmarkCompressCompressibleText` and `BenchmarkGateVersusAnalyze` in `internal/compression`.
+
+  The gate is a magic-byte comparison at 17 ns, not the full analyzer. `Analyze` also runs a Shannon
+  entropy pass over its 4 KiB sample, which costs 3.8 µs and was **+53% on a 64 KiB text write** for a
+  figure the decision does not use — so the write path calls a new `AlreadyCompressed`, and both it and
+  `Analyze` classify through the same `classifyByMagic`, leaving one authority on what "already
+  compressed" means. The check sits after the `min_size` floor, so an object below the floor is not
+  sampled, and after the enabled check, so a mount with compression off samples nothing at all.
+
+  Not done, deliberately: nothing is skipped on **entropy**. High entropy is evidence that compression
+  will not help, not proof, and no threshold for it has been measured here — declining to compress on a
+  guess is worse than spending the pass. Formats whose compression is internal to the container (CRAM,
+  Parquet, ORC, HDF5, Zarr) are also not skipped, since the container's magic bytes say nothing about its
+  contents; `docs/features/compression.md` now sorts the formats into the two lists explicitly, and
+  `TestAlreadyCompressedMatchesTheDocumentedFormatLists` fails if that page and the table disagree.
+
 - **A mount now publishes what it is spending at AWS** ([#226]). `objectfs_s3_cost` is a new gauge family
   carrying billable request counts by pricing group, bytes retrieved, three dollar figures, and — beside
   each — the rate it was computed at, labelled with the region the rates were resolved for and the storage
@@ -2960,6 +2987,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#226]: https://github.com/scttfrdmn/objectfs/issues/226
 [#220]: https://github.com/scttfrdmn/objectfs/issues/220
 [#209]: https://github.com/scttfrdmn/objectfs/issues/209
+[#184]: https://github.com/scttfrdmn/objectfs/issues/184
 [#204]: https://github.com/scttfrdmn/objectfs/issues/204
 [#285]: https://github.com/scttfrdmn/objectfs/issues/285
 [#390]: https://github.com/scttfrdmn/objectfs/issues/390

--- a/docs/features/compression.md
+++ b/docs/features/compression.md
@@ -173,19 +173,29 @@ page and not that table.
 
 ## What actually compresses
 
-Most research data does not, because it arrived compressed. `internal/compression/analyzer.go` already
-recognizes these by magic bytes, and every one of them is at or near its entropy limit — compressing it
-again spends CPU to add a few bytes:
+Most research data does not, because it arrived compressed. ObjectFS recognizes these by magic bytes and
+**skips them** — the codec is not run at all — because every one is at or near its entropy limit, so
+compressing it again spends CPU to add a few bytes:
 
 gzip · zstd · bzip2 · lz4 · xz · zip · PNG · JPEG · GIF · WebP · MP4/MOV/M4A · Matroska · Ogg · MP3 · PDF
 
 The formats that matter for research computing are worse than that list suggests, because their
-compression is *internal* and so invisible to a magic-byte check on the container:
+compression is *internal* and so invisible to a magic-byte check on the container. **These are not
+skipped**, and knowing which of the two lists your data is on is the difference between the skip helping
+you and not:
 
-- **BAM, CRAM** — BGZF, which is gzip per block
-- **Parquet, ORC** — per-column codecs, usually snappy or zstd
-- **Zarr, HDF5/NetCDF-4** — per-chunk filters, frequently zlib or blosc
-- **`.tar.gz`, `.tar.zst`, `.tar.bz2`** — compressed by construction
+- **BAM, CRAM** — BGZF, which is gzip per block. A BAM *is* skipped, because BGZF's first block starts
+  with gzip's magic bytes, so the container looks like gzip from the front. CRAM is not — its magic is
+  `CRAM`, and the compression is per-container inside
+- **Parquet, ORC** — per-column codecs, usually snappy or zstd. Magic is `PAR1`/`ORC`, so not skipped
+- **Zarr, HDF5/NetCDF-4** — per-chunk filters, frequently zlib or blosc. Not skipped
+- **`.tar.gz`, `.tar.zst`, `.tar.bz2`** — compressed by construction, and skipped: the compression is
+  the outer layer, so its magic is at the front where the check looks
+
+For the not-skipped four, the `min_size` and the "compressed form was no smaller" fallback are what
+protect you: the codec runs, produces nothing smaller, and the original is stored. You pay the CPU and
+save nothing. That is the case for leaving compression off on such a bucket rather than relying on the
+skip.
 
 What does compress:
 
@@ -201,9 +211,39 @@ files are more repetitive than real data usually is; the source tree is the real
 For a typical genomics or imaging bucket, compression saves close to nothing. Check before enabling:
 list the extensions in the bucket and see what fraction is on the second list rather than the first.
 
-ObjectFS does not yet make this check for you — it compresses whatever it is handed above `min_size`,
-including data it cannot help. The analyzer that would skip those formats exists and has no caller;
-[#184](https://github.com/scttfrdmn/objectfs/issues/184) wires it up.
+### The skip, and what it is worth
+
+ObjectFS checks the first 4 KiB of every object above `min_size` and returns it unchanged when the
+leading bytes name a compressed format ([#184](https://github.com/scttfrdmn/objectfs/issues/184)). The
+codec is not entered, so nothing is spent. Measured on an Apple M4 Max at zstd level 3, comparing the
+write path with and without the check:
+
+| object | without the skip | with it |
+|---|---|---|
+| 8 MiB zstd frame | 1.85 ms, 33 MiB allocated | 3 ns, zero allocations |
+| 1 MiB zstd frame | 237 µs, 4.3 MiB allocated | 3 ns, zero allocations |
+| 64 KiB zstd frame | 7.4 µs, 112 KiB allocated | 3 ns, zero allocations |
+| 1 MiB of compressible text | 91.5 µs | 90.4 µs |
+
+The last row is the one that decides whether this is worth having: data the skip does *not* apply to
+must not pay for it. The check is a magic-byte comparison on the first bytes — 17 ns, no allocation — so
+it is not measurable next to the codec pass it precedes. It is deliberately not the full analyzer, whose
+Shannon-entropy pass over the sample costs 3.8 µs and would have been +53% on a 64 KiB text write for a
+number the decision does not use.
+
+Reproduce with, on a quiet machine:
+
+```bash
+go test ./internal/compression/ -run '^$' \
+  -bench 'BenchmarkCompressAlreadyCompressed|BenchmarkCompressCompressibleText|BenchmarkGateVersusAnalyze' \
+  -benchmem -count=6
+```
+
+What the skip does **not** do is decide by compressibility. Entropy is evidence that compression will
+not help, not proof, and no threshold for it has been measured here — so a high-entropy object with no
+recognizable magic bytes still gets a codec pass, and is protected only by the "compressed form was no
+smaller" fallback. Whether to add an entropy gate, and where the threshold would sit, is the open half
+of #184.
 
 ---
 
@@ -311,6 +351,13 @@ measurement with its parameters stated. Nothing here is estimated.
 - **Payloads** for the amplification table alternate 4 KiB of low-entropy generated text with 4 KiB of
   `/dev/urandom`, giving a 44.8% zstd level 3 ratio at every size. The CSV in the exit-integrity table is
   277,793 bytes of `row<N>,<N>` lines.
+- **The skip table** is `go test -bench` output on an Apple M4 Max, darwin/arm64, six runs per case
+  compared with `benchstat`; every difference it reports is at p=0.002 except the 1 MiB text row, where
+  the two are indistinguishable, which is the result that row is there to state. It touches no bucket —
+  the compressor is called directly, so the figures are CPU and allocation only, with no network in
+  them. Fixtures are real zstd frames built in the benchmark rather than magic-byte prefixes over noise,
+  because zstd gives up on random bytes faster than on a frame it produced itself, which would have
+  understated the saving.
 - **Objects were written by `aws s3api put-object`**, not by ObjectFS, with the body, `Content-Encoding`,
   and `objectfs-original-size` metadata ObjectFS would have written. That keeps the reader side —
   which is what these tables measure — independent of the writer.
@@ -327,5 +374,6 @@ measurement with its parameters stated. Nothing here is estimated.
 
 - [Read-ahead & Predictive Caching](read-ahead.md) — what is served without an S3 request at all
 - [Multipart Uploads](multipart-uploads.md) — the other decision that depends on object size
-- [#184](https://github.com/scttfrdmn/objectfs/issues/184) — skip data that is already compressed
+- [#184](https://github.com/scttfrdmn/objectfs/issues/184) — the skip above; its remaining half is
+  whether per-object algorithm selection and an entropy gate are wanted at all
 - [#185](https://github.com/scttfrdmn/objectfs/issues/185) — seekable framing, which removes costs 2 and 3

--- a/internal/compression/analyzer.go
+++ b/internal/compression/analyzer.go
@@ -60,11 +60,7 @@ func Analyze(data []byte) Analysis {
 		return Analysis{ContentClass: ContentClassUnknown}
 	}
 
-	sample := data
-	if len(sample) > analysisSampleSize {
-		sample = sample[:analysisSampleSize]
-	}
-
+	sample := sampleOf(data)
 	class := classifyByMagic(sample)
 	entropy := shannonEntropy(sample)
 
@@ -91,6 +87,43 @@ func Analyze(data []byte) Analysis {
 		CompressScore: score,
 		SampleSize:    len(sample),
 	}
+}
+
+// sampleOf returns the leading analysisSampleSize bytes of data, or all of it when shorter.
+func sampleOf(data []byte) []byte {
+	if len(data) > analysisSampleSize {
+		return data[:analysisSampleSize]
+	}
+
+	return data
+}
+
+// AlreadyCompressed reports whether data's leading bytes identify a format that is compressed at the
+// byte level, so re-compressing it would spend a full codec pass to produce something no smaller.
+//
+// This is the write path's gate ([#184]), and it is deliberately *not* [Analyze]: Analyze also runs a
+// Shannon entropy pass over the sample, and on this machine that pass is 2.1µs of Analyze's 3.7µs
+// while the magic-byte comparison it needs is 16ns. Paying 2.1µs per object for a number the decision
+// discards is measurable on a 64 KiB write — 6.7µs of codec time — which is the size where transparent
+// compression is most often used.
+//
+// Both routes classify through classifyByMagic, so there is still one authority on what
+// "already compressed" means. That is the property worth protecting: a private magic-byte table in the
+// write path could be made to disagree with the one [RuleSelector] consults, which is the same class of
+// defect as a second list of supported algorithms.
+//
+// Entropy is deliberately not consulted here even as a secondary gate. High entropy is evidence that
+// compression will not help, but it is not proof — and unlike a magic byte it has no threshold this
+// repository has measured, so a gate built on it would decline to compress data on a guess. That is the
+// step-2 question in #184 and wants its own measurement.
+//
+// [#184]: https://github.com/scttfrdmn/objectfs/issues/184
+func AlreadyCompressed(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+
+	return classifyByMagic(sampleOf(data)) == ContentClassCompressed
 }
 
 // classifyByMagic detects content class from leading magic bytes.

--- a/internal/compression/s3_integration.go
+++ b/internal/compression/s3_integration.go
@@ -123,13 +123,31 @@ func (c *Compressor) Enabled() bool {
 	return c.codec.Algorithm() != comprpkg.AlgorithmNone
 }
 
-// Compress compresses data when compression is enabled and the data size
-// meets the minimum threshold.  If the compressed form is larger than the
-// original, the original is returned unchanged with wasCompressed == false.
+// Compress compresses data when compression is enabled, the data size meets the minimum threshold,
+// and the data is not already compressed.  If the compressed form is larger than the original, the
+// original is returned unchanged with wasCompressed == false.
+//
+// The already-compressed check is [AlreadyCompressed] on the first 4 KiB, and it is the difference
+// between spending CPU and spending it for nothing: the formats this project's users store most —
+// BAM, CRAM, tar.zst, JPEG, MP4 — are at their entropy limit, so without it the codec runs the whole
+// object through and produces something the size check below then discards ([#184]). Measured on an
+// M4 Max at zstd level 3: 1.85ms → 2.2µs on an 8 MiB zstd frame, 237µs → 2.1µs at 1 MiB, and 33 MiB of
+// allocation per write down to zero. Data that *does* compress pays 16ns for the magic-byte comparison
+// and is otherwise unchanged.
+//
+// Ordered after the size floor deliberately, and both gates are length or prefix comparisons rather
+// than a scan of the object. See AlreadyCompressed for why it is that function and not Analyze, which
+// costs 2.1µs more for an entropy figure this decision does not use.
 //
 // Returns: (data, wasCompressed, error)
+//
+// [#184]: https://github.com/scttfrdmn/objectfs/issues/184
 func (c *Compressor) Compress(data []byte) ([]byte, bool, error) {
 	if !c.Enabled() || int64(len(data)) < c.minSize {
+		return data, false, nil
+	}
+
+	if AlreadyCompressed(data) {
 		return data, false, nil
 	}
 

--- a/internal/compression/skip_compressed_bench_test.go
+++ b/internal/compression/skip_compressed_bench_test.go
@@ -1,0 +1,192 @@
+//go:build !integration
+
+package compression
+
+import (
+	"bytes"
+	"math/rand/v2"
+	"testing"
+
+	comprpkg "github.com/scttfrdmn/objectfs/pkg/compression"
+)
+
+// BenchmarkCompressAlreadyCompressed measures what the #184 skip is worth on the write path.
+//
+// Run it both ways to get the comparison, since the skip is not switchable at runtime — that is
+// deliberate, a config key for "compress data that cannot be compressed" is not a choice anyone should
+// be offered:
+//
+//	go test ./internal/compression/ -run '^$' -bench BenchmarkCompressAlreadyCompressed -benchmem
+//	# then delete the Analyze block in Compress and run it again
+//	benchstat before.txt after.txt
+//
+// The payload is a real zstd frame, built from a synthetic VCF, which is the ".tar.zst already in the
+// bucket" case rather than a magic-byte prefix over noise: a prefix would understate the saving,
+// because zstd gives up on random bytes faster than it gives up on a frame it already produced.
+//
+// A number rather than a plausible argument is the point. This repository has a documented history of
+// optimizations described without measurement — the throughput table on the docs index claimed
+// 800-1200 MB/s that no benchmark in the tree produced — so an optimization landing here states its
+// measured effect or it does not land.
+func BenchmarkCompressAlreadyCompressed(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20, 8 << 20} {
+		b.Run(byteSizeName(size), func(b *testing.B) {
+			c := benchCompressor(b)
+			data := zstdFrameOfAbout(b, size)
+
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range b.N {
+				if _, _, err := c.Compress(data); err != nil {
+					b.Fatalf("Compress: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCompressCompressibleText is the control.
+//
+// The skip adds an AlreadyCompressed call to every write above min_size, so the data compression *does*
+// help has to pay for it. This benchmark is what says how much, and it is the reason the gate is
+// AlreadyCompressed rather than Analyze: with Analyze it cost +53% at 64 KiB, because Analyze's entropy
+// pass is 2.1µs against 6.7µs of codec time. Measured, then fixed — see BenchmarkGateVersusAnalyze.
+func BenchmarkCompressCompressibleText(b *testing.B) {
+	for _, size := range []int{64 << 10, 1 << 20, 8 << 20} {
+		b.Run(byteSizeName(size), func(b *testing.B) {
+			c := benchCompressor(b)
+			data := bytes.Repeat([]byte("chr1\t10583\trs58108140\tG\tA\t100\tPASS\n"), size/35+1)
+
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range b.N {
+				if _, _, err := c.Compress(data); err != nil {
+					b.Fatalf("Compress: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkGateVersusAnalyze isolates the cost the skip adds, independent of any codec, and states why
+// the write path calls AlreadyCompressed instead of Analyze.
+//
+// Both classify through the same magic-byte table; Analyze additionally runs a Shannon entropy pass
+// over the 4 KiB sample, and that pass is the entire difference. Reported per object rather than per
+// byte, because that is what it is — both cap the sample at analysisSampleSize, so an 8 MiB object and
+// a 4 KiB one cost the same.
+//
+// The two sub-benchmarks are on compressible text rather than on a compressed frame on purpose. That is
+// the case where the difference is paid: a compressed object gets its whole codec pass skipped either
+// way, while text pays the gate and then compresses regardless.
+func BenchmarkGateVersusAnalyze(b *testing.B) {
+	data := bytes.Repeat([]byte("chr1\t10583\trs58108140\tG\tA\t100\tPASS\n"), 2000)
+
+	b.Run("AlreadyCompressed", func(b *testing.B) {
+		b.ReportAllocs()
+
+		for range b.N {
+			if AlreadyCompressed(data) {
+				b.Fatal("text classified as already compressed")
+			}
+		}
+	})
+
+	b.Run("Analyze", func(b *testing.B) {
+		b.ReportAllocs()
+
+		for range b.N {
+			if Analyze(data).ContentClass == ContentClassCompressed {
+				b.Fatal("text classified as already compressed")
+			}
+		}
+	})
+}
+
+// benchCompressor builds the compressor the mount path would build: zstd, no size floor.
+func benchCompressor(b *testing.B) *Compressor {
+	b.Helper()
+
+	c, err := NewCompressor(makeBenchSettings())
+	if err != nil {
+		b.Fatalf("NewCompressor: %v", err)
+	}
+
+	return c
+}
+
+// makeBenchSettings mirrors the test helper makeConfig, which lives in a _test.go file this build
+// shares, but is spelled out here so the benchmark reads without cross-referencing it.
+func makeBenchSettings() Settings {
+	return Settings{Enabled: true, Algorithm: string(comprpkg.AlgorithmZstd), MinSize: "0", Level: 0}
+}
+
+// zstdFrameOfAbout returns a real zstd frame of roughly target bytes.
+//
+// "Roughly" because the only way to hit an exact compressed size is to pad with incompressible bytes,
+// which would make the frame less like the archives this models. The uncompressed input is a mix of
+// repetitive records and high-entropy bytes so the frame does not collapse to a few hundred bytes.
+func zstdFrameOfAbout(b *testing.B, target int) []byte {
+	b.Helper()
+
+	codec, err := New(comprpkg.AlgorithmZstd, comprpkg.DefaultLevel)
+	if err != nil {
+		b.Fatalf("building the fixture codec: %v", err)
+	}
+
+	r := rand.New(rand.NewPCG(0x9E3779B97F4A7C15, 0xBF58476D1CE4E5B9))
+
+	// Grow the input until the frame reaches the target. Roughly 2× target of half-random input lands
+	// close; the loop makes that an outcome rather than an assumption.
+	var frame []byte
+
+	for chunks := target / 2048; len(frame) < target; chunks *= 2 {
+		raw := make([]byte, 0, chunks*2048)
+		for range chunks {
+			raw = append(raw, bytes.Repeat([]byte("chr1\t10583\trs58108140\tG\tA\t100\tPASS\n"), 29)...)
+
+			noise := make([]byte, 1024)
+			for i := range noise {
+				noise[i] = byte(r.UintN(256))
+			}
+
+			raw = append(raw, noise...)
+		}
+
+		if frame, err = codec.Compress(raw); err != nil {
+			b.Fatalf("compressing the fixture: %v", err)
+		}
+	}
+
+	return frame
+}
+
+// byteSizeName renders a power-of-two size as a benchmark sub-name.
+func byteSizeName(n int) string {
+	switch {
+	case n >= 1<<20:
+		return itoa(n>>20) + "MiB"
+	case n >= 1<<10:
+		return itoa(n>>10) + "KiB"
+	default:
+		return itoa(n) + "B"
+	}
+}
+
+// itoa avoids pulling strconv in for one call in a benchmark file.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+
+	var digits []byte
+	for ; n > 0; n /= 10 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+	}
+
+	return string(digits)
+}

--- a/internal/compression/skip_compressed_test.go
+++ b/internal/compression/skip_compressed_test.go
@@ -1,0 +1,303 @@
+package compression
+
+import (
+	"bytes"
+	"math/rand/v2"
+	"testing"
+
+	comprpkg "github.com/scttfrdmn/objectfs/pkg/compression"
+)
+
+// countingCodec wraps a real codec and records how many times Compress was entered.
+//
+// The count is the assertion this file is built around, and it is not interchangeable with comparing
+// bytes. Compress already returns the original when the compressed form is no smaller, so an
+// already-compressed object came back unchanged *before* #184 too — a test that only checked
+// bytes.Equal(got, data) passed on the unfixed code and would have certified a fix that does nothing.
+// What #184 changes is whether the codec runs at all, so that is what gets asserted.
+type countingCodec struct {
+	inner comprpkg.Codec
+	calls int
+}
+
+func (c *countingCodec) Compress(src []byte) ([]byte, error) {
+	c.calls++
+
+	return c.inner.Compress(src)
+}
+
+func (c *countingCodec) Decompress(src []byte) ([]byte, error) { return c.inner.Decompress(src) }
+func (c *countingCodec) Algorithm() comprpkg.Algorithm         { return c.inner.Algorithm() }
+func (c *countingCodec) ContentEncoding() string               { return c.inner.ContentEncoding() }
+
+// spyCompressor returns a Compressor whose write codec counts its invocations.
+//
+// The codec is swapped in after NewCompressor rather than injected through Settings, because Settings
+// names an algorithm rather than carrying a codec, and adding a codec field to it for a test would put
+// a seam in the production type that only tests cross.
+func spyCompressor(t *testing.T) (*Compressor, *countingCodec) {
+	t.Helper()
+
+	c, err := NewCompressor(makeConfig(true, "zstd", "0", 0))
+	if err != nil {
+		t.Fatalf("NewCompressor: %v", err)
+	}
+
+	spy := &countingCodec{inner: c.codec}
+	c.codec = spy
+
+	return c, spy
+}
+
+// highEntropyTail returns n pseudo-random bytes from a fixed seed.
+//
+// Fixed rather than time-seeded so a failure reproduces from the same bytes, and high-entropy so that
+// nothing here passes by way of the "compressed form was no smaller" fallback when the intent is to
+// test the magic-byte skip.
+func highEntropyTail(n int) []byte {
+	r := rand.New(rand.NewPCG(0x9E3779B97F4A7C15, 0xBF58476D1CE4E5B9))
+
+	tail := make([]byte, n)
+	for i := range tail {
+		tail[i] = byte(r.UintN(256))
+	}
+
+	return tail
+}
+
+// payload builds an object of the given total size beginning with prefix.
+func payload(prefix string, total int) []byte {
+	body := make([]byte, 0, total)
+	body = append(body, prefix...)
+
+	if rest := total - len(body); rest > 0 {
+		body = append(body, highEntropyTail(rest)...)
+	}
+
+	return body
+}
+
+// TestCompressSkipsAlreadyCompressedData asserts the write path does not run the codec over data that
+// arrived compressed (#184).
+//
+// The prefixes are the real magic bytes of each format, taken from what classifyByMagic recognizes,
+// because the point of routing this through AlreadyCompressed rather than a private table in the write
+// path is that the two cannot disagree — so the test states the formats a user will actually store and
+// lets classifyByMagic be the thing that recognizes them.
+//
+// The final three cases are the controls. A plain tar, plain text, and a JSON document must still be
+// compressed: a skip that fires on everything saves the same CPU and stores the same bytes as
+// compression turned off, which is the failure mode this table exists to rule out.
+func TestCompressSkipsAlreadyCompressedData(t *testing.T) {
+	t.Parallel()
+
+	// A genuine zstd frame rather than the four magic bytes with noise behind them, so that at least
+	// one case in this table is a real object of a real format. ".tar.zst" is also the case with the
+	// most direct claim on this project: it is what pkg/archive is about.
+	realZstd := func() []byte {
+		codec, err := New(comprpkg.AlgorithmZstd, comprpkg.DefaultLevel)
+		if err != nil {
+			t.Fatalf("building a zstd codec for the fixture: %v", err)
+		}
+
+		frame, err := codec.Compress(bytes.Repeat([]byte("chr1\t10583\trs58108140\tG\tA\t100\tPASS\n"), 512))
+		if err != nil {
+			t.Fatalf("compressing the fixture: %v", err)
+		}
+
+		return frame
+	}()
+
+	// A tar whose "ustar" magic sits at offset 257, which is what makes it an archive rather than an
+	// unknown binary — and the reason the control below is meaningful: a tar is a container of whatever
+	// it holds, so it is compressible and must not be skipped.
+	tarHeader := func() []byte {
+		block := make([]byte, 8192)
+		copy(block, "reference/GRCh38.fa")
+		copy(block[257:], "ustar\x0000")
+		copy(block[1024:], bytes.Repeat([]byte(">chr1 assembled sequence\nACGTACGTACGTACGT\n"), 128))
+
+		return block
+	}()
+
+	for _, tc := range []struct {
+		name string
+		data []byte
+		// skip is whether Compress must return without entering the codec.
+		skip bool
+		why  string
+	}{
+		{"tar.zst", realZstd, true, "a real zstd frame, which is what pkg/archive stores"},
+		{"tar.gz or BAM", payload("\x1f\x8b\x08\x00", 8192), true, "gzip, and BGZF inside a BAM is gzip per block"},
+		{"tar.bz2", payload("BZh9", 8192), true, "bzip2"},
+		{"lz4", payload("\x04\x22\x4d\x18", 8192), true, "an LZ4 frame"},
+		{"xz", payload("\xfd7zXZ\x00", 8192), true, "xz"},
+		{"zip or xlsx", payload("PK\x03\x04", 8192), true, "ZIP, and every Office and Zarr-in-zip file"},
+		{"png", payload("\x89PNG\r\n\x1a\n", 8192), true, "PNG, which is DEFLATE per scanline"},
+		{"jpeg", payload("\xff\xd8\xff\xe0", 8192), true, "JPEG"},
+		{"mp4", append([]byte("\x00\x00\x00\x20ftypisom"), highEntropyTail(8172)...), true, "MP4/MOV, magic at offset 4"},
+		{"mkv", payload("\x1a\x45\xdf\xa3", 8192), true, "Matroska"},
+		{"pdf", payload("%PDF-1.7\n", 8192), true, "PDF, whose streams are DEFLATE"},
+
+		{"plain tar", tarHeader, false, "an uncompressed container: compressible, and must not be skipped"},
+		{
+			"plain text",
+			bytes.Repeat([]byte("chr1\t10583\trs58108140\tG\tA\t100\tPASS\n"), 256),
+			false,
+			"an uncompressed VCF, which is what this feature is for",
+		},
+		{
+			"json",
+			bytes.Repeat([]byte(`{"sample":"NA12878","depth":31,"pass":true},`), 256),
+			false,
+			"a JSON document",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, spy := spyCompressor(t)
+
+			got, wasCompressed, err := c.Compress(tc.data)
+			if err != nil {
+				t.Fatalf("Compress: %v", err)
+			}
+
+			if tc.skip {
+				if spy.calls != 0 {
+					t.Errorf("the codec ran %d time(s) over %d bytes of %s.\n"+
+						"#184 is about not spending a compression pass on data that is already at its "+
+						"entropy limit — %s. Note that comparing the returned bytes would not have caught "+
+						"this: the size fallback in Compress returns the original either way.",
+						spy.calls, len(tc.data), tc.name, tc.why)
+				}
+
+				if wasCompressed {
+					t.Error("wasCompressed is true for data that was not compressed")
+				}
+
+				if !bytes.Equal(got, tc.data) {
+					t.Error("skipped data must come back byte-identical")
+				}
+
+				return
+			}
+
+			if spy.calls != 1 {
+				t.Errorf("the codec ran %d time(s) over %s, want exactly 1.\n"+
+					"This case is a control: %s. A skip that fires here is compression switched off "+
+					"under the name of an optimization.", spy.calls, tc.name, tc.why)
+			}
+
+			if !wasCompressed {
+				t.Errorf("%s did not compress, so this control cannot tell a skip from a codec that "+
+					"declined; pick a more compressible fixture", tc.name)
+			}
+		})
+	}
+}
+
+// TestCompressSkipHonoursTheSizeFloor asserts the two gates stay independent.
+//
+// Below min_size nothing is compressed and nothing is analyzed, which is worth pinning: Analyze is
+// cheap but it is not free, and a write path that samples every 100-byte object to decide not to
+// compress it has moved work into the hot path to answer a question the length already answered.
+func TestCompressSkipHonoursTheSizeFloor(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCompressor(makeConfig(true, "zstd", "1MB", 0))
+	if err != nil {
+		t.Fatalf("NewCompressor: %v", err)
+	}
+
+	spy := &countingCodec{inner: c.codec}
+	c.codec = spy
+
+	// Compressible text, so the only reason not to compress it is the floor.
+	small := bytes.Repeat([]byte("sequence\n"), 64)
+
+	got, wasCompressed, err := c.Compress(small)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+
+	if wasCompressed || spy.calls != 0 || !bytes.Equal(got, small) {
+		t.Errorf("below min_size: wasCompressed=%v codec calls=%d bytes preserved=%v; want false, 0, true",
+			wasCompressed, spy.calls, bytes.Equal(got, small))
+	}
+}
+
+// TestCompressDisabledDoesNotAnalyze asserts a disabled compressor still analyzes nothing.
+//
+// With compression off, Enabled() returns false on the first line and the object is never sampled.
+// This is here because the ordering inside Compress is load-bearing and invisible from outside: moving
+// the Analyze call above the Enabled check would make every write on every mount — the default
+// configuration included — sample 4 KiB to reach a decision already made.
+func TestCompressDisabledDoesNotAnalyze(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCompressor(makeConfig(false, "zstd", "0", 0))
+	if err != nil {
+		t.Fatalf("NewCompressor: %v", err)
+	}
+
+	spy := &countingCodec{inner: c.codec}
+	c.codec = spy
+
+	data := bytes.Repeat([]byte("sequence\n"), 4096)
+
+	got, wasCompressed, err := c.Compress(data)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+
+	if wasCompressed || spy.calls != 0 || !bytes.Equal(got, data) {
+		t.Errorf("disabled: wasCompressed=%v codec calls=%d bytes preserved=%v; want false, 0, true",
+			wasCompressed, spy.calls, bytes.Equal(got, data))
+	}
+}
+
+// TestAlreadyCompressedMatchesTheDocumentedFormatLists pins what docs/features/compression.md tells a
+// user about their own bucket.
+//
+// That page has two lists — formats ObjectFS skips, and formats whose compression is internal and so
+// invisible to a check on the container — and the second list is the one that decides whether to enable
+// compression at all. A reader with a Parquet bucket needs the answer to be right, and a documentation
+// claim about a magic-byte table is exactly the kind that goes stale silently. This test is the check.
+func TestAlreadyCompressedMatchesTheDocumentedFormatLists(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		magic []byte
+		// want is whether docs/features/compression.md says this format is skipped.
+		want bool
+	}{
+		// Compressed at the container level: the page says these are skipped.
+		{"BAM (BGZF, gzip magic at offset 0)", []byte("\x1f\x8b\x08\x04\x00\x00\x00\x00"), true},
+		{"tar.gz", []byte("\x1f\x8b\x08\x00"), true},
+		{"tar.zst", []byte("\x28\xb5\x2f\xfd"), true},
+		{"tar.bz2", []byte("BZh9"), true},
+
+		// Compression internal to the format: the page says these are *not* skipped, and says why.
+		{"CRAM", []byte("CRAM\x03\x00"), false},
+		{"Parquet", []byte("PAR1\x15\x04\x15"), false},
+		{"ORC", []byte("ORC\x00\x00\x00"), false},
+		{"HDF5 / NetCDF-4", []byte("\x89HDF\r\n\x1a\n"), false},
+		{"NetCDF-3", []byte("CDF\x01\x00\x00"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := append(append([]byte{}, tc.magic...), highEntropyTail(4096)...)
+
+			if got := AlreadyCompressed(data); got != tc.want {
+				t.Errorf("AlreadyCompressed(%s) = %v, want %v.\n"+
+					"docs/features/compression.md sorts this format into the other list. Either the "+
+					"magic-byte table changed and that page needs the same edit, or this expectation is "+
+					"the stale one — but they must agree, because a user decides whether to enable "+
+					"compression from that page.", tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #184, step 1 — the step the issue itself recommends landing alone.

## What changes

`Compressor.Compress` now returns the original bytes without entering the codec when the object's
leading bytes name a compressed format. That is 15 formats via the existing `classifyByMagic`: gzip,
zstd, bzip2, lz4, xz, zip, PNG, JPEG, GIF, WebP, MP4, Matroska, Ogg, MP3, PDF. A BAM is included,
because BGZF is gzip per block and so a BAM starts with gzip's magic bytes.

## What it is worth

Apple M4 Max, darwin/arm64, zstd level 3, six runs per case compared with `benchstat`:

| object | without the skip | with it |
|---|---|---|
| 8 MiB zstd frame | 1.85 ms, 33 MiB allocated | 3 ns, 0 allocations |
| 1 MiB zstd frame | 237 µs, 4.3 MiB allocated | 3 ns, 0 allocations |
| 64 KiB zstd frame | 7.4 µs, 112 KiB allocated | 3 ns, 0 allocations |
| 1 MiB compressible text | 91.5 µs | 90.4 µs |

Every difference is at p=0.002 except the last row, where the two are indistinguishable — and that
row is the one that matters most. A gate that taxes the path it does not apply to is not an
optimization, and this is the repo whose docs index once claimed 800–1200 MB/s that no benchmark
produced. So: a number, reproducible with

```
go test ./internal/compression/ -run '^$' \
  -bench 'BenchmarkCompressAlreadyCompressed|BenchmarkCompressCompressibleText|BenchmarkGateVersusAnalyze' \
  -benchmem -count=6
```

## Why `AlreadyCompressed` and not `Analyze`

The first attempt called `Analyze`, as the issue suggested, and the control benchmark said **+53% on a
64 KiB text write**. `Analyze` runs a Shannon entropy pass over its 4 KiB sample — 3.8 µs against a
6.7 µs codec pass — and the skip decision discards the entropy figure entirely. So the write path calls
a new `AlreadyCompressed` (17 ns) instead. Both route through the same `classifyByMagic`, so there is
still one authority on what "already compressed" means; a private magic-byte table in the write path
would be a second one, free to drift from the one `RuleSelector` consults.

Both gates are ordered so nothing is scanned unnecessarily: below `min_size` the object is not sampled,
and with compression disabled it is not sampled either.

## The tests assert the codec was not called

This is the trap the issue names, and it is real. `Compress` already returned the original when the
compressed form was no smaller, so an already-compressed object came back byte-identical **before**
this change — a test comparing `got` to `data` passes on the unfixed code and would certify a fix that
does nothing. `countingCodec` wraps the real codec and counts entries; the assertion is `calls == 0`.

Verified by mutation, twice:

| mutation | result |
|---|---|
| delete the gate from `Compress` | 11 skip cases fail, 3 controls pass |
| `AlreadyCompressed` → `return false` | same 11 fail |

The three controls — a plain `.tar` with `ustar` at offset 257, an uncompressed VCF, a JSON document —
assert `calls == 1`. A skip that fires on everything saves the same CPU and stores the same bytes as
compression switched off, which is the failure this table exists to rule out.

## Not done, deliberately

**No entropy gate.** High entropy is evidence compression will not help, not proof, and no threshold
for it has been measured in this repository. Declining to compress on a guess is worse than spending
the pass. That is the open half of #184 and wants its own measurement.

**Formats whose compression is internal to the container are not skipped** — CRAM, Parquet, ORC, HDF5,
Zarr. The container's magic bytes say nothing about its contents. `docs/features/compression.md` now
sorts the formats into two explicit lists, since "does ObjectFS re-compress my BAM files" is a question
a user asks, and `TestAlreadyCompressedMatchesTheDocumentedFormatLists` fails if that page and the
table disagree.

**Steps 2–3 of the issue** — whether `RuleSelector`/`AdaptiveSelector` earn their place — are left
open, per the issue's own sequencing. The read path already dispatches on the object's own
`Content-Encoding`, so per-object algorithms are *safe*; whether they are *worth it* is now a question
with a benchmark harness in hand to answer.

## Verification

- `go build ./...`, `gofmt -l .`, `go vet ./...`, `golangci-lint run` — all clean
- `go test -race ./...` — no FAIL, panic, or DATA RACE
- coverage floor `internal/compression` 87 → 90, measured 90.0%, gate re-run against a fresh profile