### PR TITLE
ci: give the modulefiles matrix legs names that can be required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,6 +909,13 @@ jobs:
   # both: a site runs one or the other, never both, and the two disagree on PATH semantics.
   # ---------------------------------------------------------------------------------------------
   modulefiles:
+    # Named explicitly, because the default name interpolates every matrix value and these legs carry
+    # an absolute interpreter path — the checks appeared as `modulefiles (lmod, lmod,
+    # /usr/share/lmod/lmod/libexec/lmod)`. Both legs are required contexts in main's branch
+    # protection, and a required context is matched by exact string: the day a distro moves
+    # modulecmd.tcl, the renamed check would never report and every PR would block on a context that
+    # can no longer arrive. The system is the part of the identity that is stable.
+    name: modulefiles (${{ matrix.system }})
     runs-on: ubuntu-latest
     strategy:
       # Both legs run to completion. A failure under Lmod says nothing about TCL and the reviewer


### PR DESCRIPTION
Prerequisite for adding the modulefiles legs to `main`'s required status checks (promised in #412).

The default matrix job name interpolates *every* matrix value, so #412's legs reported as:

- `modulefiles (lmod, lmod, /usr/share/lmod/lmod/libexec/lmod)`
- `modulefiles (tcl-modules, environment-modules, /usr/lib/x86_64-linux-gnu/modulecmd.tcl)`

A required context is matched by exact string. Requiring a name that embeds an absolute interpreter path means that when a distro moves `modulecmd.tcl`, or the runner image changes the multiarch directory, the renamed check never reports and **every PR blocks on a context that can no longer arrive** — presenting as unrelated CI breakage rather than as the path change it is.

`name: modulefiles (${{ matrix.system }})` makes the legs `modulefiles (lmod)` and `modulefiles (tcl-modules)`. The interpreter path stays a matrix value and is still asserted executable by the job's guard step, which is the right place for a moved path to surface — that guard fails loudly rather than letting the interpreter test skip into a green run.

Branch protection is updated after this merges, since a required check must exist on `main` first.