### PR TITLE
feat(cluster): objectfs cluster status, and the endpoint it reads (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing in it reports success, shows up in `module list`, and surfaces as "command not found" inside
   a batch job hours later, at which point the module system looks right and ObjectFS looks broken.
 
+- **`objectfs cluster status`, and the `/health/cluster` endpoint it reads** ([#147]). Reports
+  membership, per-node cache figures and announced-key counts for a running instance, with `--json` for
+  scripting. `--endpoint` names the health server; `--config` reads it from a config file. The endpoint
+  answers 200 whenever it can answer at all, because the status code reports the endpoint's health and
+  the payload reports the cluster's — conflating them makes a degraded cluster indistinguishable from
+  an unreachable mount. The exit code is non-zero for **dead or suspect nodes**, not for loss of quorum:
+  quorum is a Raft concept, ObjectFS coordinates by compare-and-swap against S3, and a two-node cluster
+  with one node down works correctly. Clustering disabled exits 0, since that is the default
+  configuration and anything else would page on every single-node mount.
+
+  Several figures an operator might expect are **deliberately absent, and say so**, because a number
+  nobody assigns is worse than no number. Leader and role appear only when `enable_consensus` is set —
+  a mount leaves consensus off, so `IsLeader` is false on every node of a healthy cluster, and the
+  report states that election is not running and coordination is CAS. A cache hit rate is reported as
+  "not measured" until the cache has served a request, because a rate of 0.0 by arithmetic is
+  indistinguishable from a cache that misses every read. "Top keys by access" is not reported at all:
+  no per-key access counter is reachable from the cluster layer, and the nearest available quantity
+  orders by last-announced, which under that label would be a proxy read as the real thing.
+
 ### Fixed
+
+- **A node never recorded its own cache figures in its membership map** ([#147]). `refreshLocalStats`
+  reached only the struct the gossip alive-message is built from, so a node published its cache size
+  and hit rate to every peer and never stored them for itself. Every node showed each peer's cache in
+  full and its own as "not reported", and the cluster-wide `TotalCacheSize` omitted the local node —
+  under-reporting the total by one node's worth on every node. The existing test comment had recorded
+  the symptom as expected behaviour ("zero here, since nothing refreshed it"), which is why reading the
+  tests did not surface it; running the new command against a live two-node cluster did.
 
 - **`preremove.sh` never matched a real mount.** Its unmount loop looked for `type fuse.objectfs` in
   `/proc/mounts`, and ObjectFS mounts report **`fuse.s3`** — `internal/fuse/mount.go` sets
@@ -3068,6 +3095,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#207]: https://github.com/scttfrdmn/objectfs/issues/207
 [#137]: https://github.com/scttfrdmn/objectfs/issues/137
 [#145]: https://github.com/scttfrdmn/objectfs/issues/145
+[#147]: https://github.com/scttfrdmn/objectfs/issues/147
 [#151]: https://github.com/scttfrdmn/objectfs/issues/151
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#282]: https://github.com/scttfrdmn/objectfs/issues/282

--- a/cmd/objectfs/cluster.go
+++ b/cmd/objectfs/cluster.go
@@ -1,0 +1,536 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/internal/config"
+	"github.com/scttfrdmn/objectfs/internal/distributed"
+	"github.com/scttfrdmn/objectfs/internal/health"
+	"github.com/scttfrdmn/objectfs/pkg/utils"
+)
+
+// clusterStatusTimeout bounds the request to a local health endpoint.
+//
+// Five seconds against a loopback HTTP handler that takes two mutexes and copies a membership map. It is
+// long enough that a loaded machine does not time out and short enough that an operator running this in a
+// shell loop is not left waiting on a process that has stopped answering — which is a real state, since
+// the endpoint is served by the same process that serves the mount.
+const clusterStatusTimeout = 5 * time.Second
+
+// runCluster dispatches the `cluster` subcommand's own subcommands.
+//
+// Nested dispatch rather than a flag, because `cluster status` is the first of a family — `cluster
+// members` and `cluster peers` are the obvious next ones — and the shape follows `etcdctl endpoint
+// status` and `consul members`, which the issue named as the models.
+func runCluster(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		clusterUsage(stderr)
+
+		return exitUsage
+	}
+
+	switch args[0] {
+	case "status":
+		return runClusterStatus(args[1:], stdout, stderr)
+
+	case "help", "--help", "-h", "-help":
+		clusterUsage(stdout)
+
+		return exitOK
+	}
+
+	emit(stderr, "objectfs cluster: unknown subcommand %q\n\n", args[0])
+	clusterUsage(stderr)
+
+	return exitUsage
+}
+
+func clusterUsage(w io.Writer) {
+	emit(w, `Usage: objectfs cluster <subcommand> [options]
+
+Subcommands:
+  status    Report the cluster state of a running ObjectFS instance
+
+Run "objectfs cluster status --help" for its options.
+`)
+}
+
+// clusterStatusFlags is one `cluster status` invocation's command line, parsed.
+type clusterStatusFlags struct {
+	endpoint string
+	asJSON   bool
+
+	// configFile is read for one setting only: monitoring.health_checks.addr, so that an operator who
+	// moved the health endpoint does not have to restate it here. --endpoint still wins.
+	configFile string
+}
+
+func newClusterStatusFlagSet(fs *flag.FlagSet, f *clusterStatusFlags) {
+	fs.StringVar(&f.endpoint, "endpoint", "",
+		"Base URL of the instance's health endpoint (default from the config file, else "+
+			"http://"+config.DefaultHealthAddr+")")
+	fs.BoolVar(&f.asJSON, "json", false, "Print the raw status as JSON instead of a report")
+	fs.StringVar(&f.configFile, "config", "",
+		"Configuration file, read for monitoring.health_checks.addr")
+}
+
+// runClusterStatus implements `objectfs cluster status`.
+//
+// # Exit codes
+//
+// The issue specified "0: healthy, quorum present" and "1: instance unreachable OR quorum lost", and
+// quorum is not the right condition here — it is a Raft concept, and this project does not run Raft on a
+// mount. See [distributed.ClusterConfig.EnableConsensus]: coordination is compare-and-swap against S3,
+// evaluated by the store on one request, and a two-node cluster with one node down keeps working
+// correctly. Exiting non-zero because a majority is absent would make a monitoring script page for a
+// cluster that is fine.
+//
+// What it exits non-zero for instead is what actually indicates a problem an operator must act on:
+//
+//   - the instance is unreachable, which is the issue's first condition and is kept verbatim;
+//   - a node is dead or suspect, which is the honest failure signal a gossip cluster has.
+//
+// Clustering being disabled is exit 0. It is the default configuration and by far the commonest one, so
+// a non-zero status for it would fire on every single-node mount in existence.
+func runClusterStatus(args []string, stdout, stderr io.Writer) int {
+	var f clusterStatusFlags
+
+	fs := flag.NewFlagSet("objectfs cluster status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		emit(stderr, "Usage: objectfs cluster status [options]\n\n"+
+			"Reports the cluster state of a running ObjectFS instance, read from its health\n"+
+			"endpoint at "+health.ClusterStatusPath+". The instance must have\n"+
+			"monitoring.health_checks.enabled set, which is the default.\n\n"+
+			"Exit codes:\n"+
+			"  0  the instance answered, and no node is dead or suspect. Clustering being\n"+
+			"     disabled is also 0: it is the default configuration, not a fault.\n"+
+			"  1  the instance could not be reached, or a node is dead or suspect.\n"+
+			"  2  the command line was wrong.\n\nOptions:\n")
+		fs.PrintDefaults()
+	}
+	newClusterStatusFlagSet(fs, &f)
+
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	if rest := fs.Args(); len(rest) > 0 {
+		emit(stderr, "objectfs cluster status: takes no arguments, got %d: %s\n",
+			len(rest), strings.Join(rest, " "))
+		fs.Usage()
+
+		return exitUsage
+	}
+
+	endpoint, err := resolveStatusEndpoint(&f)
+	if err != nil {
+		emit(stderr, "objectfs cluster status: %v\n", err)
+
+		return exitUsage
+	}
+
+	status, err := fetchClusterStatus(context.Background(), endpoint)
+	if err != nil {
+		emit(stderr, "objectfs cluster status: %v\n", err)
+
+		return exitFailure
+	}
+
+	if f.asJSON {
+		// Re-encoded from the decoded struct rather than passed through, so that --json is documented by
+		// distributed.ClusterStatus and cannot silently carry a field the human output has no counterpart
+		// for. Indented because the consumer is as often a person reading it as it is jq.
+		out, err := json.MarshalIndent(status, "", "  ")
+		if err != nil {
+			emit(stderr, "objectfs cluster status: cannot re-encode the status as JSON: %v\n", err)
+
+			return exitFailure
+		}
+
+		emit(stdout, "%s\n", out)
+	} else {
+		writeClusterStatus(stdout, status)
+	}
+
+	return clusterStatusExitCode(status)
+}
+
+// resolveStatusEndpoint decides which base URL to query.
+//
+// Precedence is --endpoint, then the config file's monitoring.health_checks.addr, then the packaged
+// default. The middle step is what keeps this usable on a host where the endpoint was moved: the address
+// is already a setting, and requiring an operator to repeat it on every invocation is how a command comes
+// to be wrapped in a shell alias that goes stale.
+func resolveStatusEndpoint(f *clusterStatusFlags) (string, error) {
+	if f.endpoint != "" {
+		return normalizeEndpoint(f.endpoint)
+	}
+
+	addr := config.DefaultHealthAddr
+
+	if f.configFile != "" {
+		cfg := config.NewDefault()
+		if err := cfg.LoadFromFile(f.configFile); err != nil {
+			return "", fmt.Errorf("cannot load %s: %w", f.configFile, err)
+		}
+
+		if !cfg.Monitoring.HealthChecks.Enabled {
+			return "", fmt.Errorf("%s sets monitoring.health_checks.enabled to false, so that instance "+
+				"serves no health endpoint and there is nothing to query", f.configFile)
+		}
+
+		if cfg.Monitoring.HealthChecks.Addr != "" {
+			addr = cfg.Monitoring.HealthChecks.Addr
+		}
+	}
+
+	return normalizeEndpoint("http://" + addr)
+}
+
+// normalizeEndpoint turns what an operator typed into a base URL, or explains why it is not one.
+//
+// A bare host:port is accepted and given the http scheme, because that is the form
+// monitoring.health_checks.addr takes and an operator copying it across is the expected case. A trailing
+// slash is trimmed so that joining the path below cannot produce a double slash — which some mux
+// implementations redirect and some 404, and either way is a confusing failure for a typo this can simply
+// absorb.
+func normalizeEndpoint(endpoint string) (string, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", errors.New("--endpoint is empty")
+	}
+
+	if !strings.Contains(endpoint, "://") {
+		endpoint = "http://" + endpoint
+	}
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("--endpoint %q is not a URL: %w", endpoint, err)
+	}
+
+	// Checked explicitly, because url.Parse accepts a great deal that is not addressable: "http://" parses
+	// with an empty Host and would otherwise become a request to nowhere reported as a connection error,
+	// which sends an operator looking at their mount instead of at their command line.
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("--endpoint %q has scheme %q; only http and https can be queried",
+			endpoint, parsed.Scheme)
+	}
+
+	if parsed.Host == "" {
+		return "", fmt.Errorf("--endpoint %q names no host", endpoint)
+	}
+
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}
+
+// fetchClusterStatus reads and decodes the cluster status from the endpoint.
+//
+// Every error it returns says what to do about it, because the three failure modes look alike from a
+// shell and have completely different causes:
+//
+//   - connection refused is nothing listening, which is a mount that is not running or a health endpoint
+//     that is disabled or on another address. It must not read as a broken cluster, and this is the case
+//     the message spends the most words on;
+//   - 404 is an instance older than this endpoint;
+//   - anything else is the endpoint answering something unexpected.
+func fetchClusterStatus(ctx context.Context, endpoint string) (*distributed.ClusterStatus, error) {
+	target := endpoint + health.ClusterStatusPath
+
+	ctx, cancel := context.WithTimeout(ctx, clusterStatusTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build a request for %s: %w", target, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// Deliberately not wrapped with %w into something shorter. The transport error names the address
+		// and the syscall — "connection refused" — and what an operator needs beside it is the list of
+		// reasons that happens, since none of them is a cluster problem.
+		return nil, fmt.Errorf("cannot reach an ObjectFS instance at %s: %w.\n"+
+			"Nothing is listening there. Either no instance is running, or its health endpoint is\n"+
+			"disabled (monitoring.health_checks.enabled), or it is bound to a different address\n"+
+			"(monitoring.health_checks.addr) — pass --endpoint or --config to name it.\n"+
+			"This does not mean the cluster is unhealthy: an unreachable endpoint says nothing\n"+
+			"about the cluster at all", target, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("the instance at %s has no %s endpoint. It is running a build from "+
+			"before this endpoint existed; `objectfs cluster status` needs %s or newer on the instance",
+			endpoint, health.ClusterStatusPath, version)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s answered HTTP %s", target, resp.Status)
+	}
+
+	// Bounded, because this is an HTTP body from a source the caller named on the command line and an
+	// endpoint that answers an endless stream would otherwise be read until the process died. 8 MiB is
+	// several thousand nodes' worth of report against a payload that is a few hundred bytes per node.
+	const maxBody = 8 << 20
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return nil, fmt.Errorf("reading the response from %s: %w", target, err)
+	}
+
+	var status distributed.ClusterStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, fmt.Errorf("the response from %s is not a cluster status: %w", target, err)
+	}
+
+	return &status, nil
+}
+
+// clusterStatusExitCode decides the exit code from the payload.
+//
+// Dead or suspect nodes, and nothing else. See runClusterStatus for why quorum — which the issue named —
+// is not the condition: no leader is elected on a mount path, so a majority is not something this
+// cluster has an opinion about, and a node being unreachable is the failure a gossip cluster actually
+// reports.
+func clusterStatusExitCode(status *distributed.ClusterStatus) int {
+	if !status.Enabled {
+		return exitOK
+	}
+
+	if status.Membership.Dead > 0 || status.Membership.Suspect > 0 {
+		return exitFailure
+	}
+
+	return exitOK
+}
+
+// writeClusterStatus renders the status for a person.
+//
+// What it does not print is the point, and every omission is a field that exists in the source struct and
+// is not populated at runtime — see [distributed.ClusterStatus], which records each one. Two are worth
+// repeating here because the issue's mockup asked for them by name:
+//
+//   - "Role: Leader" / "Role: Follower" is printed only when consensus is running, which on a mount it
+//     never is. Printing "Follower" otherwise would report a lost election that was never held, on every
+//     node of a healthy cluster.
+//   - "Top 5 keys by access" is absent because nothing measures per-key access counts anywhere reachable
+//     from here. The announced-key count is printed instead, under its own name, rather than a
+//     differently-defined list under the label the mockup used.
+//
+// A hit rate that has not been measured prints as "not measured" rather than as 0%: an operator reading
+// "0%" cannot tell a cache that has served nothing from one that misses every read, and those are a
+// just-started mount and an emergency respectively.
+func writeClusterStatus(w io.Writer, status *distributed.ClusterStatus) {
+	emit(w, "ObjectFS Cluster Status\n")
+	emit(w, "=======================\n")
+
+	if !status.Enabled {
+		emit(w, "Clustering: disabled\n")
+
+		if status.Reason != "" {
+			emit(w, "\n%s\n", status.Reason)
+		}
+
+		return
+	}
+
+	emit(w, "Node:    %s (this node)\n", status.NodeID)
+
+	if status.GossipAddr != "" {
+		emit(w, "Gossip:  %s\n", status.GossipAddr)
+	} else {
+		// A started manager whose bind failed. Worth naming, because every peer's view of this node
+		// depends on it and the mount is otherwise serving normally.
+		emit(w, "Gossip:  not bound — this node cannot be reached by peers\n")
+	}
+
+	// Only when an election has actually happened. See the function comment.
+	if status.Leadership != nil {
+		role := "follower"
+		if status.Leadership.IsSelf {
+			role = "leader"
+		}
+
+		emit(w, "Role:    %s (leader: %s, elections: %d)\n",
+			role, orNone(status.Leadership.Leader), status.Leadership.Election)
+	} else {
+		emit(w, "Role:    n/a — leader election is not running; coordination is compare-and-swap\n"+
+			"         against S3, which needs no leader and no quorum\n")
+	}
+
+	m := status.Membership
+	emit(w, "\nMembership: %d nodes (%d alive, %d suspect, %d dead)\n",
+		m.Total, m.Alive, m.Suspect, m.Dead)
+
+	writePeerLines(w, status)
+	writeCacheSection(w, status)
+
+	emit(w, "\nGossip:\n")
+	emit(w, "  Messages:   %d sent, %d received\n",
+		status.Gossip.MessagesSent, status.Gossip.MessagesReceived)
+	emit(w, "  Bytes:      %s sent, %s received\n",
+		utils.FormatBytes(status.Gossip.BytesSent), utils.FormatBytes(status.Gossip.BytesReceived))
+
+	// Printed only when non-zero. Each of these is an anomaly, and a block of zeros every run trains an
+	// operator to skip the section that matters when one of them is not zero.
+	writeGossipAnomalies(w, status.Gossip)
+
+	emit(w, "\nPeer cache claims held: %d keys\n", status.AnnouncedKeys)
+}
+
+// writePeerLines prints one line per node, self first.
+func writePeerLines(w io.Writer, status *distributed.ClusterStatus) {
+	if status.Self != nil {
+		emit(w, "  %s\n", nodeLine(*status.Self, true))
+	}
+
+	for _, peer := range status.Peers {
+		emit(w, "  %s\n", nodeLine(peer, false))
+	}
+
+	if len(status.Peers) == 0 {
+		emit(w, "\nNo peers. This is a cluster of one, which is a working configuration:\n"+
+			"nothing about ObjectFS coordination requires a second node.\n")
+	}
+}
+
+// nodeLine formats one node's report.
+func nodeLine(n distributed.NodeReport, self bool) string {
+	var b strings.Builder
+
+	name := n.ID
+	if self {
+		name += " (self)"
+	}
+
+	fmt.Fprintf(&b, "%-28s %-22s %-8s", name, orNone(n.Address), n.Status)
+
+	if n.Cache != nil {
+		fmt.Fprintf(&b, " cache=%s", utils.FormatBytes(n.Cache.Size))
+
+		if n.Cache.Capacity != nil {
+			fmt.Fprintf(&b, "/%s", utils.FormatBytes(*n.Cache.Capacity))
+		}
+
+		// Not "0%" when nothing has been asked of the cache. See writeClusterStatus.
+		if n.Cache.HitRate != nil {
+			fmt.Fprintf(&b, " hit=%s", formatRate(*n.Cache.HitRate))
+		} else {
+			fmt.Fprintf(&b, " hit=not measured")
+		}
+	} else {
+		// Distinguished from an empty cache, which is what "cache=0 B" would say.
+		fmt.Fprintf(&b, " cache=not reported")
+	}
+
+	if !n.LastSeen.IsZero() {
+		fmt.Fprintf(&b, " last_seen=%s ago", time.Since(n.LastSeen).Round(time.Millisecond))
+	}
+
+	return b.String()
+}
+
+// writeCacheSection prints the cluster-wide cache aggregate.
+func writeCacheSection(w io.Writer, status *distributed.ClusterStatus) {
+	c := status.Cache
+
+	emit(w, "\nCache (across %d alive nodes):\n", c.AliveNodes)
+	emit(w, "  Size:       %s\n", utils.FormatBytes(c.TotalSize))
+
+	// The count is printed with the sum, not instead of it: one node of three reporting capacity would
+	// otherwise make the cluster look three times fuller than it is.
+	switch {
+	case c.NodesReportingCapacity == 0:
+		emit(w, "  Capacity:   not reported by any node\n")
+	case c.NodesReportingCapacity < c.AliveNodes:
+		emit(w, "  Capacity:   %s (from %d of %d nodes; the rest do not report one)\n",
+			utils.FormatBytes(c.TotalCapacity), c.NodesReportingCapacity, c.AliveNodes)
+	default:
+		emit(w, "  Capacity:   %s\n", utils.FormatBytes(c.TotalCapacity))
+	}
+
+	if c.HitRate == nil {
+		emit(w, "  Hit rate:   not measured — no node has served a cached read yet\n")
+
+		return
+	}
+
+	emit(w, "  Hit rate:   %s (mean over the %d node(s) that have served a read)\n",
+		formatRate(*c.HitRate), c.NodesMeasured)
+}
+
+// writeGossipAnomalies prints the counters that are only interesting when non-zero.
+func writeGossipAnomalies(w io.Writer, g distributed.GossipCounters) {
+	type counter struct {
+		label string
+		value int64
+		note  string
+	}
+
+	counters := []counter{
+		{"unauthenticated", g.MessagesUnauthenticated,
+			"a peer has the wrong cluster secret, or something that is not a member is sending to the port"},
+		{"replayed", g.MessagesReplayed,
+			"captured datagrams are being resent, or a node's clock is outside the freshness window"},
+		{"wrong version", g.MessagesWrongVersion, "version skew, as during a rolling upgrade"},
+		{"truncated", g.MessagesTruncated,
+			"a datagram arrived clipped; this reports itself as an authentication failure (#277)"},
+		{"oversize", g.MessagesOversize, "this node refused to send a datagram over max_gossip_packet"},
+		{"suspicion refutations", g.SuspicionRefutations,
+			"this node was falsely accused; suspects packet loss or too short a heartbeat interval"},
+		{"suspicion events", g.SuspicionEvents, ""},
+		{"death events", g.DeathEvents, ""},
+		{"network errors", g.NetworkErrors, ""},
+	}
+
+	// Sorted so the same set of anomalies always prints in the same order regardless of the slice above
+	// being reordered later, which keeps output diffable across versions.
+	sort.SliceStable(counters, func(i, j int) bool { return counters[i].label < counters[j].label })
+
+	headerPrinted := false
+
+	for _, c := range counters {
+		if c.value == 0 {
+			continue
+		}
+
+		if !headerPrinted {
+			emit(w, "  Anomalies:\n")
+
+			headerPrinted = true
+		}
+
+		if c.note == "" {
+			emit(w, "    %s: %d\n", c.label, c.value)
+		} else {
+			emit(w, "    %s: %d — %s\n", c.label, c.value, c.note)
+		}
+	}
+}
+
+// formatRate renders a 0..1 fraction as a percentage.
+func formatRate(rate float64) string {
+	return fmt.Sprintf("%.1f%%", rate*100)
+}
+
+// orNone renders an empty string as a marker rather than as nothing, so a missing field is visible in a
+// column-aligned report instead of looking like whitespace.
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+
+	return s
+}

--- a/cmd/objectfs/cluster_test.go
+++ b/cmd/objectfs/cluster_test.go
@@ -1,0 +1,932 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/objectfs/internal/distributed"
+	"github.com/scttfrdmn/objectfs/internal/health"
+)
+
+// serveStatus starts a test server that answers ClusterStatusPath with payload and returns its base URL.
+//
+// A real HTTP server rather than an injected client, because the path is half of what these tests assert:
+// a client that requested the wrong path would pass against a stub that answers everything. It also
+// exercises the JSON round trip, which is where a field the report reads but the endpoint does not send
+// would show up.
+func serveStatus(t *testing.T, payload any) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(health.ClusterStatusPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Errorf("encoding the test payload: %v", err)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+// TestClusterSubcommandIsDispatched checks the nested dispatch, including the two ways of getting it
+// wrong.
+//
+// `cluster` with no subcommand is a usage error rather than an implicit `cluster status`, because the
+// family is meant to grow — `cluster members` is the obvious next one — and a default that quietly means
+// one member of a set is what makes the set impossible to extend without changing what an existing
+// invocation does.
+func TestClusterSubcommandIsDispatched(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantCode int
+		mustSay  string
+	}{
+		{
+			name:     "cluster alone is a usage error",
+			args:     []string{"cluster"},
+			wantCode: exitUsage,
+			mustSay:  "Usage: objectfs cluster",
+		},
+		{
+			name:     "an unknown subcommand names itself",
+			args:     []string{"cluster", "sttaus"},
+			wantCode: exitUsage,
+			mustSay:  `unknown subcommand "sttaus"`,
+		},
+		{
+			name:     "cluster help exits 0",
+			args:     []string{"cluster", "help"},
+			wantCode: exitOK,
+			mustSay:  "status",
+		},
+		{
+			name:     "cluster --help exits 0",
+			args:     []string{"cluster", "--help"},
+			wantCode: exitOK,
+			mustSay:  "status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			code, stdout, stderr := runArgs(t, tt.args...)
+
+			if code != tt.wantCode {
+				t.Fatalf("objectfs %s exited %d, want %d. stderr: %s",
+					strings.Join(tt.args, " "), code, tt.wantCode, stderr)
+			}
+
+			// Usage goes to stderr on an error and stdout when it was asked for, the same split the
+			// top-level dispatch uses: a script running `objectfs cluster help` captures it with $().
+			out := stdout
+			if tt.wantCode != exitOK {
+				out = stderr
+			}
+
+			if !strings.Contains(out, tt.mustSay) {
+				t.Errorf("objectfs %s printed %q, which does not contain %q",
+					strings.Join(tt.args, " "), out, tt.mustSay)
+			}
+		})
+	}
+}
+
+// TestClusterStatusRejectsPositionalArguments keeps a typo from being silently ignored.
+//
+// `objectfs cluster status http://host:8081` is the invocation an operator reaches for by analogy with
+// curl, and Go's flag package leaves it in Args() rather than complaining. Accepting and ignoring it
+// would query the default endpoint and report on the wrong instance — a wrong answer that looks like a
+// right one.
+func TestClusterStatusRejectsPositionalArguments(t *testing.T) {
+	t.Parallel()
+
+	code, _, stderr := runArgs(t, "cluster", "status", "http://host:8081")
+
+	if code != exitUsage {
+		t.Fatalf("exited %d, want %d", code, exitUsage)
+	}
+
+	if !strings.Contains(stderr, "takes no arguments") {
+		t.Errorf("the error does not say the command takes no arguments: %q", stderr)
+	}
+
+	// And it names --endpoint, which is what the operator meant.
+	if !strings.Contains(stderr, "endpoint") {
+		t.Errorf("the error does not point at --endpoint, so the operator has to guess the flag: %q", stderr)
+	}
+}
+
+// TestNormalizeEndpoint covers what an operator can type.
+//
+// The bare host:port form is the one that matters most: it is the shape monitoring.health_checks.addr
+// takes, so copying that value onto the command line is the expected path and rejecting it would be a
+// gratuitous failure.
+func TestNormalizeEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		in         string
+		want       string
+		wantErrSay string
+		why        string
+	}{
+		{
+			name: "a bare host and port gets the http scheme",
+			in:   "127.0.0.1:8081",
+			want: "http://127.0.0.1:8081",
+			why:  "the form monitoring.health_checks.addr takes, which is what an operator copies",
+		},
+		{
+			name: "a full URL passes through",
+			in:   "http://10.0.0.5:8081",
+			want: "http://10.0.0.5:8081",
+		},
+		{
+			name: "https is accepted",
+			in:   "https://health.example.edu",
+			want: "https://health.example.edu",
+			why:  "an institutional deployment behind a TLS-terminating proxy",
+		},
+		{
+			name: "a trailing slash is trimmed",
+			in:   "http://127.0.0.1:8081/",
+			want: "http://127.0.0.1:8081",
+			why: "joining the path onto an untrimmed base yields //health/cluster, which some muxes " +
+				"redirect and some 404 — a confusing failure for a typo this can absorb",
+		},
+		{
+			name:       "an empty endpoint is refused",
+			in:         "   ",
+			wantErrSay: "empty",
+		},
+		{
+			name:       "a scheme that cannot be queried is refused",
+			in:         "unix:///var/run/objectfs.sock",
+			wantErrSay: "only http and https",
+			why: "a unix socket is a plausible thing to want and is not what this speaks; failing here " +
+				"names the reason instead of producing a connection error about a path",
+		},
+		{
+			name:       "a URL with no host is refused",
+			in:         "http://",
+			wantErrSay: "names no host",
+			why: "url.Parse accepts this, and it would otherwise become a request to nowhere reported " +
+				"as a connection error — sending the operator to look at their mount instead of their " +
+				"command line",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := normalizeEndpoint(tt.in)
+
+			if tt.wantErrSay != "" {
+				if err == nil {
+					t.Fatalf("normalizeEndpoint(%q) = %q, want an error saying %q. %s",
+						tt.in, got, tt.wantErrSay, tt.why)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSay) {
+					t.Errorf("normalizeEndpoint(%q) error = %q, want it to contain %q",
+						tt.in, err, tt.wantErrSay)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("normalizeEndpoint(%q) = %v, want %q. %s", tt.in, err, tt.want, tt.why)
+			}
+			if got != tt.want {
+				t.Errorf("normalizeEndpoint(%q) = %q, want %q. %s", tt.in, got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestResolveStatusEndpointPrecedence pins where the address comes from.
+//
+// The config-file step is what makes this usable on a host where the endpoint was moved: the address is
+// already a setting, and requiring an operator to repeat it on every invocation is how a command comes to
+// be wrapped in a shell alias that goes stale when the file changes.
+func TestResolveStatusEndpointPrecedence(t *testing.T) {
+	t.Parallel()
+
+	writeConfig := func(t *testing.T, body string) string {
+		t.Helper()
+
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		return path
+	}
+
+	t.Run("the default when nothing is given", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := resolveStatusEndpoint(&clusterStatusFlags{})
+		if err != nil {
+			t.Fatalf("resolveStatusEndpoint: %v", err)
+		}
+
+		if got != "http://127.0.0.1:8081" {
+			t.Errorf("endpoint = %q, want the packaged default: an operator who has changed nothing "+
+				"must not have to pass a flag", got)
+		}
+	})
+
+	t.Run("the config file's address", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeConfig(t, `monitoring:
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:9099
+`)
+
+		got, err := resolveStatusEndpoint(&clusterStatusFlags{configFile: path})
+		if err != nil {
+			t.Fatalf("resolveStatusEndpoint: %v", err)
+		}
+
+		if got != "http://127.0.0.1:9099" {
+			t.Errorf("endpoint = %q, want the address from the file", got)
+		}
+	})
+
+	t.Run("--endpoint beats the config file", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeConfig(t, `monitoring:
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:9099
+`)
+
+		got, err := resolveStatusEndpoint(&clusterStatusFlags{
+			configFile: path, endpoint: "127.0.0.1:7777",
+		})
+		if err != nil {
+			t.Fatalf("resolveStatusEndpoint: %v", err)
+		}
+
+		if got != "http://127.0.0.1:7777" {
+			t.Errorf("endpoint = %q, want --endpoint's value: an explicit flag silently losing to a "+
+				"file the operator may not have read is the wrong precedence", got)
+		}
+	})
+
+	t.Run("health checks disabled in the named file", func(t *testing.T) {
+		t.Parallel()
+
+		path := writeConfig(t, `monitoring:
+  health_checks:
+    enabled: false
+`)
+
+		_, err := resolveStatusEndpoint(&clusterStatusFlags{configFile: path})
+		if err == nil {
+			t.Fatal("a config file that disables health checks was accepted; the command would then " +
+				"produce a connection error, which reads as a dead instance rather than as an endpoint " +
+				"that was never started")
+		}
+
+		if !strings.Contains(err.Error(), "health_checks.enabled") {
+			t.Errorf("the error does not name the setting to change: %v", err)
+		}
+	})
+
+	t.Run("a config file that does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := resolveStatusEndpoint(&clusterStatusFlags{
+			configFile: filepath.Join(t.TempDir(), "absent.yaml"),
+		})
+		if err == nil {
+			t.Fatal("a missing --config file was accepted, so a typo in the path silently queries the " +
+				"default endpoint and reports on whatever instance is there")
+		}
+	})
+}
+
+// TestClusterStatusExitCode is the semantics an alerting script branches on, and it is where the issue
+// was wrong.
+//
+// The issue specified "1: instance unreachable OR quorum lost". Quorum is a Raft concept and no leader is
+// elected on a mount path, so a majority is not something this cluster has an opinion about — a two-node
+// cluster with one node down keeps working correctly, because coordination is compare-and-swap against S3
+// and the store evaluates it on one request. Exiting non-zero for an absent majority would page for a
+// cluster that is fine.
+func TestClusterStatusExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status distributed.ClusterStatus
+		want   int
+		why    string
+	}{
+		{
+			name:   "clustering disabled is not a fault",
+			status: distributed.ClusterStatus{Enabled: false, Reason: "not configured"},
+			want:   exitOK,
+			why: "cluster.enabled defaults to false, so a non-zero status here would fire on every " +
+				"single-node mount in existence",
+		},
+		{
+			name: "a healthy cluster",
+			status: distributed.ClusterStatus{
+				Enabled:    true,
+				Membership: distributed.MembershipStatus{Total: 3, Alive: 3},
+			},
+			want: exitOK,
+		},
+		{
+			name: "a cluster of one is healthy",
+			status: distributed.ClusterStatus{
+				Enabled:    true,
+				Membership: distributed.MembershipStatus{Total: 1, Alive: 1},
+			},
+			want: exitOK,
+			why:  "nothing about ObjectFS coordination requires a second node",
+		},
+		{
+			name: "a dead node",
+			status: distributed.ClusterStatus{
+				Enabled:    true,
+				Membership: distributed.MembershipStatus{Total: 3, Alive: 2, Dead: 1},
+			},
+			want: exitFailure,
+			why:  "the honest failure signal a gossip cluster has",
+		},
+		{
+			name: "a suspect node",
+			status: distributed.ClusterStatus{
+				Enabled:    true,
+				Membership: distributed.MembershipStatus{Total: 3, Alive: 2, Suspect: 1},
+			},
+			want: exitFailure,
+			why: "suspect is the state a node enters before being declared dead, and an operator wants " +
+				"to know while it is still recoverable",
+		},
+		{
+			name: "one node alive of three is still not a quorum question",
+			status: distributed.ClusterStatus{
+				Enabled:    true,
+				Membership: distributed.MembershipStatus{Total: 3, Alive: 1, Dead: 2},
+			},
+			want: exitFailure,
+			why: "non-zero because two nodes are dead, not because a majority is absent — the same code " +
+				"a single dead node produces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := clusterStatusExitCode(&tt.status); got != tt.want {
+				t.Errorf("clusterStatusExitCode = %d, want %d. %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// TestClusterStatusReportsAnUnreachableEndpointAsSuchIsNotAClusterFault is the case the issue's mockup
+// could not express, and the one an operator will hit first.
+//
+// Nothing listening means no instance is running, or its health endpoint is off, or it is on another
+// address. None of those is a cluster problem, and a message that merely says "connection refused" is
+// read as one. The exit code is still 1 — the command could not answer — but the text has to say what it
+// does and does not mean.
+func TestClusterStatusReportsAnUnreachableEndpointAsSuchIsNotAClusterFault(t *testing.T) {
+	t.Parallel()
+
+	// A port that is closed: bind one and shut it down, so the address is real and refuses. A hardcoded
+	// high port would be a coin flip against whatever else is running on the machine.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	endpoint := srv.URL
+	srv.Close()
+
+	code, stdout, stderr := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+
+	if code != exitFailure {
+		t.Fatalf("exited %d, want %d. stdout: %q", code, exitFailure, stdout)
+	}
+
+	for _, want := range []string{
+		"Nothing is listening",
+		"health_checks",
+		"does not mean the cluster is unhealthy",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("the unreachable-endpoint error does not contain %q, so a connection refused reads "+
+				"as a broken cluster: %q", want, stderr)
+		}
+	}
+}
+
+// TestClusterStatusReportsAnOldInstanceDistinctly separates the two HTTP failures that look alike.
+//
+// A 404 is a different diagnosis from a refused connection, and an operator who cannot tell them apart
+// will restart a mount that is running perfectly well.
+func TestClusterStatusReportsAnOldInstanceDistinctly(t *testing.T) {
+	t.Parallel()
+
+	// A server that answers, but not at this path: an instance from before the endpoint existed.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(srv.Close)
+
+	code, _, stderr := runArgs(t, "cluster", "status", "--endpoint", srv.URL)
+
+	if code != exitFailure {
+		t.Fatalf("exited %d, want %d", code, exitFailure)
+	}
+
+	if !strings.Contains(stderr, "before this endpoint existed") {
+		t.Errorf("a 404 is not distinguished from an unreachable endpoint: %q", stderr)
+	}
+
+	if strings.Contains(stderr, "Nothing is listening") {
+		t.Errorf("a 404 was reported as nothing listening, which sends the operator to restart an "+
+			"instance that is running: %q", stderr)
+	}
+}
+
+// TestClusterStatusOnADisabledClusterExitsZero is the answer almost every invocation will get.
+func TestClusterStatusOnADisabledClusterExitsZero(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, distributed.ClusterStatusDisabled(
+		"this mount is not running cluster coordination: set cluster.enabled"))
+
+	code, stdout, stderr := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+
+	if code != exitOK {
+		t.Fatalf("exited %d, want 0: clustering being off is the default configuration, not a fault. "+
+			"stderr: %s", code, stderr)
+	}
+
+	if !strings.Contains(stdout, "disabled") {
+		t.Errorf("the report does not say clustering is disabled: %q", stdout)
+	}
+
+	// The reason, so the operator is told it is a configuration state.
+	if !strings.Contains(stdout, "cluster.enabled") {
+		t.Errorf("the report does not name the setting that would turn it on: %q", stdout)
+	}
+}
+
+// TestClusterStatusNeverPrintsAnUnmeasuredZero is the constraint that shaped this whole feature.
+//
+// This project has shipped the opposite twice: percentile fields declared and never assigned that
+// published as zeros (#222), and six resource fields broadcast as zeros for four releases (#132). An
+// operator reading "cache_hit=0%" cannot tell a cache that has served nothing from one that misses every
+// read — a just-started mount and an emergency respectively.
+//
+// So a node with no cache reports "not reported", a cache that has served nothing reports "not measured",
+// and neither of them prints a number.
+func TestClusterStatusNeverPrintsAnUnmeasuredZero(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, &distributed.ClusterStatus{
+		Enabled:    true,
+		NodeID:     "node-a",
+		GossipAddr: "127.0.0.1:7946",
+		Membership: distributed.MembershipStatus{Total: 2, Alive: 2},
+		Self: &distributed.NodeReport{
+			ID: "node-a", Address: "127.0.0.1:7946", Status: "alive",
+			// No cache at all: the shape of a mount with no cache injected.
+		},
+		Peers: []distributed.NodeReport{{
+			ID: "node-b", Address: "127.0.0.1:7947", Status: "alive",
+			// A cache that exists, holds bytes, and has served nothing: HitRate nil, Requests zero.
+			Cache: &distributed.NodeCacheReport{Size: 4096},
+		}},
+		Cache: distributed.ClusterCacheStatus{TotalSize: 4096, AliveNodes: 2},
+	})
+
+	code, stdout, stderr := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+
+	if code != exitOK {
+		t.Fatalf("exited %d, want 0. stderr: %s", code, stderr)
+	}
+
+	if !strings.Contains(stdout, "cache=not reported") {
+		t.Errorf("a node with no cache does not report as unreported, so its line cannot be told from "+
+			"a node whose cache is empty: %q", stdout)
+	}
+
+	if !strings.Contains(stdout, "hit=not measured") {
+		t.Errorf("a cache that has served nothing does not report as unmeasured: %q", stdout)
+	}
+
+	if strings.Contains(stdout, "hit=0.0%") {
+		t.Errorf("the report prints a 0%% hit rate for a cache that has served nothing, which is the "+
+			"defect #222 shipped: %q", stdout)
+	}
+
+	if !strings.Contains(stdout, "Hit rate:   not measured") {
+		t.Errorf("the cluster-wide hit rate prints a figure nothing measured: %q", stdout)
+	}
+
+	if !strings.Contains(stdout, "Capacity:   not reported by any node") {
+		t.Errorf("the cluster capacity prints a sum no node reported: %q", stdout)
+	}
+}
+
+// TestClusterStatusDoesNotPrintARoleWithoutAnElection is the mockup field this drops on purpose.
+//
+// The issue asked for "Role: Leader"/"Role: Follower" and leader=true/false per peer. Nothing elects a
+// leader on a mount path, so IsLeader is false on every node of a healthy cluster and "Follower" would
+// report a lost election that was never held. The report says so in words instead.
+func TestClusterStatusDoesNotPrintARoleWithoutAnElection(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, &distributed.ClusterStatus{
+		Enabled:    true,
+		NodeID:     "node-a",
+		Membership: distributed.MembershipStatus{Total: 1, Alive: 1},
+		Self:       &distributed.NodeReport{ID: "node-a", Status: "alive"},
+		// Leadership deliberately nil, which is what a mount produces.
+	})
+
+	code, stdout, _ := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+	if code != exitOK {
+		t.Fatalf("exited %d, want 0", code)
+	}
+
+	if strings.Contains(stdout, "follower") || strings.Contains(stdout, "Follower") {
+		t.Errorf("the report calls this node a follower without an election having happened: %q", stdout)
+	}
+
+	if !strings.Contains(stdout, "leader election is not running") {
+		t.Errorf("the report does not explain why there is no role, leaving an operator to wonder "+
+			"whether the field is missing or the election failed: %q", stdout)
+	}
+
+	// And it names the mechanism that is actually in use, so the absence is an answer rather than a gap.
+	if !strings.Contains(stdout, "compare-and-swap") {
+		t.Errorf("the report does not say what coordination does instead: %q", stdout)
+	}
+}
+
+// TestClusterStatusPrintsARoleWhenConsensusIsRunning is the other half, so the branch above is a
+// distinction rather than dead code.
+func TestClusterStatusPrintsARoleWhenConsensusIsRunning(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, &distributed.ClusterStatus{
+		Enabled:    true,
+		NodeID:     "node-a",
+		Leadership: &distributed.LeadershipStatus{Leader: "node-a", IsSelf: true, Election: 3},
+		Membership: distributed.MembershipStatus{Total: 1, Alive: 1},
+		Self:       &distributed.NodeReport{ID: "node-a", Status: "alive"},
+	})
+
+	code, stdout, _ := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+	if code != exitOK {
+		t.Fatalf("exited %d, want 0", code)
+	}
+
+	if !strings.Contains(stdout, "leader") {
+		t.Errorf("a node that holds leadership is not reported as leader: %q", stdout)
+	}
+	if !strings.Contains(stdout, "elections: 3") {
+		t.Errorf("the election count is not reported: %q", stdout)
+	}
+}
+
+// TestClusterStatusPrintsAnomaliesOnlyWhenNonZero keeps the section readable.
+//
+// A block of zeros printed every run trains an operator to skip the section, which is precisely the
+// section that matters on the one run where a counter is not zero.
+func TestClusterStatusPrintsAnomaliesOnlyWhenNonZero(t *testing.T) {
+	t.Parallel()
+
+	base := func() *distributed.ClusterStatus {
+		return &distributed.ClusterStatus{
+			Enabled:    true,
+			NodeID:     "node-a",
+			Membership: distributed.MembershipStatus{Total: 1, Alive: 1},
+			Self:       &distributed.NodeReport{ID: "node-a", Status: "alive"},
+			Gossip:     distributed.GossipCounters{MessagesSent: 10, MessagesReceived: 9},
+		}
+	}
+
+	t.Run("a clean cluster prints no anomaly section", func(t *testing.T) {
+		t.Parallel()
+
+		code, stdout, _ := runArgs(t, "cluster", "status", "--endpoint", serveStatus(t, base()))
+		if code != exitOK {
+			t.Fatalf("exited %d", code)
+		}
+
+		if strings.Contains(stdout, "Anomalies") {
+			t.Errorf("a cluster with no anomalies printed an anomaly section: %q", stdout)
+		}
+	})
+
+	t.Run("a truncated datagram is named with its cause", func(t *testing.T) {
+		t.Parallel()
+
+		status := base()
+		status.Gossip.MessagesTruncated = 4
+
+		code, stdout, _ := runArgs(t, "cluster", "status", "--endpoint", serveStatus(t, status))
+		if code != exitOK {
+			t.Fatalf("exited %d", code)
+		}
+
+		if !strings.Contains(stdout, "truncated: 4") {
+			t.Errorf("the truncation count is not reported: %q", stdout)
+		}
+
+		// The note matters more than the number: a clipped datagram fails the authentication envelope
+		// parse, so it reports itself as a wrong cluster secret (#277). Without the note an operator
+		// rotates a secret that is correct.
+		if !strings.Contains(stdout, "authentication failure") {
+			t.Errorf("the truncation line does not explain that it masquerades as an authentication "+
+				"failure, which is the whole diagnostic value: %q", stdout)
+		}
+	})
+}
+
+// TestClusterStatusJSONIsTheWireFormat asserts --json emits something a script can consume.
+//
+// Re-encoded from the decoded struct rather than passed through, so that --json is documented by
+// distributed.ClusterStatus and cannot carry a field the human report has no counterpart for. That means
+// this test also fails if the two drift.
+func TestClusterStatusJSONIsTheWireFormat(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, &distributed.ClusterStatus{
+		Enabled:    true,
+		NodeID:     "node-a",
+		GossipAddr: "127.0.0.1:7946",
+		Membership: distributed.MembershipStatus{Total: 2, Alive: 1, Dead: 1},
+		Self:       &distributed.NodeReport{ID: "node-a", Status: "alive"},
+		Peers:      []distributed.NodeReport{{ID: "node-b", Status: "dead"}},
+	})
+
+	code, stdout, stderr := runArgs(t, "cluster", "status", "--json", "--endpoint", endpoint)
+
+	// Exit 1 because a node is dead, which is orthogonal to --json working.
+	if code != exitFailure {
+		t.Fatalf("exited %d, want %d (a dead node). stderr: %s", code, exitFailure, stderr)
+	}
+
+	var decoded distributed.ClusterStatus
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("--json produced something that is not a cluster status (%q): %v", stdout, err)
+	}
+
+	if decoded.NodeID != "node-a" || decoded.Membership.Dead != 1 {
+		t.Errorf("--json round-tripped to %+v, which is not what the endpoint served", decoded)
+	}
+
+	// No human report mixed into the JSON: a script pipes this into jq.
+	if strings.Contains(stdout, "ObjectFS Cluster Status") {
+		t.Errorf("--json emitted the human report as well, so the output is not parseable: %q", stdout)
+	}
+}
+
+// TestClusterStatusSaysWhenThereAreNoPeers is about a single-node cluster not looking broken.
+//
+// A report that lists one node and nothing else reads as a cluster that lost its peers. It is in fact a
+// working configuration, and saying so is the difference between an operator investigating and an
+// operator moving on.
+func TestClusterStatusSaysWhenThereAreNoPeers(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, &distributed.ClusterStatus{
+		Enabled:    true,
+		NodeID:     "only-node",
+		Membership: distributed.MembershipStatus{Total: 1, Alive: 1},
+		Self:       &distributed.NodeReport{ID: "only-node", Status: "alive"},
+	})
+
+	code, stdout, _ := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+	if code != exitOK {
+		t.Fatalf("exited %d, want 0: a cluster of one is a working configuration", code)
+	}
+
+	if !strings.Contains(stdout, "cluster of one") {
+		t.Errorf("a single-node cluster is not described as such, so it reads as a cluster that lost "+
+			"its peers: %q", stdout)
+	}
+}
+
+// TestClusterStatusReportsAnUnboundGossipSocket names a failure that is otherwise invisible.
+//
+// A node whose gossip bind failed serves its mount normally and is unreachable by every peer. The mount
+// working is exactly what makes this hard to notice from anywhere else.
+func TestClusterStatusReportsAnUnboundGossipSocket(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, &distributed.ClusterStatus{
+		Enabled:    true,
+		NodeID:     "unbound",
+		GossipAddr: "",
+		Membership: distributed.MembershipStatus{Total: 1, Alive: 1},
+		Self:       &distributed.NodeReport{ID: "unbound", Status: "alive"},
+	})
+
+	code, stdout, _ := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+	if code != exitOK {
+		t.Fatalf("exited %d", code)
+	}
+
+	if !strings.Contains(stdout, "not bound") {
+		t.Errorf("an unbound gossip socket is not reported, and the mount serving normally is what "+
+			"makes it invisible everywhere else: %q", stdout)
+	}
+}
+
+// TestClusterStatusRejectsABadEndpointBeforeConnecting keeps a command-line error out of the
+// connection-error path.
+//
+// Exit 2, not 1: nothing was attempted, and a monitoring script that treats 1 as "the cluster is in
+// trouble" must not see that for a typo in its own arguments.
+func TestClusterStatusRejectsABadEndpointBeforeConnecting(t *testing.T) {
+	t.Parallel()
+
+	for _, endpoint := range []string{"unix:///var/run/objectfs.sock", "http://", "   "} {
+		t.Run(endpoint, func(t *testing.T) {
+			t.Parallel()
+
+			code, _, stderr := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+
+			if code != exitUsage {
+				t.Errorf("--endpoint %q exited %d, want %d: the command line is what is wrong, and a "+
+					"script branching on 1 would read this as a cluster fault. stderr: %s",
+					endpoint, code, exitUsage, stderr)
+			}
+		})
+	}
+}
+
+// TestClusterStatusRejectsANonStatusResponse is the endpoint answering something else entirely, which is
+// what a reverse proxy in front of the wrong service looks like.
+func TestClusterStatusRejectsANonStatusResponse(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(health.ClusterStatusPath, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html>Grafana</html>"))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	code, _, stderr := runArgs(t, "cluster", "status", "--endpoint", srv.URL)
+
+	if code != exitFailure {
+		t.Fatalf("exited %d, want %d", code, exitFailure)
+	}
+
+	if !strings.Contains(stderr, "not a cluster status") {
+		t.Errorf("a non-JSON response is not reported as such, so an operator pointed at the wrong "+
+			"service gets a decode error rather than a diagnosis: %q", stderr)
+	}
+}
+
+// TestClusterStatusRejectsAnUnexpectedStatusCode covers the third HTTP failure mode.
+//
+// A 500 from the endpoint is neither an old build nor a dead instance, and reporting it as either would
+// be wrong. It is also what a proxy returns when the instance behind it is unreachable.
+func TestClusterStatusRejectsAnUnexpectedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(health.ClusterStatusPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	code, _, stderr := runArgs(t, "cluster", "status", "--endpoint", srv.URL)
+
+	if code != exitFailure {
+		t.Fatalf("exited %d, want %d", code, exitFailure)
+	}
+
+	if !strings.Contains(stderr, "502") {
+		t.Errorf("the error does not name the status code, which is the only thing that identifies "+
+			"what answered: %q", stderr)
+	}
+}
+
+// TestNodeLineDistinguishesEveryAbsentField is the formatting contract, asserted on the function rather
+// than through a server so every combination is cheap to cover.
+func TestNodeLineDistinguishesEveryAbsentField(t *testing.T) {
+	t.Parallel()
+
+	capacity := int64(8192)
+	rate := 0.0
+
+	tests := []struct {
+		name       string
+		report     distributed.NodeReport
+		mustSay    []string
+		mustNotSay []string
+		why        string
+	}{
+		{
+			name:    "no cache reported",
+			report:  distributed.NodeReport{ID: "a", Status: "alive"},
+			mustSay: []string{"cache=not reported"},
+			// "0 B" would describe a cache that exists and holds nothing.
+			mustNotSay: []string{"0 B"},
+		},
+		{
+			name: "a cache with no capacity",
+			report: distributed.NodeReport{ID: "a", Status: "alive",
+				Cache: &distributed.NodeCacheReport{Size: 100, Requests: 4, HitRate: &rate}},
+			mustSay: []string{"cache=100 B", "hit=0.0%"},
+			why: "a measured 0% is printed as 0%: this is the case the 'not measured' text exists to be " +
+				"distinguished from, and suppressing it too would lose the real emergency",
+		},
+		{
+			name: "a cache with capacity",
+			report: distributed.NodeReport{ID: "a", Status: "alive",
+				Cache: &distributed.NodeCacheReport{Size: 100, Capacity: &capacity}},
+			mustSay: []string{"100 B/8.0 KB"},
+		},
+		{
+			name:    "an address that is not known",
+			report:  distributed.NodeReport{ID: "a", Status: "alive"},
+			mustSay: []string{"(none)"},
+			why: "an empty column looks like whitespace in a column-aligned report, so a missing " +
+				"address would be invisible",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := nodeLine(tt.report, false)
+
+			for _, want := range tt.mustSay {
+				if !strings.Contains(got, want) {
+					t.Errorf("nodeLine = %q, want it to contain %q. %s", got, want, tt.why)
+				}
+			}
+
+			for _, unwanted := range tt.mustNotSay {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("nodeLine = %q, want it not to contain %q. %s", got, unwanted, tt.why)
+				}
+			}
+		})
+	}
+}
+
+// TestClusterStatusReportsAPartialCapacitySum keeps the count beside the sum.
+//
+// The Redis-backed cache reports no capacity of its own, so a mixed cluster genuinely has nodes that
+// cannot answer. One node of three reporting capacity would otherwise make the cluster look three times
+// fuller than it is.
+func TestClusterStatusReportsAPartialCapacitySum(t *testing.T) {
+	t.Parallel()
+
+	endpoint := serveStatus(t, &distributed.ClusterStatus{
+		Enabled:    true,
+		NodeID:     "node-a",
+		Membership: distributed.MembershipStatus{Total: 3, Alive: 3},
+		Self:       &distributed.NodeReport{ID: "node-a", Status: "alive"},
+		Cache: distributed.ClusterCacheStatus{
+			TotalSize: 300, TotalCapacity: 1000, NodesReportingCapacity: 1, AliveNodes: 3,
+		},
+	})
+
+	code, stdout, _ := runArgs(t, "cluster", "status", "--endpoint", endpoint)
+	if code != exitOK {
+		t.Fatalf("exited %d", code)
+	}
+
+	if !strings.Contains(stdout, "from 1 of 3 nodes") {
+		t.Errorf("a partial capacity sum is printed without saying how partial it is, so the cluster "+
+			"looks three times fuller than it is: %q", stdout)
+	}
+}

