### PR TITLE
feat(vfs,fuse): extended attributes, stored in S3 user metadata (#167)

### DIFF
--- a/.coverage-floors
+++ b/.coverage-floors
@@ -341,7 +341,20 @@ internal/adapter         40
 # driven by a fetch registered and never finished. The second one is bounded with an explicit timeout
 # because removing the arm makes the prefetch *block* on the read it was trimmed against rather than
 # fetch too much — a parked prefetch worker, which no byte-count assertion can see.
-internal/fuse            67
+#
+# 67 → 72 with #167's extended attributes: xattr.go's five operations, the base64 name encoding, the
+# budget check and the removal tombstone are all reached by unit tests, a differential oracle against the
+# local OS filesystem, and a per-platform errno hook. Two of those tests exist because a mutation showed
+# the code they cover was unowned — deleting the clamp in xattrSize left the whole package green.
+#
+# This entry is the first one in this file set from CI's own log rather than a local run, which is the
+# lesson the three paragraphs above kept re-learning. It matters more here than the load-dependence they
+# describe: CI is ubuntu-latest and compiles unmount_path_linux.go (52 lines) where a darwin run compiles
+# unmount_path_darwin.go (44), so the two platforms do not even have the same denominator. Darwin
+# measured 72.2% and linux 72.5% for the same tree. There is no Docker on the development machine, so the
+# linux figure is not obtainable except from a PR — which means the ratchet is a second commit, after the
+# feature is green, and not part of the commit that earned the points.
+internal/fuse            72
 
 # internal/cache went 74 → 76 with the re-keying work — the byte-range keying, splitting, coalescing,
 # and coverage checks are now covered by 27 tests and a fuzz target where before they were two copies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reports `ENOTSUP` rather than go-fuse's default of "no such attribute" so that a caller can tell
   "this filesystem cannot" from "that attribute is missing".
 
+  **One errno is per-platform, because the kernels disagree.** A `setxattr` naming both `XATTR_CREATE`
+  and `XATTR_REPLACE` is `EINVAL` on macOS — also what `setxattr(2)`'s Linux man page describes — but
+  Linux's `fs/xattr.c` has no combined-flag check at all: it tests each flag independently against
+  whether the attribute exists, giving `ENODATA` when it is missing and `EEXIST` when it is present.
+  ObjectFS answers as the kernel it is running under does, so a program behaves the same on an ObjectFS
+  mount as on the local filesystem of the same host. This was found by the differential oracle on CI
+  and could not have been found locally: the oracle compares against the *local* OS filesystem, so on
+  macOS ObjectFS and the reference agreed on the wrong-for-Linux answer and every test was green.
+
   **Names and values are encoded, not stored verbatim**, and the reasons are worth stating because
   the naive mapping is silently lossy in three separate ways. A user-metadata key is an HTTP header
   name: S3 lower-cases it in transit, so `user.Foo` and `user.foo` would overwrite each other, and it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no per-key access counter is reachable from the cluster layer, and the nearest available quantity
   orders by last-announced, which under that label would be a proxy read as the real thing.
 
+- **Extended attributes** ([#167]) — `getfattr`, `setfattr`, and `setfattr -x` now work on files,
+  stored in S3 user metadata and surviving a flush. `XATTR_CREATE` and `XATTR_REPLACE` are honoured,
+  an attribute set to an empty value round-trips as empty rather than as a removal, and a directory
+  reports `ENOTSUP` rather than go-fuse's default of "no such attribute" so that a caller can tell
+  "this filesystem cannot" from "that attribute is missing".
+
+  **Names and values are encoded, not stored verbatim**, and the reasons are worth stating because
+  the naive mapping is silently lossy in three separate ways. A user-metadata key is an HTTP header
+  name: S3 lower-cases it in transit, so `user.Foo` and `user.foo` would overwrite each other, and it
+  admits only token characters where an xattr name admits any byte but NUL — so names are
+  base32-encoded, whose alphabet survives case folding. Values are binary, and a header value carries
+  neither a NUL nor a newline, so values are base64-encoded in the **URL** alphabet specifically,
+  avoiding `+` (which real S3 has been observed to read as a space in a header), `/`, and `=`. The
+  cost is 1.6 stored bytes per byte of name and a stored key that is no longer legible in the AWS
+  console; both were taken deliberately over a partial escaping scheme, whose edge cases would be the
+  entire risk on a filesystem whose first priority is integrity.
+
+  **The budget is 1758 bytes per object**, computed rather than written down: S3's 2048-byte
+  user-metadata limit less the worst-case cost of the four POSIX attribute keys and the two integrity
+  keys, each derived from its own key constant so that renaming one cannot leave the figure stale.
+  Roughly 35 attributes of the shape `user.test`=`hello` fit. The two ways to exceed it are reported
+  differently, because they call for different actions: one attribute larger than the whole budget is
+  `E2BIG` and will never fit, while a set that no longer fits alongside the others is `ENOSPC` and
+  fits again once something is removed. Both are refused at `setxattr` rather than at the next flush —
+  a `setfattr` that succeeds and breaks a later write moves the error to a caller who cannot act on it.
+
+  **`security.*` and `system.*` are refused**, and this is a security decision rather than a gap.
+  Linux reads `security.capability` on every exec and grants the capabilities it names; S3 object
+  metadata is writable by anyone holding `s3:PutObject`, so honouring that attribute would convert
+  bucket write access into file capabilities on every host that mounts the bucket — an escalation
+  ObjectFS would be creating, not inheriting. `system.posix_acl_*` is refused because storing an ACL
+  the kernel then cannot enforce is worse than not having ACLs. `user.*` and `trusted.*` are stored;
+  `trusted.*` remains root-only by the kernel's own check.
+
+  **A removal is a tombstone.** `SetObjectMetadata` is a self-copy with `MetadataDirective=REPLACE`
+  and the backend merges the object's existing metadata underneath the caller's, so that the integrity
+  keys — which only the backend has seen the bytes to compute — survive a `chmod`. Verified against a
+  real endpoint: a key omitted from the caller's map is *not* removed from the object. So a
+  `removexattr` that merely stopped rendering the key would report success while the attribute stayed
+  readable forever. The alternative is a full `PutObject` per removal, which costs a read plus a write
+  of the whole object — 20 GiB of transfer to delete a few bytes from a 10 GiB file. The tombstone
+  costs one metadata entry that lasts until the object's next content write, and it is visible in
+  `head-object` output rather than hidden. Removing an attribute that was never set writes nothing.
+
+  Object annotations were considered and not used. They are **not** unavailable — `PutObjectAnnotation`
+  and its siblings are present in the pinned SDK, and [#165]'s note that they were absent was true of
+  an older version and is now stale — and they offer far more room, 1 MiB per annotation against 2 KB
+  total here. They were rejected because support is a per-endpoint fork, and a fork would mean two
+  storage formats for one attribute set with no migration between them: annotations do not survive a
+  transition to a directory bucket, and `CopyObject`'s default annotation directive does not carry them
+  through a multipart copy. Both of those are operations ObjectFS performs *itself* to persist an
+  attribute change, so the fallback would drop attributes during ObjectFS's own writes. Lifting the
+  2 KB ceiling is therefore a deliberate, probed, migrating change, not a silent fallback.
+
 ### Fixed
 
 - **A node never recorded its own cache figures in its membership map** ([#147]). `refreshLocalStats`
@@ -3097,6 +3151,8 @@ had no message authentication, and a cluster will not start without a shared sec
 [#145]: https://github.com/scttfrdmn/objectfs/issues/145
 [#147]: https://github.com/scttfrdmn/objectfs/issues/147
 [#151]: https://github.com/scttfrdmn/objectfs/issues/151
+[#165]: https://github.com/scttfrdmn/objectfs/issues/165
+[#167]: https://github.com/scttfrdmn/objectfs/issues/167
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#282]: https://github.com/scttfrdmn/objectfs/issues/282
 [#283]: https://github.com/scttfrdmn/objectfs/issues/283

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ or "slow".
 | Directory listing | `opendir`, `readdir`, `ls` | Fully paginated — no entry cap |
 | Mkdir | `mkdir` | Writes a zero-byte marker object at `prefix/` |
 | chmod / chown | `chmod`, `chown` | On **files** only, stored as object metadata. Permission bits only |
+| Extended attributes | `getxattr`, `setxattr`, `listxattr`, `removexattr`, `getfattr`, `setfattr` | On **files** only, stored as object metadata. See [Extended attributes](#extended-attributes) for the size budget, the namespaces that are refused, and the per-call cost |
 | utimes (mtime) | `touch`, `utimensat` | mtime is stored; an atime-only update is accepted and not stored |
 | statfs | `df` | Reports a fixed synthetic capacity — S3 has no size to report |
 | Unlink | `unlink`, `rm` | Deletes the object. A missing file is `ENOENT`, not a silent success |
@@ -143,9 +144,8 @@ or "slow".
 
 POSIX `rename` is atomic: an observer sees the old name or the new one, never both and never
 neither. S3 offers nothing that can implement that. There is no atomic rename operation — the 2026
-`RenameObject` API is directory-bucket (S3 Express) only, and object annotations, which ObjectFS
-needs for attributes, are unsupported on directory buckets, so the two features are mutually
-exclusive. A rename is therefore a server-side copy followed by a delete, per object.
+`RenameObject` API is directory-bucket (S3 Express) only, and ObjectFS does not support directory
+buckets. A rename is therefore a server-side copy followed by a delete, per object.
 
 What that means in practice:
 
@@ -170,6 +170,46 @@ Anything that depends on rename atomicity — the write-temp-then-rename idiom u
 and lockfile schemes — is therefore not safe here between concurrent writers. Single-writer use is
 fine.
 
+#### Extended attributes
+
+`setfattr -n user.project -v atlas file` and `getfattr -n user.project file` work on files, and the
+attributes survive a remount because they are stored on the object. Four properties are worth knowing
+before you rely on them.
+
+**A file's attributes share a 2 KB budget, and the usable part is 1758 bytes.** S3 caps an object's
+total user metadata at 2 KB across all keys, and *rejects* a request that exceeds it rather than
+truncating. ObjectFS already spends part of that on mode, uid, gid, mtime, the content checksum, and
+the original size, leaving 1758 bytes for names and values together — measured from the widest form of
+those keys, not estimated, and re-derived by a test so that adding a stored attribute cannot shrink the
+budget silently. Names and values are encoded to survive an HTTP header, which costs about 60% on top
+of a name and 33% on top of a value. Exceeding the budget is `E2BIG` for a single value too large for
+any object, `ENOSPC` for a value that will not fit alongside what this file already has — the
+distinction `setxattr(2)` draws, and the one a caller retrying after freeing space depends on.
+
+**`security.*` and `system.*` are refused with `ENOTSUP`.** This is a privilege boundary rather than a
+missing feature. The Linux kernel reads `security.capability` from the filesystem on every `exec` and
+grants the file capabilities it names; the store behind an ObjectFS attribute is object metadata, which
+anyone holding `s3:PutObject` on the bucket can write with the AWS CLI without touching the mount. So
+honouring it would turn bucket write access into a route to file capabilities on every host that mounts
+the bucket. `system.posix_acl_access` is refused for the milder version of the same problem: nothing in
+this filesystem enforces an ACL, and one that `getfacl` reports while no access check consults it is
+worse than a `setfacl` that fails. `user.*`, `trusted.*`, and macOS's `com.apple.*` are stored.
+
+**Every `setfattr` is one `CopyObject` on the file.** `setxattr(2)` takes a path, not a descriptor, so
+there is no `close` that could batch the change — it is made durable before the call returns, exactly
+as `chmod` and `touch` are. Setting ten attributes on a file is ten metadata rewrites. That is the
+honest cost of the operation; the alternative would be reporting success for a change S3 later refused,
+with no caller left to tell.
+
+**A removed attribute leaves a marker in the object's metadata.** A metadata replace merges over an
+object's existing metadata rather than replacing it, so omitting a key cannot delete it. `removexattr`
+therefore writes a tombstone: `getfattr` correctly stops showing the attribute, and `head-object` still
+shows a key holding the marker. Deleting one attribute from a 10 GiB file would otherwise cost a full
+rewrite of the object.
+
+Directories have no extended attributes: `setfattr` on one is `ENOTSUP`, and a listing is empty. See
+[Not implemented](#not-implemented).
+
 ### Errors by design
 
 These fail, and the failure is the correct answer rather than a missing feature.
@@ -188,7 +228,8 @@ These fail, and the failure is the correct answer rather than a missing feature.
 |---|---|---|
 | `chmod` / `chown` on a **directory** | **`ENOTSUP`** — the marker object could carry the metadata, but `Getattr` does not read it back, so accepting the call would report a mode the next `stat` contradicts | [#165](https://github.com/scttfrdmn/objectfs/issues/165) |
 | Symlinks (`symlink`, `readlink`) | **`ENOTSUP`** | No `NodeSymlinker`/`NodeReadlinker` |
-| Extended attributes (`getxattr`, `setxattr`, `listxattr`) | **`ENODATA`** on Linux / **`ENOATTR`** on macOS for get and remove; `listxattr` returns an empty list | go-fuse's defaults. An empty list is the accurate answer — there are no xattrs — but note that `setxattr` reports "no such attribute" rather than "unsupported" |
+| Extended attributes on a **directory** | `setxattr` is **`ENOTSUP`**; `getxattr` and `removexattr` report the attribute missing (**`ENODATA`** on Linux, **`ENOATTR`** on macOS); `listxattr` succeeds with an empty list. A directory that exists only because objects share a prefix has no object to hold an attribute, so accepting the call would store it for some directories and discard it for others. The empty listing keeps `cp -a`, `rsync -X`, and `ls -@` from erroring per directory | [#167](https://github.com/scttfrdmn/objectfs/issues/167) |
+| `security.*` and `system.*` extended attributes | **`ENOTSUP`** — refused deliberately, on files as well as directories. Object metadata is writable by anyone with bucket write access, so an attribute the kernel acts on cannot be stored here. See [Extended attributes](#extended-attributes) | |
 | `mknod` (devices, FIFOs, sockets) | **`ENOTSUP`** | |
 | `fallocate` | **`ENOTSUP`** | |
 | Locking (`flock`, POSIX record locks) | not forwarded to ObjectFS at all | The mount does not set go-fuse's `EnableLocks`, so the kernel never asks the filesystem to arbitrate a lock; it falls back to tracking locks locally on the mounting host. A lock therefore does not fail — it just means nothing to any other host, and no cross-node coordination exists that could make it mean anything |

--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ rewrite of the object.
 Directories have no extended attributes: `setfattr` on one is `ENOTSUP`, and a listing is empty. See
 [Not implemented](#not-implemented).
 
+One errno differs by platform, and it differs because the kernels do. A `setxattr` naming both
+`XATTR_CREATE` and `XATTR_REPLACE` is `EINVAL` on macOS, which is also what `setxattr(2)`'s Linux man
+page describes — but Linux does not implement it that way: `fs/xattr.c` has no combined-flag check, so
+the flags are tested independently and the result is `ENODATA` when the attribute is missing and
+`EEXIST` when it exists. ObjectFS matches whichever kernel it is running under rather than picking one,
+so a program's behavior on an ObjectFS mount matches its behavior on the local filesystem of the same
+host.
+
 ### Errors by design
 
 These fail, and the failure is the correct answer rather than a missing feature.

--- a/internal/fuse/errno.go
+++ b/internal/fuse/errno.go
@@ -8,6 +8,8 @@ import (
 	iofs "io/fs"
 	"syscall"
 
+	"github.com/hanwen/go-fuse/v2/fuse"
+
 	"github.com/scttfrdmn/objectfs/internal/vfs"
 	objerrors "github.com/scttfrdmn/objectfs/pkg/errors"
 )
@@ -68,7 +70,25 @@ func toErrno(err error) syscall.Errno {
 		// exhaust. It is the errno every program that writes files already handles, and the honest one:
 		// the filesystem cannot accept more data right now. EDQUOT would suggest a per-user quota that
 		// does not exist, and ENOMEM is not a documented write(2) error, so callers do not check it.
+		//
+		// For extended attributes it means the same thing one level down: this file's metadata budget is
+		// full. setxattr(2) documents ENOSPC for exactly that, so a caller reading it as "remove an
+		// attribute and retry" is reading it correctly.
 		return syscall.ENOSPC
+	case errors.Is(err, vfs.ErrTooLarge):
+		// E2BIG, which setxattr(2) documents as "the value is too large for this filesystem". It has to
+		// be distinguishable from ENOSPC above: E2BIG says no object could hold this value, ENOSPC says
+		// this one has no room left. A caller retrying after freeing space is right in the second case
+		// and loops forever in the first.
+		return syscall.E2BIG
+	case errors.Is(err, vfs.ErrNoXattr):
+		// The errno for an attribute that is not there, which is ENOATTR on darwin and ENODATA on linux
+		// — go-fuse's fuse.ENOATTR is the platform's spelling, and taking it from there is what keeps
+		// this one line right on both instead of needing a build-tagged pair.
+		//
+		// Never ENOENT. Both reach getfattr, but ENOENT means the file is gone, and a caller that probes
+		// for an attribute before creating one would conclude the path had disappeared underneath it.
+		return syscall.Errno(fuse.ENOATTR)
 	}
 
 	// Coded backend failures. This runs before ErrBackend because ErrBackend wraps these.

--- a/internal/fuse/errno_test.go
+++ b/internal/fuse/errno_test.go
@@ -19,6 +19,8 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/hanwen/go-fuse/v2/fuse"
+
 	"github.com/scttfrdmn/objectfs/internal/vfs"
 	objerrors "github.com/scttfrdmn/objectfs/pkg/errors"
 )
@@ -97,6 +99,29 @@ func TestToErrnoClassifiesEveryVocabularyItReceives(t *testing.T) {
 			err:  vfs.ErrInvalid,
 			want: syscall.EINVAL,
 			why:  "a rejected argument is the caller's to fix, not a filesystem failure",
+		},
+		{
+			name: "ErrNoSpace",
+			err:  vfs.ErrNoSpace,
+			want: syscall.ENOSPC,
+			why: "every program that writes files already handles ENOSPC; EDQUOT would suggest a per-user " +
+				"quota that does not exist and ENOMEM is not a documented write(2) error, so callers do " +
+				"not check for it",
+		},
+		{
+			name: "ErrTooLarge",
+			err:  vfs.ErrTooLarge,
+			want: syscall.E2BIG,
+			why: "setxattr(2)'s errno for a value no object could hold. It has to differ from the ENOSPC " +
+				"above: a caller that frees an attribute and retries is right for ENOSPC and loops " +
+				"forever for E2BIG",
+		},
+		{
+			name: "ErrNoXattr",
+			err:  vfs.ErrNoXattr,
+			want: syscall.Errno(fuse.ENOATTR),
+			why: "ENOATTR on darwin, ENODATA on linux — and never ENOENT, which would tell a caller " +
+				"probing for an attribute that the file itself had disappeared underneath it",
 		},
 		{
 			name: "ErrIntegrity",

--- a/internal/fuse/unimplemented_test.go
+++ b/internal/fuse/unimplemented_test.go
@@ -14,15 +14,20 @@ package fuse
 // so it has left the table below, which is the other half of the same discipline: a row asserting an
 // operation fails is as wrong as a row asserting the wrong errno once the operation works.
 //
+// The four extended-attribute operations have left it for the same reason — see xattr.go and
+// xattr_test.go. Their row is the clearest case there has been for keeping the two halves in step: three
+// of the four answers a *directory* now gives are byte-identical to the defaults they replaced, so the
+// table would have kept passing while being wrong about files.
+//
 // Two things make this worth a test rather than a comment:
 //
 //   - The defaults differ per operation and are not guessable. Symlink, Link, Mknod, and Fallocate
-//     default to ENOTSUP; Getxattr and Removexattr default to ENOATTR (which *is* ENODATA on Linux);
-//     Listxattr defaults to OK with an empty list; and Unlink and Rmdir default to **success**, which is
-//     why those two were implemented to refuse before they were implemented to work.
-//   - They are a dependency's choices, so a go-fuse upgrade can change them. A bump that turned
-//     Listxattr's empty-OK into ENOTSUP would change what every `ls -@` and `rsync -X` sees, and would
-//     be invisible without this.
+//     default to ENOTSUP; Getxattr, Setxattr, and Removexattr default to ENOATTR (which *is* ENODATA on
+//     Linux); Listxattr defaults to OK with an empty list; and Unlink and Rmdir default to **success**,
+//     which is why those two were implemented to refuse before they were implemented to work.
+//   - They are a dependency's choices, so a go-fuse upgrade can change them. A bump that changed the
+//     default for an operation still in the table below would change what a user sees, and would be
+//     invisible without this.
 //
 // The bridge is driven directly rather than through a kernel mount: fs.NewNodeFS returns the
 // fuse.RawFileSystem the kernel talks to, so calling its methods runs the same dispatch — including the
@@ -103,26 +108,6 @@ func TestUnimplementedOperationsReturnTheDocumentedErrno(t *testing.T) {
 			why: "a device or FIFO has no object representation, so cp -a of one must fail rather than " +
 				"quietly create a regular file",
 		},
-		{
-			name: "setxattr",
-			call: func(raw fuse.RawFileSystem) fuse.Status {
-				in := &fuse.SetXAttrIn{InHeader: rootHeader()}
-				return raw.SetXAttr(nil, in, "user.test", []byte("value"))
-			},
-			want: errXattrMissing,
-			why: "note this is 'no such attribute' rather than 'unsupported', which is a strange answer " +
-				"for a *set*. It is go-fuse's default, and the README states it rather than implying " +
-				"ObjectFS chose it",
-		},
-		{
-			name: "removexattr",
-			call: func(raw fuse.RawFileSystem) fuse.Status {
-				h := rootHeader()
-				return raw.RemoveXAttr(nil, &h, "user.test")
-			},
-			want: errXattrMissing,
-			why:  "removing an attribute that cannot exist reports absence, which is at least accurate",
-		},
 	}
 
 	for _, tt := range tests {
@@ -176,14 +161,19 @@ func TestRenameIsDispatchedRatherThanDefaulted(t *testing.T) {
 	}
 }
 
-// TestGetxattrReportsAbsenceAndListxattrReportsEmpty covers the two xattr reads, whose signatures return
-// a size alongside the status and so do not fit the table above.
+// TestDirectoryXattrsThroughTheBridge pins what the four operations answer for a directory, driven the
+// way the kernel drives them.
 //
-// These two disagree with each other in go-fuse, and the disagreement is the point: a query for one
-// attribute reports the attribute missing, while a request to list them all succeeds with a count of
-// zero. Both are defensible, and a caller sees very different things — `getfattr -n` errors while
-// `ls -@` prints nothing and exits 0.
-func TestGetxattrReportsAbsenceAndListxattrReportsEmpty(t *testing.T) {
+// A directory is a key prefix rather than an object, so it has nowhere to hold an attribute — xattr.go
+// gives the reasoning and xattr_test.go covers the node methods. What this adds is the same four answers
+// through the bridge, where the request carries the buffer sizes and the reply carries a size alongside
+// the status, which the node signatures do not show.
+//
+// Three of these four answers are numerically identical to the go-fuse defaults they replaced, so passing
+// here does not by itself prove dispatch. That is what
+// [TestXattrOperationsAreDispatchedRatherThanDefaulted] is for: it uses a read-only mount, where EROFS is
+// an answer only ObjectFS can give. Both are needed, and neither would have caught the other's failure.
+func TestDirectoryXattrsThroughTheBridge(t *testing.T) {
 	t.Parallel()
 
 	t.Run("getxattr reports the attribute missing", func(t *testing.T) {
@@ -196,7 +186,7 @@ func TestGetxattrReportsAbsenceAndListxattrReportsEmpty(t *testing.T) {
 
 		if syscall.Errno(status) != errXattrMissing {
 			t.Errorf("getxattr returned %s, want %s. getfattr renders this to the user, and 'no such "+
-				"attribute' is the accurate answer for a filesystem that stores none.",
+				"attribute' is the accurate answer for a directory that stores none.",
 				errnoName(syscall.Errno(status)), errnoName(errXattrMissing))
 		}
 		if size != 0 {
@@ -214,13 +204,48 @@ func TestGetxattrReportsAbsenceAndListxattrReportsEmpty(t *testing.T) {
 		size, status := raw.ListXAttr(nil, &h, make([]byte, 128))
 
 		if status != fuse.OK {
-			t.Errorf("listxattr returned %s, want OK. An empty list is the truthful answer — there are "+
-				"no extended attributes — and failing instead would make `ls -@`, `cp -a`, and "+
-				"`rsync -X` report an error per file for something with nowhere to go.",
+			t.Errorf("listxattr returned %s, want OK. An empty list is the truthful answer — the "+
+				"directory has no extended attributes — and failing instead would make `ls -@`, `cp -a`, "+
+				"and `rsync -X` report an error per directory they walk.",
 				errnoName(syscall.Errno(status)))
 		}
 		if size != 0 {
-			t.Errorf("listxattr reported %d bytes of names for a filesystem that stores no attributes", size)
+			t.Errorf("listxattr reported %d bytes of names for a directory that stores no attributes", size)
+		}
+	})
+
+	t.Run("setxattr refuses rather than reporting absence", func(t *testing.T) {
+		t.Parallel()
+
+		raw := rootBridge(t)
+		in := &fuse.SetXAttrIn{InHeader: rootHeader()}
+
+		got := syscall.Errno(raw.SetXAttr(nil, in, "user.test", []byte("value")))
+
+		if got == errXattrMissing {
+			t.Fatalf("setxattr on a directory returned %s, which is go-fuse's default for an absent "+
+				"NodeSetxattrer. It is also a strange answer for a *set*: 'no such attribute' says "+
+				"nothing about a request to create one.", errnoName(got))
+		}
+		if got != syscall.ENOTSUP {
+			t.Errorf("setxattr on a directory returned %s, want ENOTSUP — the honest answer for an "+
+				"operation this filesystem cannot perform on a key prefix. Reporting success and storing "+
+				"nothing would be the worse failure.", errnoName(got))
+		}
+	})
+
+	t.Run("removexattr reports absence", func(t *testing.T) {
+		t.Parallel()
+
+		raw := rootBridge(t)
+		h := rootHeader()
+
+		got := syscall.Errno(raw.RemoveXAttr(nil, &h, "user.test"))
+
+		if got != errXattrMissing {
+			t.Errorf("removexattr on a directory returned %s, want %s. Unlike the set above, this is "+
+				"answering accurately about something that has no attributes rather than refusing "+
+				"something it might one day do.", errnoName(got), errnoName(errXattrMissing))
 		}
 	})
 }

--- a/internal/fuse/xattr.go
+++ b/internal/fuse/xattr.go
@@ -130,8 +130,14 @@ func refuseXattrNamespace(name string) bool {
 // value is a caller that sizes a short buffer, gets no ERANGE because the filesystem also compared the
 // wrapped number, and reads a truncated attribute as if it were whole — silent data loss on a read path.
 // MaxUint32 cannot be mistaken for a real attribute size and fails the caller's own allocation instead.
+//
+// The comparison widens to uint64 rather than testing `n > math.MaxUint32` directly. On a 32-bit build an
+// int *is* 32 bits, so that constant does not fit one and the package fails to compile — which is how the
+// first version of this function broke the linux/386 and linux/arm cross-builds while passing every test
+// on a 64-bit host. Widening is correct on both: where int is 32 bits the branch is simply never taken,
+// and where it is 64 bits it is the real bound.
 func xattrSize(n int) uint32 {
-	if n < 0 || n > math.MaxUint32 {
+	if n < 0 || uint64(n) > math.MaxUint32 {
 		return math.MaxUint32
 	}
 

--- a/internal/fuse/xattr.go
+++ b/internal/fuse/xattr.go
@@ -1,0 +1,391 @@
+//go:build linux || darwin
+
+package fuse
+
+// The extended-attribute half of the node contract: getxattr, setxattr, listxattr, and removexattr.
+//
+// Storage is S3 user metadata, encoded by internal/vfs/xattr.go — see that file for why metadata rather
+// than object annotations, and for the name and value encodings. This file is the translation layer, and
+// the translation is where three things are decided that internal/vfs cannot see:
+//
+//   - **The size protocol.** getxattr and listxattr are called twice by every caller: once with a
+//     zero-length buffer to learn the size, then again with a buffer that big. A zero-size call must
+//     report the size and succeed; a too-small buffer must return ERANGE *with* the size. go-fuse's
+//     doGetXAttr converts an ERANGE on a zero-size request into OK, so the two cases can share one
+//     implementation, but only if the size is returned alongside the error rather than instead of it.
+//   - **The flags.** setxattr carries XATTR_CREATE and XATTR_REPLACE, which turn a set into a
+//     create-only or replace-only operation. They are numerically **different on the two platforms**
+//     (1 and 2 on Linux, 2 and 4 on darwin) because the value that arrives here is the one the local
+//     kernel put in the request. golang.org/x/sys/unix's constants are per-platform for the same reason,
+//     which is why they are used instead of literals — a literal would be right on one platform and
+//     would silently turn XATTR_CREATE into XATTR_REPLACE on the other.
+//   - **Which attributes ObjectFS will store at all.** See [refuseXattrNamespace].
+//
+// # Why every write here flushes synchronously
+//
+// setxattr(2) and removexattr(2) take a path, not a descriptor. There is no handle whose release would
+// later persist the change, so nothing would ever flush it and it would survive only to the FlushAll at
+// unmount — a mount killed before then loses it silently. [FileNode.Setattr] flushes for exactly this
+// reason and this follows it: one metadata rewrite per call, and the failure reported to the caller that
+// caused it. The cost is real, and it is the honest cost of the operation. An asynchronous version would
+// make `setfattr` return success for a change S3 later refused, with no one left to tell.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"syscall"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"golang.org/x/sys/unix"
+
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// Compile-time proof that both node types satisfy the four optional interfaces. Each is probed by a type
+// assertion in go-fuse's bridge and silently defaulted when absent — Getxattr, Setxattr, and Removexattr
+// to ENOATTR, Listxattr to success with an empty list. A signature that drifted on a go-fuse bump would
+// take every extended attribute on the mount back to "no such attribute" with no compile error, which is
+// the failure mode rename.go's assertion exists to prevent for `mv`.
+var (
+	_ fs.NodeGetxattrer    = (*FileNode)(nil)
+	_ fs.NodeSetxattrer    = (*FileNode)(nil)
+	_ fs.NodeListxattrer   = (*FileNode)(nil)
+	_ fs.NodeRemovexattrer = (*FileNode)(nil)
+
+	_ fs.NodeGetxattrer    = (*DirectoryNode)(nil)
+	_ fs.NodeSetxattrer    = (*DirectoryNode)(nil)
+	_ fs.NodeListxattrer   = (*DirectoryNode)(nil)
+	_ fs.NodeRemovexattrer = (*DirectoryNode)(nil)
+)
+
+// errNoXattr is the errno for an attribute that is not there.
+//
+// Taken from fuse.ENOATTR because the two platforms spell it differently — ENOATTR on darwin, ENODATA on
+// linux — so naming either syscall constant directly would need a build-tagged pair of files to be right
+// on both. unimplemented_test.go aliases the same value for the same reason.
+const errNoXattr = syscall.Errno(fuse.ENOATTR)
+
+// Namespaces ObjectFS refuses to store, and reports nothing from.
+//
+// # security.
+//
+// On Linux the kernel reads `security.capability` from the filesystem on every exec and grants the named
+// file capabilities from it. Setting that attribute on a local filesystem requires CAP_SETFCAP; on this
+// one, the store behind it is object metadata that **anyone holding s3:PutObject on the bucket can write
+// directly with the AWS CLI**, without going through the mount at all. Storing and reporting the
+// attribute would therefore convert bucket write access into a route to file capabilities on every host
+// that mounts it — a privilege escalation ObjectFS would be providing, not inheriting. `security.selinux`
+// and the other LSM labels are the same shape: a label the filesystem reports is a label the kernel acts
+// on, and this one cannot vouch for who wrote it.
+//
+// go-fuse offers Options.IgnoreSecurityLabels for part of this, which answers ENOATTR for three specific
+// names before the request reaches a node. It is not enough on its own — it covers get and not set, and
+// only those three names — so the namespace is refused here as well, where every operation passes.
+//
+// # system.
+//
+// `system.posix_acl_access` and `system.posix_acl_default` are how setfacl stores an ACL. go-fuse only
+// negotiates ACL support with the kernel when Options.EnableAcl is set, which mount.go does not set, so
+// nothing on this filesystem would enforce a stored ACL. An ACL that `getfacl` reports and no access
+// check consults is worse than a refused setfacl: it tells an operator a file is restricted when it is
+// readable by anyone whose credentials reach the bucket. Refusing makes setfacl fail, which is the true
+// answer.
+//
+// Everything else is stored, `user.` and `trusted.` included. `trusted.` is root-only by the kernel's own
+// check before the request arrives, and `com.apple.*` on darwin — quarantine flags, Finder info — is what
+// makes an ObjectFS mount usable from the GUI.
+var refusedXattrPrefixes = []string{"security.", "system."}
+
+// refuseXattrNamespace reports whether name is in a namespace ObjectFS will not store.
+//
+// Matched case-sensitively: the kernel's namespaces are lower-case, and `Security.capability` is not one
+// of them — it is an ordinary attribute name that happens to look like one, and storing it grants nothing
+// because no kernel reads it.
+func refuseXattrNamespace(name string) bool {
+	for _, p := range refusedXattrPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// xattrRead answers a getxattr against a value that is already known, applying the size protocol.
+//
+// dest is the caller's buffer, which may be empty. The returned size is the attribute's full length in
+// every case, including the two failures, because that is what the caller sizes its next buffer from.
+func xattrRead(value, dest []byte) (uint32, syscall.Errno) {
+	if len(dest) == 0 {
+		// A size query. Reporting the length and succeeding is the contract; go-fuse's doGetXAttr also
+		// rewrites an ERANGE to OK here, so answering either way works — but returning the size with an
+		// error to a *direct* caller (a test, a future in-process consumer) would be a failure with a
+		// number attached, which is harder to use correctly.
+		return uint32(len(value)), 0
+	}
+	if len(dest) < len(value) {
+		return uint32(len(value)), syscall.ERANGE
+	}
+
+	return uint32(copy(dest, value)), 0
+}
+
+// xattrNameList renders attribute names as listxattr's reply: each name NUL-terminated, concatenated.
+//
+// The terminator is on every name including the last, which is what listxattr(2) specifies and what
+// every parser of the result assumes. Dropping the final one truncates the last attribute's name by a
+// byte in `getfattr -d` output, which is the kind of defect that looks like a corrupt attribute.
+func xattrNameList(names []string) []byte {
+	n := 0
+	for _, name := range names {
+		n += len(name) + 1
+	}
+
+	out := make([]byte, 0, n)
+	for _, name := range names {
+		out = append(out, name...)
+		out = append(out, 0)
+	}
+
+	return out
+}
+
+// Getxattr reports the value of one extended attribute.
+//
+// Absence is [errNoXattr], never ENOENT. Both would reach getfattr, but ENOENT means the *file* is gone,
+// and a caller probing for an attribute before creating one would conclude the path had disappeared
+// underneath it.
+func (f *FileNode) Getxattr(ctx context.Context, attr string, dest []byte) (uint32, syscall.Errno) {
+	if refuseXattrNamespace(attr) {
+		// Answered before the HEAD, deliberately. The kernel asks for security.capability on every exec,
+		// so a round trip here would put a network call in the path of running a program — and the answer
+		// would be the same one. See [refusedXattrPrefixes] for why it is this answer.
+		return 0, errNoXattr
+	}
+
+	a, err := f.attr(ctx)
+	if err != nil {
+		slog.Error("getxattr: cannot read attributes", "path", f.key(), "attr", attr, "error", err)
+
+		return 0, toErrno(err)
+	}
+
+	value, ok := a.Xattr(attr)
+	if !ok {
+		return 0, errNoXattr
+	}
+
+	return xattrRead(value, dest)
+}
+
+// Listxattr reports the names of every extended attribute the file carries.
+//
+// An empty list succeeds. That is not the same as go-fuse's default for an absent implementation, which
+// also succeeds with an empty list: the difference is that this one has looked, so a file with attributes
+// reports them. A caller cannot tell the two apart on a file with none, which is exactly why the
+// implementation being reached at all is asserted by a test rather than assumed.
+func (f *FileNode) Listxattr(ctx context.Context, dest []byte) (uint32, syscall.Errno) {
+	a, err := f.attr(ctx)
+	if err != nil {
+		slog.Error("listxattr: cannot read attributes", "path", f.key(), "error", err)
+
+		return 0, toErrno(err)
+	}
+
+	names := make([]string, 0, len(a.Xattrs))
+	for _, name := range a.XattrNames() {
+		if refuseXattrNamespace(name) {
+			// Reachable only for metadata written outside the mount, since the set path refuses these. It
+			// is filtered rather than reported for the reason [refusedXattrPrefixes] gives: a name this
+			// filesystem lists is a name a caller may then act on.
+			continue
+		}
+		names = append(names, name)
+	}
+
+	return xattrRead(xattrNameList(names), dest)
+}
+
+// Setxattr stores one extended attribute, honoring XATTR_CREATE and XATTR_REPLACE.
+//
+// # The flags, and the race in checking them
+//
+// XATTR_CREATE means "fail if it exists" and XATTR_REPLACE means "fail if it does not". Both are checked
+// by reading the current attributes and then writing, which is not atomic: two mounts issuing
+// XATTR_CREATE for the same new attribute can both see it absent and both succeed, where a local
+// filesystem would fail one of them. That is the same non-atomicity every other write on this filesystem
+// has — S3 has no compare-and-swap on metadata, and #282's conditional writes are on object content, not
+// on a metadata replace — and it is documented rather than papered over. What the check does buy is the
+// single-writer case, which is every use of `setfattr --create` a person actually types.
+//
+// A flag combination naming both is EINVAL, as setxattr(2) specifies.
+func (f *FileNode) Setxattr(ctx context.Context, attr string, data []byte, flags uint32) syscall.Errno {
+	if f.fs.config != nil && f.fs.config.ReadOnly {
+		return syscall.EROFS
+	}
+	if f.fs.buffer == nil {
+		// No write path, so nothing could persist this. ENOTSUP rather than EROFS: the mount is not
+		// declared read-only, it simply has no buffer, and claiming a read-only filesystem would be a
+		// different fact.
+		return syscall.ENOTSUP
+	}
+	if refuseXattrNamespace(attr) {
+		slog.Warn("refusing to store an extended attribute in a namespace the kernel acts on, because "+
+			"object metadata is writable by anyone with bucket write access",
+			"path", f.key(), "attr", attr)
+
+		return syscall.ENOTSUP
+	}
+
+	create := flags&unix.XATTR_CREATE != 0
+	replace := flags&unix.XATTR_REPLACE != 0
+
+	if create && replace {
+		return syscall.EINVAL
+	}
+
+	if create || replace {
+		a, err := f.attr(ctx)
+		if err != nil {
+			slog.Error("setxattr: cannot read attributes to honor the flags",
+				"path", f.key(), "attr", attr, "error", err)
+
+			return toErrno(err)
+		}
+
+		_, exists := a.Xattr(attr)
+		switch {
+		case create && exists:
+			return syscall.EEXIST
+		case replace && !exists:
+			return errNoXattr
+		}
+	}
+
+	// A nil data with a zero length is what the bridge hands over for `setfattr -n user.x` with no value,
+	// and vfs.Writer.SetXattr rejects nil because nil is the tombstone in the stored form. An empty
+	// attribute is legal and must round-trip as an empty attribute rather than as a removal, so the
+	// emptiness is made explicit here.
+	if data == nil {
+		data = []byte{}
+	}
+
+	if err := f.fs.buffer.SetXattr(ctx, f.key(), attr, data); err != nil {
+		slog.Error("setxattr failed", "path", f.key(), "attr", attr, "bytes", len(data), "error", err)
+
+		return toErrno(err)
+	}
+
+	return f.flushXattr(ctx, "setxattr", attr)
+}
+
+// Removexattr deletes one extended attribute, reporting [errNoXattr] when there is none to delete.
+//
+// The removal is stored as a tombstone rather than by dropping the metadata key, because a metadata
+// replace merges rather than replaces and so cannot delete one — see the note in internal/vfs/xattr.go.
+// The consequence a user can see is that `head-object` still shows the key, holding a marker; `getfattr`
+// does not show the attribute, which is the answer that matters.
+func (f *FileNode) Removexattr(ctx context.Context, attr string) syscall.Errno {
+	if f.fs.config != nil && f.fs.config.ReadOnly {
+		return syscall.EROFS
+	}
+	if f.fs.buffer == nil {
+		return syscall.ENOTSUP
+	}
+	if refuseXattrNamespace(attr) {
+		// Nothing in this namespace is ever stored, so there is nothing to remove and the accurate answer
+		// is absence rather than a refusal. ENOTSUP here would make `setfattr -x` on a name the filesystem
+		// never stored look like a filesystem limitation instead of a nonexistent attribute.
+		return errNoXattr
+	}
+
+	if err := f.fs.buffer.RemoveXattr(ctx, f.key(), attr); err != nil {
+		if errors.Is(err, vfs.ErrNoXattr) {
+			// Not logged at error level: removing an attribute that is not there is an ordinary answer to
+			// an ordinary question, and `setfattr -x` on a fresh file is how a script checks.
+			return errNoXattr
+		}
+		slog.Error("removexattr failed", "path", f.key(), "attr", attr, "error", err)
+
+		return toErrno(err)
+	}
+
+	return f.flushXattr(ctx, "removexattr", attr)
+}
+
+// flushXattr makes a pending extended-attribute change durable and drops every cached view of the file.
+//
+// Shared by the two write paths because the sequence is identical and because forgetting the
+// invalidation is the half that is invisible on a single-node mount: a stale metadata cache entry would
+// make the next getxattr report the value from before the write, on this host or on a peer.
+func (f *FileNode) flushXattr(ctx context.Context, op, attr string) syscall.Errno {
+	etag, err := f.fs.flushReportingETag(ctx, f.key())
+	if err != nil {
+		slog.Error("could not persist an extended attribute change",
+			"op", op, "path", f.key(), "attr", attr, "error", err)
+
+		return toErrno(err)
+	}
+
+	f.fs.invalidateBoth(ctx, f.key(), etag)
+
+	return 0
+}
+
+// Getxattr on a directory reports that it has no attributes, because it cannot have any.
+//
+// A directory here is a key prefix, not an object, so there is no metadata to read one from — the same
+// reason [DirectoryNode.Setattr] refuses chmod. Absence is the accurate answer and it is free: no
+// request is issued.
+func (n *DirectoryNode) Getxattr(ctx context.Context, attr string, dest []byte) (uint32, syscall.Errno) {
+	return 0, errNoXattr
+}
+
+// Listxattr on a directory succeeds with an empty list.
+//
+// Failing instead would make `cp -a`, `rsync -X`, and `ls -@` report an error for every directory they
+// walk, on a mount where the answer is simply that there are none — the same reasoning that has
+// [DirectoryNode.Setattr] accept a time change as a no-op rather than refusing it.
+func (n *DirectoryNode) Listxattr(ctx context.Context, dest []byte) (uint32, syscall.Errno) {
+	return 0, 0
+}
+
+// Setxattr on a directory refuses, rather than accepting a change it could not report back.
+//
+// Mkdir does write a zero-byte marker object, and an object can carry metadata, so this is not
+// impossible — it is unimplemented, and the reason it stays unimplemented is the one
+// [DirectoryNode.Setattr] gives for chmod: a directory that exists only because objects share a prefix
+// has no marker to hold anything, so an attribute would persist for some directories and vanish for
+// others depending on how the directory came to exist. `setfattr` reporting success while the next
+// `getfattr` shows nothing is the same defect as an `rm` that reports success while the object survives.
+//
+// ENOTSUP rather than go-fuse's ENOATTR default, which is what this returned before it was implemented:
+// "no such attribute" is a strange answer to a request to create one, and a caller distinguishing "this
+// filesystem cannot" from "that attribute is missing" gets the truth from ENOTSUP.
+func (n *DirectoryNode) Setxattr(ctx context.Context, attr string, data []byte, flags uint32) syscall.Errno {
+	if n.fs.config != nil && n.fs.config.ReadOnly {
+		return syscall.EROFS
+	}
+
+	slog.Warn("extended attributes on a directory are not implemented; refusing rather than reporting a "+
+		"change that would not be visible on the next getfattr",
+		"path", n.key(), "attr", attr, "issue", 167)
+
+	return syscall.ENOTSUP
+}
+
+// Removexattr on a directory reports absence, since a directory never has an attribute to remove.
+//
+// Not ENOTSUP, unlike the set above: the set is refusing something it could conceivably do, while this
+// is answering accurately about a file that has no attributes. `setfattr -x` on a directory should look
+// like a missing attribute, which it is.
+func (n *DirectoryNode) Removexattr(ctx context.Context, attr string) syscall.Errno {
+	if n.fs.config != nil && n.fs.config.ReadOnly {
+		return syscall.EROFS
+	}
+
+	return errNoXattr
+}

--- a/internal/fuse/xattr.go
+++ b/internal/fuse/xattr.go
@@ -34,6 +34,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
 	"strings"
 	"syscall"
 
@@ -114,6 +115,29 @@ func refuseXattrNamespace(name string) bool {
 	return false
 }
 
+// xattrSize converts a byte count to the uint32 the go-fuse contract returns, saturating rather than
+// wrapping.
+//
+// Unreachable by construction on the value path: an attribute is bounded by [vfs.XattrBudget], under 2 KB,
+// and a full listing by the same budget. It is here because "unreachable" is an argument about today's
+// callers and the cast is a property of the function. gosec flags it (G115) and the fix is a clamp rather
+// than a suppression, for the reason internal/distributed/cluster.go records at the same conversion: a
+// clamp is testable and a `//nolint` is not, and this repository runs gosec a second time standalone,
+// where the suppression has no effect anyway.
+//
+// The failure mode if it ever did wrap is the reason to saturate rather than truncate. Both numbers this
+// returns are a *buffer size* the caller allocates and then reads into: a wrapped length smaller than the
+// value is a caller that sizes a short buffer, gets no ERANGE because the filesystem also compared the
+// wrapped number, and reads a truncated attribute as if it were whole — silent data loss on a read path.
+// MaxUint32 cannot be mistaken for a real attribute size and fails the caller's own allocation instead.
+func xattrSize(n int) uint32 {
+	if n < 0 || n > math.MaxUint32 {
+		return math.MaxUint32
+	}
+
+	return uint32(n)
+}
+
 // xattrRead answers a getxattr against a value that is already known, applying the size protocol.
 //
 // dest is the caller's buffer, which may be empty. The returned size is the attribute's full length in
@@ -124,13 +148,13 @@ func xattrRead(value, dest []byte) (uint32, syscall.Errno) {
 		// rewrites an ERANGE to OK here, so answering either way works — but returning the size with an
 		// error to a *direct* caller (a test, a future in-process consumer) would be a failure with a
 		// number attached, which is harder to use correctly.
-		return uint32(len(value)), 0
+		return xattrSize(len(value)), 0
 	}
 	if len(dest) < len(value) {
-		return uint32(len(value)), syscall.ERANGE
+		return xattrSize(len(value)), syscall.ERANGE
 	}
 
-	return uint32(copy(dest, value)), 0
+	return xattrSize(copy(dest, value)), 0
 }
 
 // xattrNameList renders attribute names as listxattr's reply: each name NUL-terminated, concatenated.
@@ -243,8 +267,23 @@ func (f *FileNode) Setxattr(ctx context.Context, attr string, data []byte, flags
 	create := flags&unix.XATTR_CREATE != 0
 	replace := flags&unix.XATTR_REPLACE != 0
 
+	// Naming both flags is the one case where the two kernels genuinely disagree, so it is answered
+	// per-platform by [bothXattrFlagsErrno] rather than by a single errno here. Measured on both, not read
+	// off a man page: darwin returns EINVAL whether or not the attribute exists, while linux has no
+	// combined-flag check at all — its fs/xattr.c tests each flag independently against existence, making
+	// `CREATE|REPLACE` ENODATA on a missing attribute and EEXIST on a present one. Both are
+	// self-consistent, and any single hardcoded answer is wrong on one of them.
+	//
+	// This function returned EINVAL unconditionally at first, which is darwin's answer and the Linux man
+	// page's description of it. xattr_oracle_test.go caught it on CI and could not have caught it locally:
+	// the oracle compares against the *local* OS filesystem, so on darwin ObjectFS and the reference agreed
+	// and the test was green. A unit test asserting EINVAL was green there too. That is what the oracle is
+	// for — a hand-written expectation encodes the platform of whoever wrote it.
 	if create && replace {
-		return syscall.EINVAL
+		if errno := bothXattrFlagsErrno(); errno != 0 {
+			return errno
+		}
+		// Otherwise fall through: the switch below reproduces this kernel's answer from the flags alone.
 	}
 
 	if create || replace {

--- a/internal/fuse/xattr_flags_darwin.go
+++ b/internal/fuse/xattr_flags_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package fuse
+
+import "syscall"
+
+// bothXattrFlagsErrno returns EINVAL, which is what darwin's kernel returns for a setxattr naming both
+// XATTR_CREATE and XATTR_REPLACE.
+//
+// Measured rather than read: setxattr with 0x6 (CREATE|REPLACE on this platform) returns EINVAL both when
+// the attribute is absent and when it is present, so the answer does not depend on existence the way
+// linux's does. See the linux file for the other half.
+func bothXattrFlagsErrno() syscall.Errno { return syscall.EINVAL }

--- a/internal/fuse/xattr_flags_linux.go
+++ b/internal/fuse/xattr_flags_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package fuse
+
+import "syscall"
+
+// bothXattrFlagsErrno returns 0, because linux has no answer of its own for a setxattr naming both
+// XATTR_CREATE and XATTR_REPLACE.
+//
+// fs/xattr.c contains no combined-flag check. The flags are tested independently against whether the
+// attribute exists, so the pair behaves as whichever arm fires first: ENODATA when the attribute is
+// missing, because REPLACE requires it, and EEXIST when it is present, because CREATE forbids it.
+// setxattr(2)'s man page says EINVAL for this case and the kernel does not implement it; the measurement
+// is what this follows.
+//
+// Returning 0 means "no platform-specific answer, use the ordinary flag handling", which reproduces both
+// of those without naming either errno here. See the darwin file for the other half, and
+// xattr_oracle_test.go for the test that made the difference visible.
+func bothXattrFlagsErrno() syscall.Errno { return 0 }

--- a/internal/fuse/xattr_oracle_test.go
+++ b/internal/fuse/xattr_oracle_test.go
@@ -227,13 +227,30 @@ func TestXattrErrnosAgreeWithTheLocalFilesystem(t *testing.T) {
 			},
 		},
 		{
-			what: "setxattr naming both XATTR_CREATE and XATTR_REPLACE",
+			// The case the two kernels answer differently, which is why it is here and not only in a unit
+			// test: darwin returns EINVAL, linux runs the REPLACE arm and returns ENODATA. An assertion
+			// written by hand would have picked one. user.b does not exist at this point.
+			what: "setxattr naming both XATTR_CREATE and XATTR_REPLACE, attribute missing",
 			objectfs: func() syscall.Errno {
 				return x.node.Setxattr(ctx, "user.b", []byte("v"),
 					uint32(unix.XATTR_CREATE|unix.XATTR_REPLACE))
 			},
 			reference: func() syscall.Errno {
 				return oracle.set("user.b", []byte("v"), uint32(unix.XATTR_CREATE|unix.XATTR_REPLACE))
+			},
+		},
+		{
+			// The same flags against an attribute that exists, where the platforms differ in the other
+			// direction: EINVAL on darwin again, but EEXIST on linux because there the CREATE arm fires
+			// first. Both arms of the divergence are covered, so a fix that satisfied one by hardcoding an
+			// errno would fail here. user.a exists by now.
+			what: "setxattr naming both flags, attribute present",
+			objectfs: func() syscall.Errno {
+				return x.node.Setxattr(ctx, "user.a", []byte("v"),
+					uint32(unix.XATTR_CREATE|unix.XATTR_REPLACE))
+			},
+			reference: func() syscall.Errno {
+				return oracle.set("user.a", []byte("v"), uint32(unix.XATTR_CREATE|unix.XATTR_REPLACE))
 			},
 		},
 		{

--- a/internal/fuse/xattr_oracle_test.go
+++ b/internal/fuse/xattr_oracle_test.go
@@ -1,0 +1,401 @@
+//go:build linux || darwin
+
+package fuse
+
+// A differential oracle for extended attributes: one sequence of operations run against ObjectFS and
+// against the local operating-system filesystem, asserting the two agree.
+//
+// internal/difftest is the same idea for content, and this is deliberately not built on it — that
+// package's FS interface is content-shaped (WriteAt, ReadAt, Truncate, Durable) and its doc.go states
+// that it "does not compare errno values, permissions, timestamps, or anything about directories".
+// Extended attributes are almost entirely errno and naming semantics, so widening that interface would
+// change what the package is for. What is worth borrowing is the *reason* it exists: the reference is
+// not written by the person who wrote the implementation and has no opinion about ObjectFS's internals,
+// so it cannot agree by construction the way a table of expected errnos can.
+//
+// That risk is concrete here. Every errno below was chosen by reading setxattr(2), and a table of them
+// would pass whether or not the man page was read correctly — the table would simply restate the same
+// belief the implementation encodes. macOS and Linux also disagree about the *name* of the answer for a
+// missing attribute, so a hardcoded constant is wrong on one platform by construction. Asking the
+// kernel is the only reference that is independent of both.
+//
+// # What is compared, and what is not
+//
+// Compared: the errno for every operation, the value read back, the presence of a name in a listing,
+// and the size protocol's answers. Not compared: the *set* of names a listing returns, because the OS
+// adds its own (macOS puts com.apple.provenance on every file it creates), and the size limits, because
+// ObjectFS's are far smaller and deliberately so. Where ObjectFS refuses something the OS accepts —
+// security.*, a 100 KB value, a directory — the divergence is asserted as intended rather than
+// smoothed over, with the reason recorded in the case.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// osXattrs is the reference: the local filesystem, through the real syscalls.
+type osXattrs struct {
+	path string
+}
+
+// newOSXattrs creates a file on the local filesystem to hold attributes.
+//
+// t.TempDir is on whatever filesystem /tmp is, which is APFS on macOS and usually ext4 or tmpfs on
+// Linux. All three support user extended attributes; [requireOSXattrs] establishes that rather than
+// assuming it, because a filesystem mounted with user_xattr off would make every comparison below
+// vacuously agree on ENOTSUP.
+func newOSXattrs(t *testing.T) *osXattrs {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "oracle.dat")
+	if err := os.WriteFile(path, make([]byte, 4096), 0o600); err != nil {
+		t.Fatalf("creating the reference file: %v", err)
+	}
+
+	return &osXattrs{path: path}
+}
+
+// requireOSXattrs skips when the local filesystem cannot store an extended attribute at all.
+//
+// Without this, a filesystem with user_xattr disabled would answer ENOTSUP to everything and the
+// comparisons would agree with an ObjectFS that also refused everything — the exact false pass this
+// file exists to avoid.
+func (o *osXattrs) requireOSXattrs(t *testing.T) {
+	t.Helper()
+
+	if err := unix.Setxattr(o.path, "user.probe", []byte("v"), 0); err != nil {
+		t.Skipf("the local filesystem cannot store extended attributes (%v), so it cannot serve as a "+
+			"reference. This is a skip rather than a failure: the oracle is unavailable, and ObjectFS's "+
+			"own behavior is covered by xattr_test.go.", err)
+	}
+	if err := unix.Removexattr(o.path, "user.probe"); err != nil {
+		t.Skipf("the local filesystem stored an attribute but cannot remove it (%v)", err)
+	}
+}
+
+func (o *osXattrs) set(name string, value []byte, flags uint32) syscall.Errno {
+	return asErrno(unix.Setxattr(o.path, name, value, int(flags)))
+}
+
+func (o *osXattrs) remove(name string) syscall.Errno {
+	return asErrno(unix.Removexattr(o.path, name))
+}
+
+// get reads an attribute, following the same two-call protocol a caller uses.
+//
+// The syscall reports -1 for the size on failure, where a FUSE reply carries the real size alongside
+// ERANGE; that difference is libc's, not the filesystem's, so only the errno and the bytes are
+// compared. [TestGetxattrHonorsTheSizeProtocol] covers ObjectFS's size on the FUSE side.
+func (o *osXattrs) get(name string) ([]byte, syscall.Errno) {
+	size, err := unix.Getxattr(o.path, name, nil)
+	if err != nil {
+		return nil, asErrno(err)
+	}
+
+	buf := make([]byte, size)
+	n, err := unix.Getxattr(o.path, name, buf)
+	if err != nil {
+		return nil, asErrno(err)
+	}
+
+	return buf[:n], 0
+}
+
+// has reports whether a name appears in the local filesystem's listing.
+func (o *osXattrs) has(t *testing.T, name string) bool {
+	t.Helper()
+
+	size, err := unix.Listxattr(o.path, nil)
+	if err != nil {
+		t.Fatalf("listxattr on the reference file: %v", err)
+	}
+
+	buf := make([]byte, size)
+	n, err := unix.Listxattr(o.path, buf)
+	if err != nil {
+		t.Fatalf("listxattr on the reference file: %v", err)
+	}
+
+	return slices.Contains(splitNulList(buf[:n]), name)
+}
+
+// splitNulList parses the NUL-terminated name list both implementations produce.
+func splitNulList(b []byte) []string {
+	var out []string
+	start := 0
+	for i, c := range b {
+		if c == 0 {
+			if i > start {
+				out = append(out, string(b[start:i]))
+			}
+			start = i + 1
+		}
+	}
+
+	return out
+}
+
+// asErrno extracts the errno from a syscall error, so a comparison is between two errnos rather than
+// between an errno and a string.
+func asErrno(err error) syscall.Errno {
+	if err == nil {
+		return 0
+	}
+
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno
+	}
+
+	return syscall.EIO
+}
+
+// TestXattrErrnosAgreeWithTheLocalFilesystem runs one sequence against both and compares every answer.
+//
+// The sequence is ordered deliberately: each step's answer depends on the state the previous steps
+// left, so a divergence in one operation shows up in the next as well. It is the flag interactions that
+// make this worth doing — "REPLACE on a missing attribute is ENOATTR, CREATE on an existing one is
+// EEXIST, both together is EINVAL" is three chances to have read the man page backwards, and the kernel
+// settles each one without being asked what the answer should be.
+func TestXattrErrnosAgreeWithTheLocalFilesystem(t *testing.T) {
+	t.Parallel()
+
+	oracle := newOSXattrs(t)
+	oracle.requireOSXattrs(t)
+
+	x := newXattrFixture(t, "oracle.dat")
+	ctx := context.Background()
+
+	steps := []struct {
+		what string
+
+		// objectfs and reference perform the same operation on each implementation.
+		objectfs  func() syscall.Errno
+		reference func() syscall.Errno
+	}{
+		{
+			what:      "getxattr for an attribute that was never set",
+			objectfs:  func() syscall.Errno { _, e := x.get(t, "user.a"); return e },
+			reference: func() syscall.Errno { _, e := oracle.get("user.a"); return e },
+		},
+		{
+			what:      "removexattr for an attribute that was never set",
+			objectfs:  func() syscall.Errno { return x.node.Removexattr(ctx, "user.a") },
+			reference: func() syscall.Errno { return oracle.remove("user.a") },
+		},
+		{
+			what: "setxattr with XATTR_REPLACE on a missing attribute",
+			objectfs: func() syscall.Errno {
+				return x.node.Setxattr(ctx, "user.a", []byte("v"), unix.XATTR_REPLACE)
+			},
+			reference: func() syscall.Errno {
+				return oracle.set("user.a", []byte("v"), unix.XATTR_REPLACE)
+			},
+		},
+		{
+			what: "setxattr with XATTR_CREATE on a missing attribute",
+			objectfs: func() syscall.Errno {
+				return x.node.Setxattr(ctx, "user.a", []byte("first"), unix.XATTR_CREATE)
+			},
+			reference: func() syscall.Errno {
+				return oracle.set("user.a", []byte("first"), unix.XATTR_CREATE)
+			},
+		},
+		{
+			what: "setxattr with XATTR_CREATE on an attribute that now exists",
+			objectfs: func() syscall.Errno {
+				return x.node.Setxattr(ctx, "user.a", []byte("second"), unix.XATTR_CREATE)
+			},
+			reference: func() syscall.Errno {
+				return oracle.set("user.a", []byte("second"), unix.XATTR_CREATE)
+			},
+		},
+		{
+			what: "setxattr with XATTR_REPLACE on an attribute that exists",
+			objectfs: func() syscall.Errno {
+				return x.node.Setxattr(ctx, "user.a", []byte("second"), unix.XATTR_REPLACE)
+			},
+			reference: func() syscall.Errno {
+				return oracle.set("user.a", []byte("second"), unix.XATTR_REPLACE)
+			},
+		},
+		{
+			what: "setxattr naming both XATTR_CREATE and XATTR_REPLACE",
+			objectfs: func() syscall.Errno {
+				return x.node.Setxattr(ctx, "user.b", []byte("v"),
+					uint32(unix.XATTR_CREATE|unix.XATTR_REPLACE))
+			},
+			reference: func() syscall.Errno {
+				return oracle.set("user.b", []byte("v"), uint32(unix.XATTR_CREATE|unix.XATTR_REPLACE))
+			},
+		},
+		{
+			what:      "setxattr with no flags, overwriting",
+			objectfs:  func() syscall.Errno { return x.node.Setxattr(ctx, "user.a", []byte("third"), 0) },
+			reference: func() syscall.Errno { return oracle.set("user.a", []byte("third"), 0) },
+		},
+		{
+			what:      "setxattr of an empty value",
+			objectfs:  func() syscall.Errno { return x.node.Setxattr(ctx, "user.empty", []byte{}, 0) },
+			reference: func() syscall.Errno { return oracle.set("user.empty", []byte{}, 0) },
+		},
+		{
+			what:      "getxattr of that empty value",
+			objectfs:  func() syscall.Errno { _, e := x.get(t, "user.empty"); return e },
+			reference: func() syscall.Errno { _, e := oracle.get("user.empty"); return e },
+		},
+		{
+			what:      "setxattr of a value holding NUL and newline bytes",
+			objectfs:  func() syscall.Errno { return x.node.Setxattr(ctx, "user.bin", binaryValue, 0) },
+			reference: func() syscall.Errno { return oracle.set("user.bin", binaryValue, 0) },
+		},
+		{
+			what:      "removexattr of an attribute that exists",
+			objectfs:  func() syscall.Errno { return x.node.Removexattr(ctx, "user.a") },
+			reference: func() syscall.Errno { return oracle.remove("user.a") },
+		},
+		{
+			what:      "getxattr after that removal",
+			objectfs:  func() syscall.Errno { _, e := x.get(t, "user.a"); return e },
+			reference: func() syscall.Errno { _, e := oracle.get("user.a"); return e },
+		},
+		{
+			what:      "removexattr again, of the attribute just removed",
+			objectfs:  func() syscall.Errno { return x.node.Removexattr(ctx, "user.a") },
+			reference: func() syscall.Errno { return oracle.remove("user.a") },
+		},
+	}
+
+	for _, step := range steps {
+		// Not subtests: the sequence is stateful, so these have to run in order and cannot be parallel.
+		got, want := step.objectfs(), step.reference()
+
+		if got != want {
+			t.Errorf("%s:\n\tObjectFS returned %s\n\tthe local filesystem returned %s\n"+
+				"These are the same operation on the same state. A caller that branches on the errno — "+
+				"and every caller of setxattr does, which is why the flags exist — behaves differently "+
+				"on this filesystem than on a local one.",
+				step.what, errnoName(got), errnoName(want))
+		}
+	}
+
+	// The values agree too, not just the errnos. An implementation that returned the right errno and the
+	// wrong bytes would pass everything above.
+	for _, name := range []string{"user.empty", "user.bin"} {
+		gotValue, gotErrno := x.get(t, name)
+		wantValue, wantErrno := oracle.get(name)
+
+		if gotErrno != wantErrno {
+			t.Errorf("reading %s back: ObjectFS %s, local filesystem %s",
+				name, errnoName(gotErrno), errnoName(wantErrno))
+
+			continue
+		}
+		if string(gotValue) != string(wantValue) {
+			t.Errorf("reading %s back: ObjectFS returned %q, the local filesystem returned %q",
+				name, gotValue, wantValue)
+		}
+	}
+
+	// And the listing agrees about the names this test set, without asserting the whole set: macOS puts
+	// com.apple.provenance on every file it creates, which is the OS's business and not a divergence.
+	objectfsNames := make(map[string]bool)
+	for _, n := range x.list(t) {
+		objectfsNames[n] = true
+	}
+
+	for _, name := range []string{"user.empty", "user.bin"} {
+		if want := oracle.has(t, name); objectfsNames[name] != want {
+			t.Errorf("listxattr: ObjectFS lists %s = %v, the local filesystem = %v",
+				name, objectfsNames[name], want)
+		}
+	}
+
+	if objectfsNames["user.a"] {
+		t.Error("listxattr still names user.a after it was removed, while the local filesystem does not")
+	}
+}
+
+// binaryValue holds the bytes an HTTP header cannot carry as themselves, which is why values are
+// encoded. The local filesystem stores them without complaint, so it is a real reference for what a
+// caller may expect to get back.
+var binaryValue = []byte{0x00, 0x0a, 0x0d, 0x20, 0x7f, 0xff, 0x00}
+
+// TestXattrDivergencesFromTheLocalFilesystemAreIntentional records where the two deliberately disagree.
+//
+// A differential oracle is only usable if the intended divergences are written down, because otherwise
+// every one of them is a failure and the test gets deleted. Each case below is something the local
+// filesystem accepts and ObjectFS refuses, with the reason — and asserting them makes the refusals
+// deliberate rather than incidental, so removing one is a test failure rather than a quiet change of
+// behavior.
+func TestXattrDivergencesFromTheLocalFilesystemAreIntentional(t *testing.T) {
+	t.Parallel()
+
+	oracle := newOSXattrs(t)
+	oracle.requireOSXattrs(t)
+
+	x := newXattrFixture(t, "divergence.dat")
+	ctx := context.Background()
+
+	t.Run("a value larger than the metadata budget", func(t *testing.T) {
+		// Parallel with its siblings: each case below asserts a *refusal*, so none of them writes an
+		// attribute and there is no shared state for them to race. If a case is ever changed to one that
+		// stores something, it has to stop being parallel.
+		t.Parallel()
+
+		big := make([]byte, 64*1024)
+
+		// The local filesystem takes it — ext4 allows a value up to one block, APFS far more.
+		if errno := oracle.set("user.big", big, 0); errno != 0 {
+			t.Skipf("the local filesystem also refuses a %d-byte value (%s), so there is no divergence "+
+				"to record here", len(big), errnoName(errno))
+		}
+
+		if errno := x.node.Setxattr(ctx, "user.big", big, 0); errno != syscall.E2BIG {
+			t.Errorf("ObjectFS returned %s for a %d-byte value, want E2BIG. S3 caps an object's total "+
+				"user metadata at 2 KB and rejects the request rather than truncating, so this cannot be "+
+				"stored — and E2BIG is what setxattr(2) documents for a value too large for the "+
+				"filesystem.", errnoName(errno), len(big))
+		}
+	})
+
+	t.Run("an attribute in a namespace the kernel acts on", func(t *testing.T) {
+		t.Parallel()
+
+		// Not compared against the local filesystem's answer: setting security.capability there needs
+		// CAP_SETFCAP and would fail as EPERM for an unrelated reason. The divergence being recorded is
+		// that ObjectFS refuses it for *every* caller, privileged or not.
+		if errno := x.node.Setxattr(ctx, "security.capability", []byte("\x01\x00\x00\x02"), 0); errno != syscall.ENOTSUP {
+			t.Errorf("ObjectFS returned %s for security.capability, want ENOTSUP. A local filesystem "+
+				"stores this for a privileged caller and the kernel grants the capabilities it names on "+
+				"every exec; the store here is object metadata, writable by anyone with bucket write "+
+				"access, so honoring it would convert that into file capabilities on every mounting host.",
+				errnoName(errno))
+		}
+	})
+
+	t.Run("an attribute on a directory", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+
+		if err := unix.Setxattr(dir, "user.d", []byte("v"), 0); err != nil {
+			t.Skipf("the local filesystem also refuses an attribute on a directory (%v)", err)
+		}
+
+		node := &DirectoryNode{fs: x.fs, path: "some/dir"}
+		if errno := node.Setxattr(ctx, "user.d", []byte("v"), 0); errno != syscall.ENOTSUP {
+			t.Errorf("ObjectFS returned %s for an attribute on a directory, want ENOTSUP. A local "+
+				"filesystem stores it; a directory here is a key prefix, and one that exists only because "+
+				"objects share that prefix has no object to hold it — so it would persist for some "+
+				"directories and vanish for others.", errnoName(errno))
+		}
+	})
+}

--- a/internal/fuse/xattr_test.go
+++ b/internal/fuse/xattr_test.go
@@ -1,0 +1,1023 @@
+//go:build linux || darwin
+
+package fuse
+
+// Tests for the four extended-attribute operations, against a real S3 endpoint and the real write path.
+//
+// Every durability assertion reads through a fresh HeadObject or through a write path built from
+// nothing, never through the same in-memory record the operation just wrote. A setxattr that updates the
+// node's attributes and never reaches S3 satisfies any assertion that asks the write path what it
+// believes — and "extended attributes do not survive a remount" is exactly that failure, in the same
+// shape as the chmod defect attributes_test.go covers.
+//
+// The bridge is driven directly where the property under test belongs to the kernel-facing contract: the
+// size protocol, the ERANGE path, and the flags all live in the request rather than in a node method's
+// arguments. fs.NewNodeFS returns the fuse.RawFileSystem the kernel talks to, so calling its methods
+// runs the same dispatch the kernel would, with no mount, no privileges, and no macFUSE.
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	gofuse "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+	"golang.org/x/sys/unix"
+
+	"github.com/scttfrdmn/objectfs/internal/vfs"
+)
+
+// xattrFixture is a readPathFixture with a seeded object and a FileNode over it.
+type xattrFixture struct {
+	*readPathFixture
+
+	key  string
+	node *FileNode
+}
+
+// newXattrFixture seeds one object and returns a node addressing it.
+//
+// RequireMetadataReplace is asserted here rather than per test: every write below flushes with no content
+// pending, which is the SetObjectMetadata path, and against an endpoint that ignores the directive the
+// flush's own read-back fails loudly. Requiring the capability makes the skip explicit instead of leaving
+// a suite of tests that fail for a reason unrelated to what they check.
+func newXattrFixture(t *testing.T, key string) *xattrFixture {
+	t.Helper()
+
+	f := newReadPathFixture(t)
+	f.srv.RequireMetadataReplace()
+	f.srv.SeedRandom(key, 4096)
+
+	return &xattrFixture{readPathFixture: f, key: key, node: &FileNode{fs: f.fs, path: key}}
+}
+
+// remount discards every byte of in-memory state, so the next read answers only from what S3 holds.
+//
+// This is the assertion that matters for a persistence feature and the one a mock cannot make: it
+// replaces the write path with one that has never seen a single operation from this test.
+func (x *xattrFixture) remount(t *testing.T) {
+	t.Helper()
+
+	x.fs.buffer = newWriterOver(t, x.readPathFixture)
+	x.fs.invalidate(x.key)
+}
+
+// get reads one attribute the way a caller does: a size query, then a read into a buffer that size.
+func (x *xattrFixture) get(t *testing.T, name string) ([]byte, syscall.Errno) {
+	t.Helper()
+
+	size, errno := x.node.Getxattr(context.Background(), name, nil)
+	if errno != 0 {
+		return nil, errno
+	}
+
+	buf := make([]byte, size)
+	n, errno := x.node.Getxattr(context.Background(), name, buf)
+	if errno != 0 {
+		return nil, errno
+	}
+
+	return buf[:n], 0
+}
+
+// list reads the attribute names, following the same two-call protocol.
+func (x *xattrFixture) list(t *testing.T) []string {
+	t.Helper()
+
+	size, errno := x.node.Listxattr(context.Background(), nil)
+	if errno != 0 {
+		t.Fatalf("listxattr size query: errno %v", errno)
+	}
+	if size == 0 {
+		return nil
+	}
+
+	buf := make([]byte, size)
+	n, errno := x.node.Listxattr(context.Background(), buf)
+	if errno != 0 {
+		t.Fatalf("listxattr read: errno %v", errno)
+	}
+
+	var names []string
+	for raw := range bytes.SplitSeq(buf[:n], []byte{0}) {
+		if len(raw) > 0 {
+			names = append(names, string(raw))
+		}
+	}
+
+	return names
+}
+
+// TestSetxattrThenGetxattrRoundTripsThroughStorage is the acceptance criterion from #167, as close to
+// `setfattr -n user.test -v hello f && getfattr -n user.test f` as this can be driven without a mount.
+//
+// The read after the remount is the whole test. Everything before it would also pass if the value never
+// left this process.
+func TestSetxattrThenGetxattrRoundTripsThroughStorage(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "roundtrip.dat")
+
+	if errno := x.node.Setxattr(context.Background(), "user.test", []byte("hello"), 0); errno != 0 {
+		t.Fatalf("setxattr user.test=hello: errno %v", errno)
+	}
+
+	got, errno := x.get(t, "user.test")
+	if errno != 0 {
+		t.Fatalf("getxattr user.test: errno %v", errno)
+	}
+	if string(got) != "hello" {
+		t.Errorf("getxattr returned %q, want %q", got, "hello")
+	}
+
+	// The stored form is on the object, under a key that is not the attribute name.
+	meta := x.srv.ObjectMetadata(x.key)
+	var found bool
+	for k := range meta {
+		if strings.HasPrefix(strings.ToLower(k), "objectfs-xattr-") {
+			found = true
+		}
+		if strings.EqualFold(k, "objectfs-xattr-user.test") || strings.EqualFold(k, "user.test") {
+			t.Errorf("the attribute is stored under %q, which is the raw name; S3 lower-cases metadata "+
+				"keys, so user.Test and user.test would collide", k)
+		}
+	}
+	if !found {
+		t.Fatalf("no objectfs-xattr- key on the object after setxattr. Metadata: %v", meta)
+	}
+
+	// And the remount: nothing in memory, only what S3 holds.
+	x.remount(t)
+
+	got, errno = x.get(t, "user.test")
+	if errno != 0 {
+		t.Fatalf("getxattr after discarding all in-memory state: errno %v. The attribute did not survive "+
+			"to storage, which is the whole of what setxattr promises.", errno)
+	}
+	if string(got) != "hello" {
+		t.Errorf("after a remount the attribute reads %q, want %q", got, "hello")
+	}
+}
+
+// TestSetxattrIsDurableWithoutAClose covers why the write path flushes synchronously.
+//
+// setxattr(2) takes a path, so there is no descriptor whose release would persist the change later.
+// Nothing would ever flush it: it would survive only to the FlushAll at unmount, and a mount killed
+// before then would lose it with no error anywhere. The assertion is that S3 already holds the attribute
+// the instant Setxattr returns — no Fsync, no Release, no FlushAll.
+func TestSetxattrIsDurableWithoutAClose(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "durable.dat")
+
+	if errno := x.node.Setxattr(context.Background(), "user.sync", []byte("v"), 0); errno != 0 {
+		t.Fatalf("setxattr: errno %v", errno)
+	}
+
+	// Read the object's metadata directly, with no ObjectFS layer involved at all.
+	meta := x.srv.ObjectMetadata(x.key)
+	if len(meta) == 0 {
+		t.Fatalf("the object carries no user metadata at all after setxattr")
+	}
+
+	attrs := vfs.AttrFromMetadata(meta, 0, processStart, "")
+	if v, ok := attrs.Xattr("user.sync"); !ok || string(v) != "v" {
+		t.Errorf("S3 does not hold user.sync immediately after setxattr returned (got %q, present=%v). "+
+			"Nothing else will ever flush it: setxattr has no descriptor to release, so the attribute "+
+			"would be lost by any mount that is killed before unmount.", v, ok)
+	}
+}
+
+// TestGetxattrReportsAbsenceAsNoAttrNotNoEnt is the misclassification that matters most here.
+//
+// ENOENT and ENOATTR are both errnos a caller sees from getxattr, and they mean different things: ENOENT
+// says the *file* is gone. A program probing for an attribute before creating one would conclude the path
+// had disappeared underneath it, and `getfattr` renders the two differently to a person.
+func TestGetxattrReportsAbsenceAsNoAttrNotNoEnt(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "absent.dat")
+
+	_, errno := x.node.Getxattr(context.Background(), "user.nothing", make([]byte, 64))
+
+	if errno == syscall.ENOENT {
+		t.Fatal("getxattr for a missing attribute returned ENOENT, which says the file does not exist. " +
+			"A caller checking for an attribute before creating it would conclude the path is gone.")
+	}
+	if errno != errNoXattr {
+		t.Errorf("getxattr for a missing attribute returned %s, want %s",
+			errnoName(errno), errnoName(errNoXattr))
+	}
+
+	// The same distinction for removexattr, which has the same two candidate errnos.
+	if errno := x.node.Removexattr(context.Background(), "user.nothing"); errno != errNoXattr {
+		t.Errorf("removexattr for a missing attribute returned %s, want %s",
+			errnoName(errno), errnoName(errNoXattr))
+	}
+}
+
+// TestRemovexattrStopsTheAttributeBeingReadable is the removal, checked past the layer that could fake
+// it.
+//
+// The mechanism is a tombstone, because [types.Backend.SetObjectMetadata] merges the object's existing
+// metadata underneath the caller's and therefore cannot delete a key — a removexattr that simply stopped
+// rendering the key would report success while the attribute stayed readable forever. So the assertion
+// is made after a remount: in-memory state would hide exactly that bug.
+func TestRemovexattrStopsTheAttributeBeingReadable(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "removal.dat")
+	ctx := context.Background()
+
+	if errno := x.node.Setxattr(ctx, "user.doomed", []byte("here"), 0); errno != 0 {
+		t.Fatalf("setxattr: errno %v", errno)
+	}
+	if errno := x.node.Setxattr(ctx, "user.kept", []byte("stays"), 0); errno != 0 {
+		t.Fatalf("setxattr of the second attribute: errno %v", errno)
+	}
+	if errno := x.node.Removexattr(ctx, "user.doomed"); errno != 0 {
+		t.Fatalf("removexattr: errno %v", errno)
+	}
+
+	x.remount(t)
+
+	if _, errno := x.get(t, "user.doomed"); errno != errNoXattr {
+		t.Errorf("after a remount the removed attribute reads with errno %s, want %s. The removal did "+
+			"not reach storage: omitting a key from a metadata replace does not delete it, because the "+
+			"backend merges the object's existing metadata underneath.",
+			errnoName(errno), errnoName(errNoXattr))
+	}
+
+	// A removal must not take the neighbors with it. A metadata replace writes the whole set, so a path
+	// that rendered only the changed attribute would delete every other one.
+	got, errno := x.get(t, "user.kept")
+	if errno != 0 {
+		t.Fatalf("the other attribute is gone after removing an unrelated one: errno %v", errno)
+	}
+	if string(got) != "stays" {
+		t.Errorf("the other attribute reads %q, want %q", got, "stays")
+	}
+
+	if names := x.list(t); len(names) != 1 || names[0] != "user.kept" {
+		t.Errorf("listxattr reports %v after one of two attributes was removed, want [user.kept]", names)
+	}
+}
+
+// TestListxattrNamesEveryAttributeAndNulTerminatesThem covers the reply format and the size protocol
+// together, since a caller cannot use either without the other.
+func TestListxattrNamesEveryAttributeAndNulTerminatesThem(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "list.dat")
+	ctx := context.Background()
+
+	want := []string{"user.a", "user.b", "user.c"}
+	for _, name := range want {
+		if errno := x.node.Setxattr(ctx, name, []byte("v"), 0); errno != 0 {
+			t.Fatalf("setxattr %s: errno %v", name, errno)
+		}
+	}
+
+	x.remount(t)
+
+	// The size query first, which is what every caller issues before allocating.
+	size, errno := x.node.Listxattr(ctx, nil)
+	if errno != 0 {
+		t.Fatalf("listxattr size query: errno %v", errno)
+	}
+
+	var wantSize int
+	for _, name := range want {
+		wantSize += len(name) + 1
+	}
+	if int(size) != wantSize {
+		t.Errorf("listxattr reported a size of %d, want %d (each name plus its NUL). A caller allocates "+
+			"exactly this and gets ERANGE forever if it is short.", size, wantSize)
+	}
+
+	buf := make([]byte, size)
+	n, errno := x.node.Listxattr(ctx, buf)
+	if errno != 0 {
+		t.Fatalf("listxattr read: errno %v", errno)
+	}
+	if int(n) != wantSize {
+		t.Errorf("listxattr wrote %d bytes, want %d", n, wantSize)
+	}
+
+	// The final name must be terminated too. Dropping the last NUL truncates it by a byte in getfattr's
+	// output, which looks like a corrupted attribute name rather than a formatting slip.
+	if n == 0 || buf[n-1] != 0 {
+		t.Errorf("the name list does not end with a NUL: %q", buf[:n])
+	}
+
+	got := x.list(t)
+	if len(got) != len(want) {
+		t.Fatalf("listxattr named %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("listxattr named %v, want %v (sorted, so that two identical calls agree)", got, want)
+		}
+	}
+
+	// A buffer one byte short must report ERANGE *with* the size, not instead of it: the size is what the
+	// caller retries with.
+	shortSize, errno := x.node.Listxattr(ctx, make([]byte, wantSize-1))
+	if errno != syscall.ERANGE {
+		t.Errorf("listxattr into a buffer one byte too small returned %s, want ERANGE", errnoName(errno))
+	}
+	if int(shortSize) != wantSize {
+		t.Errorf("listxattr reported %d alongside ERANGE, want %d — a caller sizes its next buffer from "+
+			"this number and loops forever if it is wrong", shortSize, wantSize)
+	}
+}
+
+// TestGetxattrHonorsTheSizeProtocol is the same two-call contract for a single attribute.
+func TestGetxattrHonorsTheSizeProtocol(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "sizes.dat")
+	ctx := context.Background()
+
+	value := []byte("a value of some length")
+	if errno := x.node.Setxattr(ctx, "user.v", value, 0); errno != 0 {
+		t.Fatalf("setxattr: errno %v", errno)
+	}
+
+	size, errno := x.node.Getxattr(ctx, "user.v", nil)
+	if errno != 0 {
+		t.Fatalf("getxattr size query returned errno %v; a zero-length buffer is a size query and must "+
+			"succeed", errno)
+	}
+	if int(size) != len(value) {
+		t.Errorf("getxattr reported a size of %d, want %d", size, len(value))
+	}
+
+	short, errno := x.node.Getxattr(ctx, "user.v", make([]byte, len(value)-1))
+	if errno != syscall.ERANGE {
+		t.Errorf("getxattr into a short buffer returned %s, want ERANGE", errnoName(errno))
+	}
+	if int(short) != len(value) {
+		t.Errorf("getxattr reported %d alongside ERANGE, want %d", short, len(value))
+	}
+
+	// An exactly-sized buffer must be filled completely, and a larger one must report the value's length
+	// rather than the buffer's.
+	for _, extra := range []int{0, 64} {
+		buf := make([]byte, len(value)+extra)
+		n, errno := x.node.Getxattr(ctx, "user.v", buf)
+		if errno != 0 {
+			t.Fatalf("getxattr into a buffer of %d bytes: errno %v", len(buf), errno)
+		}
+		if int(n) != len(value) {
+			t.Errorf("getxattr into a buffer of %d bytes reported %d, want %d", len(buf), n, len(value))
+		}
+		if !bytes.Equal(buf[:n], value) {
+			t.Errorf("getxattr returned %q, want %q", buf[:n], value)
+		}
+	}
+}
+
+// TestXattrNamesDifferingOnlyInCaseAreDistinct is the collision S3's wire format creates, checked where
+// it actually happens: at the endpoint.
+//
+// S3 lower-cases user-metadata keys in transit. Storing an attribute under its own name would make
+// user.Foo and user.foo the same key, so setting the second would destroy the first with no error
+// anywhere — the encoding test in internal/vfs asserts the encoder's property, and this asserts the
+// consequence survives a real HTTP round trip through a real endpoint.
+func TestXattrNamesDifferingOnlyInCaseAreDistinct(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "case.dat")
+	ctx := context.Background()
+
+	if errno := x.node.Setxattr(ctx, "user.foo", []byte("lower"), 0); errno != 0 {
+		t.Fatalf("setxattr user.foo: errno %v", errno)
+	}
+	if errno := x.node.Setxattr(ctx, "user.Foo", []byte("upper"), 0); errno != 0 {
+		t.Fatalf("setxattr user.Foo: errno %v", errno)
+	}
+
+	x.remount(t)
+
+	for _, tc := range []struct{ name, want string }{
+		{"user.foo", "lower"},
+		{"user.Foo", "upper"},
+	} {
+		got, errno := x.get(t, tc.name)
+		if errno != 0 {
+			t.Fatalf("getxattr %s after a remount: errno %v", tc.name, errno)
+		}
+		if string(got) != tc.want {
+			t.Errorf("%s reads %q, want %q. The two names collided in storage, so setting one destroyed "+
+				"the other — and neither setfattr reported anything.", tc.name, got, tc.want)
+		}
+	}
+
+	if names := x.list(t); len(names) != 2 {
+		t.Errorf("listxattr reports %v, want both user.Foo and user.foo", names)
+	}
+}
+
+// TestSetxattrCannotRewriteThePOSIXAttributes is the security-relevant case.
+//
+// The stored key for an attribute is objectfs-xattr-<base32>, so no name a caller can choose produces
+// objectfs-mode. Without that, `setfattr -n objectfs-mode -v 4777 f` would rewrite the file's permission
+// bits — an unprivileged process editing the field the filesystem reports as the mode, on a filesystem
+// where the mode is the only POSIX-visible access control there is.
+//
+// Checked against storage rather than against the encoder, because the property has to hold through the
+// merge SetObjectMetadata performs: the POSIX keys and the xattr keys land in the same metadata map.
+func TestSetxattrCannotRewriteThePOSIXAttributes(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "collide.dat")
+	ctx := context.Background()
+
+	// Establish a known mode and owner first, so a change is visible as a change.
+	in := setAttrIn(fuse.FATTR_MODE|fuse.FATTR_UID, func(in *fuse.SetAttrIn) {
+		in.Mode, in.Uid = 0o600, 4242
+	})
+	if errno := x.node.Setattr(ctx, nil, in, &fuse.AttrOut{}); errno != 0 {
+		t.Fatalf("chmod+chown: errno %v", errno)
+	}
+
+	attacks := []struct{ name, value string }{
+		{"objectfs-mode", "4777"},
+		{"objectfs-uid", "0"},
+		{"objectfs-gid", "0"},
+		{"objectfs-sha256", strings.Repeat("f", 64)},
+		{"objectfs-original-size", "0"},
+		{"user.objectfs-mode", "4777"},
+		{"OBJECTFS-MODE", "4777"},
+	}
+
+	for _, a := range attacks {
+		if errno := x.node.Setxattr(ctx, a.name, []byte(a.value), 0); errno != 0 {
+			t.Fatalf("setxattr %s: errno %v (the attribute should be storable — it just must not reach "+
+				"the POSIX keys)", a.name, errno)
+		}
+	}
+
+	x.remount(t)
+
+	var out fuse.AttrOut
+	if errno := x.node.Getattr(ctx, nil, &out); errno != 0 {
+		t.Fatalf("Getattr: errno %v", errno)
+	}
+
+	if got := out.Mode & 0o7777; got != 0o600 {
+		t.Errorf("the file's mode is %#o after setting an attribute named objectfs-mode, want 0600. An "+
+			"unprivileged setfattr just changed a file's permissions.", got)
+	}
+	if out.Uid != 4242 {
+		t.Errorf("the file's owner is %d after setting an attribute named objectfs-uid, want 4242", out.Uid)
+	}
+
+	// The attributes themselves are still ordinary attributes, readable under the names they were set
+	// with. Refusing them would also be defensible, but silently dropping them would not.
+	for _, a := range attacks {
+		got, errno := x.get(t, a.name)
+		if errno != 0 {
+			t.Errorf("the attribute named %q did not survive: errno %v", a.name, errno)
+			continue
+		}
+		if string(got) != a.value {
+			t.Errorf("the attribute named %q reads %q, want %q", a.name, got, a.value)
+		}
+	}
+
+	// And the integrity keys the backend owns are still the backend's. An attribute named
+	// objectfs-sha256 must not have become the object's recorded checksum.
+	meta := x.srv.ObjectMetadata(x.key)
+	if got := meta["objectfs-sha256"]; got == strings.Repeat("f", 64) {
+		t.Error("the object's objectfs-sha256 is the value passed to setxattr, so a caller can declare " +
+			"any checksum it likes for content it did not write")
+	}
+}
+
+// TestSetxattrStoresArbitraryBytes covers the binary-value case, through a real HTTP request.
+//
+// An xattr value is bytes: `setfattr -e hex` exists because people store them, and a value carrying a
+// NUL or a newline cannot go into an HTTP header as itself. The encoding is tested in internal/vfs; what
+// this adds is that the encoded form survives the SDK, the signer, and the endpoint — the layers a unit
+// test over the encoder cannot reach.
+func TestSetxattrStoresArbitraryBytes(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "binary.dat")
+	ctx := context.Background()
+
+	values := map[string][]byte{
+		"user.nul":     {0, 1, 2, 0},
+		"user.newline": []byte("line\r\nline"),
+		"user.highbit": {0xff, 0xfe, 0x80},
+		"user.empty":   {},
+		"user.spaces":  []byte("  leading and trailing  "),
+	}
+
+	for name, value := range values {
+		if errno := x.node.Setxattr(ctx, name, value, 0); errno != 0 {
+			t.Fatalf("setxattr %s = %v: errno %v", name, value, errno)
+		}
+	}
+
+	x.remount(t)
+
+	for name, want := range values {
+		got, errno := x.get(t, name)
+		if errno != 0 {
+			t.Errorf("getxattr %s after a remount: errno %v", name, errno)
+			continue
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s reads %v, want %v", name, got, want)
+		}
+	}
+
+	// An empty value is an attribute that exists, distinct from one that was removed. Both are the empty
+	// string in an untagged storage form, and conflating them would make every `setfattr -n user.x` with
+	// no value read as a removal.
+	if names := x.list(t); len(names) != len(values) {
+		t.Errorf("listxattr reports %d attributes, want %d: an empty attribute exists and must be listed",
+			len(names), len(values))
+	}
+}
+
+// TestSetxattrOfANilValueStoresAnEmptyAttribute closes the gap between two representations of "nothing"
+// that mean opposite things.
+//
+// A nil value is the tombstone in the stored form, and [vfs.Writer.SetXattr] rejects nil for exactly that
+// reason — passing it through would make a set indistinguishable from a removal. But a *caller* handing
+// over nil means the empty value, which is what `setfattr -n user.x f` with no `-v` sets, so it has to be
+// normalised at this boundary rather than refused at the one below.
+//
+// This test exists because a verifying mutation found nothing covering it: removing the normalisation
+// left every other test in this package passing, while `setfattr -n user.x f` returned EINVAL and stored
+// nothing. The `[]byte{}` cases elsewhere do not reach it — an empty slice is not a nil one, and that
+// distinction is the entire defect.
+func TestSetxattrOfANilValueStoresAnEmptyAttribute(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "nilvalue.dat")
+	ctx := context.Background()
+
+	if errno := x.node.Setxattr(ctx, "user.novalue", nil, 0); errno != 0 {
+		t.Fatalf("setxattr with a nil value returned %s, want success. That is `setfattr -n user.x f` "+
+			"with no -v, which sets an attribute whose value is zero bytes.", errnoName(errno))
+	}
+
+	x.remount(t)
+
+	got, errno := x.get(t, "user.novalue")
+	if errno != 0 {
+		t.Fatalf("the attribute is absent after a nil-valued set: errno %s. A nil value is the tombstone "+
+			"in the stored form, so passing it through unnormalised turns a set into a removal.",
+			errnoName(errno))
+	}
+	if len(got) != 0 {
+		t.Errorf("the attribute reads %q, want an empty value", got)
+	}
+
+	// It exists, which is the half a tombstone would get wrong.
+	var found bool
+	for _, name := range x.list(t) {
+		if name == "user.novalue" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("listxattr does not name the attribute, so it was stored as a removal rather than as an " +
+			"empty value")
+	}
+}
+
+// TestSetxattrHonorsCreateAndReplaceFlags covers the two flags, and the platform difference in their
+// values.
+//
+// XATTR_CREATE and XATTR_REPLACE are numerically different on Linux and darwin (1 and 2 versus 2 and 4),
+// and the value that arrives is the local kernel's. A literal in the implementation would be right on one
+// platform and would silently turn CREATE into REPLACE on the other, which is why unix.XATTR_* is used —
+// and why this test names them the same way rather than hardcoding what it expects to receive.
+func TestSetxattrHonorsCreateAndReplaceFlags(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "flags.dat")
+	ctx := context.Background()
+
+	// REPLACE on an attribute that does not exist: ENOATTR.
+	if errno := x.node.Setxattr(ctx, "user.f", []byte("v"), unix.XATTR_REPLACE); errno != errNoXattr {
+		t.Errorf("setxattr with XATTR_REPLACE on a missing attribute returned %s, want %s",
+			errnoName(errno), errnoName(errNoXattr))
+	}
+	if _, errno := x.get(t, "user.f"); errno != errNoXattr {
+		t.Error("a refused XATTR_REPLACE created the attribute anyway")
+	}
+
+	// CREATE on an attribute that does not exist: success.
+	if errno := x.node.Setxattr(ctx, "user.f", []byte("first"), unix.XATTR_CREATE); errno != 0 {
+		t.Fatalf("setxattr with XATTR_CREATE on a missing attribute: errno %v", errno)
+	}
+
+	// CREATE on one that now does: EEXIST, and the value must not change.
+	if errno := x.node.Setxattr(ctx, "user.f", []byte("second"), unix.XATTR_CREATE); errno != syscall.EEXIST {
+		t.Errorf("setxattr with XATTR_CREATE on an existing attribute returned %s, want EEXIST",
+			errnoName(errno))
+	}
+	if got, _ := x.get(t, "user.f"); string(got) != "first" {
+		t.Errorf("a refused XATTR_CREATE changed the value to %q, want %q", got, "first")
+	}
+
+	// REPLACE on one that exists: success.
+	if errno := x.node.Setxattr(ctx, "user.f", []byte("second"), unix.XATTR_REPLACE); errno != 0 {
+		t.Fatalf("setxattr with XATTR_REPLACE on an existing attribute: errno %v", errno)
+	}
+	if got, _ := x.get(t, "user.f"); string(got) != "second" {
+		t.Errorf("XATTR_REPLACE left the value as %q, want %q", got, "second")
+	}
+
+	// Both flags at once is EINVAL, per setxattr(2).
+	both := uint32(unix.XATTR_CREATE | unix.XATTR_REPLACE)
+	if errno := x.node.Setxattr(ctx, "user.g", []byte("v"), both); errno != syscall.EINVAL {
+		t.Errorf("setxattr with both XATTR_CREATE and XATTR_REPLACE returned %s, want EINVAL",
+			errnoName(errno))
+	}
+
+	// The two constants must not be the same number, or every test above is checking one code path
+	// twice. They differ per platform, which is the reason this is asserted rather than assumed.
+	if unix.XATTR_CREATE == unix.XATTR_REPLACE {
+		t.Fatal("unix.XATTR_CREATE and unix.XATTR_REPLACE are the same value on this platform, so the " +
+			"create and replace cases above are indistinguishable")
+	}
+}
+
+// TestSetxattrRefusesValuesLargerThanTheMetadataBudget covers the two size failures and, more
+// importantly, that they are told apart.
+//
+// S3 caps an object's total user metadata at 2 KB and fails the request rather than truncating. E2BIG
+// says no object could hold this value; ENOSPC says this one has no room left. A caller that retries
+// after freeing space is right in the second case and loops forever in the first, which is why they are
+// separate errnos in setxattr(2) and why collapsing them here would discard information the syscall
+// interface can carry.
+func TestSetxattrRefusesValuesLargerThanTheMetadataBudget(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "budget.dat")
+	ctx := context.Background()
+
+	// One value larger than the entire budget.
+	huge := bytes.Repeat([]byte("x"), vfs.XattrBudget+1)
+	if errno := x.node.Setxattr(ctx, "user.huge", huge, 0); errno != syscall.E2BIG {
+		t.Errorf("setxattr of a %d-byte value returned %s, want E2BIG. S3 caps an object's user "+
+			"metadata at 2 KB and fails the whole request, so accepting this would move the failure to a "+
+			"later flush that no caller is left to see.", len(huge), errnoName(errno))
+	}
+
+	// Enough attributes that each fits and the set does not. The count is derived from the budget rather
+	// than written as a literal, so a change to what ObjectFS reserves cannot make this vacuous.
+	chunk := bytes.Repeat([]byte("y"), 128)
+	var filled bool
+	for i := range 100 {
+		name := "user.fill" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+
+		errno := x.node.Setxattr(ctx, name, chunk, 0)
+		if errno == 0 {
+			continue
+		}
+		if errno == syscall.ENOSPC {
+			filled = true
+
+			break
+		}
+		t.Fatalf("setxattr %s returned %s, want either success or ENOSPC", name, errnoName(errno))
+	}
+	if !filled {
+		t.Errorf("100 attributes of %d bytes each fit inside a %d-byte budget without ENOSPC; the limit "+
+			"is not being enforced", len(chunk), vfs.XattrBudget)
+	}
+
+	// The object is still intact and still readable. A refused setxattr must not have left the file
+	// dirty with a change it cannot persist, or the next flush of any kind fails.
+	if got := x.srv.ObjectSize(x.key); got != 4096 {
+		t.Errorf("the object is %d bytes after a refused setxattr, want 4096", got)
+	}
+}
+
+// TestXattrsInKernelActedNamespacesAreRefused is a privilege-escalation boundary, not a compatibility
+// choice.
+//
+// On Linux the kernel reads security.capability from the filesystem on every exec and grants the named
+// capabilities. The store behind this filesystem is object metadata, which anyone holding s3:PutObject on
+// the bucket can write with the AWS CLI without touching the mount — so honoring the attribute would turn
+// bucket write access into a route to file capabilities on every host that mounts it. system.posix_acl_*
+// is the milder version: go-fuse is not configured for ACLs, so a stored ACL would be reported by getfacl
+// and enforced by nothing.
+func TestXattrsInKernelActedNamespacesAreRefused(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "namespaces.dat")
+	ctx := context.Background()
+
+	refused := []string{
+		"security.capability",
+		"security.selinux",
+		"system.posix_acl_access",
+		"system.posix_acl_default",
+	}
+
+	for _, name := range refused {
+		if errno := x.node.Setxattr(ctx, name, []byte("\x01\x00\x00\x02"), 0); errno != syscall.ENOTSUP {
+			t.Errorf("setxattr %s returned %s, want ENOTSUP. Object metadata is writable by anyone with "+
+				"bucket write access, so an attribute the kernel acts on must not be storable here.",
+				name, errnoName(errno))
+		}
+		if _, errno := x.node.Getxattr(ctx, name, nil); errno != errNoXattr {
+			t.Errorf("getxattr %s returned %s, want %s", name, errnoName(errno), errnoName(errNoXattr))
+		}
+	}
+
+	// Nothing reached the object.
+	for k := range x.srv.ObjectMetadata(x.key) {
+		if strings.HasPrefix(strings.ToLower(k), "objectfs-xattr-") {
+			t.Errorf("the object carries an extended attribute key %q after only refused sets", k)
+		}
+	}
+
+	// A name that merely looks like one of those namespaces is an ordinary attribute: the kernel's
+	// namespaces are lower-case, and no kernel reads Security.capability, so refusing it would deny a
+	// legitimate name for no benefit.
+	if errno := x.node.Setxattr(ctx, "Security.capability", []byte("ordinary"), 0); errno != 0 {
+		t.Errorf("setxattr of the ordinary name Security.capability returned %s, want success",
+			errnoName(errno))
+	}
+	if got, errno := x.get(t, "Security.capability"); errno != 0 || string(got) != "ordinary" {
+		t.Errorf("Security.capability reads %q with errno %v, want %q", got, errno, "ordinary")
+	}
+}
+
+// The stored form of security.capability = {1,0,0,2}, computed independently of ObjectFS's encoder.
+//
+// Written out as literals because that is what an out-of-band writer has: base32 of the name under the
+// objectfs-xattr- prefix, lower-cased as S3 would deliver it, and "v" plus base64url of the value. If the
+// encoding changes these stop matching, and the test fails at the "did the write land" assertion rather
+// than quietly checking a filter against a key ObjectFS no longer looks for.
+const (
+	outOfBandXattrKey   = "objectfs-xattr-onswg5lsnf2hsltdmfygcytjnruxi6i"
+	outOfBandXattrValue = "vAQAAAg"
+)
+
+// TestARefusedNamespaceWrittenOutsideTheMountIsNotReported is the other half of the namespace refusal,
+// and the half that carries the actual privilege argument.
+//
+// Refusing `setfattr security.capability` only closes the door a mount controls. The threat the refusal
+// exists for is the door it does not: anyone holding s3:PutObject on the bucket can write the encoded
+// metadata key with the AWS CLI, never touching a mount. If getxattr and listxattr then reported that
+// attribute, the kernel would read it on the next exec and grant the capabilities it names — so the read
+// side has to filter too, and the write-side refusal alone would be security theater.
+//
+// This test exists because a verifying mutation found nothing covering it: deleting the filter from
+// Listxattr left every other test in this package passing, because every attribute in them was written
+// *through* the mount, where the set path had already refused it. The out-of-band write is the only way
+// to reach the branch.
+func TestARefusedNamespaceWrittenOutsideTheMountIsNotReported(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "outofband.dat")
+	ctx := context.Background()
+
+	// One ordinary attribute through the mount, so the object has a legitimate one alongside.
+	if errno := x.node.Setxattr(ctx, "user.ok", []byte("fine"), 0); errno != 0 {
+		t.Fatalf("setxattr: errno %v", errno)
+	}
+
+	// Now the out-of-band write. The key and value are computed here rather than by calling ObjectFS's
+	// encoder, deliberately: an attacker with bucket credentials does not call ObjectFS's functions
+	// either, and a test that shared the encoder would agree with it by construction — the same reason
+	// this package prefers a real endpoint to a mock. If the encoding ever changes, the assertion below
+	// that the object really carries the attribute fails loudly rather than passing vacuously.
+	meta := x.srv.ObjectMetadata(x.key)
+	meta[outOfBandXattrKey] = outOfBandXattrValue
+
+	if _, err := x.srv.Client().CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket:            aws.String(x.srv.Bucket),
+		Key:               aws.String(x.key),
+		CopySource:        aws.String(x.srv.Bucket + "/" + x.key),
+		Metadata:          meta,
+		MetadataDirective: awstypes.MetadataDirectiveReplace,
+	}); err != nil {
+		t.Fatalf("writing the attribute out of band: %v", err)
+	}
+
+	x.remount(t)
+
+	// The object really does carry it, or this test is asserting nothing.
+	var carried bool
+	for k := range x.srv.ObjectMetadata(x.key) {
+		if strings.EqualFold(k, outOfBandXattrKey) {
+			carried = true
+		}
+	}
+	if !carried {
+		t.Fatalf("the out-of-band write did not land, so this test cannot check the filter. Metadata: %v",
+			x.srv.ObjectMetadata(x.key))
+	}
+
+	// And ObjectFS reports nothing about it.
+	for _, name := range x.list(t) {
+		if name == "security.capability" {
+			t.Error("listxattr names security.capability for an attribute written directly to the " +
+				"bucket. The kernel reads that attribute on every exec and grants the capabilities it " +
+				"names, so anyone with s3:PutObject would gain file capabilities on every mounting host — " +
+				"refusing it only on the write path leaves the route that matters wide open.")
+		}
+	}
+
+	if _, errno := x.node.Getxattr(ctx, "security.capability", nil); errno != errNoXattr {
+		t.Errorf("getxattr for the out-of-band security.capability returned %s, want %s",
+			errnoName(errno), errnoName(errNoXattr))
+	}
+
+	// The legitimate attribute is untouched, so the filter is a filter and not a blanket refusal.
+	if got, errno := x.get(t, "user.ok"); errno != 0 || string(got) != "fine" {
+		t.Errorf("the ordinary attribute reads %q with errno %v, want %q", got, errno, "fine")
+	}
+}
+
+// TestXattrOperationsAreRefusedOnAReadOnlyMount pins the read-only guard on the two write paths.
+func TestXattrOperationsAreRefusedOnAReadOnlyMount(t *testing.T) {
+	t.Parallel()
+
+	filesystem := NewFileSystem(t.Context(), nil, nil, nil, nil, &Config{ReadOnly: true})
+	file := &FileNode{fs: filesystem, path: "ro.dat"}
+	dir := &DirectoryNode{fs: filesystem, path: "ro"}
+	ctx := context.Background()
+
+	if errno := file.Setxattr(ctx, "user.x", []byte("v"), 0); errno != syscall.EROFS {
+		t.Errorf("setxattr on a read-only mount returned %s, want EROFS", errnoName(errno))
+	}
+	if errno := file.Removexattr(ctx, "user.x"); errno != syscall.EROFS {
+		t.Errorf("removexattr on a read-only mount returned %s, want EROFS", errnoName(errno))
+	}
+	if errno := dir.Setxattr(ctx, "user.x", []byte("v"), 0); errno != syscall.EROFS {
+		t.Errorf("setxattr on a directory of a read-only mount returned %s, want EROFS", errnoName(errno))
+	}
+	if errno := dir.Removexattr(ctx, "user.x"); errno != syscall.EROFS {
+		t.Errorf("removexattr on a directory of a read-only mount returned %s, want EROFS",
+			errnoName(errno))
+	}
+}
+
+// TestDirectoryXattrsRefuseRatherThanDiscard records the decision for directories.
+//
+// A directory here is a key prefix, not an object, so there is nothing to hold an attribute — the same
+// reason [DirectoryNode.Setattr] refuses chmod. Mkdir does write a marker object, which is why this is
+// unimplemented rather than impossible; what makes refusing right is that a directory existing only
+// because objects share a prefix has no marker, so an attribute would persist for some directories and
+// vanish for others. Reporting success and storing nothing is the defect shape this project treats as
+// worse than an error.
+//
+// The two errnos differ deliberately, and the split is the interesting part: a set refuses (ENOTSUP,
+// "this filesystem cannot") while a get, a list, and a remove answer accurately about a file that has no
+// attributes (ENOATTR, and an empty list).
+func TestDirectoryXattrsRefuseRatherThanDiscard(t *testing.T) {
+	t.Parallel()
+
+	f := newReadPathFixture(t)
+	dir := &DirectoryNode{fs: f.fs, path: "some/dir"}
+	ctx := context.Background()
+
+	if errno := dir.Setxattr(ctx, "user.x", []byte("v"), 0); errno != syscall.ENOTSUP {
+		t.Errorf("setxattr on a directory returned %s, want ENOTSUP. Reporting success for an attribute "+
+			"the next getfattr would not show is the same defect as an rm that reports success while the "+
+			"object survives.", errnoName(errno))
+	}
+
+	if _, errno := dir.Getxattr(ctx, "user.x", nil); errno != errNoXattr {
+		t.Errorf("getxattr on a directory returned %s, want %s", errnoName(errno), errnoName(errNoXattr))
+	}
+
+	if errno := dir.Removexattr(ctx, "user.x"); errno != errNoXattr {
+		t.Errorf("removexattr on a directory returned %s, want %s",
+			errnoName(errno), errnoName(errNoXattr))
+	}
+
+	// Listing succeeds with nothing in it. Failing would make `cp -a`, `rsync -X`, and `ls -@` report an
+	// error for every directory they walk, over an answer that is simply "there are none".
+	size, errno := dir.Listxattr(ctx, nil)
+	if errno != 0 {
+		t.Errorf("listxattr on a directory returned %s, want success with an empty list", errnoName(errno))
+	}
+	if size != 0 {
+		t.Errorf("listxattr on a directory reported %d bytes of names", size)
+	}
+}
+
+// TestXattrOperationsAreDispatchedRatherThanDefaulted is the counterpart to unimplemented_test.go's
+// table, for the four rows that left it.
+//
+// Every one of these operations is an optional interface go-fuse probes with a type assertion, and the
+// defaults are exactly the answers ObjectFS used to give: ENOATTR for get, set, and remove, and OK with
+// an empty list for list. So a signature that drifted on a go-fuse bump — or a build tag that excluded
+// xattr.go on some platform — would take the whole feature back to "no such attribute" with no compile
+// error and no test failure anywhere else. xattr.go has compile-time assertions for the interfaces; this
+// asserts the consequence, that the bridge dispatches to them.
+//
+// EROFS is the expected answer because the fixture is a read-only mount with no backend: it pins that the
+// call arrived at ObjectFS's own code, which is the one thing the interface assertion cannot check.
+func TestXattrOperationsAreDispatchedRatherThanDefaulted(t *testing.T) {
+	t.Parallel()
+
+	filesystem := NewFileSystem(t.Context(), nil, nil, nil, nil, &Config{ReadOnly: true})
+	raw := gofuse.NewNodeFS(filesystem.Root(), &gofuse.Options{})
+
+	in := &fuse.SetXAttrIn{InHeader: rootHeader()}
+	if got := syscall.Errno(raw.SetXAttr(nil, in, "user.test", []byte("value"))); got != syscall.EROFS {
+		t.Errorf("SetXAttr through the bridge returned %s, want EROFS. %s is go-fuse's default for an "+
+			"absent NodeSetxattrer, so reaching it means the interface is no longer satisfied and every "+
+			"setfattr on the mount is silently refused again.", errnoName(got), errnoName(errNoXattr))
+	}
+
+	h := rootHeader()
+	if got := syscall.Errno(raw.RemoveXAttr(nil, &h, "user.test")); got != syscall.EROFS {
+		t.Errorf("RemoveXAttr through the bridge returned %s, want EROFS", errnoName(got))
+	}
+}
+
+// TestXattrsSurviveAContentWrite is the interaction between the two flush paths.
+//
+// A PutObject writes user metadata wholesale, so a content write that rendered only the POSIX attributes
+// would delete every extended attribute the file had — silently, on the next ordinary `echo >> file`.
+// This is the same defect shape as the write path chowning a file to root, one field over.
+func TestXattrsSurviveAContentWrite(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "content.dat")
+	ctx := context.Background()
+
+	if errno := x.node.Setxattr(ctx, "user.keep", []byte("through a write"), 0); errno != 0 {
+		t.Fatalf("setxattr: errno %v", errno)
+	}
+
+	// A content write, flushed the way Setattr flushes: this takes the PutObject path, not the metadata
+	// replace, because the plan is no longer a no-op.
+	if err := x.fs.buffer.Write(x.key, 0, []byte("REPLACED")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := x.fs.buffer.FlushReportingETag(ctx, x.key); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	x.remount(t)
+
+	got, errno := x.get(t, "user.keep")
+	if errno != 0 {
+		t.Fatalf("the attribute is gone after a content write: errno %v. A PUT replaces user metadata "+
+			"wholesale, so a write path that did not carry the attributes forward would delete them on "+
+			"every ordinary write.", errno)
+	}
+	if string(got) != "through a write" {
+		t.Errorf("the attribute reads %q after a content write, want %q", got, "through a write")
+	}
+
+	// The content went up too, so this is not passing because the write was dropped.
+	stored, err := x.fs.backend.GetObject(ctx, x.key, 0, 8)
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if string(stored) != "REPLACED" {
+		t.Errorf("the object begins %q, want %q", stored, "REPLACED")
+	}
+}
+
+// TestXattrReadsGoThroughTheWritePathBeforeStorage covers read-after-write on the same node.
+//
+// [FileNode.attr] asks the write path first and storage second, and it must: a getxattr that consulted
+// only S3 would report the previous value for as long as the metadata cache entry lived, which is the
+// read-after-write defect the read path already had for content in v0.10.0.
+func TestXattrReadsGoThroughTheWritePathBeforeStorage(t *testing.T) {
+	t.Parallel()
+
+	x := newXattrFixture(t, "raw.dat")
+	ctx := context.Background()
+
+	if errno := x.node.Setxattr(ctx, "user.v", []byte("first"), 0); errno != 0 {
+		t.Fatalf("first setxattr: errno %v", errno)
+	}
+	if errno := x.node.Setxattr(ctx, "user.v", []byte("second"), 0); errno != 0 {
+		t.Fatalf("second setxattr: errno %v", errno)
+	}
+
+	got, errno := x.get(t, "user.v")
+	if errno != 0 {
+		t.Fatalf("getxattr: errno %v", errno)
+	}
+	if string(got) != "second" {
+		t.Errorf("getxattr immediately after an overwrite reads %q, want %q — a read that consulted only "+
+			"storage, or a stale cache entry, would report the previous value", got, "second")
+	}
+}

--- a/internal/fuse/xattr_test.go
+++ b/internal/fuse/xattr_test.go
@@ -697,26 +697,45 @@ func TestSetxattrHonorsCreateAndReplaceFlags(t *testing.T) {
 // compared the same wrapped number — so it reads a truncated attribute and cannot tell. MaxUint32 is not
 // mistakable for a real attribute size, so the caller's own allocation fails instead.
 //
-// The 1<<32 case is skipped on a 32-bit platform, where an int cannot hold it and the conversion is not
-// lossy in the first place; the guard is a compile-time-safe comparison rather than a build tag.
+// The over-MaxUint32 cases are computed rather than written as literals, and that is not a style choice:
+// `math.MaxUint32` and `math.MaxUint32 + 1` are untyped constants that do not fit an int on a 32-bit
+// platform, so a table naming them fails to *compile* for linux/386 and linux/arm. The first version of
+// this test did exactly that, and so did the function it covers — both passed everything on a 64-bit host
+// and broke two cross-builds. `maxUint32AsInt` is -1 where an int cannot hold the value, which drops those
+// rows on the platforms where the conversion is not lossy to begin with.
 func TestXattrSizeSaturatesRatherThanWrapping(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
+	type sizeCase struct {
 		name string
 		n    int
 		want uint32
-	}{
+	}
+
+	cases := []sizeCase{
 		{"zero", 0, 0},
 		{"an ordinary attribute", 11, 11},
-		{"the largest value that fits", math.MaxUint32, math.MaxUint32},
-		{"one past it", math.MaxUint32 + 1, math.MaxUint32},
 		{"negative, which no length is but the type allows", -1, math.MaxUint32},
-	} {
-		if tc.n > 0 && uint64(tc.n) > uint64(math.MaxInt) {
-			continue // unrepresentable as an int on this platform
-		}
+	}
 
+	// Appended only where an int can hold the value. Building the rows conditionally rather than filtering
+	// them afterwards: a filter has to recognize the 32-bit rows by their *value*, and on that platform the
+	// arithmetic that produces them collapses onto values the other rows already use, so the filter would
+	// let a row through paired with the wrong expectation.
+	//
+	// The bound goes through a uint64 *variable* rather than `int(uint64(math.MaxUint32))`, which is still a
+	// constant expression and so still fails to compile on a 32-bit platform even inside a branch that can
+	// never be taken there — constant conversions are checked before any branch is considered.
+	var maxUint32 uint64 = math.MaxUint32
+	if maxUint32 <= uint64(math.MaxInt) {
+		maxUint32AsInt := int(maxUint32)
+		cases = append(cases,
+			sizeCase{"the largest value that fits", maxUint32AsInt, math.MaxUint32},
+			sizeCase{"one past it", maxUint32AsInt + 1, math.MaxUint32},
+		)
+	}
+
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/fuse/xattr_test.go
+++ b/internal/fuse/xattr_test.go
@@ -18,6 +18,7 @@ package fuse
 import (
 	"bytes"
 	"context"
+	"math"
 	"strings"
 	"syscall"
 	"testing"
@@ -641,11 +642,37 @@ func TestSetxattrHonorsCreateAndReplaceFlags(t *testing.T) {
 		t.Errorf("XATTR_REPLACE left the value as %q, want %q", got, "second")
 	}
 
-	// Both flags at once is EINVAL, per setxattr(2).
+	// Both flags at once, against a *missing* attribute, is answered per-platform because the kernels
+	// disagree — see bothXattrFlagsErrno. darwin returns EINVAL; linux has no combined-flag check, so the
+	// REPLACE arm fires and it is ENODATA. This assertion used to say EINVAL unconditionally, which is
+	// darwin's answer and what setxattr(2)'s man page describes, and it was green on darwin and red on CI.
+	//
+	// Expressed through the same platform hook the implementation uses, with a fallback of errNoXattr
+	// rather than repeating a platform constant here: hardcoding either errno in the test is the mistake
+	// being fixed. xattr_oracle_test.go is what pins the value against the real kernel.
 	both := uint32(unix.XATTR_CREATE | unix.XATTR_REPLACE)
-	if errno := x.node.Setxattr(ctx, "user.g", []byte("v"), both); errno != syscall.EINVAL {
-		t.Errorf("setxattr with both XATTR_CREATE and XATTR_REPLACE returned %s, want EINVAL",
-			errnoName(errno))
+	wantBoth := bothXattrFlagsErrno()
+	if wantBoth == 0 {
+		wantBoth = errNoXattr
+	}
+	if errno := x.node.Setxattr(ctx, "user.g", []byte("v"), both); errno != wantBoth {
+		t.Errorf("setxattr with both XATTR_CREATE and XATTR_REPLACE on a missing attribute returned %s, "+
+			"want %s", errnoName(errno), errnoName(wantBoth))
+	}
+
+	// And against an attribute that *exists*, where the two kernels differ in the other direction: still
+	// EINVAL on darwin, but EEXIST on linux because there the CREATE arm is what fires. user.f exists by
+	// this point, set above.
+	wantBothPresent := bothXattrFlagsErrno()
+	if wantBothPresent == 0 {
+		wantBothPresent = syscall.EEXIST
+	}
+	if errno := x.node.Setxattr(ctx, "user.f", []byte("v"), both); errno != wantBothPresent {
+		t.Errorf("setxattr with both flags on an existing attribute returned %s, want %s",
+			errnoName(errno), errnoName(wantBothPresent))
+	}
+	if got, _ := x.get(t, "user.f"); string(got) != "second" {
+		t.Errorf("a refused both-flags setxattr changed the value to %q, want %q", got, "second")
 	}
 
 	// The two constants must not be the same number, or every test above is checking one code path
@@ -653,6 +680,52 @@ func TestSetxattrHonorsCreateAndReplaceFlags(t *testing.T) {
 	if unix.XATTR_CREATE == unix.XATTR_REPLACE {
 		t.Fatal("unix.XATTR_CREATE and unix.XATTR_REPLACE are the same value on this platform, so the " +
 			"create and replace cases above are indistinguishable")
+	}
+}
+
+// TestXattrSizeSaturatesRatherThanWrapping pins the clamp on the int → uint32 conversion that every
+// getxattr and listxattr reply passes through.
+//
+// Unreachable through the filesystem: an attribute is bounded by vfs.XattrBudget, well under 2 KB. Tested
+// anyway, because the alternative to the clamp was a lint suppression and a suppression cannot be tested
+// at all — and because the mutation check showed the clamp was uncovered. Deleting it (returning a bare
+// uint32(n)) left every other test in this package green.
+//
+// The reason it is a clamp and not a truncation is what the wrap would do to a *reader*. Both values this
+// function returns are a buffer size the caller allocates and then reads into. A wrapped length smaller
+// than the value gives a caller that allocates a short buffer and gets no ERANGE — because the filesystem
+// compared the same wrapped number — so it reads a truncated attribute and cannot tell. MaxUint32 is not
+// mistakable for a real attribute size, so the caller's own allocation fails instead.
+//
+// The 1<<32 case is skipped on a 32-bit platform, where an int cannot hold it and the conversion is not
+// lossy in the first place; the guard is a compile-time-safe comparison rather than a build tag.
+func TestXattrSizeSaturatesRatherThanWrapping(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		n    int
+		want uint32
+	}{
+		{"zero", 0, 0},
+		{"an ordinary attribute", 11, 11},
+		{"the largest value that fits", math.MaxUint32, math.MaxUint32},
+		{"one past it", math.MaxUint32 + 1, math.MaxUint32},
+		{"negative, which no length is but the type allows", -1, math.MaxUint32},
+	} {
+		if tc.n > 0 && uint64(tc.n) > uint64(math.MaxInt) {
+			continue // unrepresentable as an int on this platform
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := xattrSize(tc.n); got != tc.want {
+				t.Errorf("xattrSize(%d) = %d, want %d. A value that is neither the input nor the clamp "+
+					"means the conversion wrapped, and a wrapped size is a short buffer a caller fills "+
+					"with a truncated attribute while believing it is whole.", tc.n, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/vfs/attr.go
+++ b/internal/vfs/attr.go
@@ -3,6 +3,7 @@ package vfs
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -100,6 +101,16 @@ type Attr struct {
 	// v0.10.0 wrote this on every upload and never once read it back. It is the only stored evidence
 	// that what came out of the object store is what went in.
 	Checksum string
+
+	// Xattrs holds the file's extended attributes, keyed by their full name as the caller gave it —
+	// "user.test", not a stored form. A nil value is a tombstone: the attribute has been removed and
+	// the removal has not yet been overwritten by a content write. See xattr.go.
+	//
+	// The map is shared by every copy of an Attr, which are passed by value throughout this package, so
+	// it must never be written in place. [Attr.WithXattr] and [Attr.WithoutXattr] copy it and are the
+	// only way to change it; read it through [Attr.Xattr] and [Attr.XattrNames], which know what a nil
+	// value means.
+	Xattrs map[string][]byte
 }
 
 // blockSize is the unit stat reports Blocks in. POSIX fixes it at 512 regardless of any real block
@@ -265,6 +276,7 @@ func AttrFromMetadataWithDefaults(
 	if v, ok := lookupMeta(meta, metaChecksum); ok {
 		a.Checksum = v
 	}
+	a.Xattrs = xattrsFromMetadata(meta)
 
 	a.Atime = a.Mtime
 	a.Ctime = a.Mtime
@@ -317,6 +329,10 @@ func MetadataWarnings(meta map[string]string) []string {
 		return err
 	})
 
+	// Extended attributes last, and every unusable one rather than the first: a caller reading this in
+	// a log is asking which of its attributes did not survive.
+	warns = append(warns, xattrMetadataWarnings(meta)...)
+
 	return warns
 }
 
@@ -327,6 +343,10 @@ func MetadataWarnings(meta map[string]string) []string {
 // are the storage layer's to write. Checksum is likewise the storage layer's, computed over the
 // bytes it uploads. Duplicating either here would create a second source of truth for a value that
 // integrity checking depends on.
+//
+// Extended attributes are included, under objectfs-xattr-… keys that cannot collide with the four
+// above; see xattr.go for the encoding and for why a removal appears here as a tombstone rather than
+// as an absent key.
 func (a Attr) Metadata() map[string]string {
 	m := map[string]string{
 		metaMode: strconv.FormatUint(uint64(a.Mode.Perm()), 8),
@@ -336,6 +356,7 @@ func (a Attr) Metadata() map[string]string {
 	if !a.Mtime.IsZero() {
 		m[metaMtime] = a.Mtime.UTC().Format(time.RFC3339Nano)
 	}
+	maps.Copy(m, a.xattrMetadata())
 	return m
 }
 

--- a/internal/vfs/attr_test.go
+++ b/internal/vfs/attr_test.go
@@ -349,7 +349,7 @@ func TestAttrFromMetadata(t *testing.T) {
 			want.Atime = want.Mtime
 			want.Ctime = want.Mtime
 
-			if got != want {
+			if !attrEqual(got, want) {
 				t.Fatalf("AttrFromMetadata =\n  %+v\nwant\n  %+v", got, want)
 			}
 			if err := got.Validate(); err != nil {

--- a/internal/vfs/errors.go
+++ b/internal/vfs/errors.go
@@ -56,6 +56,24 @@ var (
 	// could have absorbed is worse than the unbounded growth it replaced.
 	ErrNoSpace = errors.New("vfs: no space in write buffer")
 
+	// ErrTooLarge reports that a single value is larger than this filesystem can store, whatever else
+	// is or is not already stored alongside it.
+	//
+	// Distinct from ErrNoSpace, and the distinction is the caller's to act on. "This attribute cannot
+	// fit on any object" tells a program to store less; "there is no room left on this file" tells it
+	// to remove something first. setxattr(2) has separate errnos for the two — E2BIG and ENOSPC — so
+	// collapsing them here would discard information the syscall interface is able to carry.
+	ErrTooLarge = errors.New("vfs: value too large")
+
+	// ErrNoXattr reports that a file has no extended attribute by that name.
+	//
+	// It must never be reported as ErrNotFound. Both would be an errno a caller sees from getxattr, but
+	// ENOENT means the *file* does not exist, and tools branch on that: `getfattr` reports a missing
+	// file rather than a missing attribute, and a caller probing for an attribute before creating one
+	// could conclude the path is gone. This is the same class of misclassification as ErrNotFound's own
+	// warning, at one level down.
+	ErrNoXattr = errors.New("vfs: no such extended attribute")
+
 	// ErrIntegrity reports that stored data could not be verified against its recorded checksum,
 	// or that its storage encoding is not one this build can decode.
 	//

--- a/internal/vfs/handle.go
+++ b/internal/vfs/handle.go
@@ -165,6 +165,44 @@ func (n *Node) SetAttr(mode, uid, gid bool, from Attr) error {
 	return nil
 }
 
+// SetXattr sets the extended attribute name to value and marks the node's attributes for write-back.
+//
+// It goes through [Attr.WithXattr], so the budget is enforced here and a refusal leaves the node
+// untouched — a rejected setxattr must not leave the file dirty with a change it cannot persist.
+func (n *Node) SetXattr(name string, value []byte) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	next, err := n.attr.WithXattr(name, value)
+	if err != nil {
+		return fmt.Errorf("setxattr %q on %q: %w", name, n.Path, err)
+	}
+
+	n.attr = next
+	n.dirtyAttr = true
+	n.generation++
+	return nil
+}
+
+// RemoveXattr removes the extended attribute name, reporting [ErrNoXattr] when the file has none.
+//
+// Nothing is marked dirty when the attribute was absent. A removexattr that fails must not cost a
+// metadata rewrite, and must not leave the node needing a flush that would write nothing.
+func (n *Node) RemoveXattr(name string) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	next, existed := n.attr.WithoutXattr(name)
+	if !existed {
+		return fmt.Errorf("removexattr %q on %q: %w", name, n.Path, ErrNoXattr)
+	}
+
+	n.attr = next
+	n.dirtyAttr = true
+	n.generation++
+	return nil
+}
+
 // Dirty reports whether the node has anything that must reach the object store: content, a
 // truncation, or an attribute change.
 //

--- a/internal/vfs/writer.go
+++ b/internal/vfs/writer.go
@@ -362,6 +362,45 @@ func (w *Writer) SetAttr(ctx context.Context, key string, mode, uid, gid bool, f
 	return n.SetAttr(mode, uid, gid, from)
 }
 
+// SetXattr records a new value for key's extended attribute name, to be persisted at flush.
+//
+// It creates the node if there is none, which reads the object's stored attributes first — so the
+// attributes already on the object, including its other extended attributes, are the ones this change
+// is merged into. A node built from defaults would persist an xattr alongside mode 0644 and uid 0,
+// which is the defect [Writer.node] documents for content writes and which applies identically here.
+func (w *Writer) SetXattr(ctx context.Context, key, name string, value []byte) error {
+	if key == "" {
+		return fmt.Errorf("%w: empty key", ErrInvalid)
+	}
+	if value == nil {
+		// nil is the tombstone in the stored representation, so accepting it here would make a set
+		// indistinguishable from a remove. An empty attribute value is legal and is expressed as an empty
+		// non-nil slice, which is what the FUSE layer passes for `setfattr -n user.x` with no value.
+		return fmt.Errorf("%w: nil extended attribute value for %q; use RemoveXattr to remove one",
+			ErrInvalid, name)
+	}
+
+	n, err := w.node(ctx, key)
+	if err != nil {
+		return err
+	}
+	return n.SetXattr(name, value)
+}
+
+// RemoveXattr records the removal of key's extended attribute name, to be persisted at flush. It
+// returns [ErrNoXattr] when the file has no such attribute.
+func (w *Writer) RemoveXattr(ctx context.Context, key, name string) error {
+	if key == "" {
+		return fmt.Errorf("%w: empty key", ErrInvalid)
+	}
+
+	n, err := w.node(ctx, key)
+	if err != nil {
+		return err
+	}
+	return n.RemoveXattr(name)
+}
+
 // Attr returns key's current attributes, including changes not yet persisted, and whether the write
 // path holds any state for the key at all.
 //

--- a/internal/vfs/writer_test.go
+++ b/internal/vfs/writer_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/scttfrdmn/objectfs/internal/vfs"
 	"github.com/scttfrdmn/objectfs/pkg/types"
@@ -2335,4 +2336,287 @@ func TestPrefixOperationsOnAnExactKeyTakeThatKey(t *testing.T) {
 				"file returning from the dead at the name it was moved away from, with no error anywhere")
 		}
 	})
+}
+
+// TestSetXattrMergesWithAttributesAlreadyOnTheObject is the defect [vfs.Writer.node] exists to prevent,
+// applied to extended attributes.
+//
+// setxattr on a file nobody has opened creates the node, and a node built from defaults carries mode
+// 0644 and uid 0. Flushing that would persist an attribute *and* silently chown the file to root and
+// reset its permissions — from a `setfattr`, which no user would expect to touch ownership. The same
+// applies to the file's other extended attributes: a node that did not read them first would render
+// metadata omitting them, and while a merge on the wire saves the stored ones from deletion, a
+// subsequent removal of a different attribute would resurrect anything the node never knew about.
+func TestSetXattrMergesWithAttributesAlreadyOnTheObject(t *testing.T) {
+	t.Parallel()
+
+	backend := newFakeBackend()
+	backend.PutWithMeta("f", []byte("contents"), map[string]string{
+		"objectfs-mode": "600",
+		"objectfs-uid":  "4242",
+		"objectfs-gid":  "4243",
+	})
+
+	w, err := vfs.NewWriter(context.Background(), backend)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	if err := w.SetXattr(context.Background(), "f", "user.project", []byte("atlas")); err != nil {
+		t.Fatalf("SetXattr: %v", err)
+	}
+	if err := w.Flush("f"); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	meta := backend.Meta("f")
+
+	for key, want := range map[string]string{
+		"objectfs-mode": "600",
+		"objectfs-uid":  "4242",
+		"objectfs-gid":  "4243",
+	} {
+		if got := meta[key]; got != want {
+			t.Errorf("%s is %q after a setxattr, want %q. The node was built from defaults rather than "+
+				"from the object's stored attributes, so setting an extended attribute also rewrote the "+
+				"file's mode and ownership.", key, got, want)
+		}
+	}
+
+	// And the attribute itself landed.
+	attrs := vfs.AttrFromMetadata(meta, 0, time.Unix(0, 0).UTC(), "")
+	if got, ok := attrs.Xattr("user.project"); !ok || string(got) != "atlas" {
+		t.Errorf("the attribute reads %q (present=%v) after a flush, want %q", got, ok, "atlas")
+	}
+}
+
+// TestRemoveXattrPersistsATombstoneAndKeepsTheOtherAttributes is the successful removal, end to end
+// through the write path.
+//
+// Every other test of removal at this layer covers a refusal, so the path that actually changes something
+// was reachable only through internal/fuse — and the thing worth asserting here is what reaches the
+// *object*, which is a tombstone rather than an absent key. [types.Backend.SetObjectMetadata] merges the
+// caller's metadata over what the object already carries, so a removal rendered as an omitted key would
+// change nothing on the wire while removexattr returned success, and the attribute would stay readable.
+//
+// The surviving attribute is asserted alongside it because the two failures have one cause: a removal that
+// rendered only the changed attribute would delete the others on any endpoint that replaces wholesale.
+func TestRemoveXattrPersistsATombstoneAndKeepsTheOtherAttributes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	w, backend := newWriter(t)
+	backend.Put("f", []byte("contents"))
+
+	for name, value := range map[string]string{"user.doomed": "gone", "user.kept": "stays"} {
+		if err := w.SetXattr(ctx, "f", name, []byte(value)); err != nil {
+			t.Fatalf("SetXattr %s: %v", name, err)
+		}
+	}
+	if err := w.Flush("f"); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if err := w.RemoveXattr(ctx, "f", "user.doomed"); err != nil {
+		t.Fatalf("RemoveXattr: %v", err)
+	}
+	if !w.Dirty("f") {
+		t.Error("the removal left the node clean, so no flush would ever carry it to the object")
+	}
+	if err := w.Flush("f"); err != nil {
+		t.Fatalf("Flush after the removal: %v", err)
+	}
+
+	// Read the object's metadata back the way a fresh mount would.
+	attrs := vfs.AttrFromMetadata(backend.Meta("f"), 0, time.Unix(0, 0).UTC(), "")
+
+	if _, ok := attrs.Xattr("user.doomed"); ok {
+		t.Error("the removed attribute is still readable from the object's metadata. A metadata replace " +
+			"merges over what is already there, so a removal that omits the key changes nothing — and " +
+			"removexattr already reported success.")
+	}
+	if got, ok := attrs.Xattr("user.kept"); !ok || string(got) != "stays" {
+		t.Errorf("the other attribute reads %q (present=%v) after an unrelated removal, want %q",
+			got, ok, "stays")
+	}
+
+	// And the tombstone is on the object, not merely absent from the decode. Those are different: an
+	// omitted key also decodes as absent here, while leaving the old value on a real endpoint.
+	if len(attrs.Xattrs) != 2 {
+		t.Errorf("the object carries %d extended-attribute entries, want 2 (one value and one tombstone): "+
+			"%v", len(attrs.Xattrs), attrs.Xattrs)
+	}
+}
+
+// TestXattrOperationsRefuseAnEmptyKey covers the guard both write-path entry points open with.
+//
+// An empty key is not a file. It reaches [types.Backend] as a HeadObject on "", which S3 answers with a
+// 400 rather than a 404, so without this guard a caller gets a transport error where it should get
+// EINVAL — and [vfs.Writer.node] would cache a node under the empty key on the way. The other write
+// methods guard it for the same reason; these two are new and are held to it.
+func TestXattrOperationsRefuseAnEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	w, _ := newWriter(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		op  string
+		run func() error
+	}{
+		{"SetXattr", func() error { return w.SetXattr(ctx, "", "user.x", []byte("v")) }},
+		{"RemoveXattr", func() error { return w.RemoveXattr(ctx, "", "user.x") }},
+	} {
+		err := tc.run()
+
+		if err == nil {
+			t.Errorf("%s accepted an empty key", tc.op)
+
+			continue
+		}
+		if !errors.Is(err, vfs.ErrInvalid) {
+			t.Errorf("%s on an empty key returned %v, which is not ErrInvalid, so the FUSE layer maps it "+
+				"to EIO rather than EINVAL", tc.op, err)
+		}
+	}
+}
+
+// TestXattrOperationsReportAFailureToReadTheObjectsAttributes is the case where the node cannot be built.
+//
+// Both operations have to read the object's current attributes before changing one, because a change is
+// merged into them — see [TestSetXattrMergesWithAttributesAlreadyOnTheObject] for what happens when it is
+// not. So a HEAD that fails for a reason other than absence has to fail the setxattr: the alternative is
+// to proceed from defaults, which persists an attribute and chowns the file to root at the same time. A
+// throttled or denied HEAD is exactly the case where that is tempting and exactly where it is worst.
+func TestXattrOperationsReportAFailureToReadTheObjectsAttributes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	denied := errors.New("AccessDenied: not authorized to perform s3:GetObject")
+
+	for _, tc := range []struct {
+		op  string
+		run func(*vfs.Writer) error
+	}{
+		{"SetXattr", func(w *vfs.Writer) error { return w.SetXattr(ctx, "f", "user.x", []byte("v")) }},
+		{"RemoveXattr", func(w *vfs.Writer) error { return w.RemoveXattr(ctx, "f", "user.x") }},
+	} {
+		w, backend := newWriter(t)
+		backend.Put("f", []byte("contents"))
+		backend.headErr = denied
+
+		err := tc.run(w)
+
+		if err == nil {
+			t.Errorf("%s reported success while the object's attributes could not be read. The node would "+
+				"be built from defaults, so the next flush would persist mode 0644 and uid 0 over whatever "+
+				"the object actually carries.", tc.op)
+
+			continue
+		}
+		if !errors.Is(err, denied) {
+			t.Errorf("%s lost the underlying cause: %v", tc.op, err)
+		}
+		if w.Dirty("f") {
+			t.Errorf("%s left the node dirty after failing, so the next flush writes a change that was "+
+				"never accepted", tc.op)
+		}
+	}
+}
+
+// TestSetXattrRefusesAValueOverTheBudgetWithoutDirtyingTheNode is the budget refusal at the layer that
+// enforces it, and the half of it that only this layer can show.
+//
+// internal/fuse asserts the errno. What matters here is that a refused set leaves nothing pending: S3
+// rejects an over-budget PUT outright rather than truncating, so a node left dirty by a refused setxattr
+// turns one failed setfattr into a flush that can never succeed — and the caller that sees that failure is
+// whatever later writes to the file, not the one that caused it.
+func TestSetXattrRefusesAValueOverTheBudgetWithoutDirtyingTheNode(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+	backend.Put("f", []byte("contents"))
+
+	err := w.SetXattr(context.Background(), "f", "user.big", make([]byte, 4096))
+
+	if err == nil {
+		t.Fatal("SetXattr accepted a value larger than the whole metadata budget")
+	}
+	if !errors.Is(err, vfs.ErrTooLarge) {
+		t.Errorf("the error is not ErrTooLarge, so the FUSE layer cannot answer E2BIG: %v", err)
+	}
+	if w.Dirty("f") {
+		t.Error("the refused setxattr left the node dirty. The next flush would attempt a metadata write " +
+			"S3 rejects, so an unrelated later write to this file fails for a setfattr that already " +
+			"reported an error.")
+	}
+}
+
+// TestRemoveXattrReportsAbsenceWithoutDirtyingTheNode covers the two halves of removing something that
+// is not there.
+//
+// The errno matters at the FUSE layer, and internal/fuse covers it. What is only visible here is that a
+// refused removal leaves nothing pending: a node marked dirty for a change it did not make would issue a
+// metadata rewrite — a CopyObject on the object — on the next flush, for a `setfattr -x` that failed.
+//
+// A verifying mutation drove this test's existence: making RemoveXattr report success for a missing
+// attribute failed only in internal/fuse, and the dirty-node half failed nowhere at all.
+func TestRemoveXattrReportsAbsenceWithoutDirtyingTheNode(t *testing.T) {
+	t.Parallel()
+
+	backend := newFakeBackend()
+	backend.PutWithMeta("f", []byte("contents"), map[string]string{"objectfs-mode": "644"})
+
+	w, err := vfs.NewWriter(context.Background(), backend)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	err = w.RemoveXattr(context.Background(), "f", "user.never")
+
+	if err == nil {
+		t.Fatal("removing an attribute that does not exist reported success. setfattr -x would exit 0 " +
+			"for a name the file never had, so a script checking whether an attribute was present would " +
+			"conclude it was.")
+	}
+	if !errors.Is(err, vfs.ErrNoXattr) {
+		t.Errorf("the error is not ErrNoXattr, so the FUSE layer cannot map it to the errno getfattr "+
+			"needs: %v", err)
+	}
+
+	if w.Dirty("f") {
+		t.Error("the failed removal left the node dirty, so the next flush issues a metadata rewrite — " +
+			"a CopyObject on the object — to persist a change that was refused")
+	}
+}
+
+// TestSetXattrRejectsANilValueRatherThanStoringATombstone pins the boundary between the two meanings of
+// "no value".
+//
+// A nil value is how a removal is represented in the stored form, so accepting one here would make a set
+// indistinguishable from a remove — `setfattr -n user.x` would delete the attribute it was asked to
+// create. The FUSE layer normalises a nil to an empty slice for exactly this reason; this asserts the
+// layer below refuses it, so that a future caller which forgets to normalise fails loudly instead of
+// deleting data.
+func TestSetXattrRejectsANilValueRatherThanStoringATombstone(t *testing.T) {
+	t.Parallel()
+
+	w, backend := newWriter(t)
+	backend.Put("f", []byte("contents"))
+
+	err := w.SetXattr(context.Background(), "f", "user.x", nil)
+
+	if err == nil {
+		t.Fatal("SetXattr accepted a nil value. nil is the tombstone in the stored representation, so " +
+			"this would store a removal for the attribute it was asked to set.")
+	}
+	if !errors.Is(err, vfs.ErrInvalid) {
+		t.Errorf("the error is not ErrInvalid: %v", err)
+	}
+
+	// An empty value is legal and must be accepted, or `setfattr -n user.x f` with no -v fails.
+	if err := w.SetXattr(context.Background(), "f", "user.x", []byte{}); err != nil {
+		t.Errorf("SetXattr refused an empty value: %v. That is `setfattr -n user.x f` with no -v, which "+
+			"sets an attribute whose value is zero bytes.", err)
+	}
 }

--- a/internal/vfs/xattr.go
+++ b/internal/vfs/xattr.go
@@ -1,0 +1,419 @@
+package vfs
+
+import (
+	"encoding/base32"
+	"encoding/base64"
+	"fmt"
+	"maps"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Extended attributes, stored in S3 user metadata.
+//
+// # Why metadata and not object annotations
+//
+// #167 specifies "object annotations where available, x-amz-meta- keys otherwise". Its premise is not
+// that annotations are unavailable — PutObjectAnnotation, GetObjectAnnotation,
+// ListObjectAnnotations, and DeleteObjectAnnotation are all present in the pinned SDK
+// (service/s3 v1.106.3), and #165's note that they were absent was true of v1.88.4 and is now stale.
+// The premise that fails is "where available": it is a per-endpoint fork, and this project's thesis
+// says a capability is established by probing rather than by asking. Annotations offer far more room
+// than metadata — 1 MiB per annotation, 1,000 per object, against 2 KB total here — so the tradeoff
+// is real and the fork is the cost of it.
+//
+// Metadata is chosen for two reasons, and only the second is about portability:
+//
+//  1. **A fork would be two storage formats for one attribute set, with no way to migrate between
+//     them.** An attribute written as an annotation is invisible to a mount that reads metadata, and a
+//     bucket does not gain or lose annotation support atomically — a tier transition to a directory
+//     bucket loses annotations, and CopyObject's default AnnotationDirective for a multipart copy does
+//     not carry them. Two of those are the operations ObjectFS performs *itself* to persist an
+//     attribute change, so a fork would drop attributes during ObjectFS's own writes. The decision
+//     recorded on the metadata key block in attr.go went the same way for the same reason.
+//  2. Metadata works on every S3-compatible implementation and on directory buckets, and it needs no
+//     capability probe — it is the mechanism every write on this filesystem already depends on.
+//
+// So the honest statement of the limitation is not "annotations are unavailable" but "extended
+// attributes on ObjectFS share a 2 KB budget, and lifting it means a migration". If a caller needs
+// megabyte-scale attributes, an annotations backend is the way to get them and it should be a
+// deliberate, probed, migrating change rather than a silent fallback — a correctness capability by the
+// thesis's classification, since the failure mode is an attribute that reads as absent.
+//
+// # The three encoding problems, and why each rule exists
+//
+// An xattr name and value are arbitrary bytes from the caller. An S3 user-metadata entry is an HTTP
+// header, and three separate properties of that make a direct mapping wrong:
+//
+//  1. **Case.** S3 lower-cases user-metadata keys in transit, which attr.go records as "a bug that
+//     only shows up against real S3". So `user.Foo` and `user.foo` would name the same stored key and
+//     silently overwrite each other. The name is therefore base32-encoded, whose alphabet survives
+//     case folding without loss.
+//  2. **Character set.** An xattr name may hold any byte but NUL, and a header field name may hold
+//     only token characters. Base32 solves this at the same time, with one rule rather than an escape
+//     scheme whose edge cases are the whole risk.
+//  3. **Value bytes.** An xattr value is binary — `setfattr` will happily store a NUL or a newline —
+//     and a header value may not carry either. Values are base64-encoded, in the URL alphabet
+//     specifically: it avoids `+`, `/`, and `=`, so nothing downstream that treats a header value as a
+//     URL fragment or strips padding can corrupt one. That is not hypothetical caution about S3
+//     specifically — [Backend.copySource] documents a real case where S3 read `+` in a header as a
+//     space.
+//
+// The cost of base32 is 1.6 bytes stored per byte of name, and that a stored key is no longer legible
+// in the AWS console. Both were accepted deliberately over a partial escaping scheme: one rule that is
+// always right beats a shorter rule with a class of inputs that breaks it, on a filesystem whose first
+// priority is integrity.
+const (
+	// metaXattrPrefix begins every stored extended attribute's key.
+	//
+	// It is what makes an xattr unable to collide with a POSIX attribute. No user-supplied name can
+	// produce a stored key outside this prefix, and none of objectfs-mode, objectfs-uid, objectfs-gid,
+	// objectfs-mtime, objectfs-sha256, or objectfs-original-size begins with it — so a caller setting
+	// `user.objectfs-mode` gets a key of objectfs-xattr-<base32 of that name> and cannot reach the
+	// file's actual mode. That is a security property rather than a tidiness one: the alternative is a
+	// filesystem where an unprivileged setfattr rewrites a file's permission bits.
+	metaXattrPrefix = "objectfs-xattr-"
+
+	// xattrPresentTag and xattrRemovedTag are the first byte of a stored value, distinguishing an
+	// attribute that exists from one that has been removed.
+	//
+	// A tag is needed because both states are otherwise the empty string, and both are real: an
+	// attribute set to an empty value is legal (`setfattr -n user.x` with no -v), and a removal has to
+	// be expressible. With the tag, every stored value is non-empty, which also removes a dependency on
+	// whether a given S3 implementation preserves an empty metadata value at all.
+	xattrPresentTag = "v"
+	xattrRemovedTag = "-"
+)
+
+// Why a removal is a tombstone rather than a deletion.
+//
+// [types.Backend.SetObjectMetadata] is a self-copy with MetadataDirective=REPLACE, and the S3 backend
+// merges the object's existing metadata underneath the caller's so that the integrity keys — which
+// only the backend has seen the bytes to compute — survive a chmod. A consequence, verified against a
+// real endpoint rather than reasoned about: a key omitted from the caller's map is *not* removed from
+// the object. So "remove this metadata key" is not an operation the write path has, and a removexattr
+// that simply stopped rendering the key would report success while the attribute stayed readable
+// forever — the same defect shape as an `rm` that returns success while the object survives.
+//
+// The alternative to a tombstone is to force a full-content PutObject on every removexattr, since a
+// PUT does write metadata wholesale. That is correct and costs a read plus a write of the entire
+// object to delete a few bytes: 20 GiB of transfer to remove an attribute from a 10 GiB file. A
+// tombstone costs one metadata entry that stays until the object's next content write, which is the
+// cheaper wrong-in-a-visible-way, and it is loud in the one place it shows: the entry is visible in
+// `head-object` output.
+//
+// A removal of an attribute that was never set writes nothing at all, so tombstones accumulate only
+// for attributes a caller actually used.
+
+// s3UserMetadataLimit is the total size S3 allows for one object's user metadata, in bytes.
+//
+// AWS measures it as the sum, over every user-metadata entry, of the UTF-8 byte length of the key plus
+// the value. Exceeding it fails the request rather than truncating, so this has to be enforced before
+// the write is accepted — a setfattr that succeeds and makes the next flush fail moves the error to a
+// caller that cannot act on it.
+const s3UserMetadataLimit = 2048
+
+// metaHeaderPrefix is the header-name prefix S3 puts in front of every user-metadata key on the wire.
+//
+// It is counted against the limit here. AWS's documentation says the measurement is over "each key and
+// value" without stating whether the key includes this prefix, and the two readings differ by 11 bytes
+// per entry. Counting it is the conservative reading: if AWS does not count it, ObjectFS leaves a
+// little of the budget unused, and if it does, nothing fails. The other choice fails PUTs.
+const metaHeaderPrefix = "x-amz-meta-"
+
+// metadataBytes returns what m costs against [s3UserMetadataLimit].
+func metadataBytes(m map[string]string) int {
+	n := 0
+	for k, v := range m {
+		n += len(metaHeaderPrefix) + len(k) + len(v)
+	}
+	return n
+}
+
+// reservedMetadataBytes is the worst-case cost of the metadata ObjectFS writes for itself: the four
+// POSIX attribute keys this package renders, plus the two integrity keys the storage backend adds.
+//
+// Computed from the key constants rather than written as a number, so that renaming a key or adding
+// one cannot leave the figure stale — which is the failure this repository has hit repeatedly with
+// numbers transcribed into prose. Each value is the longest that key can hold.
+var reservedMetadataBytes = metadataBytes(map[string]string{
+	// The widest permission rendering, the widest uint32, and the widest RFC 3339 nanosecond stamp.
+	metaMode:  strconv.FormatUint(0o777, 8),
+	metaUID:   strconv.FormatUint(1<<32-1, 10),
+	metaGID:   strconv.FormatUint(1<<32-1, 10),
+	metaMtime: time.Date(9999, 12, 31, 23, 59, 59, 123456789, time.UTC).Format(time.RFC3339Nano),
+
+	// Written by the storage backend, not here, and reserved anyway: they are on the object and they
+	// count against the same limit. objectfs-original-size appears only on compressed objects, so
+	// reserving it always is deliberately pessimistic — a budget that is right only for uncompressed
+	// files is a budget that fails when compression is enabled.
+	metaChecksum:     strings.Repeat("0", 64),
+	metaOriginalSize: strconv.FormatInt(1<<63-1, 10),
+})
+
+// XattrBudget is the number of metadata bytes extended attributes may occupy on one object.
+//
+// It is the S3 limit less what ObjectFS already spends on POSIX attributes and integrity, and it is a
+// budget for the *encoded* form: a name costs 11 bytes of header prefix plus 15 of key prefix plus
+// ceil(len(name)*8/5), and a value costs 1 plus ceil(len(value)*4/3). Roughly 35 attributes of the
+// shape `user.test`=`hello` fit.
+//
+// It does not account for user metadata some other tool put on the object, which the metadata replace
+// preserves and which counts against the same limit. That metadata is not visible to this package —
+// [AttrFromMetadata] keeps only the keys it understands — and threading the whole stored map through
+// the flush protocol to count it would be a larger change than the accuracy is worth. The consequence
+// is bounded and honest: with enough foreign metadata a setfattr inside this budget is refused by S3
+// instead, and because the FUSE layer flushes an xattr synchronously the caller sees that refusal on
+// its own setxattr call rather than discovering it later.
+var XattrBudget = s3UserMetadataLimit - reservedMetadataBytes
+
+// xattrNameEncoding is base32 without padding. Padding is dropped because "=" is not a header-name
+// character; case is folded by the accessors, since S3 lower-cases the key in transit.
+var xattrNameEncoding = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// xattrValueEncoding is unpadded base64 in the URL alphabet. See the note on this file's constants for
+// why the URL alphabet and not the standard one.
+var xattrValueEncoding = base64.RawURLEncoding
+
+// encodeXattrKey returns the S3 user-metadata key that stores the attribute named name.
+func encodeXattrKey(name string) string {
+	return metaXattrPrefix + strings.ToLower(xattrNameEncoding.EncodeToString([]byte(name)))
+}
+
+// decodeXattrKey returns the attribute name a stored metadata key names, and whether the key is one of
+// ObjectFS's extended attributes at all.
+//
+// Both the prefix match and the base32 decode are case-insensitive, for the reason [lookupMeta]
+// documents: S3 lower-cases user-metadata keys, MinIO title-cases them, and a Go http.Header round
+// trip canonicalises them to Objectfs-Xattr-…. A case-sensitive decode here would work in a unit test
+// and lose every attribute against real storage.
+func decodeXattrKey(key string) (string, bool) {
+	if len(key) < len(metaXattrPrefix) || !strings.EqualFold(key[:len(metaXattrPrefix)], metaXattrPrefix) {
+		return "", false
+	}
+
+	raw, err := xattrNameEncoding.DecodeString(strings.ToUpper(key[len(metaXattrPrefix):]))
+	if err != nil {
+		return "", false
+	}
+
+	return string(raw), true
+}
+
+// encodeXattrValue renders an attribute value for storage. A nil value is a tombstone.
+func encodeXattrValue(value []byte) string {
+	if value == nil {
+		return xattrRemovedTag
+	}
+
+	return xattrPresentTag + xattrValueEncoding.EncodeToString(value)
+}
+
+// decodeXattrValue returns the attribute value a stored metadata value holds, whether it is a
+// tombstone, and whether it could be decoded at all.
+func decodeXattrValue(stored string) (value []byte, removed, ok bool) {
+	switch {
+	case stored == xattrRemovedTag:
+		return nil, true, true
+	case strings.HasPrefix(stored, xattrPresentTag):
+		raw, err := xattrValueEncoding.DecodeString(stored[len(xattrPresentTag):])
+		if err != nil {
+			return nil, false, false
+		}
+		// raw is non-nil even for an empty value, which is load-bearing rather than incidental: nil is the
+		// tombstone here, so a nil returned for an attribute set to zero bytes would make an existing
+		// attribute read as removed. base64's DecodeString allocates its result, so a zero-length decode is
+		// an empty non-nil slice. A guard normalising it stood here and was removed as unreachable — code no
+		// test can enter is code no test can check. [TestAnEmptyValueDecodesToANonNilSlice] pins the property
+		// instead, so a change of encoder that broke it fails a test rather than being caught by a guard
+		// nobody could confirm still worked.
+		return raw, false, true
+	default:
+		return nil, false, false
+	}
+}
+
+// Xattr returns the value of the extended attribute named name, and whether the file has one.
+//
+// A tombstoned attribute reports absent, which is what it is. Callers must not read [Attr.Xattrs]
+// directly to answer this: a nil value there means removed, not empty.
+func (a Attr) Xattr(name string) ([]byte, bool) {
+	v, ok := a.Xattrs[name]
+	if !ok || v == nil {
+		return nil, false
+	}
+
+	return v, true
+}
+
+// XattrNames returns the names of the file's extended attributes, sorted, excluding tombstones.
+//
+// Sorted so that listxattr is stable across calls. The kernel does not require an order, but a
+// listing that changes between two identical calls makes every test of it flaky and makes `getfattr
+// -d` output diff noisily for no reason.
+func (a Attr) XattrNames() []string {
+	names := make([]string, 0, len(a.Xattrs))
+	for name, v := range a.Xattrs {
+		if v == nil {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
+}
+
+// WithXattr returns a copy of a with the extended attribute name set to value.
+//
+// The returned Attr holds a new map: nothing mutates the receiver's, so an [Attr] already handed to a
+// caller — [Node.Attr] returns one under a lock and the caller reads it without — cannot observe a
+// change or race one. Copy-on-write is what makes the map in a value type safe to share.
+//
+// A value of nil sets a tombstone; use [Attr.WithoutXattr], which says so.
+//
+// The budget is enforced here rather than at the FUSE boundary, because here is where the encoded form
+// exists. Two distinct errors come out of it, matching setxattr(2): [ErrTooLarge] when this one
+// attribute could not fit on an object with no others, and [ErrNoSpace] when it cannot fit alongside
+// the ones already stored. The distinction is what a caller acts on — the first says the value is too
+// big, the second says the file is full — and collapsing them would make a 3 KB value and a full file
+// indistinguishable.
+func (a Attr) WithXattr(name string, value []byte) (Attr, error) {
+	if name == "" {
+		return a, fmt.Errorf("%w: empty extended attribute name", ErrInvalid)
+	}
+
+	// The one-attribute check first, so the E2BIG case is decided without allocating a map it is going
+	// to reject, and so the two errors cannot be reported in the wrong order: an attribute that is too
+	// large on its own is E2BIG whatever else the file holds.
+	alone := xattrMetadataBytes(map[string][]byte{name: value})
+	if alone > XattrBudget {
+		return a, fmt.Errorf("%w: extended attribute %q needs %d metadata bytes and the whole budget is "+
+			"%d", ErrTooLarge, name, alone, XattrBudget)
+	}
+
+	next := make(map[string][]byte, len(a.Xattrs)+1)
+	maps.Copy(next, a.Xattrs)
+	next[name] = value
+
+	if total := xattrMetadataBytes(next); total > XattrBudget {
+		return a, fmt.Errorf("%w: extended attributes would need %d metadata bytes of the %d available",
+			ErrNoSpace, total, XattrBudget)
+	}
+
+	a.Xattrs = next
+
+	return a, nil
+}
+
+// WithoutXattr returns a copy of a with the extended attribute name removed, and whether it was there
+// to remove.
+//
+// A false second return means nothing changed and the receiver's copy is returned unmodified, so a
+// caller can report ENOATTR without having written anything. That matters beyond the errno: writing a
+// tombstone for an attribute that never existed would spend budget, and would make `setfattr -x` on an
+// absent attribute cost an S3 round trip.
+func (a Attr) WithoutXattr(name string) (Attr, bool) {
+	if _, ok := a.Xattr(name); !ok {
+		return a, false
+	}
+
+	next := make(map[string][]byte, len(a.Xattrs))
+	maps.Copy(next, a.Xattrs)
+	// nil, not delete: see the tombstone note above. Omitting the key would leave the attribute
+	// readable on the object forever, because a metadata replace merges rather than replaces.
+	next[name] = nil
+
+	a.Xattrs = next
+
+	return a, true
+}
+
+// xattrMetadataBytes returns what a set of extended attributes costs against [XattrBudget].
+func xattrMetadataBytes(xattrs map[string][]byte) int {
+	m := make(map[string]string, len(xattrs))
+	for name, value := range xattrs {
+		m[encodeXattrKey(name)] = encodeXattrValue(value)
+	}
+
+	return metadataBytes(m)
+}
+
+// xattrsFromMetadata decodes every extended attribute an object's user metadata carries, returning nil
+// when it carries none.
+//
+// Undecodable entries are skipped rather than reported, on the policy [AttrFromMetadata] states: a
+// file must stay readable when someone hand-writes a malformed objectfs-xattr-… key with the AWS CLI.
+// [MetadataWarnings] is how a caller learns what was ignored.
+func xattrsFromMetadata(meta map[string]string) map[string][]byte {
+	var xattrs map[string][]byte
+
+	for k, v := range meta {
+		name, ok := decodeXattrKey(k)
+		if !ok {
+			continue
+		}
+		value, removed, ok := decodeXattrValue(v)
+		if !ok {
+			continue
+		}
+		if xattrs == nil {
+			xattrs = make(map[string][]byte)
+		}
+		if removed {
+			xattrs[name] = nil
+			continue
+		}
+		xattrs[name] = value
+	}
+
+	return xattrs
+}
+
+// xattrMetadata renders a's extended attributes as S3 user metadata, to be merged with the POSIX
+// attribute keys by [Attr.Metadata].
+//
+// Tombstones are rendered, not skipped. They are the removal, and a flush that dropped them would
+// leave every removed attribute readable on the object.
+func (a Attr) xattrMetadata() map[string]string {
+	if len(a.Xattrs) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(a.Xattrs))
+	for name, value := range a.Xattrs {
+		m[encodeXattrKey(name)] = encodeXattrValue(value)
+	}
+
+	return m
+}
+
+// xattrMetadataWarnings describes every objectfs-xattr- entry that was present and unusable.
+func xattrMetadataWarnings(meta map[string]string) []string {
+	var keys []string
+	for k := range meta {
+		if len(k) >= len(metaXattrPrefix) && strings.EqualFold(k[:len(metaXattrPrefix)], metaXattrPrefix) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var warns []string
+	for _, k := range keys {
+		name, ok := decodeXattrKey(k)
+		if !ok {
+			warns = append(warns, fmt.Sprintf("%s ignored: the name after %q is not base32",
+				k, metaXattrPrefix))
+			continue
+		}
+		if _, _, ok := decodeXattrValue(meta[k]); !ok {
+			warns = append(warns, fmt.Sprintf("%s (extended attribute %q) ignored: value %q is neither a "+
+				"%q tombstone nor %q followed by base64",
+				k, name, meta[k], xattrRemovedTag, xattrPresentTag))
+		}
+	}
+
+	return warns
+}

--- a/internal/vfs/xattr_test.go
+++ b/internal/vfs/xattr_test.go
@@ -1,0 +1,745 @@
+package vfs
+
+// Tests for the extended-attribute encoding and for the Attr accessors over it.
+//
+// Nothing here needs a backend: the properties under test are the encoding's — that a name survives S3
+// lower-casing, that a value survives being an HTTP header, that a stored key cannot collide with a
+// POSIX attribute key — and each of them is decided entirely by this package. The tests that need a
+// real endpoint are the ones asserting an attribute survives to storage and back, and those live in
+// internal/fuse alongside the operations that write it.
+
+import (
+	"bytes"
+	"errors"
+	"maps"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// attrEqual compares two Attr values including their extended attributes.
+//
+// It exists because adding Xattrs made Attr non-comparable, so `got != want` on a whole Attr no longer
+// compiles. reflect.DeepEqual is exactly as strict as == was for every other field — including
+// time.Time, where it compares the wall clock, the monotonic reading, and the location just as ==
+// does — and it distinguishes a nil value from an empty one, which is the tombstone/empty-attribute
+// distinction this package rests on. Comparing field by field instead would go stale the next time a
+// field is added, which is the failure mode that motivated this type in the first place.
+func attrEqual(a, b Attr) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+// TestXattrKeyEncodingSurvivesCaseFolding is the case-collision property, which is the one #167 names
+// and the one that cannot be checked by looking at a stored key.
+//
+// S3 lower-cases user-metadata keys in transit. A stored key built by concatenating the attribute name
+// would therefore make user.Foo and user.foo the same key, and setting one would overwrite the other
+// with no error anywhere — the second setfattr reports success and the first attribute is gone. Base32
+// is what makes the two distinct after folding.
+func TestXattrKeyEncodingSurvivesCaseFolding(t *testing.T) {
+	t.Parallel()
+
+	lower := encodeXattrKey("user.foo")
+	upper := encodeXattrKey("user.Foo")
+
+	if lower == upper {
+		t.Fatalf("user.foo and user.Foo both encode to %q, so setting one destroys the other", lower)
+	}
+
+	// The keys as ObjectFS writes them must already be lower-case, so that what S3 stores is what was
+	// sent. An encoder emitting upper-case would still decode correctly here but would make a stored
+	// key differ from the one that was written, and every case-sensitive comparison anywhere downstream
+	// would then be wrong in a way only real storage shows.
+	for _, k := range []string{lower, upper} {
+		if k != strings.ToLower(k) {
+			t.Errorf("encoded key %q is not lower-case, so S3's folding changes it in transit", k)
+		}
+	}
+
+	// And the round trip, through the folding S3 performs and the title-casing MinIO performs.
+	for _, name := range []string{"user.foo", "user.Foo", "user.FOO", "USER.foo"} {
+		key := encodeXattrKey(name)
+		for _, wire := range []string{key, strings.ToUpper(key), titleCase(key)} {
+			got, ok := decodeXattrKey(wire)
+			if !ok {
+				t.Errorf("decodeXattrKey(%q) rejected a key ObjectFS wrote for %q", wire, name)
+				continue
+			}
+			if got != name {
+				t.Errorf("%q round-tripped through %q as %q", name, wire, got)
+			}
+		}
+	}
+}
+
+// TestXattrKeysCannotCollideWithPOSIXAttributeKeys is the security-relevant case.
+//
+// If a caller could choose an attribute name whose stored key is objectfs-mode, then `setfattr -n
+// objectfs-mode -v 4777` would rewrite the file's permission bits — an unprivileged process editing a
+// field the filesystem reports as the file's mode. The prefix is what makes that unreachable, and
+// this asserts it for the names most likely to try.
+func TestXattrKeysCannotCollideWithPOSIXAttributeKeys(t *testing.T) {
+	t.Parallel()
+
+	reserved := []string{metaMode, metaUID, metaGID, metaMtime, metaChecksum, metaOriginalSize}
+
+	names := []string{
+		"objectfs-mode", "objectfs-uid", "objectfs-gid", "objectfs-mtime",
+		"objectfs-sha256", "objectfs-original-size",
+		"user.objectfs-mode", "OBJECTFS-MODE",
+		// A name that already starts with the xattr prefix must not be able to produce a key that
+		// decodes as some *other* attribute either.
+		metaXattrPrefix + "objectfs-mode",
+	}
+
+	for _, name := range names {
+		key := encodeXattrKey(name)
+
+		for _, r := range reserved {
+			if strings.EqualFold(key, r) {
+				t.Errorf("attribute %q encodes to %q, which is the stored key for %q. A caller could "+
+					"rewrite a file's POSIX attributes with setfattr.", name, key, r)
+			}
+		}
+
+		// The stronger statement: the key is inside the xattr namespace, so no future POSIX key can
+		// collide either unless someone names one objectfs-xattr-….
+		if !strings.HasPrefix(key, metaXattrPrefix) {
+			t.Errorf("attribute %q encodes to %q, outside the %q namespace", name, key, metaXattrPrefix)
+		}
+
+		// And it still round-trips: namespacing must not come at the cost of the name.
+		if got, ok := decodeXattrKey(key); !ok || got != name {
+			t.Errorf("attribute %q encoded to %q and decoded to %q (ok=%v)", name, key, got, ok)
+		}
+	}
+
+	// The reserved keys themselves must not read as extended attributes, or a chmod would appear in
+	// `getfattr -d` output and a flush would rewrite the mode key as an xattr.
+	for _, r := range reserved {
+		if name, ok := decodeXattrKey(r); ok {
+			t.Errorf("the POSIX attribute key %q decodes as extended attribute %q", r, name)
+		}
+	}
+}
+
+// TestXattrValueEncodingRoundTripsArbitraryBytes covers the header-safety property.
+//
+// A metadata value is an HTTP header value, so a raw xattr value containing a NUL, a newline, or a
+// non-UTF-8 byte would either be rejected or silently mangled by something between here and S3.
+// setfattr will store any of those, and `-e hex` exists precisely because people do.
+func TestXattrValueEncodingRoundTripsArbitraryBytes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string][]byte{
+		"empty":                     {},
+		"ascii":                     []byte("hello"),
+		"nul":                       {0},
+		"nul in the middle":         []byte("a\x00b"),
+		"crlf":                      []byte("a\r\nb"),
+		"every byte":                allBytes(),
+		"invalid utf-8":             {0xff, 0xfe, 0xfd},
+		"header delimiters":         []byte(": ;,\"\\"),
+		"plus and slash and equals": []byte("+/=+/="),
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			stored := encodeXattrValue(value)
+
+			// Nothing in the stored form may need escaping in a header value.
+			if strings.ContainsAny(stored, "\x00\r\n \t\"\\+/=,;:") {
+				t.Errorf("encoded value %q carries a character that is not safe in an HTTP header value",
+					stored)
+			}
+
+			got, removed, ok := decodeXattrValue(stored)
+			if !ok {
+				t.Fatalf("decodeXattrValue(%q) failed for a value this package encoded", stored)
+			}
+			if removed {
+				t.Fatalf("a set value decoded as a tombstone, so the attribute would read as absent")
+			}
+			if !bytes.Equal(got, value) {
+				t.Fatalf("value round-tripped as %v, want %v", got, value)
+			}
+			if got == nil {
+				t.Error("an existing attribute decoded to a nil value, which is the tombstone " +
+					"representation: it would read as removed")
+			}
+		})
+	}
+}
+
+func allBytes() []byte {
+	b := make([]byte, 256)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}
+
+// TestXattrTombstoneIsDistinctFromAnEmptyValue pins the distinction the tag exists for.
+//
+// `setfattr -n user.x f` with no -v sets an attribute whose value is zero bytes, and that attribute
+// exists: getfattr reports it and listxattr names it. A removed attribute does not exist. Without the
+// tag both are the empty string in storage, and the two states would be indistinguishable — so either
+// every empty attribute would read as removed, or every removal would leave an empty attribute behind.
+func TestXattrTombstoneIsDistinctFromAnEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	empty := encodeXattrValue([]byte{})
+	tomb := encodeXattrValue(nil)
+
+	if empty == tomb {
+		t.Fatalf("an empty attribute and a removed one both store as %q", empty)
+	}
+	if empty == "" || tomb == "" {
+		t.Errorf("a stored value is the empty string (empty=%q tombstone=%q); an S3 implementation that "+
+			"drops empty metadata values would lose it entirely", empty, tomb)
+	}
+
+	if _, removed, ok := decodeXattrValue(empty); !ok || removed {
+		t.Errorf("an empty attribute decoded as removed=%v ok=%v", removed, ok)
+	}
+	if v, removed, ok := decodeXattrValue(tomb); !ok || !removed || v != nil {
+		t.Errorf("a tombstone decoded as value=%v removed=%v ok=%v", v, removed, ok)
+	}
+}
+
+// TestAnEmptyValueDecodesToANonNilSlice pins the one property of the value encoder the tombstone rests on.
+//
+// nil means "removed" throughout this package, so [decodeXattrValue] returning nil for an attribute whose
+// value is zero bytes would make an existing empty attribute read as removed — `getfattr` reporting ENOATTR
+// for an attribute `setfattr -n user.x` just created. base64's DecodeString allocates, so this holds today
+// and a guard for it in decodeXattrValue was unreachable and was removed. That makes this test the only
+// thing standing between a future encoder change and the defect, which is why it asserts the nil-ness
+// directly rather than only the round trip: [Attr.Xattr] maps both nil and absent to "not there", so a
+// round-trip assertion would report the same answer either way and pass.
+func TestAnEmptyValueDecodesToANonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	value, removed, ok := decodeXattrValue(encodeXattrValue([]byte{}))
+
+	if !ok || removed {
+		t.Fatalf("an empty attribute decoded as removed=%v ok=%v", removed, ok)
+	}
+	if value == nil {
+		t.Error("an empty attribute value decoded to nil. nil is the tombstone, so this attribute now " +
+			"reads as removed: getfattr answers ENOATTR for an attribute setfattr created.")
+	}
+	if len(value) != 0 {
+		t.Errorf("an empty attribute value decoded to %q", value)
+	}
+}
+
+// TestXattrAccessorsTreatATombstoneAsAbsent covers the read side of the tombstone.
+func TestXattrAccessorsTreatATombstoneAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	a := Attr{Xattrs: map[string][]byte{
+		"user.gone":  nil,
+		"user.empty": {},
+		"user.set":   []byte("x"),
+	}}
+
+	if _, ok := a.Xattr("user.gone"); ok {
+		t.Error("Xattr reported a removed attribute as present, so getfattr would return a nil value " +
+			"for something that was deleted")
+	}
+	if v, ok := a.Xattr("user.empty"); !ok || v == nil || len(v) != 0 {
+		t.Errorf("Xattr on an empty attribute returned %v, %v; an empty value is a real value", v, ok)
+	}
+	if v, ok := a.Xattr("user.set"); !ok || string(v) != "x" {
+		t.Errorf("Xattr on a set attribute returned %q, %v", v, ok)
+	}
+	if _, ok := a.Xattr("user.never"); ok {
+		t.Error("Xattr invented an attribute that was never set")
+	}
+
+	want := []string{"user.empty", "user.set"}
+	if got := a.XattrNames(); !reflect.DeepEqual(got, want) {
+		t.Errorf("XattrNames = %v, want %v (sorted, and without the tombstone)", got, want)
+	}
+}
+
+// TestWithXattrDoesNotMutateTheReceiver is the copy-on-write property.
+//
+// Attr is a value type passed by copy everywhere in this package, and [Node.Attr] returns one under a
+// lock which the caller then reads without it. A map written in place would be visible through every
+// existing copy and would be a data race against any concurrent reader — so the whole reason Attr can
+// carry a map at all is that these two methods never write the one they were given.
+func TestWithXattrDoesNotMutateTheReceiver(t *testing.T) {
+	t.Parallel()
+
+	original := Attr{Xattrs: map[string][]byte{"user.a": []byte("1")}}
+	snapshot := maps.Clone(original.Xattrs)
+
+	next, err := original.WithXattr("user.b", []byte("2"))
+	if err != nil {
+		t.Fatalf("WithXattr: %v", err)
+	}
+	if !reflect.DeepEqual(original.Xattrs, snapshot) {
+		t.Errorf("WithXattr mutated the receiver's map: %v, was %v", original.Xattrs, snapshot)
+	}
+	if _, ok := next.Xattr("user.b"); !ok {
+		t.Error("WithXattr did not set the attribute on the returned copy")
+	}
+
+	removed, existed := next.WithoutXattr("user.a")
+	if !existed {
+		t.Fatal("WithoutXattr reported an attribute absent that was set")
+	}
+	if !reflect.DeepEqual(original.Xattrs, snapshot) {
+		t.Errorf("WithoutXattr mutated the receiver's map: %v, was %v", original.Xattrs, snapshot)
+	}
+	if _, ok := removed.Xattr("user.a"); ok {
+		t.Error("WithoutXattr left the attribute readable")
+	}
+	if _, ok := next.Xattr("user.a"); !ok {
+		t.Error("WithoutXattr reached back into the map its receiver was sharing")
+	}
+}
+
+// TestWithoutXattrReportsAbsenceWithoutWriting is what lets removexattr answer ENOATTR without
+// spending an S3 round trip, and — more importantly — without leaving the node dirty.
+func TestWithoutXattrReportsAbsenceWithoutWriting(t *testing.T) {
+	t.Parallel()
+
+	a := Attr{Xattrs: map[string][]byte{"user.gone": nil}}
+
+	for _, name := range []string{"user.never", "user.gone"} {
+		got, existed := a.WithoutXattr(name)
+		if existed {
+			t.Errorf("WithoutXattr(%q) reported an attribute that is not there", name)
+		}
+		if len(got.Xattrs) != len(a.Xattrs) {
+			t.Errorf("WithoutXattr(%q) changed the attribute set for an attribute that is not there", name)
+		}
+	}
+}
+
+// TestChangingOneXattrKeepsTheOthers is the other half of copy-on-write, and the half that a
+// single-attribute test cannot see.
+//
+// [TestWithXattrDoesNotMutateTheReceiver] checks that the receiver's map is not written; this checks that
+// the returned copy still holds what the receiver held. Those are different failures with the same cause,
+// and a map with one entry in it distinguishes neither: drop the copy from [Attr.WithoutXattr] and a
+// one-entry map yields exactly the empty map the removal was supposed to produce.
+//
+// A verifying mutation is why this exists. Replacing the copy in WithoutXattr with a copy of nothing left
+// every test in this package and in internal/fuse passing, because the FUSE layer's removal test reads its
+// surviving attribute back after a remount, and a metadata replace *merges* — so the sibling ObjectFS had
+// silently dropped from memory was still on the object and came back on the next HEAD. The defect is real
+// for the caller that reads before the next flush completes: getxattr answers from the in-memory Attr,
+// which would report ENOATTR for an attribute nothing ever removed.
+func TestChangingOneXattrKeepsTheOthers(t *testing.T) {
+	t.Parallel()
+
+	base := Attr{Xattrs: map[string][]byte{
+		"user.first":  []byte("1"),
+		"user.second": []byte("2"),
+		"user.third":  []byte("3"),
+	}}
+
+	t.Run("a removal", func(t *testing.T) {
+		t.Parallel()
+
+		got, existed := base.WithoutXattr("user.second")
+		if !existed {
+			t.Fatal("WithoutXattr reported the attribute absent")
+		}
+
+		for _, name := range []string{"user.first", "user.third"} {
+			if _, ok := got.Xattr(name); !ok {
+				t.Errorf("removing user.second also lost %s. Nothing removed it, so a getxattr before the "+
+					"next flush would answer ENOATTR for an attribute that exists.", name)
+			}
+		}
+		if _, ok := got.Xattr("user.second"); ok {
+			t.Error("the removed attribute is still readable")
+		}
+	})
+
+	t.Run("a set", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := base.WithXattr("user.fourth", []byte("4"))
+		if err != nil {
+			t.Fatalf("WithXattr: %v", err)
+		}
+
+		for _, name := range []string{"user.first", "user.second", "user.third", "user.fourth"} {
+			if _, ok := got.Xattr(name); !ok {
+				t.Errorf("after setting user.fourth, %s is gone", name)
+			}
+		}
+	})
+
+	// And the rendered metadata carries all of them, because that is what reaches the object. A set that
+	// rendered only the changed attribute would still work against a merging endpoint and would delete
+	// every other attribute against one that replaces wholesale — a PutObject, which is what a content
+	// write does.
+	t.Run("the rendered metadata", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := base.WithXattr("user.fourth", []byte("4"))
+		if err != nil {
+			t.Fatalf("WithXattr: %v", err)
+		}
+
+		meta := got.xattrMetadata()
+		for _, name := range []string{"user.first", "user.second", "user.third", "user.fourth"} {
+			if _, ok := meta[encodeXattrKey(name)]; !ok {
+				t.Errorf("the rendered metadata has no entry for %s (keys: %v)", name, meta)
+			}
+		}
+	})
+}
+
+// TestRemovalRendersATombstoneRatherThanOmittingTheKey is the property the whole tombstone mechanism
+// exists for, stated where it is cheap to check.
+//
+// [types.Backend.SetObjectMetadata] merges the caller's metadata over the object's existing metadata, so
+// **omitting a key does not delete it**. A removal that dropped the key from the map would therefore
+// render metadata that reads as "change nothing about this attribute", the endpoint would leave the old
+// value in place, and the attribute would stay readable forever — while removexattr returned success.
+//
+// A verifying mutation confirmed this needs its own test: replacing the tombstone with delete(next, name)
+// left every other test in this package passing, and only the fuse-layer test that reads back through a
+// fresh HEAD caught it. That is the layer where the defect is real, but it should not be the only place
+// it is visible, because this is where the decision lives.
+func TestRemovalRendersATombstoneRatherThanOmittingTheKey(t *testing.T) {
+	t.Parallel()
+
+	a := Attr{Xattrs: map[string][]byte{"user.doomed": []byte("value")}}
+
+	removed, existed := a.WithoutXattr("user.doomed")
+	if !existed {
+		t.Fatal("WithoutXattr reported the attribute absent")
+	}
+
+	// The name must still be in the map, holding nil. An absent key would be a no-op on the wire.
+	value, present := removed.Xattrs["user.doomed"]
+	if !present {
+		t.Fatal("WithoutXattr omitted the key from the attribute set. A metadata replace merges over the " +
+			"object's existing metadata, so an omitted key changes nothing and the attribute stays " +
+			"readable on the object — after removexattr returned success.")
+	}
+	if value != nil {
+		t.Errorf("the removed attribute holds %q, want a nil tombstone", value)
+	}
+
+	// And it must render as a metadata entry, since that is what reaches S3.
+	meta := removed.xattrMetadata()
+	key := encodeXattrKey("user.doomed")
+
+	stored, ok := meta[key]
+	if !ok {
+		t.Fatalf("the rendered metadata has no entry for the removed attribute (keys: %v). The removal "+
+			"would never reach the object.", meta)
+	}
+	if _, isRemoved, decoded := decodeXattrValue(stored); !decoded || !isRemoved {
+		t.Errorf("the rendered entry %q does not decode as a removal (removed=%v ok=%v)",
+			stored, isRemoved, decoded)
+	}
+
+	// The round trip closes it: a reader must see the attribute as absent, not as an empty value.
+	back := AttrFromMetadata(removed.Metadata(), 0, time.Unix(0, 0).UTC(), "")
+	if _, ok := back.Xattr("user.doomed"); ok {
+		t.Error("after a metadata round trip the removed attribute reads as present")
+	}
+}
+
+// TestXattrBudgetIsTheS3LimitLessWhatObjectFSAlreadySpends states the arithmetic, so a change to the
+// POSIX key set that quietly shrinks the xattr budget shows up here rather than as a failing PUT.
+func TestXattrBudgetIsTheS3LimitLessWhatObjectFSAlreadySpends(t *testing.T) {
+	t.Parallel()
+
+	if XattrBudget+reservedMetadataBytes != s3UserMetadataLimit {
+		t.Fatalf("budget %d + reserved %d != limit %d", XattrBudget, reservedMetadataBytes,
+			s3UserMetadataLimit)
+	}
+	if XattrBudget <= 0 {
+		t.Fatalf("the xattr budget is %d: ObjectFS's own metadata fills the object", XattrBudget)
+	}
+
+	// The reservation must actually cover what Metadata() renders for a file with the widest plausible
+	// values, or the budget is a number that permits a PUT S3 will reject.
+	widest := Attr{
+		Mode:  0o777,
+		UID:   1<<32 - 1,
+		GID:   1<<32 - 1,
+		Mtime: widestTime,
+	}
+	posix := widest.Metadata()
+	// The two integrity keys the backend adds, at their widest.
+	posix[metaChecksum] = strings.Repeat("0", 64)
+	posix[metaOriginalSize] = "9223372036854775807"
+
+	if got := metadataBytes(posix); got > reservedMetadataBytes {
+		t.Errorf("ObjectFS's own metadata costs %d bytes at its widest but only %d are reserved, so a "+
+			"file at the xattr budget exceeds S3's %d-byte limit", got, reservedMetadataBytes,
+			s3UserMetadataLimit)
+	}
+
+	t.Logf("S3 limit %d - reserved %d = xattr budget %d bytes",
+		s3UserMetadataLimit, reservedMetadataBytes, XattrBudget)
+}
+
+// TestWithXattrDistinguishesTooLargeFromNoSpace pins the two-errno split, which is what a caller acts
+// on: E2BIG says shrink the value, ENOSPC says remove something else first.
+func TestWithXattrDistinguishesTooLargeFromNoSpace(t *testing.T) {
+	t.Parallel()
+
+	// One attribute larger than the entire budget.
+	if _, err := (Attr{}).WithXattr("user.big", make([]byte, XattrBudget)); !errors.Is(err, ErrTooLarge) {
+		t.Errorf("an attribute larger than the whole budget returned %v, want ErrTooLarge; the caller "+
+			"needs E2BIG to know the value is the problem", err)
+	}
+
+	// Two attributes that each fit and together do not. The sizes are derived from the budget rather
+	// than written as literals, so a change to the reservation cannot make this case vacuous.
+	half := make([]byte, XattrBudget/3)
+	a, err := (Attr{}).WithXattr("user.one", half)
+	if err != nil {
+		t.Fatalf("the first half-budget attribute was refused: %v", err)
+	}
+	b, err := a.WithXattr("user.two", half)
+	if err != nil {
+		t.Fatalf("the second half-budget attribute was refused: %v", err)
+	}
+	if _, err := b.WithXattr("user.three", half); !errors.Is(err, ErrNoSpace) {
+		t.Errorf("a third attribute past the budget returned %v, want ErrNoSpace", err)
+	}
+
+	// An attribute exactly at the budget is accepted. A boundary that is off by one turns a legal
+	// setfattr into ENOSPC, which is the direction that looks like a filesystem bug to a user.
+	exact := make([]byte, 0)
+	for xattrMetadataBytes(map[string][]byte{"user.x": exact}) < XattrBudget {
+		exact = append(exact, 'a')
+	}
+	if xattrMetadataBytes(map[string][]byte{"user.x": exact}) == XattrBudget {
+		if _, err := (Attr{}).WithXattr("user.x", exact); err != nil {
+			t.Errorf("an attribute costing exactly the budget was refused: %v", err)
+		}
+	}
+
+	if _, err := (Attr{}).WithXattr("", []byte("x")); !errors.Is(err, ErrInvalid) {
+		t.Errorf("an empty attribute name returned %v, want ErrInvalid", err)
+	}
+}
+
+// widestTime renders as the longest RFC 3339 nanosecond stamp a metadata value can hold, which is what
+// [reservedMetadataBytes] budgets for.
+var widestTime = time.Date(9999, 12, 31, 23, 59, 59, 123456789, time.UTC)
+
+// titleCase applies the mangling MinIO applies to a metadata key. strings.Title is deprecated and
+// x/text/cases needs a language tag for something the S3 wire format does per ASCII byte, so it is
+// spelled out.
+func titleCase(s string) string {
+	parts := strings.Split(s, "-")
+	for i, p := range parts {
+		if p != "" {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, "-")
+}
+
+// TestXattrsSurviveAMetadataRoundTrip is the property every operation above rests on: what
+// [Attr.Metadata] renders is what [AttrFromMetadata] reads back.
+//
+// It runs through the mangling real storage applies — lower-casing, title-casing — because that is
+// where a case-sensitive decode would fail and a unit test over the exact map would not.
+func TestXattrsSurviveAMetadataRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	in := Attr{
+		Mode: 0o640,
+		UID:  501,
+		GID:  20,
+		Xattrs: map[string][]byte{
+			"user.test":          []byte("hello"),
+			"user.Test":          []byte("different attribute, same folded name"),
+			"user.binary":        {0, 1, 0xff},
+			"user.empty":         {},
+			"user.removed":       nil,
+			"user.objectfs-mode": []byte("4777"),
+		},
+	}
+
+	meta := in.Metadata()
+
+	for _, mangle := range []func(string) string{
+		func(s string) string { return s },
+		strings.ToLower,
+		strings.ToUpper,
+	} {
+		wire := make(map[string]string, len(meta))
+		for k, v := range meta {
+			wire[mangle(k)] = v
+		}
+
+		out := AttrFromMetadata(wire, 0, in.Mtime, "")
+
+		if got, want := len(out.Xattrs), len(in.Xattrs); got != want {
+			t.Fatalf("round trip produced %d attributes, want %d: %v", got, want, out.Xattrs)
+		}
+		for name, want := range in.Xattrs {
+			got, ok := out.Xattrs[name]
+			if !ok {
+				t.Errorf("attribute %q did not survive the round trip", name)
+				continue
+			}
+			if (got == nil) != (want == nil) || !bytes.Equal(got, want) {
+				t.Errorf("attribute %q round-tripped as %v, want %v", name, got, want)
+			}
+		}
+
+		// The POSIX attributes must be unaffected — in particular, user.objectfs-mode above must not
+		// have touched the mode.
+		if out.Mode != in.Mode {
+			t.Errorf("mode is %#o after a round trip carrying a user.objectfs-mode attribute, want %#o. "+
+				"An unprivileged setfattr just changed a file's permissions.", out.Mode, in.Mode)
+		}
+		if out.UID != in.UID || out.GID != in.GID {
+			t.Errorf("ownership is %d:%d after the round trip, want %d:%d",
+				out.UID, out.GID, in.UID, in.GID)
+		}
+	}
+}
+
+// TestMetadataWarningsReportsUnusableXattrEntries covers the diagnostic path for metadata someone
+// wrote by hand.
+//
+// A malformed entry is skipped rather than failing the read, on the policy AttrFromMetadata states —
+// which means the only way anyone learns is this list. An entry silently discarded is the defect
+// MetadataWarnings exists to prevent.
+func TestMetadataWarningsReportsUnusableXattrEntries(t *testing.T) {
+	t.Parallel()
+
+	meta := map[string]string{
+		metaXattrPrefix + "not!base32":    "vaGVsbG8",
+		encodeXattrKey("user.bad"):        "this is not tagged",
+		encodeXattrKey("user.badbase64"):  "v!!!!",
+		encodeXattrKey("user.fine"):       encodeXattrValue([]byte("ok")),
+		encodeXattrKey("user.tombstoned"): encodeXattrValue(nil),
+	}
+
+	warns := MetadataWarnings(meta)
+	if len(warns) != 3 {
+		t.Fatalf("MetadataWarnings reported %d warnings, want 3: %v", len(warns), warns)
+	}
+
+	joined := strings.Join(warns, "\n")
+	for _, want := range []string{"not!base32", "user.bad", "user.badbase64"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("no warning mentions %q:\n%s", want, joined)
+		}
+	}
+	for _, unwanted := range []string{"user.fine", "user.tombstoned"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("a usable entry (%s) was reported as a warning:\n%s", unwanted, joined)
+		}
+	}
+
+	// And the usable ones are still read.
+	a := AttrFromMetadata(meta, 0, time.Unix(0, 0).UTC(), "")
+	if v, ok := a.Xattr("user.fine"); !ok || string(v) != "ok" {
+		t.Errorf("a usable attribute was lost alongside the malformed ones: %q, %v", v, ok)
+	}
+}
+
+// FuzzXattrEncodingRoundTrip is the round-trip property over arbitrary names and values.
+//
+// The encoding is the whole of this feature's correctness: a name that does not survive means an
+// attribute a caller set is unreadable, and a value that does not survive means silent corruption of
+// something a user asked to be stored byte-for-byte. Both are exactly the shape a fuzzer finds and a
+// table does not — the table below holds the inputs a human thinks of.
+func FuzzXattrEncodingRoundTrip(f *testing.F) {
+	f.Add("user.test", []byte("hello"))
+	f.Add("user.Test", []byte(""))
+	f.Add("", []byte{0})
+	f.Add("objectfs-mode", []byte("4777"))
+	f.Add("user.\x00embedded", []byte{0xff, 0xfe})
+	f.Add(strings.Repeat("x", 200), []byte("v"))
+
+	f.Fuzz(func(t *testing.T, name string, value []byte) {
+		key := encodeXattrKey(name)
+
+		// The namespace guarantee has to hold for every name, not just plausible ones, because it is
+		// what stops a caller reaching objectfs-mode.
+		if !strings.HasPrefix(key, metaXattrPrefix) {
+			t.Fatalf("name %q encoded to %q, outside the %q namespace", name, key, metaXattrPrefix)
+		}
+		for _, reserved := range []string{metaMode, metaUID, metaGID, metaMtime, metaChecksum, metaOriginalSize} {
+			if strings.EqualFold(key, reserved) {
+				t.Fatalf("name %q encoded to the POSIX attribute key %q", name, reserved)
+			}
+		}
+
+		// A stored key must be a legal HTTP header field name, or the request fails or is mangled.
+		for i := range len(key) {
+			if c := key[i]; (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-' {
+				t.Fatalf("encoded key %q holds byte %q at %d, which is not a header token character",
+					key, c, i)
+			}
+		}
+
+		// Through the folding S3 applies, in both directions.
+		for _, wire := range []string{key, strings.ToUpper(key), strings.ToLower(key)} {
+			got, ok := decodeXattrKey(wire)
+			if !ok {
+				t.Fatalf("decodeXattrKey(%q) rejected a key encoded from %q", wire, name)
+			}
+			if got != name {
+				t.Fatalf("name %q round-tripped through %q as %q", name, wire, got)
+			}
+		}
+
+		stored := encodeXattrValue(value)
+		if stored == xattrRemovedTag && value != nil {
+			t.Fatalf("value %v encoded to the tombstone, so the attribute would read as removed", value)
+		}
+		for i := range len(stored) {
+			if c := stored[i]; c < 0x21 || c > 0x7e {
+				t.Fatalf("encoded value %q holds byte %q at %d, which is not safe in a header value",
+					stored, c, i)
+			}
+		}
+
+		got, removed, ok := decodeXattrValue(stored)
+		if !ok {
+			t.Fatalf("decodeXattrValue(%q) rejected a value this package encoded", stored)
+		}
+		if removed != (value == nil) {
+			t.Fatalf("value %v round-tripped with removed=%v", value, removed)
+		}
+		if !removed && !bytes.Equal(got, value) {
+			t.Fatalf("value %v round-tripped as %v", value, got)
+		}
+
+		// And through the whole Attr, which is the path a flush and a stat actually take.
+		if name == "" || value == nil {
+			return
+		}
+		a, err := (Attr{}).WithXattr(name, value)
+		if err != nil {
+			// A refusal is a legal outcome for an oversized attribute; what must not happen is a
+			// successful set that does not survive.
+			return
+		}
+		back := AttrFromMetadata(a.Metadata(), 0, time.Unix(0, 0).UTC(), "")
+		v, present := back.Xattr(name)
+		if !present {
+			t.Fatalf("attribute %q did not survive Metadata/AttrFromMetadata", name)
+		}
+		if !bytes.Equal(v, value) {
+			t.Fatalf("attribute %q survived as %v, want %v", name, v, value)
+		}
+	})
+}


### PR DESCRIPTION
Closes #167.

`getfattr`, `setfattr`, and `setfattr -x` on files, stored in S3 user metadata and durable across a
remount. `XATTR_CREATE`/`XATTR_REPLACE` honored; an attribute set to an empty value round-trips as
empty rather than as a removal; a directory answers `ENOTSUP` rather than go-fuse's default of "no
such attribute", so a caller can tell "this filesystem cannot" from "that attribute is missing".

## The security property, verified by mutation

The `objectfs-xattr-` prefix looks like what keeps a caller's attribute away from the POSIX keys, but
it isn't — the **base32 encoding** is. Blanking the prefix showed nothing under a narrow `-run`
filter. Replacing `encodeXattrKey`'s body with `strings.ToLower(name)` makes
`TestSetxattrCannotRewriteThePOSIXAttributes` fail on `setxattr objectfs-sha256`. The test drives
seven adversarial names including `objectfs-mode`, `user.objectfs-mode`, and `OBJECTFS-MODE`. The
alternative to encoding is a filesystem where an unprivileged `setfattr` rewrites a file's permission
bits.

## Three encoding problems, one rule each

A user-metadata key is an HTTP header name, and the direct mapping is silently lossy three ways:

1. **Case** — S3 lower-cases keys in transit, so `user.Foo` and `user.foo` would overwrite each other.
2. **Character set** — an xattr name admits any byte but NUL; a header field name admits only token
   characters.
3. **Value bytes** — an xattr value is binary, and a header value carries neither a NUL nor a newline.

Names are base32 (its alphabet survives case folding), values base64 in the **URL** alphabet
specifically — avoiding `+`, which `Backend.copySource` documents real S3 reading as a space in a
header. Cost: 1.6 stored bytes per name byte, and a stored key no longer legible in the console. Both
taken deliberately over a partial escaping scheme, whose edge cases would be the entire risk.

## Budget: 1758 bytes, computed not transcribed

S3's 2048-byte limit less the worst-case cost of four POSIX keys plus two integrity keys, each derived
from its own key constant so that renaming one cannot leave the figure stale, and asserted as an
identity by `TestXattrBudgetIsTheS3LimitLessWhatObjectFSAlreadySpends`. Confirmed by measurement here,
not read off a comment.

The two overruns are distinguished because they call for different actions: one attribute larger than
the whole budget is **`E2BIG`** and never fits; a set that no longer fits alongside the others is
**`ENOSPC`** and fits again once something is removed. Both refuse at `setxattr`, not at the next
flush — a `setfattr` that succeeds and breaks a later write moves the error to a caller who cannot act
on it.

## `security.*` and `system.*` refused

A privilege boundary, not a gap. Linux reads `security.capability` on every `exec` and grants the
capabilities it names. Object metadata is writable by anyone holding `s3:PutObject`, with the AWS CLI,
without touching the mount — so honoring that attribute would convert bucket write access into file
capabilities on **every host that mounts the bucket**, an escalation ObjectFS would be creating rather
than inheriting. `system.posix_acl_*` is refused for the milder version: an ACL `getfacl` reports
while no access check consults it is worse than a `setfacl` that fails. `user.*`, `trusted.*`, and
`com.apple.*` are stored; `trusted.*` stays root-only by the kernel's own check.

## A removal is a tombstone

`SetObjectMetadata` is a self-copy with `MetadataDirective=REPLACE`, and the backend merges the
object's existing metadata underneath the caller's so the integrity keys — which only the backend has
seen the bytes to compute — survive a `chmod`. Verified against a real endpoint rather than reasoned
about: **a key omitted from the caller's map is not removed from the object.** So a `removexattr` that
merely stopped rendering the key would report success while the attribute stayed readable forever —
the same defect shape as an `rm` that returns success while the object survives.

The alternative is a full `PutObject` per removal: 20 GiB of transfer to delete a few bytes from a
10 GiB file. The tombstone costs one metadata entry until the object's next content write, and it is
visible in `head-object` rather than hidden. Removing an attribute never set writes nothing.

## Why metadata and not object annotations

#167 says "object annotations where available". The premise that fails is *where available* — not
availability. `PutObjectAnnotation` and its siblings **are** present in the pinned `service/s3
v1.106.3` (checked: `api_op_PutObjectAnnotation.go` et al. exist), so #165's note that they were
absent was true of an older version and is now stale. They also offer far more room: 1 MiB per
annotation, 1,000 per object, against 2 KB total here. The tradeoff is real.

They lose on the fork. Support is per-endpoint, and two storage formats for one attribute set have no
migration between them: annotations do not survive a transition to a directory bucket, and
`CopyObject`'s default annotation directive does not carry them through a multipart copy. **Both are
operations ObjectFS performs itself to persist an attribute change** — so a fallback would drop
attributes during ObjectFS's own writes. By the project thesis's classification this is a
*correctness* capability (the failure mode is an attribute that reads as absent), so it fails closed
rather than degrading silently. Lifting the 2 KB ceiling is a deliberate, probed, migrating change.

## A false README claim removed

README said directory buckets don't support "object annotations, which ObjectFS needs for attributes".
ObjectFS uses metadata, not annotations, so the reason was wrong even though the conclusion is right.
Replaced with the accurate statement that directory buckets are unsupported.

## Coverage floor: deliberately not ratcheted here

`internal/fuse` measures **72.1%** locally against a floor of 67, and the obvious move is to ratchet.
Not in this PR: that figure is from **darwin**, and CI measures on **linux**, which compiles
`unmount_path_linux.go` (52 lines) where I compiled `unmount_path_darwin.go` (44) — a different
statement count and a different result. `.coverage-floors`'s own header records this exact mistake
three times over, including one floor set from an isolated run that failed the very next full-repo
gate: *"A floor is a claim about a measurement, so the measurement has to be the one CI takes."* No
Docker here to measure linux. The ratchet lands as a second commit on this PR, from the number CI
reports below.

## Verification

Local, all clean: `go build ./...`, `gofmt -l .`, `go vet ./...`, `golangci-lint run` (0 issues),
`go test -race -timeout 20m ./...` with no FAIL, panic, or DATA RACE, and `coverage-gate: 35
package(s) at or above their floor` — `internal/vfs 98.6% (floor 98%)`, `internal/fuse 72.1% (floor
67%)`. `fuse.ENOATTR` confirmed to be `syscall.ENODATA` on Linux and `syscall.ENOATTR` on
Darwin/FreeBSD in go-fuse v2.11.0, which is why there is no build-tagged pair here; cross-compiles
clean for `GOOS=linux`.

`xattr_oracle_test.go` runs the operation sequence against the local OS filesystem as an oracle,
allowing for the attributes macOS adds on its own (`com.apple.provenance` on every file it creates).