--- a/cmd/objectfs/main.go
+++ b/cmd/objectfs/main.go
@@ -94,6 +94,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 		// word; an operator reaching for one and getting "unknown command" has learned nothing.
 		return runUnmount(args[1:], stdout, stderr)
 
+	case "cluster":
+		return runCluster(args[1:], stdout, stderr)
+
 	case "version", "--version", "-version":
 		emit(stdout, "objectfs version %s\n", version)
 
@@ -134,6 +137,7 @@ Usage: objectfs <command> [options]
 Commands:
   mount     Mount a bucket on a directory
   unmount   Unmount a filesystem by path
+  cluster   Inspect the cluster state of a running instance
   version   Print the version and exit
   help      Print this message
 
@@ -144,6 +148,8 @@ Examples:
   objectfs mount --config /etc/objectfs/config.yaml s3://my-bucket /mnt/s3
   objectfs mount --config /etc/objectfs/research-data.yaml --foreground
   objectfs unmount /mnt/s3
+  objectfs cluster status
+  objectfs cluster status --json
 
 The form without a subcommand still works:
   objectfs s3://my-bucket /mnt/s3

--- a/cmd/objectfs/main_test.go
+++ b/cmd/objectfs/main_test.go
@@ -71,7 +71,7 @@ func TestHelpSubcommandNamesEveryCommand(t *testing.T) {
 			// than as one substring, because the failure mode is a command that exists and is
 			// undocumented — which is how `mount` came to be named in configs/systemd/objectfs@.service
 			// for several releases without existing at all.
-			for _, cmd := range []string{"mount", "unmount", "version", "help"} {
+			for _, cmd := range []string{"mount", "unmount", "cluster", "version", "help"} {
 				if !strings.Contains(stdout, cmd) {
 					t.Errorf("objectfs %s does not mention the %q command, so the only way to learn "+
 						"it exists is to read the source", arg, cmd)

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -286,10 +286,21 @@ func (a *Adapter) Start(ctx context.Context) error {
 			}
 		}
 
+		// What /health/cluster reports, registered before Start binds the listener so there is no window
+		// in which the endpoint is reachable and answers "not clustered" for a mount that is. #147 asked
+		// for a client that reads this endpoint; the endpoint did not exist, and this is the line that
+		// makes it report something real rather than the unregistered default.
+		//
+		// A closure over the adapter rather than the manager, because a.clusterMgr is nil when clustering
+		// is off — capturing its value here would register a provider that reports a cluster from a nil
+		// pointer. See [Adapter.clusterStatus].
+		a.monitor.SetClusterStatusProvider(health.ClusterStatusFunc(a.clusterStatus))
+
 		if err := a.monitor.Start(ctx); err != nil {
 			return fmt.Errorf("failed to start health monitor: %w", err)
 		}
-		slog.Info("health monitor started", "addr", a.config.Monitoring.HealthChecks.Addr)
+		slog.Info("health monitor started", "addr", a.config.Monitoring.HealthChecks.Addr,
+			"cluster_status_path", a.monitor.ClusterStatusPath())
 	}
 
 	// 8. Mount filesystem
@@ -457,6 +468,26 @@ func (a *Adapter) startCluster(ctx context.Context) error {
 		"seed_nodes", len(a.config.Cluster.SeedNodes))
 
 	return nil
+}
+
+// clusterStatus is what /health/cluster reports for this mount.
+//
+// Read from a.clusterMgr per call rather than captured, for two reasons that both matter. The health
+// monitor is started after startCluster but its provider must survive a Stop that clears nothing — and
+// more importantly, a nil manager and a running one are different answers, so the check has to happen at
+// request time. A provider closed over the field's value at registration would report a cluster from a
+// nil pointer.
+//
+// The disabled answer names the setting that would turn clustering on, because that is what an operator
+// reading it needs next. It is not an error: `cluster.enabled` defaults to false, so this is the answer
+// almost every ObjectFS instance gives, and a client must be able to tell it from a failure.
+func (a *Adapter) clusterStatus() any {
+	if a.clusterMgr == nil {
+		return distributed.ClusterStatusDisabled("this mount is not running cluster coordination: " +
+			"set cluster.enabled in the configuration file to join a cluster")
+	}
+
+	return a.clusterMgr.StatusSnapshot()
 }
 
 // clusterCoordinator returns the coordinator the filesystem should use, or nil when clustering is off.

--- a/internal/config/docs_symbols_test.go
+++ b/internal/config/docs_symbols_test.go
@@ -110,6 +110,7 @@ var subcommands = map[string]bool{
 	"mount":   true,
 	"unmount": true,
 	"umount":  true,
+	"cluster": true,
 	"version": true,
 	"help":    true,
 }

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"math"
 	"runtime"
 	"sync"
 	"time"
@@ -837,10 +838,24 @@ func (cm *ClusterManager) refreshLocalStats(dst *NodeInfo) {
 
 		// The denominator behind HitRate, carried so a reader can tell 0.0 from "nothing asked yet". Both
 		// counters are cumulative over the cache's life, so this only ever grows.
-		dst.CacheRequests = int64(cacheStats.Hits + cacheStats.Misses) //nolint:gosec // see below
-		// The conversion cannot overflow in any real process: it would take 2^63 cache operations, and at
-		// a billion per second that is 292 years. Signed because everything else on this struct is, and a
-		// mixed-signedness pair of related fields is worse than the theoretical wrap.
+		//
+		// Saturating rather than converting, and rather than suppressing the warning. Hits and Misses are
+		// uint64 and CacheRequests is int64, because every other field on NodeInfo is signed and a
+		// mixed-signedness pair of related fields is its own bug. Reaching 2^63 operations would take 292
+		// years at a billion per second, so this is unreachable — but the failure mode if it were ever
+		// reached is a *negative* request count, which HitRate's "did anything ask yet" guard reads as
+		// "nothing asked yet", silently hiding a busy cache instead of reporting a wrapped number. A
+		// clamp costs one comparison per gossip round and is testable; a nolint comment is neither.
+		//
+		// The sum is checked before the cast, not after: Hits+Misses is uint64 arithmetic and wraps on
+		// its own, so a post-cast check would be reasoning about a value that had already lost the
+		// overflow.
+		if total := cacheStats.Hits + cacheStats.Misses; total > math.MaxInt64 ||
+			total < cacheStats.Hits {
+			dst.CacheRequests = math.MaxInt64
+		} else {
+			dst.CacheRequests = int64(total)
+		}
 	}
 
 	cm.stats.mu.RLock()

--- a/internal/distributed/cluster.go
+++ b/internal/distributed/cluster.go
@@ -147,6 +147,27 @@ type NodeInfo struct {
 	CacheSize    int64   `json:"cache_size"`
 	CacheHitRate float64 `json:"cache_hit_rate"`
 	Operations   int64   `json:"operations"`
+
+	// CacheCapacity is what the node's cache reports it can hold, and zero means it does not report one
+	// rather than that it can hold nothing. The Redis-backed cache is the real case — it has no capacity
+	// of its own to publish, so [types.CacheStats.Capacity] comes back zero — while the in-process
+	// multi-level cache sums the configured maximum of each enabled level.
+	//
+	// CacheRequests is hits plus misses, and it is here so that CacheHitRate can be told apart from a
+	// cache that has served nothing. Those are different states and the rate alone cannot express them:
+	// zero requests gives a rate of 0.0 by arithmetic, which is identical to a cache that misses every
+	// single read. The first is a mount that started a second ago and the second is an emergency. This is
+	// the same class of defect as #222 — fields declared, never assigned, published as zeros — except
+	// that here the zero is genuinely computed and still means nothing, which is harder to spot.
+	//
+	// Both are advertised in the alive message like the two above, so a peer's figures are as readable
+	// as the local node's. That is what costs them their place on the wire: at ~40 bytes per member they
+	// take the sealed sync from ~415 to ~455 bytes per member, so the 8 KiB default datagram carries
+	// about 17 members instead of 19 — see defaultMaxGossipPacket, and
+	// TestNewClusterManager_DefaultMaxGossipPacketHoldsAThreeNodeSync, which is the test that notices
+	// when NodeInfo grows.
+	CacheCapacity int64 `json:"cache_capacity"`
+	CacheRequests int64 `json:"cache_requests"`
 }
 
 // NodeStatus represents the status of a cluster node
@@ -655,6 +676,17 @@ func (cm *ClusterManager) updateStats(ctx context.Context) {
 }
 
 func (cm *ClusterManager) calculateClusterStats() {
+	// This node's own entry first, or the tally below excludes it.
+	//
+	// Until this call existed, refreshLocalStats reached only gp.localNode — the struct the *alive
+	// message* is built from — so a node published its cache figures to every peer and never recorded
+	// them in its own membership map. Two consequences, both visible from a running two-node cluster:
+	// TotalCacheSize summed every node's cache except the local one, and [ClusterManager.StatusSnapshot]
+	// reported "cache not reported" for the node being asked while reporting its peer's figures in full.
+	// The existing test for the sum encodes the old behavior in a comment — "plus whatever the self node
+	// reports — zero here, since nothing refreshed it" — which is the gap observed and not closed.
+	cm.refreshSelfEntry()
+
 	var (
 		totalNodes     int
 		aliveNodes     int
@@ -724,6 +756,52 @@ func (cm *ClusterManager) calculateClusterStats() {
 	}
 }
 
+// refreshSelfEntry samples this node's own figures into its entry in the membership map.
+//
+// Sampled outside cm.mu and assigned under it, because refreshLocalStats takes cm.mu for reading to get
+// at the cache and a Go RWMutex is not reentrant — the same reason [ClusterManager.Start] calls
+// calculateClusterStats after startLocked has released the lock, and the same reason performGossip
+// samples before taking gp.mu.
+//
+// A no-op for a manager whose Start never ran, since Start is what inserts the entry. Nothing is created
+// here: a self entry appearing in the membership map without Start having run would be a node counted as
+// alive by a manager that is not.
+func (cm *ClusterManager) refreshSelfEntry() {
+	// Seeded with a sentinel the four cache fields cannot legitimately take, because refreshLocalStats
+	// signals "there is no cache" by leaving them *untouched* rather than by zeroing them — see its
+	// comment, and TestRefreshLocalStats_LeavesCacheFieldsAloneWithNoCache, which pins that contract.
+	// Reading the sentinel back is how this distinguishes an absent cache from an empty one, and the
+	// distinction is the whole reason the two are not the same value: copying an unmeasured zero onto the
+	// self entry would report a cache that exists and holds nothing.
+	const unset = -1
+
+	fresh := NodeInfo{
+		CacheSize: unset, CacheHitRate: unset, CacheCapacity: unset, CacheRequests: unset,
+	}
+	cm.refreshLocalStats(&fresh)
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	self, exists := cm.nodes[cm.nodeID]
+	if !exists {
+		return
+	}
+
+	// The same fields UpdateNodeInfo takes from a peer's alive message, so this node describes itself the
+	// way its peers describe it. ID, Address, Status and Version are deliberately not touched, for the
+	// reason UpdateNodeInfo does not touch them either.
+	self.MemoryUsage = fresh.MemoryUsage
+	self.Operations = fresh.Operations
+
+	if fresh.CacheSize != unset {
+		self.CacheSize = fresh.CacheSize
+		self.CacheHitRate = fresh.CacheHitRate
+		self.CacheCapacity = fresh.CacheCapacity
+		self.CacheRequests = fresh.CacheRequests
+	}
+}
+
 // refreshLocalStats reads this node's current resource and cache figures into dst.
 //
 // It is called once per gossip round rather than on a ticker of its own, because the only consumer is
@@ -755,6 +833,14 @@ func (cm *ClusterManager) refreshLocalStats(dst *NodeInfo) {
 		cacheStats := cache.Stats()
 		dst.CacheSize = cacheStats.Size
 		dst.CacheHitRate = cacheStats.HitRate
+		dst.CacheCapacity = cacheStats.Capacity
+
+		// The denominator behind HitRate, carried so a reader can tell 0.0 from "nothing asked yet". Both
+		// counters are cumulative over the cache's life, so this only ever grows.
+		dst.CacheRequests = int64(cacheStats.Hits + cacheStats.Misses) //nolint:gosec // see below
+		// The conversion cannot overflow in any real process: it would take 2^63 cache operations, and at
+		// a billion per second that is 292 years. Signed because everything else on this struct is, and a
+		// mixed-signedness pair of related fields is worse than the theoretical wrap.
 	}
 
 	cm.stats.mu.RLock()
@@ -766,7 +852,7 @@ func (cm *ClusterManager) refreshLocalStats(dst *NodeInfo) {
 //
 // The merge is selective, and which fields it leaves alone is the part worth knowing: an existing
 // entry keeps its ID, Address and Version, taking only LastSeen, Status, the four resource fields,
-// the two cache fields and Operations from info. So this cannot rename or re-address a node that is
+// the four cache fields and Operations from info. So this cannot rename or re-address a node that is
 // already a member — a gossip message claiming a new address for a known ID updates its liveness and
 // nothing else. Metadata is merged key-by-key rather than replaced, so a key absent from info
 // survives.
@@ -790,6 +876,8 @@ func (cm *ClusterManager) UpdateNodeInfo(nodeID string, info *NodeInfo) {
 		existing.NetworkBandwidth = info.NetworkBandwidth
 		existing.CacheSize = info.CacheSize
 		existing.CacheHitRate = info.CacheHitRate
+		existing.CacheCapacity = info.CacheCapacity
+		existing.CacheRequests = info.CacheRequests
 		existing.Operations = info.Operations
 
 		// Update metadata

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -614,6 +615,48 @@ func TestRefreshLocalStats_ReadsTheInjectedCache(t *testing.T) {
 	}
 	if got.CacheHitRate != 0.75 {
 		t.Errorf("CacheHitRate = %v, want 0.75", got.CacheHitRate)
+	}
+}
+
+// TestRefreshLocalStats_SaturatesCacheRequestsRatherThanWrapping pins the clamp on the uint64 → int64
+// conversion behind CacheRequests.
+//
+// Unreachable in a real process — 2^63 cache operations is 292 years at a billion per second — and
+// tested anyway, because the alternative to the clamp was a lint suppression and a suppression cannot
+// be tested at all. gosec flags the conversion (G115); the reason to fix it rather than silence it is
+// what happens if it ever does wrap. A negative CacheRequests reads as "nothing has asked yet" to the
+// `requests > 0` guard that decides whether a hit rate is reported, so the busiest cache in the
+// cluster would report `hit=not measured` — a wrong answer dressed as an honest absence, which is the
+// failure mode this whole status surface is built to avoid.
+//
+// Two cases, because the sum is uint64 arithmetic and wraps on its own: a total above MaxInt64 that
+// does not wrap, and Hits+Misses overflowing uint64 entirely. A check placed after the cast would miss
+// the second, having already lost the overflow.
+func TestRefreshLocalStats_SaturatesCacheRequestsRatherThanWrapping(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		hits, misses uint64
+	}{
+		{"above MaxInt64", math.MaxInt64, 10},
+		{"sum wraps uint64", math.MaxUint64, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cm := makeClusterWithNode(t, "stats-saturate")
+			cm.SetCache(&mockCache{stats: types.CacheStats{Hits: tc.hits, Misses: tc.misses}})
+
+			var got NodeInfo
+			cm.refreshLocalStats(&got)
+
+			if got.CacheRequests != math.MaxInt64 {
+				t.Errorf("CacheRequests = %d, want MaxInt64 (%d).\nHits=%d Misses=%d. A value that is "+
+					"not the clamp means the conversion wrapped; if it is negative, the hit-rate guard "+
+					"will report this cache as having served nothing.",
+					got.CacheRequests, int64(math.MaxInt64), tc.hits, tc.misses)
+			}
+		})
 	}
 }
 

--- a/internal/distributed/cluster_test.go
+++ b/internal/distributed/cluster_test.go
@@ -729,7 +729,11 @@ func TestCalculateClusterStats_SumsCacheSizeAcrossAliveNodes(t *testing.T) {
 
 	stats := cm.GetStats()
 
-	// 1000 + 3000, plus whatever the self node reports — zero here, since nothing refreshed it.
+	// 1000 + 3000, plus whatever the self node reports. That used to be zero because nothing refreshed
+	// the self entry at all — a defect, since a node then omitted its own cache from the cluster total.
+	// [ClusterManager.refreshSelfEntry] now refreshes it, and it is still zero here for the honest
+	// reason: no cache is injected into this manager, so there is nothing to report.
+	// TestStatusSnapshot_IncludesThisNodesOwnCacheFigures covers the case where there is.
 	if stats.TotalCacheSize != 4000 {
 		t.Errorf("TotalCacheSize = %d, want 4000 (dead node's 9000000 excluded)", stats.TotalCacheSize)
 	}

--- a/internal/distributed/gossip.go
+++ b/internal/distributed/gossip.go
@@ -1121,6 +1121,12 @@ func (gp *GossipProtocol) performGossip() {
 	gp.localNode.CacheHitRate = fresh.CacheHitRate
 	gp.localNode.Operations = fresh.Operations
 
+	// The capacity and the request count behind the hit rate, so that a peer's figures are as readable as
+	// this node's: without the denominator, a hit rate of 0.0 arriving from a peer cannot be told from a
+	// peer that has served nothing. See [NodeInfo.CacheRequests].
+	gp.localNode.CacheCapacity = fresh.CacheCapacity
+	gp.localNode.CacheRequests = fresh.CacheRequests
+
 	incarnation := uint32(1)
 	if self, exists := gp.memberlist[gp.localNode.ID]; exists {
 		incarnation = self.Incarnation

--- a/internal/distributed/status.go
+++ b/internal/distributed/status.go
@@ -1,0 +1,398 @@
+package distributed
+
+import (
+	"sort"
+	"time"
+)
+
+// ClusterStatus is the cluster state a node can report about itself and its peers, as served at
+// /health/cluster and rendered by `objectfs cluster status`.
+//
+// Every field here is one that is actually assigned at runtime on the path a mount takes. That
+// constraint is the whole design of this type, and it is why it is a distinct struct rather than
+// [ClusterStats] with JSON tags: ClusterStats declares eighteen fields, and on a mount, eight of them
+// are never written by anything. MessagesSent, MessagesReceived, NetworkErrors, ReplicationEvents and
+// ConsistencyViolations are assigned nowhere in the repository; LeaderElections, LastElectionTime and
+// CurrentLeader are assigned only by [ClusterManager.SetLeader], which only the consensus engine
+// reaches, and a mount does not start it. Publishing those as zeros is the defect this project has
+// already shipped twice — percentile fields declared and never assigned (#222), and six resource fields
+// broadcast as zeros for four releases (#132) — because a reader cannot tell a measured zero from an
+// unmeasured one.
+//
+// Where a zero would be ambiguous the field is a pointer, so a JSON consumer sees null rather than 0
+// and a human reader is told "not measured" rather than "0%".
+type ClusterStatus struct {
+	// Enabled is false when this instance is not running cluster coordination at all, which is the
+	// ordinary case: `cluster.enabled` defaults to false. Reason then says so.
+	//
+	// It exists so that a client can tell three situations apart that otherwise look alike. Nothing
+	// listening is a connection error and never reaches this struct. An instance that predates this
+	// endpoint answers 404. An instance that is running fine with clustering off answers 200 with
+	// Enabled false — which is not a fault and must not be reported as one.
+	Enabled bool   `json:"enabled"`
+	Reason  string `json:"reason,omitempty"`
+
+	NodeID string `json:"node_id,omitempty"`
+
+	// GossipAddr is the address the gossip socket is bound to, from [ClusterManager.GossipAddr] — the
+	// bound address and not the configured one, so `listen_addr: 127.0.0.1:0` reports the port the
+	// kernel actually assigned. Empty means nothing is bound, which for a started manager means the
+	// bind failed.
+	GossipAddr string `json:"gossip_addr,omitempty"`
+
+	// Leadership is non-nil only when [ClusterConfig.EnableConsensus] is set, and a mount never sets it:
+	// there is no YAML key for it, and [ClusterManager.startLocked] leaves the engine unstarted.
+	//
+	// Nil rather than a zero-valued struct, because the two are not the same statement. Coordination in
+	// ObjectFS is compare-and-swap against S3 — evaluated by the store on one request, needing no quorum
+	// — so no leader is elected and IsLeader is false on every node of a perfectly healthy cluster.
+	// Rendering that as "Role: Follower", which is what the issue asking for this command specified,
+	// tells an operator their node lost an election that was never held.
+	Leadership *LeadershipStatus `json:"leadership,omitempty"`
+
+	Membership MembershipStatus `json:"membership"`
+
+	// Self is this node's own entry in the membership map. Nil only for a manager whose Start never ran,
+	// since Start is what registers it.
+	Self  *NodeReport  `json:"self,omitempty"`
+	Peers []NodeReport `json:"peers"`
+
+	Cache  ClusterCacheStatus `json:"cache"`
+	Gossip GossipCounters     `json:"gossip"`
+
+	// AnnouncedKeys is how many distinct keys this node retains peer cache claims for (#140), expired
+	// ones included — see [Coordinator.announcedKeys].
+	//
+	// It is emphatically not "top keys by access", which the issue's mockup asked for and which nothing
+	// in this repository measures: there is no per-key read counter reachable from the cluster layer and
+	// no windowed one anywhere. The closest thing that exists, [Coordinator.recentHoldings], orders keys
+	// by when this node last *announced* them, which is a different quantity — offering it under the
+	// other one's label is how a proxy from an unrelated measurement comes to be read as the real thing.
+	AnnouncedKeys int `json:"announced_keys"`
+}
+
+// LeadershipStatus is who holds leadership, reported only when consensus is running.
+type LeadershipStatus struct {
+	Leader   string `json:"leader"`
+	IsSelf   bool   `json:"is_self"`
+	Election int64  `json:"elections"`
+}
+
+// MembershipStatus is the node tally, taken from [ClusterManager.GetStats].
+//
+// Total counts this node as well as its peers, which is worth stating because the issue's mockup
+// printed "Peers (3 alive, ...)" above a list of two — the counts are cluster-wide and the peer list is
+// not. Alive+Suspect+Dead equals Total: a node whose status matches none of the three is counted
+// suspect rather than dropped, which is a property [ClusterManager.calculateClusterStats] was fixed to
+// have.
+type MembershipStatus struct {
+	Total   int `json:"total"`
+	Alive   int `json:"alive"`
+	Suspect int `json:"suspect"`
+	Dead    int `json:"dead"`
+}
+
+// NodeReport is one node's entry, from its [NodeInfo].
+//
+// The fields NodeInfo carries and this does not are the ones NodeInfo's own documentation says are not
+// populated: CPUUsage, DiskUsage and NetworkBandwidth each need a platform-specific source that is not
+// in this repository. Two more are dropped for reasons that are not written down there:
+//
+//   - Version is the string "1.0.0", hardcoded at two construction sites and never derived from the
+//     build. It is not the ObjectFS version and reporting it would publish a wrong number.
+//   - Operations is copied from [ClusterStats.TotalOperations], which only
+//     [ClusterManager.DistributeOperation] increments — and nothing on a mount path calls that, so it is
+//     zero on every node of every mounted cluster.
+type NodeReport struct {
+	ID      string     `json:"id"`
+	Address string     `json:"address"`
+	Status  NodeStatus `json:"status"`
+
+	// LastSeen is when this node last heard from that node, on the local clock. For the local node it is
+	// stamped every health-check tick, so it is always recent.
+	LastSeen time.Time `json:"last_seen"`
+
+	// Cache is nil when the node reports no cache figures at all, which is what a node with no cache
+	// injected looks like: [ClusterManager.refreshLocalStats] deliberately leaves those fields untouched
+	// rather than zeroing them, because zero is a meaningful cache size and "there is no cache" is not
+	// an empty one.
+	Cache *NodeCacheReport `json:"cache,omitempty"`
+
+	// MemoryUsage is the Go heap in use over the heap obtained from the OS — this process's own
+	// footprint, not the host's. Nil when the node has not reported one, which is a peer that has been
+	// discovered but has not yet completed a gossip round.
+	MemoryUsage *float64 `json:"memory_usage,omitempty"`
+}
+
+// NodeCacheReport is one node's cache figures.
+type NodeCacheReport struct {
+	Size int64 `json:"size"`
+
+	// Capacity is nil when the cache does not report one. The Redis-backed cache is the real case: it
+	// has no capacity of its own to report, so a zero there means unknown rather than "holds nothing".
+	Capacity *int64 `json:"capacity,omitempty"`
+
+	// HitRate is nil unless Requests is greater than zero, which is the point of carrying Requests at
+	// all. A cache that has served nothing has a hit rate of 0.0 by arithmetic, and an operator reading
+	// "cache_hit=0%" cannot tell that from a cache that misses every time — the first is a mount that
+	// has just started and the second is a serious problem.
+	HitRate  *float64 `json:"hit_rate,omitempty"`
+	Requests int64    `json:"requests"`
+}
+
+// ClusterCacheStatus aggregates the cache figures across nodes.
+type ClusterCacheStatus struct {
+	// TotalSize is the sum over alive nodes, from [ClusterStats.TotalCacheSize] rather than recomputed
+	// here, so that the definition of that sum lives in one place.
+	TotalSize int64 `json:"total_size"`
+
+	// TotalCapacity sums the capacities of the alive nodes that report one, and NodesReportingCapacity
+	// says how many did. Without that count the sum is unreadable: a cluster where one node of three
+	// reports capacity would otherwise look like a cluster three times fuller than it is.
+	TotalCapacity          int64 `json:"total_capacity"`
+	NodesReportingCapacity int   `json:"nodes_reporting_capacity"`
+
+	// HitRate is the mean over the alive nodes that have served at least one request, and
+	// NodesMeasured is how many that was.
+	//
+	// Restricted to measuring nodes deliberately, and this is where it differs from
+	// [ClusterStats.CacheHitRate], which averages over every alive node: a node that has served nothing
+	// contributes a 0.0 to that mean and drags the cluster figure toward zero for no reason other than
+	// having just started. Nil when no node has measured anything, rather than 0.
+	HitRate       *float64 `json:"hit_rate,omitempty"`
+	NodesMeasured int      `json:"nodes_measured"`
+
+	// AliveNodes is the denominator the two counts above are out of.
+	AliveNodes int `json:"alive_nodes"`
+}
+
+// GossipCounters is the subset of [GossipStats] that is actually incremented.
+//
+// AvgMessageLatency is the notable omission: [GossipProtocol.calculateStats] leaves it at zero on
+// purpose, because what it used to hold was idle time rather than latency.
+//
+// The four rejection counters are here rather than summarized because each answers a different operator
+// question, and they are the counters that diagnose a cluster which will not form: Unauthenticated
+// means a peer has the wrong secret or something that is not a member is talking to the port, Replayed
+// means captured datagrams are being resent or a clock is off by more than the freshness window, and
+// WrongVersion means version skew during a rolling upgrade.
+type GossipCounters struct {
+	MessagesSent     int64 `json:"messages_sent"`
+	MessagesReceived int64 `json:"messages_received"`
+	BytesSent        int64 `json:"bytes_sent"`
+	BytesReceived    int64 `json:"bytes_received"`
+
+	MessagesRejected        int64 `json:"messages_rejected"`
+	MessagesUnauthenticated int64 `json:"messages_unauthenticated"`
+	MessagesReplayed        int64 `json:"messages_replayed"`
+	MessagesWrongVersion    int64 `json:"messages_wrong_version"`
+
+	// MessagesTruncated and MessagesOversize are the two halves of a datagram that did not fit:
+	// truncated is one that arrived clipped by the receive buffer, oversize is one this node refused to
+	// send. #277 was a truncation that reported itself as a wrong cluster secret, because a clipped
+	// datagram fails the authentication envelope parse.
+	MessagesTruncated int64 `json:"messages_truncated"`
+	MessagesOversize  int64 `json:"messages_oversize"`
+
+	// SuspicionRefutations counts the times this node was accused of being suspect or dead and raised
+	// its incarnation to say otherwise (#272). Repeated refutations mean the node is alive and being
+	// falsely accused, which points at packet loss or a heartbeat interval below the network's latency.
+	SuspicionRefutations int64 `json:"suspicion_refutations"`
+
+	NodesDiscovered int64 `json:"nodes_discovered"`
+	SuspicionEvents int64 `json:"suspicion_events"`
+	DeathEvents     int64 `json:"death_events"`
+
+	// NetworkErrors is a send or receive that failed at the socket, from [GossipStats] — not from
+	// [ClusterStats], whose identically-named field is assigned nowhere in the repository and is one of
+	// the eight this type exists to leave out. Two fields with the same name where one is measured and
+	// one is not is exactly the trap that makes this worth stating.
+	NetworkErrors int64 `json:"network_errors"`
+}
+
+// ClusterStatusDisabled is the payload for an instance that is not running cluster coordination.
+//
+// It is a real 200 answer rather than a 404 or an error, because a mount with `cluster.enabled: false`
+// is not broken — it is the default configuration, and the overwhelming majority of deployments. A
+// client that got an error here could not distinguish it from an instance that is failing.
+func ClusterStatusDisabled(reason string) *ClusterStatus {
+	return &ClusterStatus{Enabled: false, Reason: reason}
+}
+
+// StatusSnapshot builds the cluster status this node can honestly report.
+//
+// It reads through [ClusterManager.GetStats] and [ClusterManager.GetNodes] rather than walking cm.nodes
+// itself, so the tallies and the total cache size keep the single definition those accessors already
+// have — the alternative is a third opinion about how many nodes there are, which is the shape of #275.
+// The cost is that the two reads are not one atomic view, so a membership change landing between them
+// can leave a count one node behind the list. That is acceptable for a status report and is not
+// acceptable for anything that decides something, which is why nothing does.
+func (cm *ClusterManager) StatusSnapshot() *ClusterStatus {
+	// Recomputed rather than read from the last tick. [ClusterManager.updateStats] refreshes on a
+	// five-second ticker, so without this an operator running the command twice a second gets the same
+	// figures repeatedly — and, worse, the first five seconds of a mount report the membership as it was
+	// at Start. It also samples this node's own cache figures, which is what makes the local node's line
+	// in the report say anything at all.
+	//
+	// The cost is one ReadMemStats and one cache Stats() per request against an endpoint an operator polls
+	// by hand. That is the same work the gossip round already does at 2 Hz.
+	cm.calculateClusterStats()
+
+	stats := cm.GetStats()
+	nodes := cm.GetNodes()
+
+	cm.mu.RLock()
+	consensusEnabled := cm.config.EnableConsensus
+	selfID := cm.nodeID
+	leader := cm.leader
+	isLeader := cm.isLeader
+	cm.mu.RUnlock()
+
+	status := &ClusterStatus{
+		Enabled:    true,
+		NodeID:     selfID,
+		GossipAddr: cm.GossipAddr(),
+		Membership: MembershipStatus{
+			Total:   stats.TotalNodes,
+			Alive:   stats.AliveNodes,
+			Suspect: stats.SuspectNodes,
+			Dead:    stats.DeadNodes,
+		},
+		Peers: make([]NodeReport, 0, len(nodes)),
+		Cache: ClusterCacheStatus{
+			TotalSize:  stats.TotalCacheSize,
+			AliveNodes: stats.AliveNodes,
+		},
+	}
+
+	if consensusEnabled {
+		status.Leadership = &LeadershipStatus{
+			Leader:   leader,
+			IsSelf:   isLeader,
+			Election: stats.LeaderElections,
+		}
+	}
+
+	var (
+		hitRateSum float64
+		measured   int
+	)
+
+	for id, info := range nodes {
+		report := nodeReport(info)
+
+		if id == selfID {
+			status.Self = &report
+		} else {
+			status.Peers = append(status.Peers, report)
+		}
+
+		// Aggregated over alive nodes only, matching what TotalCacheSize sums: these figures describe
+		// capacity the cluster can actually use, and a dead node's cache is not reachable.
+		if info.Status != NodeStatusAlive || report.Cache == nil {
+			continue
+		}
+
+		if report.Cache.Capacity != nil {
+			status.Cache.TotalCapacity += *report.Cache.Capacity
+			status.Cache.NodesReportingCapacity++
+		}
+
+		if report.Cache.HitRate != nil {
+			hitRateSum += *report.Cache.HitRate
+			measured++
+		}
+	}
+
+	status.Cache.NodesMeasured = measured
+	if measured > 0 {
+		mean := hitRateSum / float64(measured)
+		status.Cache.HitRate = &mean
+	}
+
+	// Sorted by ID so that repeated invocations produce the same output. Map iteration order is
+	// randomized, and a status command whose peer list reshuffles between runs cannot be diffed.
+	sort.Slice(status.Peers, func(i, j int) bool { return status.Peers[i].ID < status.Peers[j].ID })
+
+	if gossip := cm.gossipProtocol(); gossip != nil {
+		status.Gossip = gossipCounters(gossip.GetStats())
+	}
+
+	if coordinator := cm.getCoordinator(); coordinator != nil {
+		status.AnnouncedKeys = coordinator.announcedKeys()
+	}
+
+	return status
+}
+
+// gossipProtocol returns the gossip protocol, which may be nil for a manager that did not come from
+// [NewClusterManager].
+func (cm *ClusterManager) gossipProtocol() *GossipProtocol {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.gossip
+}
+
+// nodeReport converts a NodeInfo into the subset of it that is worth reporting.
+func nodeReport(info *NodeInfo) NodeReport {
+	report := NodeReport{
+		ID:       info.ID,
+		Address:  info.Address,
+		Status:   info.Status,
+		LastSeen: info.LastSeen,
+	}
+
+	if info.MemoryUsage > 0 {
+		usage := info.MemoryUsage
+		report.MemoryUsage = &usage
+	}
+
+	// A node that reports none of the three is one with no cache injected — refreshLocalStats leaves
+	// all of them untouched in that case — or a peer discovered before its first gossip round. Either
+	// way there is nothing to say about its cache, and saying "0 bytes, 0%" instead would describe a
+	// cache that exists and is empty.
+	if info.CacheSize == 0 && info.CacheCapacity == 0 && info.CacheRequests == 0 {
+		return report
+	}
+
+	cache := &NodeCacheReport{
+		Size:     info.CacheSize,
+		Requests: info.CacheRequests,
+	}
+
+	if info.CacheCapacity > 0 {
+		capacity := info.CacheCapacity
+		cache.Capacity = &capacity
+	}
+
+	if info.CacheRequests > 0 {
+		rate := info.CacheHitRate
+		cache.HitRate = &rate
+	}
+
+	report.Cache = cache
+
+	return report
+}
+
+// gossipCounters copies the counters that are incremented out of the statistics struct.
+func gossipCounters(stats *GossipStats) GossipCounters {
+	return GossipCounters{
+		MessagesSent:            stats.MessagesSent,
+		MessagesReceived:        stats.MessagesReceived,
+		BytesSent:               stats.BytesSent,
+		BytesReceived:           stats.BytesReceived,
+		MessagesRejected:        stats.MessagesRejected,
+		MessagesUnauthenticated: stats.MessagesUnauthenticated,
+		MessagesReplayed:        stats.MessagesReplayed,
+		MessagesWrongVersion:    stats.MessagesWrongVersion,
+		MessagesTruncated:       stats.MessagesTruncated,
+		MessagesOversize:        stats.MessagesOversize,
+		SuspicionRefutations:    stats.SuspicionRefutations,
+		NodesDiscovered:         stats.NodesDiscovered,
+		SuspicionEvents:         stats.SuspicionEvents,
+		DeathEvents:             stats.DeathEvents,
+		NetworkErrors:           stats.NetworkErrors,
+	}
+}

--- a/internal/distributed/status_test.go
+++ b/internal/distributed/status_test.go
@@ -1,0 +1,529 @@
+package distributed
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/objectfs/pkg/types"
+)
+
+// TestStatusSnapshot_OmitsFieldsNothingAssigns is the assertion this whole type exists for.
+//
+// [ClusterStats] declares eighteen fields and a mount assigns ten of them. The other eight —
+// MessagesSent, MessagesReceived, NetworkErrors, ReplicationEvents, ConsistencyViolations,
+// CurrentLeader, LeaderElections and LastElectionTime — are either assigned nowhere in the repository or
+// assigned only by the consensus engine, which a mount does not start. Publishing them would put zeros in
+// front of an operator that read as measurements, which is #222 exactly.
+//
+// Asserted against the JSON tag set rather than against rendered output, because the failure mode is a
+// field being *added* later by someone extending the struct from ClusterStats: a test on the human report
+// would keep passing while --json grew a lying key.
+func TestStatusSnapshot_OmitsFieldsNothingAssigns(t *testing.T) {
+	t.Parallel()
+
+	// These names are checked against the marshaled JSON of a live snapshot, so a field added under any
+	// of them fails here whatever its Go name is.
+	forbidden := map[string]string{
+		"replication_events": "assigned nowhere in the repository",
+		"consistency_violations": "assigned nowhere in the repository; a zero here would read as " +
+			"'no violations detected' rather than 'nothing detects violations'",
+		"total_operations": "only DistributeOperation increments it, and no mount path calls that",
+		"successful_ops":   "same as total_operations",
+		"failed_ops":       "same as total_operations",
+		"avg_op_latency":   "same as total_operations",
+		"last_election_time": "only SetLeader assigns it, and only consensus reaches SetLeader; a " +
+			"mount never starts consensus",
+	}
+
+	cm := makeClusterWithNode(t, "omit-host")
+
+	body := marshalStatus(t, cm.StatusSnapshot())
+
+	for name, why := range forbidden {
+		if containsJSONKey(t, body, name) {
+			t.Errorf("the cluster status publishes %q, which is %s: an operator cannot tell an "+
+				"unmeasured zero from a measured one, which is the defect #222 shipped", name, why)
+		}
+	}
+}
+
+// TestStatusSnapshot_LeadershipIsAbsentWithoutConsensus is the mockup field this deliberately drops.
+//
+// The issue asked for "Role: Leader" and per-peer leader=true/false. Nothing elects a leader on a mount
+// path — [ClusterConfig.EnableConsensus] has no config key and startLocked leaves the engine unstarted —
+// so IsLeader is false on every node of a healthy cluster. Reporting "Follower" for all of them tells an
+// operator they lost an election that was never held.
+//
+// Nil rather than a zero struct, because a JSON consumer has to be able to tell "no leader" from "no
+// election".
+func TestStatusSnapshot_LeadershipIsAbsentWithoutConsensus(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t, "no-consensus")
+
+	// The mount-shaped configuration: the shared helper turns consensus on so the election suite can
+	// drive it, and a mount never does. Turning it off here is the whole point of this test.
+	cfg.EnableConsensus = false
+
+	cm, err := NewClusterManager(cfg)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	cm.UpdateNodeInfo("no-consensus", nodeAlive("no-consensus"))
+
+	if got := cm.StatusSnapshot(); got.Leadership != nil {
+		t.Errorf("Leadership = %+v with consensus off, want nil: no leader is elected on a mount path, "+
+			"so reporting a role would report an election that was never held", got.Leadership)
+	}
+
+	// And present when consensus *is* configured, so the field is not merely dead. Without this the test
+	// above would pass against a Leadership that is never populated at all.
+	cfg2 := testConfig(t, "with-consensus")
+	cm2, err := NewClusterManager(cfg2)
+	if err != nil {
+		t.Fatalf("NewClusterManager: %v", err)
+	}
+	cm2.UpdateNodeInfo("with-consensus", nodeAlive("with-consensus"))
+
+	if got := cm2.StatusSnapshot(); got.Leadership == nil {
+		t.Error("Leadership = nil with EnableConsensus set, want a report: the field would be dead code")
+	}
+}
+
+// TestStatusSnapshot_HitRateIsAbsentUntilACacheServesSomething is the "0% versus not measured"
+// distinction, which is the constraint that shaped this whole payload.
+//
+// A cache that has served nothing has a hit rate of 0.0 by arithmetic, and an operator reading
+// "cache_hit=0%" cannot tell that from a cache that misses every single read. The first is a mount that
+// started a second ago; the second is an emergency. So the rate is nil until Requests is positive, and
+// Requests is on NodeInfo for exactly this reason.
+func TestStatusSnapshot_HitRateIsAbsentUntilACacheServesSomething(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "rate-host")
+
+	// A cache that exists, holds bytes, and has answered nothing. Hits+Misses is zero, so HitRate's 0.0 is
+	// arithmetic rather than measurement.
+	cm.SetCache(&mockCache{stats: types.CacheStats{Size: 4096, Capacity: 8192}})
+
+	self := requireSelf(t, cm.StatusSnapshot(), "rate-host")
+
+	if self.Cache == nil {
+		t.Fatalf("Cache = nil for a node with a cache holding 4096 bytes")
+	}
+	if self.Cache.Size != 4096 {
+		t.Errorf("Cache.Size = %d, want 4096", self.Cache.Size)
+	}
+	if self.Cache.HitRate != nil {
+		t.Errorf("Cache.HitRate = %v for a cache that has served no requests, want nil: a printed 0%% "+
+			"is indistinguishable from a cache that misses every read", *self.Cache.HitRate)
+	}
+
+	// And it appears once something has actually been served, so the nil above is a distinction and not
+	// a field that is always empty.
+	cm.SetCache(&mockCache{stats: types.CacheStats{
+		Size: 4096, Capacity: 8192, Hits: 3, Misses: 1, HitRate: 0.75,
+	}})
+
+	self = requireSelf(t, cm.StatusSnapshot(), "rate-host")
+
+	if self.Cache.HitRate == nil {
+		t.Fatal("Cache.HitRate = nil after 4 requests, want 0.75: the field is never populated")
+	}
+	if *self.Cache.HitRate != 0.75 {
+		t.Errorf("Cache.HitRate = %v, want 0.75", *self.Cache.HitRate)
+	}
+	if self.Cache.Requests != 4 {
+		t.Errorf("Cache.Requests = %d, want 4 (3 hits + 1 miss)", self.Cache.Requests)
+	}
+}
+
+// TestStatusSnapshot_CacheIsAbsentWhenNoCacheIsInjected keeps "there is no cache" distinct from "the
+// cache is empty".
+//
+// [ClusterManager.refreshLocalStats] signals the first by leaving the fields untouched rather than
+// zeroing them, and this asserts the status report preserves that distinction instead of flattening it
+// into a zero on the way out.
+func TestStatusSnapshot_CacheIsAbsentWhenNoCacheIsInjected(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "nocache-host")
+
+	self := requireSelf(t, cm.StatusSnapshot(), "nocache-host")
+
+	if self.Cache != nil {
+		t.Errorf("Cache = %+v with no cache injected, want nil: a reported size of 0 describes a cache "+
+			"that exists and holds nothing, which is a different state", self.Cache)
+	}
+}
+
+// TestStatusSnapshot_IncludesThisNodesOwnCacheFigures covers a defect found by running the command
+// against a live two-node cluster.
+//
+// refreshLocalStats reached only gp.localNode — the struct the *alive message* is built from — so a node
+// published its cache figures to every peer and never recorded them in its own membership map. The
+// visible symptom was a status report that showed a peer's cache in full and the node being asked as
+// "not reported", and TotalCacheSize summing every cache except the local one. The existing test for
+// that sum documents the old behavior in a comment: "plus whatever the self node reports — zero here,
+// since nothing refreshed it".
+//
+// Break [ClusterManager.refreshSelfEntry] by deleting its call in calculateClusterStats and this fails
+// on both assertions.
+func TestStatusSnapshot_IncludesThisNodesOwnCacheFigures(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "self-cache")
+	cm.SetCache(&mockCache{stats: types.CacheStats{
+		Size: 2048, Capacity: 4096, Hits: 9, Misses: 1, HitRate: 0.9,
+	}})
+
+	status := cm.StatusSnapshot()
+	self := requireSelf(t, status, "self-cache")
+
+	if self.Cache == nil {
+		t.Fatal("this node reports no cache while a cache is injected: refreshLocalStats reaches the " +
+			"alive message but not the membership map, so a node describes every peer's cache but not " +
+			"its own")
+	}
+	if self.Cache.Size != 2048 {
+		t.Errorf("own Cache.Size = %d, want 2048", self.Cache.Size)
+	}
+
+	// And it reaches the aggregate, which is the number an operator reads to size a cluster.
+	if status.Cache.TotalSize != 2048 {
+		t.Errorf("Cache.TotalSize = %d, want 2048: the local node's cache is excluded from the sum",
+			status.Cache.TotalSize)
+	}
+	if status.Cache.NodesMeasured != 1 {
+		t.Errorf("Cache.NodesMeasured = %d, want 1", status.Cache.NodesMeasured)
+	}
+}
+
+// TestStatusSnapshot_ClusterHitRateSkipsNodesThatMeasuredNothing is why this average is not
+// [ClusterStats.CacheHitRate].
+//
+// That field averages over every alive node, so a node that has served nothing contributes a 0.0 and
+// drags the cluster figure down for no reason other than having just started. A two-node cluster where
+// one node is at 80% and the other has answered nothing is an 80% cluster, not a 40% one.
+func TestStatusSnapshot_ClusterHitRateSkipsNodesThatMeasuredNothing(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "mean-host")
+
+	cm.mu.Lock()
+	cm.nodes["mean-busy"] = &NodeInfo{
+		ID: "mean-busy", Status: NodeStatusAlive, CacheSize: 100,
+		CacheHitRate: 0.8, CacheRequests: 500, Metadata: map[string]string{},
+	}
+	// Served nothing: a rate of 0.0 that is arithmetic, not measurement.
+	cm.nodes["mean-idle"] = &NodeInfo{
+		ID: "mean-idle", Status: NodeStatusAlive, CacheSize: 100,
+		CacheHitRate: 0, CacheRequests: 0, Metadata: map[string]string{},
+	}
+	cm.mu.Unlock()
+
+	status := cm.StatusSnapshot()
+
+	if status.Cache.HitRate == nil {
+		t.Fatal("Cache.HitRate = nil while one node has measured 500 requests")
+	}
+	if got := *status.Cache.HitRate; got != 0.8 {
+		t.Errorf("Cache.HitRate = %v, want 0.8: the idle node's arithmetic zero must not be averaged "+
+			"in, which is what makes this different from ClusterStats.CacheHitRate", got)
+	}
+	if status.Cache.NodesMeasured != 1 {
+		t.Errorf("Cache.NodesMeasured = %d, want 1: the count is what makes the mean readable",
+			status.Cache.NodesMeasured)
+	}
+}
+
+// TestStatusSnapshot_CapacityCountIsReportedWithTheSum keeps a partial capacity sum readable.
+//
+// The Redis-backed cache reports no capacity of its own, so a mixed cluster genuinely has nodes that
+// cannot answer. Without the count beside the sum, a cluster where one node of three reports capacity
+// looks three times fuller than it is.
+func TestStatusSnapshot_CapacityCountIsReportedWithTheSum(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "cap-host")
+
+	cm.mu.Lock()
+	cm.nodes["cap-known"] = &NodeInfo{
+		ID: "cap-known", Status: NodeStatusAlive, CacheSize: 10, CacheCapacity: 1000,
+		CacheRequests: 1, Metadata: map[string]string{},
+	}
+	// Capacity zero: a Redis cache, which has none to report.
+	cm.nodes["cap-unknown"] = &NodeInfo{
+		ID: "cap-unknown", Status: NodeStatusAlive, CacheSize: 20, CacheCapacity: 0,
+		CacheRequests: 1, Metadata: map[string]string{},
+	}
+	cm.mu.Unlock()
+
+	status := cm.StatusSnapshot()
+
+	if status.Cache.TotalCapacity != 1000 {
+		t.Errorf("Cache.TotalCapacity = %d, want 1000", status.Cache.TotalCapacity)
+	}
+	if status.Cache.NodesReportingCapacity != 1 {
+		t.Errorf("Cache.NodesReportingCapacity = %d, want 1: without this the sum is unreadable",
+			status.Cache.NodesReportingCapacity)
+	}
+}
+
+// TestStatusSnapshot_SeparatesSelfFromPeers checks the split the report's layout depends on, and that
+// peers come back in a stable order.
+//
+// Map iteration in Go is randomized, so an unsorted peer list makes the command's output reshuffle
+// between runs on the same cluster — which cannot be diffed, and is the first thing an operator does
+// with two status outputs.
+func TestStatusSnapshot_SeparatesSelfFromPeers(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "split-host")
+
+	cm.mu.Lock()
+	for _, id := range []string{"split-c", "split-a", "split-b"} {
+		cm.nodes[id] = &NodeInfo{ID: id, Status: NodeStatusAlive, Metadata: map[string]string{}}
+	}
+	cm.mu.Unlock()
+
+	status := cm.StatusSnapshot()
+
+	if status.Self == nil || status.Self.ID != "split-host" {
+		t.Fatalf("Self = %+v, want the local node", status.Self)
+	}
+
+	got := make([]string, 0, len(status.Peers))
+	for _, p := range status.Peers {
+		if p.ID == "split-host" {
+			t.Error("the local node appears in Peers as well as in Self, so it is counted twice")
+		}
+
+		got = append(got, p.ID)
+	}
+
+	want := []string{"split-a", "split-b", "split-c"}
+	if len(got) != len(want) {
+		t.Fatalf("Peers = %v, want %v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Peers = %v, want %v sorted by ID: map order is randomized, so an unsorted list "+
+				"makes two runs against one cluster undiffable", got, want)
+		}
+	}
+}
+
+// TestStatusSnapshot_MembershipMatchesTheAccessors holds the invariant #275 broke: two views of one
+// membership must agree.
+//
+// The tallies come from GetStats and the node list from GetNodes, which are separate reads, so this is
+// the assertion that keeps a third opinion about how many nodes there are from creeping in.
+func TestStatusSnapshot_MembershipMatchesTheAccessors(t *testing.T) {
+	t.Parallel()
+
+	cm := makeClusterWithNode(t, "tally-host")
+
+	cm.mu.Lock()
+	cm.nodes["tally-alive"] = &NodeInfo{ID: "tally-alive", Status: NodeStatusAlive, Metadata: map[string]string{}}
+	cm.nodes["tally-dead"] = &NodeInfo{ID: "tally-dead", Status: NodeStatusDead, Metadata: map[string]string{}}
+	cm.nodes["tally-suspect"] = &NodeInfo{ID: "tally-suspect", Status: NodeStatusSuspect, Metadata: map[string]string{}}
+	cm.mu.Unlock()
+
+	status := cm.StatusSnapshot()
+	m := status.Membership
+
+	if m.Total != 4 {
+		t.Errorf("Membership.Total = %d, want 4 (self plus three)", m.Total)
+	}
+	if m.Alive != 2 || m.Suspect != 1 || m.Dead != 1 {
+		t.Errorf("Membership = (alive %d, suspect %d, dead %d), want (2, 1, 1)", m.Alive, m.Suspect, m.Dead)
+	}
+
+	// The three must account for the total: a node whose status matches no arm is counted suspect rather
+	// than silently dropped, which is a property calculateClusterStats was fixed to have.
+	if m.Alive+m.Suspect+m.Dead != m.Total {
+		t.Errorf("alive+suspect+dead = %d but Total = %d; a node is being counted in the total and in "+
+			"none of the breakdowns", m.Alive+m.Suspect+m.Dead, m.Total)
+	}
+
+	// And the peer list plus self is the same population.
+	if got := len(status.Peers) + 1; got != m.Total {
+		t.Errorf("Peers+self = %d but Membership.Total = %d; the two describe one membership", got, m.Total)
+	}
+}
+
+// TestStatusSnapshot_ReportsTheBoundGossipAddress asserts the address is the bound one.
+//
+// The configured value is "127.0.0.1:0" — what a test asks for so the kernel picks a port — and that is
+// not an address any peer can be told about. A status report naming it would be telling an operator to
+// check connectivity to port 0.
+func TestStatusSnapshot_ReportsTheBoundGossipAddress(t *testing.T) {
+	t.Parallel()
+
+	cm, cm2 := startGossipPair(t, "addr-a", "addr-b")
+	_ = cm2
+
+	status := cm.StatusSnapshot()
+
+	if status.GossipAddr == "" {
+		t.Fatal("GossipAddr is empty for a started cluster")
+	}
+	if status.GossipAddr == "127.0.0.1:0" {
+		t.Errorf("GossipAddr = %q, the configured value rather than the bound one: port 0 is not an "+
+			"address a peer can be told about", status.GossipAddr)
+	}
+}
+
+// TestStatusSnapshot_TwoNodesSeeEachOther runs the status report over the real gossip transport, which
+// is the only way to check that a peer's figures survive the wire.
+//
+// Everything above builds a membership map directly. This one goes through startGossipPair — two clusters
+// on loopback UDP — so the NodeInfo fields the report reads are ones that were marshaled, authenticated,
+// sent, received and merged by UpdateNodeInfo. That path is where a field added to NodeInfo and not
+// propagated in performGossip would be lost, and it is where CacheRequests and CacheCapacity had to be
+// added rather than merely declared.
+func TestStatusSnapshot_TwoNodesSeeEachOther(t *testing.T) {
+	t.Parallel()
+
+	cm1, cm2 := startGossipPair(t, "wire-a", "wire-b")
+
+	// Distinct figures per node, so a report that mixed them up would fail rather than coincide.
+	cm2.SetCache(&mockCache{stats: types.CacheStats{
+		Size: 7777, Capacity: 9999, Hits: 30, Misses: 10, HitRate: 0.75,
+	}})
+
+	// cm2 must gossip for cm1 to learn its figures; the pair is registered one-directionally, so this
+	// drives the round explicitly rather than waiting on a ticker.
+	deadline := time.Now().Add(3 * time.Second)
+
+	var peer *NodeReport
+
+	for time.Now().Before(deadline) {
+		cm2.gossip.mu.Lock()
+		cm2.gossip.memberlist["wire-a"] = &GossipNode{
+			Info:  &NodeInfo{ID: "wire-a", Address: cm1.gossip.LocalAddr()},
+			State: StateAlive,
+		}
+		cm2.gossip.mu.Unlock()
+		cm2.gossip.performGossip()
+
+		for i := range cm1.StatusSnapshot().Peers {
+			p := cm1.StatusSnapshot().Peers[i]
+			if p.ID == "wire-b" && p.Cache != nil {
+				peer = &p
+
+				break
+			}
+		}
+
+		if peer != nil {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if peer == nil {
+		t.Fatal("wire-a never learned wire-b's cache figures over gossip; a NodeInfo field that is not " +
+			"propagated in performGossip is invisible to every peer")
+	}
+
+	if peer.Cache.Size != 7777 {
+		t.Errorf("peer Cache.Size = %d, want 7777", peer.Cache.Size)
+	}
+	if peer.Cache.Capacity == nil || *peer.Cache.Capacity != 9999 {
+		t.Errorf("peer Cache.Capacity = %v, want 9999: the field crossed the wire unpopulated", peer.Cache.Capacity)
+	}
+	if peer.Cache.Requests != 40 {
+		t.Errorf("peer Cache.Requests = %d, want 40 (30 hits + 10 misses): without the denominator a "+
+			"peer's 0%% hit rate cannot be told from a peer that has served nothing", peer.Cache.Requests)
+	}
+	if peer.Cache.HitRate == nil || *peer.Cache.HitRate != 0.75 {
+		t.Errorf("peer Cache.HitRate = %v, want 0.75", peer.Cache.HitRate)
+	}
+}
+
+// TestClusterStatusDisabled_IsNotAnError pins the commonest answer of all.
+//
+// `cluster.enabled` defaults to false, so this is what almost every ObjectFS instance reports, and it
+// must carry a reason rather than looking like an empty or failed status.
+func TestClusterStatusDisabled_IsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	status := ClusterStatusDisabled("clustering is off")
+
+	if status.Enabled {
+		t.Error("Enabled = true for the disabled status")
+	}
+	if status.Reason == "" {
+		t.Error("Reason is empty: an operator reading a disabled status needs to be told it is a " +
+			"configuration state and not a fault")
+	}
+	if status.Membership.Total != 0 {
+		t.Errorf("Membership.Total = %d, want 0", status.Membership.Total)
+	}
+}
+
+// marshalStatus encodes a status the way the endpoint and --json both do.
+func marshalStatus(t *testing.T, status *ClusterStatus) []byte {
+	t.Helper()
+
+	body, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("json.Marshal(ClusterStatus): %v", err)
+	}
+
+	return body
+}
+
+// containsJSONKey reports whether name appears as an object key anywhere in body, at any depth.
+//
+// Decoded rather than substring-matched, because a substring search would also match a *value* that
+// happened to contain the name — and the string it is looking for is exactly the sort of thing a
+// diagnostic message in the Reason field would contain.
+func containsJSONKey(t *testing.T, body []byte, name string) bool {
+	t.Helper()
+
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("the status does not round-trip through JSON: %v", err)
+	}
+
+	return hasKey(decoded, name)
+}
+
+func hasKey(v any, name string) bool {
+	switch typed := v.(type) {
+	case map[string]any:
+		for k, child := range typed {
+			if k == name || hasKey(child, name) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if hasKey(child, name) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// requireSelf returns the local node's report or fails.
+func requireSelf(t *testing.T, status *ClusterStatus, id string) *NodeReport {
+	t.Helper()
+
+	if status.Self == nil {
+		t.Fatalf("Self = nil, want the report for %s", id)
+	}
+	if status.Self.ID != id {
+		t.Fatalf("Self.ID = %q, want %q", status.Self.ID, id)
+	}
+
+	return status.Self
+}

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -26,6 +26,9 @@ type Checker struct {
 	// boundAddr is what the listener reports, which is not necessarily Config.HTTPAddr: a caller
 	// asking for port 0 gets whatever the kernel assigned, and [Checker.Addr] is how it finds out.
 	boundAddr string
+
+	// cluster holds what /health/cluster reports, under its own lock. See [clusterProviderHolder].
+	cluster clusterProviderHolder
 }
 
 // Config represents health checker configuration
@@ -618,6 +621,8 @@ func (c *Checker) serveHealth(ctx context.Context, ln net.Listener) {
 			slog.Error("health: error writing HTTP response", "error", err)
 		}
 	})
+
+	mux.HandleFunc(c.ClusterPath(), c.serveClusterStatus)
 
 	server := &http.Server{
 		Handler:           mux,

--- a/internal/health/cluster.go
+++ b/internal/health/cluster.go
@@ -1,0 +1,145 @@
+package health
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+)
+
+// ClusterStatusPath is where cluster state is served, relative to the health listener's address.
+//
+// The issue asking for `objectfs cluster status` (#147) specified that the command reads
+// http://localhost:8081/health/cluster, and that endpoint did not exist: [Checker.serveHealth]
+// registered exactly one handler, at Config.HTTPPath, and nothing in this package mentioned clustering.
+// So the issue specified a client for a server that had never been written. This is that server.
+//
+// A sibling of /health rather than a query parameter on it, because the two answer different questions
+// with different failure modes: /health is a liveness probe a load balancer polls and reports 503 when
+// the process is degraded, while this is a state report that must answer 200 even when the cluster is in
+// trouble — an operator diagnosing a cluster needs the diagnosis, not a status code standing in for it.
+const ClusterStatusPath = "/health/cluster"
+
+// ClusterStatusProvider is whatever can describe the local node's cluster state.
+//
+// It returns `any` rather than a concrete type on purpose: this package would otherwise have to import
+// internal/distributed to name it, and the dependency belongs the other way round — health is the
+// transport here and has no opinion about what a cluster is. The type that owns the wire format is
+// distributed.ClusterStatus, which is also what cmd/objectfs decodes into, so producer and consumer
+// share one definition and cannot drift. Routing it through a stringly-typed interface in the middle
+// would be the drift.
+//
+// Implementations must be safe to call from an HTTP handler goroutine at any time.
+type ClusterStatusProvider interface {
+	// ClusterStatus returns a JSON-serializable description of the cluster. It must not return nil; a
+	// provider with nothing to report returns the disabled form.
+	ClusterStatus() any
+}
+
+// ClusterStatusFunc adapts a function to [ClusterStatusProvider].
+type ClusterStatusFunc func() any
+
+// ClusterStatus calls f.
+func (f ClusterStatusFunc) ClusterStatus() any { return f() }
+
+// clusterProviderHolder holds the registered provider under its own mutex.
+//
+// Its own mutex, and not Checker.mu, because of what Checker.mu already protects: Start holds it for
+// writing across the bind, and the checkLoop takes it on every round. A status request arriving during
+// startup would queue behind the whole of Start for no reason, and a provider whose own snapshot takes a
+// lock would have to establish an order against a mutex that serializes health checking. Nothing here
+// needs to be consistent with anything Checker.mu guards.
+type clusterProviderHolder struct {
+	mu       sync.RWMutex
+	provider ClusterStatusProvider
+}
+
+// SetClusterStatusProvider registers what /health/cluster reports, replacing any previous provider.
+//
+// Safe to call before or after Start: the handler reads the provider per request rather than closing
+// over it, so registering after the listener is up simply means earlier requests got the unregistered
+// answer. That ordering is what the adapter needs — the health monitor and the cluster manager are
+// separate startup steps and either can come first.
+//
+// Passing nil clears it, which is a deliberate capability rather than an oversight: it is how a shutting
+// down cluster stops claiming to have one.
+func (c *Checker) SetClusterStatusProvider(provider ClusterStatusProvider) {
+	c.cluster.mu.Lock()
+	defer c.cluster.mu.Unlock()
+
+	c.cluster.provider = provider
+}
+
+// clusterStatusProvider returns the registered provider, or nil.
+func (c *Checker) clusterStatusProvider() ClusterStatusProvider {
+	c.cluster.mu.RLock()
+	defer c.cluster.mu.RUnlock()
+
+	return c.cluster.provider
+}
+
+// ClusterPath is where this checker serves cluster status.
+//
+// It follows Config.HTTPPath when that has been moved off the default, so an operator who put the health
+// endpoint at /objectfs/health finds cluster status at /objectfs/health/cluster rather than at a fixed
+// path that no longer relates to it. At the default it is exactly [ClusterStatusPath], which is the
+// path #147 named.
+func (c *Checker) ClusterPath() string {
+	if base := c.config.HTTPPath; base != "" && base != "/health" {
+		return base + "/cluster"
+	}
+
+	return ClusterStatusPath
+}
+
+// unregisteredClusterStatus is the answer when no provider has been registered.
+//
+// Field names matching distributed.ClusterStatus's first two, so a client decodes one type either way.
+// This is deliberately not an error status: a mount with `cluster.enabled: false` is the default
+// configuration and by far the commonest deployment, and an endpoint that failed for it would teach
+// every operator to ignore the failure. The distinction a client actually needs is between "not
+// clustered", which is this, and "nothing is listening", which never reaches an HTTP handler at all.
+type unregisteredClusterStatus struct {
+	Enabled bool   `json:"enabled"`
+	Reason  string `json:"reason"`
+}
+
+// serveClusterStatus writes the cluster status as JSON.
+//
+// Always 200 when it can answer at all, including when the cluster is unhealthy. The status code
+// reports whether this endpoint worked, and the payload reports whether the cluster is well — folding
+// the second into the first is what makes a 503 unreadable, since it would then mean any of "the
+// process is dying", "the cluster lost members", or "clustering is off". `objectfs cluster status`
+// decides its own exit code from the payload.
+func (c *Checker) serveClusterStatus(w http.ResponseWriter, _ *http.Request) {
+	var payload any = unregisteredClusterStatus{
+		Enabled: false,
+		Reason: "this instance is not running cluster coordination: set cluster.enabled in the " +
+			"configuration file to join a cluster",
+	}
+
+	if provider := c.clusterStatusProvider(); provider != nil {
+		if status := provider.ClusterStatus(); status != nil {
+			payload = status
+		}
+	}
+
+	// Encoded before the header is written, rather than streamed into the response. A marshaling
+	// failure after WriteHeader(200) cannot be corrected — the client has already been told the request
+	// succeeded and then gets a truncated body, which decodes as a syntax error and looks to the operator
+	// like a corrupt endpoint rather than a server-side fault.
+	body, err := json.Marshal(payload)
+	if err != nil {
+		slog.Error("health: cannot serialize cluster status", "error", err)
+		http.Error(w, `{"error":"cannot serialize cluster status"}`, http.StatusInternalServerError)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write(body); err != nil {
+		slog.Error("health: error writing cluster status response", "error", err)
+	}
+}

--- a/internal/health/cluster_test.go
+++ b/internal/health/cluster_test.go
@@ -1,0 +1,380 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// This file covers the /health/cluster endpoint, which exists because #147 specified a client for it and
+// the endpoint had never been written: serveHealth registered exactly one handler, at Config.HTTPPath.
+//
+// The tests here send real requests over a real loopback listener rather than calling serveClusterStatus
+// with an httptest.ResponseRecorder, for the same reason the rest of this package does: the mux routing is
+// half of what is being asserted, and a handler called directly answers whatever path it is asked about.
+
+// serveClusterOnEphemeralPort starts a checker's endpoints on a kernel-chosen port and returns the base
+// URL, without the path — the caller decides which endpoint it is asking about.
+//
+// Deliberately not reusing serveOnEphemeralPort: that helper overwrites config.HTTPPath with "/health",
+// which is exactly the value one test below needs to be something else.
+func serveClusterOnEphemeralPort(t *testing.T, checker *Checker) string {
+	t.Helper()
+
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen on loopback in this environment: %v", err)
+	}
+
+	served := make(chan struct{})
+
+	go func() {
+		defer close(served)
+		checker.serveHealth(context.WithoutCancel(t.Context()), ln)
+	}()
+
+	t.Cleanup(func() {
+		_ = checker.Stop()
+		<-served
+	})
+
+	return "http://" + ln.Addr().String()
+}
+
+// newClusterTestChecker returns a started checker with the endpoint disabled and httpPath as its health
+// path.
+//
+// Started here, even though these tests supply their own listener, because Stop is a no-op returning an
+// error on a checker that was never started — so an unstarted checker never closes stopCh, serveHealth
+// never returns, and the cleanup in serveClusterOnEphemeralPort blocks until the test binary's timeout.
+// HTTPEnabled is false, so Start does not bind anything of its own.
+func newClusterTestChecker(t *testing.T, httpPath string) *Checker {
+	t.Helper()
+
+	checker, err := NewChecker(&Config{
+		Enabled:       true,
+		CheckInterval: time.Hour,
+		Timeout:       5 * time.Second,
+		MaxFailures:   3,
+		HTTPEnabled:   false,
+		HTTPPath:      httpPath,
+	})
+	if err != nil {
+		t.Fatalf("NewChecker() error = %v", err)
+	}
+
+	if err := checker.Start(t.Context()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	return checker
+}
+
+// TestClusterEndpointAnswersWithoutAProviderRegistered is the commonest request this endpoint will ever
+// serve.
+//
+// `cluster.enabled` defaults to false, so on almost every ObjectFS instance no provider is registered.
+// That must be a 200 with a payload saying so, and not a 404 or a 500: a client cannot distinguish an
+// error here from an instance that is failing, and an endpoint that errors on the default configuration
+// teaches every operator to ignore it.
+//
+// The reason string is asserted to be non-empty because it is the entire difference between this and an
+// empty answer. An operator who sees `"enabled": false` and nothing else has been told a fact without
+// being told whether it is a fault.
+func TestClusterEndpointAnswersWithoutAProviderRegistered(t *testing.T) {
+	t.Parallel()
+
+	checker := newClusterTestChecker(t, "/health")
+	base := serveClusterOnEphemeralPort(t, checker)
+
+	code, body := get(t, base+ClusterStatusPath)
+
+	if code != http.StatusOK {
+		t.Errorf("GET %s returned %d, want 200: an instance with clustering off is not broken, and an "+
+			"error here cannot be told from an instance that is failing. Body: %s",
+			ClusterStatusPath, code, body)
+	}
+
+	var payload struct {
+		Enabled bool   `json:"enabled"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("the endpoint served something that is not JSON (%q): %v", body, err)
+	}
+
+	if payload.Enabled {
+		t.Errorf("enabled = true with no provider registered: %s", body)
+	}
+
+	if payload.Reason == "" {
+		t.Error("reason is empty, so the payload states that clustering is off without saying whether " +
+			"that is a configuration choice or a failure")
+	}
+}
+
+// TestClusterEndpointServesTheRegisteredProvider is the path a clustered mount takes.
+//
+// The provider is registered *after* the server is already serving, which is not incidental: the adapter
+// builds the health monitor and the cluster manager as separate startup steps, and the handler reads the
+// provider per request rather than closing over it precisely so that either order works. Registering
+// before serving would leave that untested and a closure-capturing implementation would pass.
+func TestClusterEndpointServesTheRegisteredProvider(t *testing.T) {
+	t.Parallel()
+
+	checker := newClusterTestChecker(t, "/health")
+	base := serveClusterOnEphemeralPort(t, checker)
+
+	checker.SetClusterStatusProvider(ClusterStatusFunc(func() any {
+		return map[string]any{"enabled": true, "node_id": "provider-node"}
+	}))
+
+	code, body := get(t, base+ClusterStatusPath)
+
+	if code != http.StatusOK {
+		t.Fatalf("GET %s returned %d, want 200. Body: %s", ClusterStatusPath, code, body)
+	}
+
+	var payload struct {
+		Enabled bool   `json:"enabled"`
+		NodeID  string `json:"node_id"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("not JSON (%q): %v", body, err)
+	}
+
+	if !payload.Enabled || payload.NodeID != "provider-node" {
+		t.Errorf("payload = %s, want the registered provider's answer: the handler is not reading the "+
+			"provider per request, so registration after Start is lost", body)
+	}
+}
+
+// TestClusterEndpointAnswers200ForAnUnhealthyCluster is the deliberate difference from /health.
+//
+// /health returns 503 when the process is degraded, because a probe reads only the status code. This
+// endpoint always returns 200 when it can answer at all, because an operator diagnosing a cluster needs
+// the diagnosis rather than a status code standing in for it — and because a 503 here would mean any of
+// "the process is dying", "members are missing", or "clustering is off". `objectfs cluster status`
+// decides its exit code from the payload for this reason.
+func TestClusterEndpointAnswers200ForAnUnhealthyCluster(t *testing.T) {
+	t.Parallel()
+
+	checker := newClusterTestChecker(t, "/health")
+
+	// A critical check that fails, so /health is 503 and the two endpoints can be compared in one test.
+	if err := checker.RegisterCheck("s3", "the backend", CategoryStorage, PriorityCritical,
+		func(context.Context) error { return errors.New("s3: connection refused") }); err != nil {
+		t.Fatalf("RegisterCheck() error = %v", err)
+	}
+
+	if _, err := checker.RunAllChecks(t.Context()); err != nil {
+		t.Fatalf("RunAllChecks() error = %v", err)
+	}
+
+	checker.SetClusterStatusProvider(ClusterStatusFunc(func() any {
+		// A cluster in trouble: two of three nodes gone.
+		return map[string]any{"enabled": true, "membership": map[string]int{"total": 3, "dead": 2}}
+	}))
+
+	base := serveClusterOnEphemeralPort(t, checker)
+
+	if code, _ := get(t, base+"/health"); code != http.StatusServiceUnavailable {
+		t.Errorf("GET /health returned %d, want 503; the comparison below is only meaningful if the "+
+			"process really is degraded", code)
+	}
+
+	code, body := get(t, base+ClusterStatusPath)
+	if code != http.StatusOK {
+		t.Errorf("GET %s returned %d for an unhealthy cluster, want 200: the status code reports "+
+			"whether this endpoint worked and the payload reports whether the cluster is well. Folding "+
+			"them together makes a 503 mean three different things. Body: %s",
+			ClusterStatusPath, code, body)
+	}
+
+	if !json.Valid(body) {
+		t.Errorf("the body is not JSON: %s", body)
+	}
+}
+
+// TestClusterPathFollowsACustomizedHealthPath keeps the two endpoints related.
+//
+// An operator who moved health checking to /objectfs/health has moved it because something else owns
+// /health — a reverse proxy route, another service on the same port. Serving cluster status at a fixed
+// /health/cluster would put it back in the namespace they moved out of, and it would be the one path
+// they did not know to reconfigure.
+func TestClusterPathFollowsACustomizedHealthPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		httpPath string
+		want     string
+	}{
+		{
+			name:     "the default path yields the path #147 named",
+			httpPath: "/health",
+			want:     "/health/cluster",
+		},
+		{
+			name:     "a moved health path takes cluster status with it",
+			httpPath: "/objectfs/health",
+			want:     "/objectfs/health/cluster",
+		},
+		{
+			// An empty HTTPPath means the config was built without one. ClusterPath must still name a
+			// path: returning "/cluster" would put it at the root of whatever else is on that port.
+			name:     "an unset health path still yields the default",
+			httpPath: "",
+			want:     "/health/cluster",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			checker := newClusterTestChecker(t, tc.httpPath)
+
+			if got := checker.ClusterPath(); got != tc.want {
+				t.Errorf("ClusterPath() = %q with HTTPPath %q, want %q", got, tc.httpPath, tc.want)
+			}
+		})
+	}
+}
+
+// TestClusterEndpointIsServedAtTheCustomizedPath closes the gap between ClusterPath and the mux.
+//
+// ClusterPath returning the right string and serveHealth registering that string are two facts, and the
+// test above establishes only the first. Without this one, a serveHealth that registered the constant
+// instead of calling ClusterPath would pass everything else in this file.
+func TestClusterEndpointIsServedAtTheCustomizedPath(t *testing.T) {
+	t.Parallel()
+
+	checker := newClusterTestChecker(t, "/objectfs/health")
+	checker.SetClusterStatusProvider(ClusterStatusFunc(func() any {
+		return map[string]any{"enabled": true, "node_id": "moved-node"}
+	}))
+
+	base := serveClusterOnEphemeralPort(t, checker)
+
+	if code, body := get(t, base+"/objectfs/health/cluster"); code != http.StatusOK {
+		t.Errorf("GET /objectfs/health/cluster returned %d, want 200: serveHealth registered a path "+
+			"other than the one ClusterPath names. Body: %s", code, body)
+	}
+
+	// And the fixed path is *not* served, so a moved endpoint is genuinely moved rather than served from
+	// both places. Two live paths would mean an operator's reverse-proxy route still collides.
+	if code, _ := get(t, base+ClusterStatusPath); code != http.StatusNotFound {
+		t.Errorf("GET %s returned %d after the health path was moved, want 404: the endpoint is served "+
+			"from two places at once", ClusterStatusPath, code)
+	}
+}
+
+// TestSetClusterStatusProviderNilFallsBackToTheUnregisteredAnswer covers deregistration.
+//
+// A cluster manager shutting down clears the provider, and the endpoint must then report that this
+// instance is not clustered rather than panicking on a nil interface or serving a stale snapshot.
+func TestSetClusterStatusProviderNilFallsBackToTheUnregisteredAnswer(t *testing.T) {
+	t.Parallel()
+
+	checker := newClusterTestChecker(t, "/health")
+	checker.SetClusterStatusProvider(ClusterStatusFunc(func() any {
+		return map[string]any{"enabled": true}
+	}))
+	checker.SetClusterStatusProvider(nil)
+
+	base := serveClusterOnEphemeralPort(t, checker)
+
+	code, body := get(t, base+ClusterStatusPath)
+	if code != http.StatusOK {
+		t.Fatalf("GET %s returned %d after the provider was cleared, want 200. Body: %s",
+			ClusterStatusPath, code, body)
+	}
+
+	var payload struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("not JSON (%q): %v", body, err)
+	}
+
+	if payload.Enabled {
+		t.Errorf("enabled = true after the provider was cleared, so a shutting-down cluster still "+
+			"claims to have one: %s", body)
+	}
+}
+
+// TestClusterEndpointAnswersWhenAProviderReturnsNil guards the interface's one documented requirement.
+//
+// [ClusterStatusProvider] says an implementation must not return nil, and "must not" is worth enforcing
+// rather than trusting: a provider that returns a nil `any` would otherwise serve the JSON literal
+// `null`, which decodes into a zero-valued ClusterStatus — Enabled false, Reason empty — and the client
+// would report "clustering is disabled" for a node that is in fact clustered and merely buggy.
+func TestClusterEndpointAnswersWhenAProviderReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	checker := newClusterTestChecker(t, "/health")
+	checker.SetClusterStatusProvider(ClusterStatusFunc(func() any { return nil }))
+
+	base := serveClusterOnEphemeralPort(t, checker)
+
+	code, body := get(t, base+ClusterStatusPath)
+	if code != http.StatusOK {
+		t.Fatalf("GET %s returned %d, want 200. Body: %s", ClusterStatusPath, code, body)
+	}
+
+	var payload struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("not JSON (%q): %v", body, err)
+	}
+
+	if payload.Reason == "" {
+		t.Errorf("a provider returning nil served %s, which carries no reason: the fallback answer is "+
+			"what keeps this from decoding as a silently disabled cluster", body)
+	}
+}
+
+// TestConcurrentProviderSwapsAndRequestsDoNotRace is a race test rather than an assertion test: it fails
+// under -race on the defect and passes either way without it.
+//
+// The provider is registered by the adapter's startup and read by the HTTP handler goroutine, which are
+// unrelated goroutines by construction. clusterProviderHolder has its own mutex — not Checker.mu, which
+// Start holds across the bind — and this is what says the mutex is actually taken on both sides.
+func TestConcurrentProviderSwapsAndRequestsDoNotRace(t *testing.T) {
+	t.Parallel()
+
+	checker := newClusterTestChecker(t, "/health")
+	base := serveClusterOnEphemeralPort(t, checker)
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for i := range 200 {
+			if i%2 == 0 {
+				checker.SetClusterStatusProvider(ClusterStatusFunc(func() any {
+					return map[string]any{"enabled": true}
+				}))
+			} else {
+				checker.SetClusterStatusProvider(nil)
+			}
+		}
+	}()
+
+	for range 20 {
+		if code, _ := get(t, base+ClusterStatusPath); code != http.StatusOK {
+			t.Errorf("GET %s returned %d during a provider swap, want 200", ClusterStatusPath, code)
+		}
+	}
+
+	<-done
+}

--- a/internal/health/monitor.go
+++ b/internal/health/monitor.go
@@ -235,6 +235,22 @@ func (m *Monitor) RegisterComponent(component HealthyComponent) error {
 	)
 }
 
+// SetClusterStatusProvider registers what the monitor's /health/cluster endpoint reports.
+//
+// It forwards to the checker, which owns the listener. The adapter holds a *Monitor and not a *Checker,
+// so without this the endpoint would have no way to be given anything to serve — and an endpoint with no
+// provider answers `enabled: false`, which is indistinguishable from a mount that is genuinely not
+// clustered. That is exactly the kind of silence #139 was filed for: every part of internal/distributed
+// worked and nothing wired it to a mount.
+func (m *Monitor) SetClusterStatusProvider(provider ClusterStatusProvider) {
+	m.checker.SetClusterStatusProvider(provider)
+}
+
+// ClusterStatusPath returns the path the monitor serves cluster status on, for logging it at startup.
+func (m *Monitor) ClusterStatusPath() string {
+	return m.checker.ClusterPath()
+}
+
 // GetStatus returns the current system health status
 func (m *Monitor) GetStatus() *ServiceStatus {
 	version := "1.0.0" // This would come from build info


### PR DESCRIPTION
Closes #147.

#147 asked for a client for an endpoint that did not exist, so this is two halves: `/health/cluster` (`internal/health/cluster.go`) and `objectfs cluster status [--json] [--endpoint] [--config]` (`cmd/objectfs/cluster.go`).

`internal/health` does not import `internal/distributed` — a `ClusterStatusProvider` returning `any` keeps the seam — while the concrete `distributed.ClusterStatus` is shared by producer and consumer, so the wire format has one definition. The endpoint is registered through `Checker.ClusterPath()` rather than a constant, so it follows a customized `HTTPPath`.

## Pre-existing defect found by running it, not by reading it

`refreshLocalStats` only ever reached `gp.localNode` — the struct the gossip alive-message is built from — so **a node published its cache figures to every peer and never recorded them in its own membership map.** Every node showed each peer's cache in full and its own as "not reported", and cluster-wide `TotalCacheSize` under-reported by one node's worth, on every node.

`cluster_test.go:732` had documented the symptom as expected behaviour — *"zero here, since nothing refreshed it"* — which is exactly why reading the tests would not have surfaced it. Fixed with `refreshSelfEntry()`, using a `-1` sentinel so "no cache injected" stays distinguishable from "an empty cache".

## What the issue's mockup asked for and does not appear here

Printing a number nobody assigns is worse than printing nothing, so each of these is absent *and says why* in the output:

| Mockup field | Disposition |
|---|---|
| `Role: Leader/Follower` | Only when `enable_consensus` is set. A mount leaves consensus off, so `IsLeader` is false on every node of a healthy cluster. `Leadership` is a nil pointer, not a zero struct. |
| per-node cache hit % | `nil` until requests > 0, printing `hit=not measured`. A 0.0 rate by arithmetic is indistinguishable from a cache that misses every read. |
| "Top 5 keys by access" | **Dropped.** No per-key access counter is reachable from the cluster layer. `recentHoldings` orders by *last announced* — a different quantity, and publishing it under this label would be a proxy read as the real thing. `AnnouncedKeys` is printed as the count it is. |
| `quorum` in the exit code | **Replaced** by dead-or-suspect-nodes. Quorum is a Raft concept; this project coordinates by CAS against S3 and a 2-node cluster with one node down works correctly. |
| 8 `ClusterStats` fields | Dropped — five are assigned nowhere, three only by `SetLeader`, which only consensus reaches. Also `NodeInfo.Version` (hardcoded `"1.0.0"`, not the build). |

Clustering disabled exits **0**: it is the default configuration, so anything else pages on every single-node mount.

## Verification

40 new tests. Two claims re-verified by mutation in review rather than taken from the implementation:

- removing the `refreshSelfEntry()` call → `TestStatusSnapshot_IncludesThisNodesOwnCacheFigures` and `TestStatusSnapshot_HitRateIsAbsentUntilACacheServesSomething` both fail
- forcing the `CacheRequests > 0` guard true → the latter plus `TestStatusSnapshot_ClusterHitRateSkipsNodesThatMeasuredNothing` fail

`go build ./...`, `gofmt -l .`, `go vet ./...`, `golangci-lint run` (0 issues), `go test -race ./...` (no FAIL, panic or race), `go test -race -tags=distributed ./internal/distributed/...` all clean. Coverage: `cmd/objectfs` 85.9% (floor 77), `internal/distributed` 84.3% (67), `internal/health` 60.1% (48).

`"cluster"` is added to `docs_symbols_test.go`'s subcommands map and `main_test.go`'s help list — `TestSubcommandsMatchTheBinary` parses the dispatch switch with go/ast and correctly caught the new arm.