### PR TITLE
feat(deploy): Kubernetes and Compose manifests, and the cluster env vars they need (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,86 @@ jobs:
           -run 'TestShippedConfigs|TestDocumentedConfigYAML|TestLoadFromFile|TestTopLevelKeys'
 
   # ---------------------------------------------------------------------------------------------
+  # deploy-manifests — deploy/kubernetes/ and deploy/docker/, which operators are told to apply.
+  #
+  # The same two-halves structure as systemd-unit below, for the same reason and against the same
+  # defect. `go test` checks that every objectfs command line in a manifest uses a subcommand the
+  # binary dispatches and flags it parses, that every OBJECTFS_* name is read by something, and that
+  # the ConfigMap's embedded config survives the real strict unmarshal. This job adds the half that
+  # needs tools rather than Go: schema validation and the Compose parser.
+  #
+  # Neither half is enough alone, and the shape of what each one misses is worth naming. kubeconform
+  # approves any string in an `args:` list, so a container invoking a subcommand that does not exist
+  # is schema-valid — exactly the hole `systemd-analyze verify` left in the shipped unit for a year.
+  # Conversely `go test` cannot know whether a manifest is valid Kubernetes at all: it reads the
+  # files as text and as loose YAML, so a misplaced key under `spec:` or a probe field that moved
+  # between API versions passes it and fails `kubectl apply`.
+  #
+  # -strict, which rejects unknown fields. Without it a typo'd field name is silently ignored by the
+  # validator exactly as it is by the API server, which is the failure this is here to catch: a
+  # `terminationGracePeriodSecond` (singular) would leave the default 30s in place, and 30s is the
+  # value that SIGKILLs a mount through buffered writes.
+  #
+  # `docker compose config` is the Compose half, and it is not a formality — it caught a real defect
+  # in this file's own placeholder secret, where 64 unquoted zeros parsed as the integer 0 and
+  # rendered back as "0", a one-byte secret failing minSecretLen with nothing in the file appearing
+  # to set it. It also expands the YAML anchors, which is the only way to confirm the three nodes end
+  # up with three distinct identities rather than three copies of node 1's.
+  #
+  # What this job deliberately does not do: apply anything. That needs a cluster and a FUSE-capable
+  # runner, and it is worth having as its own job rather than as a half-measure here.
+  # ---------------------------------------------------------------------------------------------
+  deploy-manifests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: ${{ env.GO_VERSION_FILE }}
+        cache: true
+
+    - name: The manifests name env vars the binary reads and flags it parses
+      run: go test ./internal/config/ -v -run 'TestDeploy'
+
+    - name: The Kubernetes manifests are valid, with no unknown fields
+      run: |
+        # Pinned by version rather than tracking latest: this validates against bundled schemas, and a
+        # validator that changes under the repository would turn an unrelated PR red.
+        curl -fsSL \
+          https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz \
+          | tar -xz kubeconform
+        ./kubeconform -strict -summary deploy/kubernetes/
+
+    - name: The Compose file parses, and the three nodes get three identities
+      run: |
+        docker compose -f deploy/docker/docker-compose.yaml config > /tmp/compose-resolved.yaml
+
+        # The anchors are what make one node definition serve three, so the thing worth asserting is
+        # that they produced three *different* node IDs. A merge key that overrode the wrong field, or
+        # an override accidentally deleted, yields three nodes claiming the same identity in gossip —
+        # which is a cluster that forms and then disagrees about who owns what, not one that fails.
+        ids=$(grep -c 'OBJECTFS_CLUSTER_NODE_ID' /tmp/compose-resolved.yaml)
+        distinct=$(grep 'OBJECTFS_CLUSTER_NODE_ID' /tmp/compose-resolved.yaml | sort -u | wc -l)
+        if [ "$ids" != "3" ] || [ "$distinct" != "3" ]; then
+          echo "::error::expected 3 nodes with 3 distinct OBJECTFS_CLUSTER_NODE_ID values, got" \
+            "$ids nodes and $distinct distinct. Two nodes sharing an identity is a cluster that" \
+            "forms and then disagrees about who owns which key."
+          grep 'OBJECTFS_CLUSTER_NODE_ID' /tmp/compose-resolved.yaml
+          exit 1
+        fi
+
+        # The placeholder secret must survive YAML as a string of usable length. 64 unquoted zeros
+        # became the integer 0 here once; minSecretLen is 32, so that is a cluster refusing to start
+        # over a value the file appears to set correctly.
+        secret=$(grep -m1 'OBJECTFS_CLUSTER_SECRET' /tmp/compose-resolved.yaml | sed 's/.*: *//')
+        if [ "${#secret}" -lt 32 ]; then
+          echo "::error::the resolved OBJECTFS_CLUSTER_SECRET is ${#secret} bytes, under" \
+            "minSecretLen (32). An unquoted numeric-looking secret is coerced by YAML; quote it."
+          exit 1
+        fi
+
+  # ---------------------------------------------------------------------------------------------
   # systemd-unit — configs/systemd/objectfs@.service, which operators are told to install.
   #
   # Two halves, and they check different things. `go test` checks that every objectfs command line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attribute change, so the fallback would drop attributes during ObjectFS's own writes. Lifting the
   2 KB ceiling is therefore a deliberate, probed, migrating change, not a silent fallback.
 
+- **Deployment manifests, and the five cluster environment variables they need** ([#146]).
+  `deploy/kubernetes/` holds a StatefulSet, a DaemonSet, a headless Service and a ConfigMap;
+  `deploy/docker/` holds a three-node Compose cluster over MinIO. `deploy/` was previously an empty
+  directory.
+
+  **Finding it first: four of the environment variables this work is built on did not exist.**
+  [#146]'s specification configured its nodes with `OBJECTFS_CLUSTER_ENABLED`, `_NODE_ID`,
+  `_ADVERTISE_ADDR` and `_SEEDS`, and `getEnvMappings` held none of them — established by calling it,
+  not by grep: 24 mappings, no cluster entries. Both `sdks/python/README.md` and
+  `sdks/javascript/README.md` already told operators to `export OBJECTFS_CLUSTER_ENABLED=true`. The
+  outcome that produces is the worst available: every pod starts, mounts, and serves reads, each one a
+  cluster of one, with no error anywhere — because an unread variable cannot complain. Cache
+  invalidations from peers are never received, so a node serves an object another node has already
+  overwritten. Five variables are now read (`_LISTEN_ADDR` is the fifth), and
+  `internal/config/deploy_test.go` compares every `OBJECTFS_*` name in every manifest against
+  `getEnvMappings` in both directions.
+
+  `OBJECTFS_CLUSTER_ENABLED` uses `strconv.ParseBool` and **returns** the error, joining the two
+  monitoring toggles rather than the feature flags that coerce anything but `"true"` to false. The
+  asymmetry is deliberate and it is an integrity argument: coerced to false, the mount succeeds, serves
+  reads, and is invisible to every peer, which is a stale read with nothing logged. `_SEEDS` is
+  comma-separated with entries trimmed and empties dropped, so a manifest wrapped across lines does not
+  produce an empty seed — which would reach the gossip layer as an address to dial and be reported as an
+  unreachable peer rather than as the configuration error it is.
+
+  **A StatefulSet, where [#146] specified a DaemonSet, and both are shipped.** A clustered node needs a
+  stable identity: `node_id` names it in gossip, `advertise_addr` is what peers dial back, and a seed
+  list must name something still there after a restart. A DaemonSet's pods get generated names that
+  change on reschedule and no per-pod DNS, so no seed list can be written. A StatefulSet plus a headless
+  Service gives each replica an ordinal name and a resolvable record, and the three per-pod values come
+  from the downward API — which is the second reason the environment variables must exist, since one
+  ConfigMap is shared by every replica and cannot carry a per-pod value. `advertise_addr` is built from
+  the DNS name rather than `status.podIP` because a pod IP changes on reschedule and a peer holding the
+  old one only sees a member that stopped answering. The DaemonSet is kept for the genuinely
+  uncoordinated case — one independent mount per host — and says plainly that those nodes exchange no
+  invalidations, so each cache is its own until `cache.ttl` expires.
+
+  **MinIO, not the LocalStack [#146] specified.** Coordination rests on conditional writes, and a
+  conditional write is a *correctness* capability: per the project thesis it fails closed rather than
+  degrading, so an endpoint that accepts `If-None-Match` and ignores it does not yield a slower cluster
+  but two nodes each believing it holds the same exclusive claim.
+  `docs/design/conditional-write-compatibility.md` is the probed matrix and MinIO is a row in it,
+  measured at a pinned release, enforcing preconditions as AWS does. LocalStack is not a row. Standing
+  the development environment on an unmeasured endpoint would make it the one place a coordination bug
+  is invisible. The image is pinned by release tag for the same reason the matrix records commits.
+
+  Two things the manifests get right that are invisible until they are wrong, both now asserted in
+  tests. `OBJECTFS_HEALTH_ADDR` moves the health endpoint off loopback: `DefaultHealthAddr` is
+  `127.0.0.1:8081`, correct for a host install of an unauthenticated endpoint and unusable in a pod,
+  where the kubelet probes over the pod IP, gets a refused connection, never passes readiness, and is
+  restarted forever by a liveness probe that could not have succeeded — while the manifest names the
+  right port and path throughout. And `terminationGracePeriodSeconds` is 120 rather than the default 30,
+  because a FUSE mount is unmounted by its own process on a signal: SIGKILL at the end of the grace
+  period leaves the kernel holding a mount whose server is gone, and any dirty range that had not
+  reached S3 is lost. Liveness is also deliberately far more patient than readiness (10 failures against
+  3), since readiness failing removes a pod from a Service while liveness failing kills it — discarding
+  buffered writes and doing nothing about a slow backend.
+
+  `internal/config/deploy_test.go` is the gate, and it exists because a schema validator cannot be one.
+  `kubeconform` approves all five resources here and would equally approve a container invoking a
+  subcommand that does not exist — the same hole `systemd-analyze verify` left in the shipped unit for a
+  year. So it checks what a schema cannot: that every `objectfs` command line uses a subcommand and
+  flags scraped from `cmd/objectfs/main.go`, that every `OBJECTFS_*` name is read by something, that the
+  ConfigMap's embedded config loads through `LoadFromFile` — the real strict unmarshal, so an invented
+  key fails here rather than at pod startup — and that health is bound off loopback in every pod spec.
+  All four were verified by mutation. `kubeconform -strict` and `docker-compose config` were also run;
+  the latter caught a defect in the Compose file's own placeholder secret, where 64 unquoted zeros were
+  read by YAML as the integer `0`, giving a one-byte secret that fails `minSecretLen` while nothing in
+  the file appeared to set it — and which a real `openssl rand -hex 32` value would almost never
+  reproduce, since it usually contains a letter.
+
 ### Fixed
 
 - **A node never recorded its own cache figures in its membership map** ([#147]). `refreshLocalStats`
@@ -3162,6 +3233,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#151]: https://github.com/scttfrdmn/objectfs/issues/151
 [#165]: https://github.com/scttfrdmn/objectfs/issues/165
 [#167]: https://github.com/scttfrdmn/objectfs/issues/167
+[#146]: https://github.com/scttfrdmn/objectfs/issues/146
 [#169]: https://github.com/scttfrdmn/objectfs/issues/169
 [#282]: https://github.com/scttfrdmn/objectfs/issues/282
 [#283]: https://github.com/scttfrdmn/objectfs/issues/283

--- a/README.md
+++ b/README.md
@@ -563,6 +563,40 @@ There is no pprof listener at any address. See
 - [`configs/example.yaml`](configs/example.yaml) — a short, copyable starting point. Every key in it is read on the mount path.
 - [`examples/config.yaml`](examples/config.yaml) — the complete schema: every key ObjectFS accepts, at its default value. Keys that parse and validate but are not yet read on the mount path are marked `not yet wired`, so this file is also the honest inventory of what is and is not implemented.
 
+### Containers and Kubernetes
+
+`deploy/` holds manifests that are checked on every PR rather than only written:
+
+- [`deploy/kubernetes/`](deploy/kubernetes/) — a **StatefulSet** for a clustered deployment, a
+  **DaemonSet** for one independent mount per host, plus the headless Service and ConfigMap they need.
+- [`deploy/docker/`](deploy/docker/) — a three-node Compose cluster over a local MinIO, for developing
+  distributed mode.
+
+Both need `SYS_ADMIN` and `/dev/fuse`, because mounting is privileged. Neither uses
+`privileged: true`, which would grant every capability and every device for the sake of that one.
+
+Three points where a container needs something a host install does not, all of them handled in the
+manifests and worth knowing if you write your own:
+
+- **Health and metrics must bind `0.0.0.0`.** They default to loopback, which is right for an
+  unauthenticated endpoint on a host and unusable in a pod: the kubelet probes over the pod IP, so a
+  loopback listener refuses the connection and the pod is restarted forever by a probe that could never
+  have passed. `OBJECTFS_HEALTH_ADDR` and `OBJECTFS_METRICS_ADDR` are the fix.
+- **A clustered node needs a stable identity, which is why it is a StatefulSet.** `node_id` and
+  `advertise_addr` differ per pod, and one ConfigMap is shared by every replica — so they come from the
+  downward API through `OBJECTFS_CLUSTER_NODE_ID` and `OBJECTFS_CLUSTER_ADVERTISE_ADDR`. A DaemonSet's
+  pods have generated names and no per-pod DNS, so no seed list can name them; that shape is for the
+  uncoordinated case, where each node's cache is its own and no invalidations are exchanged.
+- **Allow more than 30 seconds to stop.** A FUSE mount is unmounted by its own process on a signal, so
+  a SIGKILL at the end of the grace period leaves the kernel holding a mount whose server is gone and
+  loses any dirty range that had not reached S3. Both manifests set 120.
+
+The Compose file uses MinIO rather than LocalStack deliberately: coordination rests on conditional
+writes, which fail closed rather than degrading, and MinIO is a measured row in
+[docs/design/conditional-write-compatibility.md](docs/design/conditional-write-compatibility.md) while
+LocalStack is not. A green Compose run means the mesh forms — not that behavior is correct on AWS,
+which is what the integration suite is for.
+
 ### Cost estimation and institutional discounts
 
 Storage-cost estimates use a built-in rate table, and an institution with negotiated rates can

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -1,0 +1,166 @@
+# A three-node ObjectFS cluster over a local S3 endpoint, for developing distributed mode.
+#
+# This is #146's local half. It is a development harness and says so in several places below, because
+# every simplification it makes for the sake of one `podman compose up` is a thing a real deployment
+# must not copy: the cluster secret is in this file, the S3 credentials are in this file, and the
+# containers run with SYS_ADMIN so they can mount FUSE.
+#
+#   podman compose -f deploy/docker/docker-compose.yaml up --build
+#   podman compose -f deploy/docker/docker-compose.yaml exec objectfs-1 objectfs cluster status
+#   podman compose -f deploy/docker/docker-compose.yaml down -v
+#
+# `docker compose` works identically; podman is what this was written against.
+#
+# MinIO, not LocalStack. #146's issue body specified LocalStack, and that is the one part of its spec
+# not followed here, for a reason this project has written down at length. Coordination in ObjectFS is
+# built on conditional writes, and a conditional write is a *correctness* capability: per CLAUDE.md it
+# fails closed rather than degrading, so an endpoint that accepts `If-None-Match` and ignores it does
+# not produce a slower cluster, it produces two nodes each believing it holds the same exclusive claim.
+# docs/design/conditional-write-compatibility.md is the probed matrix, and MinIO is a row in it —
+# measured, at a pinned release, enforcing preconditions exactly as AWS does. LocalStack is not a row.
+# Standing this file up on an endpoint whose precondition behaviour nobody has measured would make the
+# development environment the one place a coordination bug is invisible.
+#
+# What this deliberately does not model: AWS. The matrix's own header says AWS S3 is the only row
+# verified against the real service and the only one CI keeps verified. A green run here means the
+# gossip mesh forms and the mounts work — not that a behaviour is correct on the backend nearly every
+# user runs. For that, `AWS_PROFILE=aws AWS_REGION=us-west-2 go test -race -tags=integration ./...`.
+---
+name: objectfs-cluster
+
+services:
+  # ---------------------------------------------------------------------------------------------
+  # The S3 endpoint. Pinned by digest, not by tag: `latest` moved under this project once already
+  # (the compat matrix records MinIO at RELEASE.2025-09-07T16-13-09Z with its commit, for exactly
+  # this reason), and a development environment that silently changes its backend between two
+  # `up` invocations is a debugging session nobody can reproduce.
+  # ---------------------------------------------------------------------------------------------
+  minio:
+    image: docker.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: objectfs
+      MINIO_ROOT_PASSWORD: objectfs123
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      # The readiness probe, not the liveness one. `/minio/health/live` answers before the object
+      # layer is up, so a node that started on it would get a connection refused from its first
+      # HeadBucket and fail the mount — the exact race a healthcheck exists to remove.
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+
+  # One-shot: create the bucket the three nodes mount. A separate service rather than an entrypoint
+  # wrapper on each node, because three nodes racing to create the same bucket is a race this file
+  # would be teaching people to write.
+  create-bucket:
+    image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        mc alias set local http://minio:9000 objectfs objectfs123
+        mc mb --ignore-existing local/objectfs-dev
+        echo "bucket objectfs-dev ready"
+
+  # ---------------------------------------------------------------------------------------------
+  # The three ObjectFS nodes.
+  #
+  # Every node runs the same image and the same config file; what differs is four environment
+  # variables. That is not a stylistic choice — three of them have no config-file alternative in a
+  # multi-replica deployment, which is why internal/config now reads them (see the cluster block in
+  # getEnvMappings). A ConfigMap or a baked-in config.yaml is shared by every replica, so per-node
+  # identity has to arrive some other way, and the environment is the way both compose and
+  # Kubernetes offer.
+  #
+  # SYS_ADMIN and /dev/fuse are what a FUSE mount needs and cannot be reduced away: mounting is a
+  # privileged operation. `privileged: true` is *not* used, and the difference is worth keeping —
+  # SYS_ADMIN plus the one device is a much smaller grant than all capabilities plus every device.
+  #
+  # OBJECTFS_CLUSTER_SECRET is inline here and must never be inline anywhere real. A cluster refuses
+  # to start without a secret because an unauthenticated gossip port lets any host on the network
+  # join and announce ownership of cached objects (#206); the value below is 64 hex characters of
+  # nothing in particular, published in a git repository, and therefore worth exactly as much as no
+  # secret at all. deploy/kubernetes/ uses a Secret for this. Generate a real one with:
+  #
+  #   openssl rand -hex 32
+  # ---------------------------------------------------------------------------------------------
+  objectfs-1: &objectfs-node
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      create-bucket:
+        condition: service_completed_successfully
+    devices:
+      - /dev/fuse:/dev/fuse
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      # FUSE needs mount(2), which the default seccomp profile blocks. Without this the container
+      # starts, runs, and fails at the mount with EPERM — a failure that looks like a permissions
+      # problem in the bucket rather than in the sandbox.
+      - apparmor:unconfined
+    command:
+      - mount
+      - --config=/etc/objectfs/config.yaml
+      - --foreground
+    volumes:
+      - ./node-config.yaml:/etc/objectfs/config.yaml:ro
+    environment: &objectfs-env
+      OBJECTFS_S3_ENDPOINT: http://minio:9000
+      OBJECTFS_S3_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: objectfs
+      AWS_SECRET_ACCESS_KEY: objectfs123
+      OBJECTFS_CLUSTER_ENABLED: "true"
+      OBJECTFS_CLUSTER_LISTEN_ADDR: 0.0.0.0:8080
+      # Not a secret. See the block comment above.
+      #
+      # Quoted, and the first version of this line was not, which is worth recording because the
+      # failure was silent and pointed somewhere else. The placeholder was 64 zeros unquoted; YAML
+      # reads that as the integer zero, and `docker-compose config` renders it back as "0". A 1-byte
+      # secret is below minSecretLen (32), so every node would refuse to start citing a secret length
+      # nothing in this file appears to set. Worse, a *real* secret from `openssl rand -hex 32` almost
+      # always contains a letter and so does not coerce — meaning the placeholder would fail in a way
+      # the real value never does, which is the least useful direction for an example to be wrong in.
+      OBJECTFS_CLUSTER_SECRET: "objectfs-development-cluster-not-a-secret-0123456789abcdef"
+      # Both listeners move off loopback, which is the default. A container's health endpoint on
+      # 127.0.0.1 is reachable only from inside that container, so compose's own healthcheck can
+      # see it but nothing else can — and in Kubernetes the kubelet probes over the pod IP and gets
+      # a connection refused. Same one-line fix in both places; see the k8s manifests.
+      OBJECTFS_HEALTH_ADDR: 0.0.0.0:8081
+      OBJECTFS_METRICS_ADDR: 0.0.0.0:8080
+      OBJECTFS_CLUSTER_NODE_ID: objectfs-1
+      OBJECTFS_CLUSTER_ADVERTISE_ADDR: objectfs-1:8080
+      # Every node seeds from node 1, including node 1 itself. Seeding from oneself is a no-op
+      # rather than an error, and listing one well-known seed everywhere is what keeps this file
+      # from needing a different value per node beyond identity.
+      OBJECTFS_CLUSTER_SEEDS: objectfs-1:8080
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8081/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  objectfs-2:
+    <<: *objectfs-node
+    environment:
+      <<: *objectfs-env
+      OBJECTFS_CLUSTER_NODE_ID: objectfs-2
+      OBJECTFS_CLUSTER_ADVERTISE_ADDR: objectfs-2:8080
+
+  objectfs-3:
+    <<: *objectfs-node
+    environment:
+      <<: *objectfs-env
+      OBJECTFS_CLUSTER_NODE_ID: objectfs-3
+      OBJECTFS_CLUSTER_ADVERTISE_ADDR: objectfs-3:8080

--- a/deploy/docker/node-config.yaml
+++ b/deploy/docker/node-config.yaml
@@ -1,0 +1,44 @@
+# The config every node in deploy/docker/docker-compose.yaml mounts, identically.
+#
+# What is *not* here is the point of the file: no node_id, no advertise_addr, no seed list, and no
+# endpoint or credentials. Those come from the environment, because this one file is shared by three
+# containers and three of those values must differ per node. See the cluster block in
+# internal/config/config.go's getEnvMappings for the five variables and why they exist.
+#
+# Keys are checked at load, not ignored: LoadFromFile uses yaml.UnmarshalStrict, so a key that does not
+# exist fails the mount naming itself rather than being silently dropped. `objectfs mount --config
+# deploy/docker/node-config.yaml --dry-run` validates this file without mounting anything, and is what
+# internal/config/deploy_test.go runs.
+global:
+  log_level: DEBUG
+
+mount:
+  uri: s3://objectfs-dev
+  mount_point: /mnt/objectfs
+
+storage:
+  s3:
+    # Path-style addressing, which a local endpoint needs: virtual-host addressing would resolve
+    # `objectfs-dev.minio`, a name only the bucket's own DNS would answer.
+    force_path_style: true
+
+cluster:
+  # `enabled` is here as false and the environment turns it on, rather than true here. That direction
+  # is deliberate: this file is also the one a reader copies as a starting point, and a config whose
+  # default state is "clustered" fails to start for anyone who copies it without a secret — clustering
+  # refuses to run unauthenticated (#206).
+  enabled: false
+  # replication_factor is a selection width, not a copy count. There is one copy of the bytes and S3
+  # holds it; this is how many nodes an operation considers in preference order.
+  replication_factor: 3
+
+monitoring:
+  metrics:
+    enabled: true
+    # Overridden to 0.0.0.0 by OBJECTFS_METRICS_ADDR in compose. Loopback is the right default for a
+    # host install of an unauthenticated endpoint and the wrong one inside a container, where it means
+    # only that container can reach it.
+    addr: 127.0.0.1:8080
+  health_checks:
+    enabled: true
+    addr: 127.0.0.1:8081

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,47 @@
+# The config file every ObjectFS pod mounts, shared by the StatefulSet and the DaemonSet.
+#
+# One ConfigMap for every replica is exactly why the cluster environment variables exist: a ConfigMap is
+# shared by every pod that mounts it, so anything that must differ per pod — node_id, advertise_addr —
+# cannot be written here. Those come from the downward API. See the env block in statefulset.yaml.
+#
+# The bucket is here rather than in the pod spec because it is the same for every replica, and because
+# `mount.uri` is validated at config load by the same code that validates the command-line argument.
+# Change objectfs-example to a real bucket before applying.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: objectfs-config
+  labels:
+    app.kubernetes.io/name: objectfs
+data:
+  config.yaml: |
+    global:
+      log_level: INFO
+
+    mount:
+      uri: s3://objectfs-example
+      mount_point: /mnt/objectfs
+
+    storage:
+      s3:
+        region: us-west-2
+
+    cluster:
+      # False here and turned on by OBJECTFS_CLUSTER_ENABLED in the StatefulSet, so that the DaemonSet
+      # — which mounts this same ConfigMap and does not set that variable — gets an unclustered node
+      # without needing a second ConfigMap. The direction matters for a reader too: a config whose
+      # default is "clustered" fails to start for anyone who applies it without a gossip secret,
+      # because clustering refuses to run unauthenticated (#206).
+      enabled: false
+      replication_factor: 3
+
+    monitoring:
+      metrics:
+        enabled: true
+        # Overridden to 0.0.0.0 by OBJECTFS_METRICS_ADDR in both workloads. Loopback is correct for a
+        # host install of an unauthenticated endpoint and wrong in a pod, where the kubelet probes over
+        # the pod IP and a loopback listener refuses it.
+        addr: 127.0.0.1:8080
+      health_checks:
+        enabled: true
+        addr: 127.0.0.1:8081

--- a/deploy/kubernetes/daemonset.yaml
+++ b/deploy/kubernetes/daemonset.yaml
@@ -1,0 +1,128 @@
+# ObjectFS as a single-node mount on every host in the cluster.
+#
+# This is #146's DaemonSet, and it is deliberately *not* clustered. A DaemonSet's pods get generated
+# names that change on reschedule and no stable per-pod DNS, so there is no identity for gossip to use
+# and no address a seed list could name — which is why statefulset.yaml exists for the clustered case.
+# What a DaemonSet is genuinely right for is the shape here: one mount per host, each independent, each
+# reading the same bucket. Nothing coordinates, so nothing needs an identity.
+#
+# The consequence is worth being explicit about rather than leaving implied: because these nodes are not
+# in a cluster, they do not exchange cache invalidations. Each pod's cache is its own. If a writer
+# elsewhere overwrites an object, a pod here serves its cached copy until the entry's TTL expires
+# (cache.ttl). For a read-mostly or read-only dataset — which is the common HPC case, and what this
+# project is for — that is fine and cheap. For a dataset written concurrently from more than one place,
+# it is a stale read, and the StatefulSet is the answer.
+#
+#   kubectl apply -f deploy/kubernetes/configmap.yaml -f deploy/kubernetes/daemonset.yaml
+#
+# No secrets needed for the unclustered case beyond S3 credentials, and on AWS prefer IRSA to those:
+# annotate the ServiceAccount in statefulset.yaml with a role and delete the AWS_* entries below.
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: objectfs
+  labels:
+    app.kubernetes.io/name: objectfs-node
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: objectfs-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: objectfs-node
+    spec:
+      serviceAccountName: objectfs
+      # Same reasoning as the StatefulSet: a FUSE mount is unmounted by its own process on a signal,
+      # and SIGKILL at the end of the grace period leaves the kernel holding a mount whose server is
+      # gone, plus any dirty range that had not reached S3. 30s is enough for an idle mount and not for
+      # one flushing.
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: objectfs
+          image: ghcr.io/scttfrdmn/objectfs:latest
+          args:
+            - mount
+            - --config=/etc/objectfs/config.yaml
+            - --foreground
+          ports:
+            - name: health
+              containerPort: 8081
+          securityContext:
+            # SYS_ADMIN is mount(2). Not `privileged: true`, which would be every capability and every
+            # device for the sake of this one.
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            # No cluster variables at all, which is what makes this the unclustered workload. The
+            # ConfigMap has `cluster.enabled: false` and nothing here overrides it.
+            #
+            # Health off loopback is still required: the kubelet probes over the pod IP, so a loopback
+            # listener refuses the connection and the pod is restarted forever by a liveness probe that
+            # could never have passed.
+            - name: OBJECTFS_HEALTH_ADDR
+              value: 0.0.0.0:8081
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: objectfs-s3
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: objectfs-s3
+                  key: secret-access-key
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            # Ten failures at 30s, not three. Readiness failing removes the pod from a Service;
+            # liveness failing kills it, discarding buffered writes and doing nothing about a slow
+            # backend. So liveness is patient on purpose.
+            failureThreshold: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/objectfs
+              readOnly: true
+            - name: fuse
+              mountPath: /dev/fuse
+            # hostPath, unlike the StatefulSet's emptyDir, because the point of a DaemonSet mount is
+            # that other pods on the host can reach it — which needs a path on the host and
+            # `mountPropagation: Bidirectional` to make the mount visible outside this container's
+            # namespace. Both are left commented: Bidirectional propagation requires a privileged
+            # container on some versions, and a hostPath that a pod mounts over is worth an operator's
+            # deliberate decision rather than a default.
+            #
+            # HostToContainer is not sufficient here. This pod is the one creating the mount, so the
+            # propagation has to go outward.
+            - name: mountpoint
+              mountPath: /mnt/objectfs
+              # mountPropagation: Bidirectional
+      volumes:
+        - name: config
+          configMap:
+            name: objectfs-config
+        - name: fuse
+          hostPath:
+            path: /dev/fuse
+            type: CharDevice
+        - name: mountpoint
+          emptyDir: {}
+          # Replace the emptyDir above with this to expose the mount to the host:
+          # hostPath:
+          #   path: /mnt/objectfs
+          #   type: DirectoryOrCreate

--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -1,0 +1,250 @@
+# ObjectFS as a clustered StatefulSet.
+#
+# A StatefulSet and not the DaemonSet #146's issue body specified, and the reason is the thing this
+# whole change is about. A clustered ObjectFS node needs a stable identity: `cluster.node_id` names it
+# in gossip, `cluster.advertise_addr` is the address peers dial back on, and the seed list has to name
+# something that will still be there after a restart. A DaemonSet gives pods generated names that
+# change on every reschedule and no stable DNS, so a seed list cannot be written and a peer that comes
+# back is a new member rather than the same one returning. A StatefulSet plus a headless Service gives
+# each replica an ordinal name and a resolvable per-pod DNS record, which is what the seed list below
+# is made of.
+#
+# The DaemonSet shape is still the right one for a *single-node* mount on every host — one mount per
+# node, no cluster, no identity to keep — and that is daemonset.yaml in this directory. Both are here
+# because they answer different questions, not because one supersedes the other.
+#
+#   kubectl apply -f deploy/kubernetes/
+#
+# Before that: create the two secrets. Neither is in this repository and neither should be.
+#
+#   kubectl create secret generic objectfs-cluster --from-literal=secret="$(openssl rand -hex 32)"
+#   kubectl create secret generic objectfs-s3 \
+#     --from-literal=access-key-id=... --from-literal=secret-access-key=...
+#
+# On AWS, prefer IRSA to the objectfs-s3 secret entirely: annotate the ServiceAccount with a role and
+# delete the two AWS_* entries below. The SDK's default credential chain picks the role up with no
+# further configuration, and a role is not a long-lived key sitting in etcd.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: objectfs
+  labels:
+    app.kubernetes.io/name: objectfs
+  # For IRSA, annotate here and drop the AWS_* env entries in the StatefulSet:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/<role>
+---
+# Headless, which is what makes the per-pod DNS records exist. `clusterIP: None` means no virtual IP
+# and no load balancing: instead each pod gets objectfs-<ordinal>.objectfs.<namespace>.svc, which is
+# the name the seed list uses and the name a peer dials. A normal ClusterIP Service would give one
+# address that round-robins across all three, which is the opposite of what gossip needs — a member
+# has to be able to reach one specific peer.
+apiVersion: v1
+kind: Service
+metadata:
+  name: objectfs
+  labels:
+    app.kubernetes.io/name: objectfs
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: objectfs
+  ports:
+    - name: gossip
+      port: 8080
+      targetPort: gossip
+      protocol: TCP
+    - name: health
+      port: 8081
+      targetPort: health
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: objectfs
+  labels:
+    app.kubernetes.io/name: objectfs
+spec:
+  serviceName: objectfs
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: objectfs
+  # Parallel, not the default OrderedReady. OrderedReady starts pod 0, waits for it to be Ready, then
+  # starts pod 1 — and readiness here means the health endpoint answers, which happens after the mount
+  # comes up. Every replica seeds from objectfs-0, so ordered start is not required for the mesh to
+  # form, and parallel start means a three-node cluster is up in one pod's start time rather than
+  # three. It also matters on a rolling restart: OrderedReady would take the cluster down to one node
+  # in the middle of it.
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: objectfs
+    spec:
+      serviceAccountName: objectfs
+      # A FUSE mount is torn down by the process that made it, on a signal. The default 30s is enough
+      # for an idle mount and not for one with buffered writes to flush, and the cost of getting it
+      # wrong is asymmetric: SIGKILL at the end of the grace period leaves the kernel with a mount
+      # whose server is gone, and any dirty range that had not reached S3 is lost. Integrity first.
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: objectfs
+          image: ghcr.io/scttfrdmn/objectfs:latest
+          args:
+            - mount
+            - --config=/etc/objectfs/config.yaml
+            - --foreground
+          ports:
+            - name: gossip
+              containerPort: 8080
+            - name: health
+              containerPort: 8081
+          securityContext:
+            # SYS_ADMIN is mount(2) and cannot be reduced away — mounting is privileged. What *is*
+            # reduced: this is not `privileged: true`, which would grant every capability and every
+            # device, and allowPrivilegeEscalation stays false so a setuid binary inside the container
+            # gains nothing beyond this one capability.
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: false
+            # The image creates and runs as uid 1000. Named here as well as in the image so the
+            # manifest is checkable on its own: a PodSecurity policy or an admission controller reads
+            # this, not the image's USER line.
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            # ---------------------------------------------------------------------------------------
+            # The three per-pod values. This is the reason the cluster environment variables exist:
+            # every pod in this StatefulSet mounts the same ConfigMap, so a per-pod value cannot come
+            # from a config file, and the downward API delivers a pod's own identity as an environment
+            # variable and in no other form.
+            # ---------------------------------------------------------------------------------------
+            - name: OBJECTFS_CLUSTER_ENABLED
+              value: "true"
+            # metadata.name is the pod's ordinal name — objectfs-0, objectfs-1, objectfs-2 — which a
+            # StatefulSet guarantees is stable across reschedules. That stability is what makes it
+            # usable as a cluster identity; a Deployment's generated suffix is not.
+            - name: OBJECTFS_CLUSTER_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # The headless Service's per-pod record, assembled from the two above. Not status.podIP:
+            # a pod IP changes on reschedule, and a peer holding the old one has no way to learn the
+            # new one — it just sees a member that stopped answering. The DNS name survives the
+            # reschedule, which is the whole reason the Service above is headless.
+            - name: OBJECTFS_CLUSTER_ADVERTISE_ADDR
+              value: $(POD_NAME).objectfs.$(POD_NAMESPACE).svc:8080
+            - name: OBJECTFS_CLUSTER_LISTEN_ADDR
+              value: 0.0.0.0:8080
+            # Seed from ordinal 0 only, and every pod including pod 0 itself, which is a no-op rather
+            # than an error. One seed is enough for a mesh to form and it avoids the alternative:
+            # listing all replicas, which would have to be edited every time `replicas` changes and
+            # would silently name pods that do not exist if it were not.
+            - name: OBJECTFS_CLUSTER_SEEDS
+              value: objectfs-0.objectfs.$(POD_NAMESPACE).svc:8080
+            # ---------------------------------------------------------------------------------------
+            # Both listeners off loopback. This is not optional in Kubernetes, and getting it wrong
+            # fails in a way that looks unrelated: the kubelet probes over the *pod IP*, so a health
+            # endpoint bound to 127.0.0.1 refuses the connection, the readiness probe never passes,
+            # and the pod is restarted forever by a liveness probe that could never have succeeded.
+            # Loopback is the right default for a host install of an unauthenticated endpoint
+            # (config.DefaultHealthAddr) and the wrong one here.
+            # ---------------------------------------------------------------------------------------
+            - name: OBJECTFS_HEALTH_ADDR
+              value: 0.0.0.0:8081
+            - name: OBJECTFS_METRICS_ADDR
+              value: 0.0.0.0:8080
+            # The gossip secret. A cluster refuses to start without one, because an unauthenticated
+            # gossip port lets any host that can reach it join and announce ownership of cached
+            # objects (#206) — a peer's announcement is believed, so a hostile member can direct
+            # reads at itself. OBJECTFS_CLUSTER_SECRET takes precedence over cluster.secret_file and
+            # is the form an orchestrator injects; the file form additionally requires mode 0600,
+            # which a projected Secret volume does not give you.
+            - name: OBJECTFS_CLUSTER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: objectfs-cluster
+                  key: secret
+            # Delete these two when using IRSA. See the header.
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: objectfs-s3
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: objectfs-s3
+                  key: secret-access-key
+          # Both probes on /health, with different thresholds rather than different endpoints.
+          #
+          # The failureThreshold difference is the load-bearing part. Readiness failing takes the pod
+          # out of the Service; liveness failing kills it. A mount that is slow to answer because S3
+          # is slow should stop receiving traffic and must not be killed — restarting it discards
+          # buffered writes and does nothing about the backend. So liveness is deliberately far more
+          # patient than readiness.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/objectfs
+              readOnly: true
+            - name: fuse
+              mountPath: /dev/fuse
+            # The mount point itself, and the reason it is a volume rather than just a directory in
+            # the image: `mountPropagation: Bidirectional` is what makes the FUSE mount visible
+            # outside this container. Without it the mount exists only in this container's mount
+            # namespace, so a sidecar or another container in the pod sees an empty directory — which
+            # is the shape almost every real use of this has.
+            #
+            # Bidirectional requires a privileged container in some Kubernetes versions and is
+            # therefore commented out rather than enabled by default; uncomment it, and the matching
+            # entry in volumes, when a consumer needs to see the mount. HostToContainer is the
+            # weaker, safer direction and is not enough here — this pod is the one *creating* the
+            # mount.
+            - name: mountpoint
+              mountPath: /mnt/objectfs
+              # mountPropagation: Bidirectional
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              # No CPU limit, deliberately. A CFS quota throttles a process that is mid-flush, and
+              # what that produces is a FUSE server that stops answering the kernel for tens of
+              # milliseconds at a time — read latency that looks like the backend being slow. The
+              # memory limit stays, because the failure mode there is unbounded growth.
+              memory: 2Gi
+      volumes:
+        - name: config
+          configMap:
+            name: objectfs-config
+        - name: fuse
+          hostPath:
+            path: /dev/fuse
+            type: CharDevice
+        - name: mountpoint
+          emptyDir: {}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1147,6 +1147,78 @@ func getEnvMappings() []envMapping {
 			return nil
 		}},
 
+		// Cluster settings. These five exist because a container orchestrator has no other way to
+		// configure them: three of the five are *per-pod* values, and a ConfigMap is shared by every pod
+		// that mounts it. Kubernetes supplies a pod's own name and IP through the downward API, which
+		// arrives as an environment variable and nothing else — so `node_id` and `advertise_addr` are
+		// reachable from a manifest only through this table. See deploy/kubernetes/statefulset.yaml,
+		// which is the caller.
+		//
+		// OBJECTFS_CLUSTER_ENABLED was documented before it existed, which is why it is first here. Both
+		// sdks/python/README.md and sdks/javascript/README.md told operators to `export
+		// OBJECTFS_CLUSTER_ENABLED=true`, and #146's issue body built a three-node compose file on it
+		// plus _NODE_ID, _ADVERTISE_ADDR and _SEEDS. None of the four were in this table: verified by
+		// calling getEnvMappings() rather than by grep, 24 entries and not one of them. So a deployment
+		// following the documentation got a silent single-node mount — every node up, none of them in a
+		// cluster, and no error anywhere, because an unread variable cannot complain.
+		//
+		// Note the asymmetry with SecretFile, which is deliberate and stays: the secret itself has
+		// OBJECTFS_CLUSTER_SECRET (distributed.ClusterSecretEnv) and no config key, because a secret in
+		// a world-readable config file is published to every user on the node. Here it is the reverse —
+		// the path is configurable and the material is not.
+		{"OBJECTFS_CLUSTER_ENABLED", func(c *Configuration, val string) error {
+			// ParseBool with the error returned, like the two monitoring toggles above and unlike the
+			// feature flags, which coerce anything that is not "true" to false. Same reasoning, and it
+			// applies more strongly here. A typo coerced to false is a node that mounts successfully,
+			// serves reads, and is invisible to every peer — cache announcements go nowhere and
+			// invalidations from other nodes are never received, so it can serve a stale object after a
+			// peer overwrote it. That is an integrity outcome, and refusing to start while naming the
+			// variable is unambiguously better than reaching it.
+			enabled, err := strconv.ParseBool(val)
+			if err != nil {
+				return fmt.Errorf("OBJECTFS_CLUSTER_ENABLED=%q is not a boolean: %w", val, err)
+			}
+
+			c.Cluster.Enabled = enabled
+
+			return nil
+		}},
+		{"OBJECTFS_CLUSTER_NODE_ID", func(c *Configuration, val string) error {
+			c.Cluster.NodeID = val
+			return nil
+		}},
+		{"OBJECTFS_CLUSTER_LISTEN_ADDR", func(c *Configuration, val string) error {
+			c.Cluster.ListenAddr = val
+			return nil
+		}},
+		{"OBJECTFS_CLUSTER_ADVERTISE_ADDR", func(c *Configuration, val string) error {
+			c.Cluster.AdvertiseAddr = val
+			return nil
+		}},
+		// Comma-separated, because the environment holds strings and this field is a []string. The
+		// separator is a comma rather than a space for the reason every seed list in this project uses
+		// one — a shell that splits on whitespace turns one variable into several words, and a
+		// `docker-compose.yaml` or a manifest passing seeds inline would then need quoting that is easy
+		// to get wrong and silent when wrong.
+		//
+		// Empty fields are dropped and each entry is trimmed, so a trailing comma or a value wrapped for
+		// readability across lines does not produce an empty seed. An empty seed is worth avoiding
+		// specifically: it would reach the gossip layer as an address to dial, fail, and be reported as
+		// an unreachable peer rather than as a configuration error.
+		{"OBJECTFS_CLUSTER_SEEDS", func(c *Configuration, val string) error {
+			var seeds []string
+
+			for seed := range strings.SplitSeq(val, ",") {
+				if trimmed := strings.TrimSpace(seed); trimmed != "" {
+					seeds = append(seeds, trimmed)
+				}
+			}
+
+			c.Cluster.SeedNodes = seeds
+
+			return nil
+		}},
+
 		// Read-ahead. Four variables where there were six, matching the four keys the manager reads
 		// (#176). OBJECTFS_READAHEAD_STRATEGY, _PATTERN_DETECTION and _ML_PREDICTION are gone with the
 		// settings they assigned to, and OBJECTFS_READ_AHEAD_SIZE is gone with performance.read_ahead_size

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -493,6 +493,106 @@ func TestLoadFromEnvGovernsTheListeners(t *testing.T) {
 	}
 }
 
+// TestLoadFromEnvConfiguresACluster covers the five cluster variables together.
+//
+// They exist for #146's manifests, and three of the five have no alternative: `node_id` and
+// `advertise_addr` are per-pod, a ConfigMap is shared by every pod that mounts it, and Kubernetes hands
+// a pod its own name and IP through the downward API — which arrives as an environment variable and
+// nothing else. A StatefulSet cannot give each replica a distinct identity any other way.
+//
+// The reason to test them rather than trust the table is that all four of the names #146's issue body
+// used were absent from it, and both SDK READMEs documented OBJECTFS_CLUSTER_ENABLED. The failure that
+// produced was silent in the worst direction: three nodes up, each one a cluster of one, no error
+// anywhere, cache invalidations from peers never received. An unread variable cannot complain.
+//
+// t.Setenv forbids t.Parallel; see the comment on TestLoadFromEnv.
+//
+//nolint:paralleltest // t.Setenv forbids t.Parallel
+func TestLoadFromEnvConfiguresACluster(t *testing.T) {
+	t.Run("each variable reaches the field the cluster reads", func(t *testing.T) {
+		t.Setenv("OBJECTFS_CLUSTER_ENABLED", "true")
+		t.Setenv("OBJECTFS_CLUSTER_NODE_ID", "objectfs-1")
+		t.Setenv("OBJECTFS_CLUSTER_LISTEN_ADDR", "0.0.0.0:8080")
+		t.Setenv("OBJECTFS_CLUSTER_ADVERTISE_ADDR", "10.1.2.3:8080")
+		t.Setenv("OBJECTFS_CLUSTER_SEEDS", "objectfs-0.objectfs:8080,objectfs-1.objectfs:8080")
+
+		cfg := NewDefault()
+		if cfg.Cluster.Enabled {
+			t.Fatal("cluster must default to disabled for the Enabled assertion below to mean anything")
+		}
+
+		if err := cfg.LoadFromEnv(); err != nil {
+			t.Fatalf("LoadFromEnv() error = %v", err)
+		}
+
+		if !cfg.Cluster.Enabled {
+			t.Error("OBJECTFS_CLUSTER_ENABLED=true did not reach cluster.enabled, so a deployment that " +
+				"asks for a cluster gets a silent single-node mount — which is what both SDK READMEs " +
+				"documented before this variable existed")
+		}
+		if cfg.Cluster.NodeID != "objectfs-1" {
+			t.Errorf("cluster.node_id = %q, want the exported value. This one comes from the downward "+
+				"API and has no config-file alternative in a StatefulSet", cfg.Cluster.NodeID)
+		}
+		if cfg.Cluster.ListenAddr != "0.0.0.0:8080" {
+			t.Errorf("cluster.listen_addr = %q, want the exported value", cfg.Cluster.ListenAddr)
+		}
+		if cfg.Cluster.AdvertiseAddr != "10.1.2.3:8080" {
+			t.Errorf("cluster.advertise_addr = %q, want the exported value. A wrong advertise address "+
+				"is a node peers cannot dial back", cfg.Cluster.AdvertiseAddr)
+		}
+
+		wantSeeds := []string{"objectfs-0.objectfs:8080", "objectfs-1.objectfs:8080"}
+		if len(cfg.Cluster.SeedNodes) != len(wantSeeds) {
+			t.Fatalf("cluster.seed_nodes = %v, want %v", cfg.Cluster.SeedNodes, wantSeeds)
+		}
+		for i, want := range wantSeeds {
+			if cfg.Cluster.SeedNodes[i] != want {
+				t.Errorf("cluster.seed_nodes[%d] = %q, want %q", i, cfg.Cluster.SeedNodes[i], want)
+			}
+		}
+	})
+
+	// Whitespace and a trailing comma, which is what a manifest wrapped for readability produces. An
+	// empty seed would reach the gossip layer as an address to dial and be reported as an unreachable
+	// peer rather than as the configuration error it is, so it is dropped here instead.
+	t.Run("the seed list tolerates the whitespace a manifest introduces", func(t *testing.T) {
+		t.Setenv("OBJECTFS_CLUSTER_SEEDS", " a:8080 ,\n b:8080 ,, ")
+
+		cfg := NewDefault()
+		if err := cfg.LoadFromEnv(); err != nil {
+			t.Fatalf("LoadFromEnv() error = %v", err)
+		}
+
+		if len(cfg.Cluster.SeedNodes) != 2 {
+			t.Fatalf("cluster.seed_nodes = %#v, want exactly [a:8080 b:8080] — an empty or untrimmed "+
+				"entry becomes a peer the node dials and reports as unreachable", cfg.Cluster.SeedNodes)
+		}
+		if cfg.Cluster.SeedNodes[0] != "a:8080" || cfg.Cluster.SeedNodes[1] != "b:8080" {
+			t.Errorf("cluster.seed_nodes = %#v, want [a:8080 b:8080]", cfg.Cluster.SeedNodes)
+		}
+	})
+
+	// A non-boolean must fail startup naming the variable, like the two monitoring toggles and unlike
+	// the feature flags, which coerce. The asymmetry is the point and it is stronger here: coerced to
+	// false, the mount succeeds, serves reads, and is invisible to every peer — so it can serve a stale
+	// object after another node overwrote it, having never received the invalidation. Integrity is what
+	// is at stake, not a feature being off.
+	t.Run("OBJECTFS_CLUSTER_ENABLED refuses a non-boolean", func(t *testing.T) {
+		t.Setenv("OBJECTFS_CLUSTER_ENABLED", "yes-please")
+
+		err := NewDefault().LoadFromEnv()
+		if err == nil {
+			t.Fatal("OBJECTFS_CLUSTER_ENABLED=yes-please was accepted. Coerced to false it is a node " +
+				"that mounts, serves reads, and never hears a peer's invalidation — a stale read with " +
+				"nothing logged")
+		}
+		if !contains(err.Error(), "OBJECTFS_CLUSTER_ENABLED") {
+			t.Errorf("the error does not name the variable at fault: %v", err)
+		}
+	})
+}
+
 func TestLoadFromEnv_S3Region(t *testing.T) {
 	// t.Setenv requires sequential execution; no t.Parallel here.
 

--- a/internal/config/deploy_test.go
+++ b/internal/config/deploy_test.go
@@ -1,0 +1,377 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Gates on the deployment manifests in deploy/, which #146 added.
+//
+// These files are the shape of thing this repository has been burned by twice — a shipped artifact that
+// nothing executes. The systemd unit spent a year calling `objectfs s3://%i /mnt/objectfs/%i`, a form
+// that fused the instance name and the bucket into one string, and it passed `systemd-analyze verify`
+// the whole time, because systemd checks that a unit is well-formed systemd and has no idea what flags
+// the program accepts. A Kubernetes manifest has the identical hole: `kubeconform` will happily approve
+// a Pod whose container invokes a subcommand that does not exist and an environment variable nothing
+// reads. Schema-valid and wrong is the default state of a manifest.
+//
+// So the checks here are the ones a schema validator cannot make:
+//
+//   - every objectfs command line in a manifest uses a subcommand the binary dispatches and flags it
+//     parses — scraped from cmd/objectfs/main.go, reusing docs_symbols_test.go's machinery so there is
+//     one definition of "a flag this binary accepts";
+//   - every OBJECTFS_* variable a manifest sets is one getEnvMappings actually reads. This is the
+//     check that caught the defect #146 was built on: the issue body's compose file set four cluster
+//     variables and *none* of them existed, so a three-node deployment would have come up as three
+//     independent single-node mounts with no error anywhere. Both SDK READMEs documented one of them.
+//     An unread variable cannot complain, which is why something has to ask on its behalf;
+//   - the embedded config in the ConfigMap loads, under the same strict unmarshal a real mount uses;
+//   - the health endpoint is off loopback in every pod spec, because the kubelet probes over the pod
+//     IP and a 127.0.0.1 listener refuses it — a pod restarted forever by a probe that could never
+//     have passed.
+//
+// What is deliberately not here: applying any of this. That needs a cluster, and a CI job that stands
+// one up is worth having separately. These run wherever `go test` does.
+
+// deployManifests are the files under test, relative to the module root.
+var deployManifests = []string{
+	"deploy/docker/docker-compose.yaml",
+	"deploy/docker/node-config.yaml",
+	"deploy/kubernetes/configmap.yaml",
+	"deploy/kubernetes/daemonset.yaml",
+	"deploy/kubernetes/statefulset.yaml",
+}
+
+// envVarRef matches an OBJECTFS_* variable name wherever it appears in a manifest.
+var envVarRef = regexp.MustCompile(`OBJECTFS_[A-Z0-9_]+`)
+
+// TestDeployManifestsExist fails before any subtest can pass vacuously.
+//
+// Every assertion below iterates over files or over matches within them, and each of those loops
+// passes trivially on an empty set. A rename that moved deploy/ would otherwise turn this whole file
+// green, which is the failure mode it is here to prevent.
+func TestDeployManifestsExist(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	for _, rel := range deployManifests {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Errorf("%s is missing: %v. Every check in deploy_test.go loops over these files, so a "+
+				"moved or renamed manifest makes them all pass on an empty set", rel, err)
+		}
+	}
+}
+
+// TestDeployManifestsSetOnlyEnvVarsTheBinaryReads is the check kubeconform cannot make.
+//
+// #146's issue body specified OBJECTFS_CLUSTER_ENABLED, _NODE_ID, _ADVERTISE_ADDR and _SEEDS, and
+// getEnvMappings held none of the four — verified by calling it rather than by reading the file. A
+// manifest built on that spec produces the worst available outcome: three pods that start cleanly,
+// mount successfully, serve reads, and are each a cluster of one. No error, because nothing read the
+// variable, and cache invalidations from peers are simply never received — so a node can serve an
+// object another node has already overwritten.
+//
+// The variables now exist. This is what keeps them and the manifests from drifting apart again in
+// either direction: a renamed mapping fails here, and so does a manifest that invents a name.
+func TestDeployManifestsSetOnlyEnvVarsTheBinaryReads(t *testing.T) {
+	t.Parallel()
+
+	read := make(map[string]bool, len(getEnvMappings()))
+	for _, m := range getEnvMappings() {
+		read[m.envVar] = true
+	}
+
+	if len(read) == 0 {
+		t.Fatal("getEnvMappings() returned nothing, so every name below would be reported as " +
+			"unread and the failures would all be about this test rather than about the manifests")
+	}
+
+	// Variables read somewhere other than the config table. Each is genuinely consumed, just not by
+	// LoadFromEnv, so a manifest may legitimately set it.
+	//
+	// OBJECTFS_CLUSTER_SECRET is the interesting one and the asymmetry is deliberate: it is read by
+	// distributed.LoadClusterSecret (as ClusterSecretEnv) and has no config-file key at all, because a
+	// secret written into a world-readable config file is published to every user on the node. Here it
+	// is the reverse of the other cluster settings — the material is in the environment and the path
+	// is in the file.
+	readElsewhere := map[string]string{
+		"OBJECTFS_CLUSTER_SECRET": "distributed.LoadClusterSecret, via ClusterSecretEnv",
+		"OBJECTFS_CONFIG":         "the systemd unit, which passes it to --config",
+	}
+
+	root := repoRoot(t)
+
+	for _, rel := range deployManifests {
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+
+			body := readDeployManifest(t, root, rel)
+
+			seen := make(map[string]bool)
+			for _, name := range envVarRef.FindAllString(body, -1) {
+				if seen[name] {
+					continue
+				}
+
+				seen[name] = true
+
+				if read[name] || readElsewhere[name] != "" {
+					continue
+				}
+
+				t.Errorf("%s names %s, which nothing reads. getEnvMappings() has no entry for it and "+
+					"it is not in readElsewhere, so a deployment setting it gets silence — the pod "+
+					"starts, the setting has no effect, and nothing reports it. This is exactly how "+
+					"#146's spec came to name four cluster variables that did not exist. Either wire "+
+					"it in getEnvMappings or stop setting it here.", rel, name)
+			}
+		})
+	}
+}
+
+// TestDeployManifestsInvokeTheRealBinary is the systemd-unit check, applied to containers.
+//
+// Same defect class and the same reasoning as TestSystemdUnitInvokesTheRealBinary: a schema validator
+// approves any string in an args list. The scraped sets come from cmd/objectfs/main.go through
+// docs_symbols_test.go's cliFlags, so this compares against the binary rather than against a list
+// somebody maintains.
+func TestDeployManifestsInvokeTheRealBinary(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	//nolint:gosec // a path built from the module root this test located itself
+	mainGo, err := os.ReadFile(filepath.Join(root, "cmd", "objectfs", "main.go"))
+	if err != nil {
+		t.Fatalf("reading cmd/objectfs/main.go, which declares the flags: %v", err)
+	}
+
+	subcommands := dispatchedSubcommands(t, string(mainGo))
+	if len(subcommands) == 0 {
+		t.Fatal("scraped no subcommands from cmd/objectfs/main.go; without them the loop below " +
+			"approves anything")
+	}
+
+	// The one argument in these manifests that is neither a flag nor a subcommand: the mount's own
+	// config path, which reaches the binary as --config=<path> and is checked separately by
+	// TestDeployConfigMapConfigLoads.
+	var checkedCommands int
+
+	for _, rel := range deployManifests {
+		if !strings.HasSuffix(rel, ".yaml") || strings.HasSuffix(rel, "node-config.yaml") {
+			continue
+		}
+
+		body := readDeployManifest(t, root, rel)
+
+		// The args are YAML list items, one token per line: `- mount`, `- --foreground`. Parsing them
+		// out of the raw text rather than through a typed unmarshal keeps this working across the two
+		// schemas in play (compose's `command:` and Kubernetes' `args:`) without modeling either.
+		inArgs := false
+
+		for raw := range strings.SplitSeq(body, "\n") {
+			line := strings.TrimSpace(raw)
+
+			switch {
+			case strings.HasPrefix(line, "command:"), strings.HasPrefix(line, "args:"):
+				inArgs = true
+
+				continue
+			case line == "" || strings.HasPrefix(line, "#"):
+				continue
+			case !strings.HasPrefix(line, "- "):
+				// Any non-list line ends the block. A `command:` with a string value on the same line
+				// is not a form these manifests use, and would show up as an uninspected command
+				// rather than as a false pass, because checkedCommands would not advance.
+				inArgs = false
+
+				continue
+			}
+
+			if !inArgs {
+				continue
+			}
+
+			token := strings.TrimSpace(strings.TrimPrefix(line, "- "))
+
+			// Flags may be --flag or --flag=value; only the name is checked here.
+			if strings.HasPrefix(token, "-") {
+				name := strings.TrimLeft(token, "-")
+				name, _, _ = strings.Cut(name, "=")
+
+				if !cliFlags[name] {
+					t.Errorf("%s passes --%s, which the binary does not parse. flag.Parse exits 1 on "+
+						"an unknown flag, so this is a container that crash-loops with a usage "+
+						"message — and every schema validator approves it", rel, name)
+				}
+
+				checkedCommands++
+
+				continue
+			}
+
+			// A bare token in an args block is either the subcommand or something like a bucket URI.
+			// Only the first is checked, and a subcommand is what these manifests start with.
+			if subcommands[token] {
+				checkedCommands++
+			}
+		}
+	}
+
+	// Mutation-proofing: this whole loop is text matching, and a change to the manifests' formatting
+	// would make it inspect nothing while still passing. The floor is deliberately loose — it only has
+	// to be high enough that "found no args at all" fails.
+	if checkedCommands < 6 {
+		t.Errorf("inspected only %d command tokens across the manifests, which is fewer than the "+
+			"`mount --config --foreground` in each of the two pod specs. The args blocks are being "+
+			"parsed out of raw YAML text, so a formatting change can silently stop matching — that "+
+			"is what this floor is for", checkedCommands)
+	}
+}
+
+// TestDeployConfigMapConfigLoads runs the embedded config through the real loader.
+//
+// The ConfigMap's config.yaml is a string inside a YAML document, so nothing about it is checked by
+// validating the manifest: kubeconform sees a valid `data` map with a valid string value. But
+// LoadFromFile uses yaml.UnmarshalStrict, so a key that does not exist fails a real mount at load —
+// which means an invented or renamed key in here is a pod that starts and immediately exits, and the
+// only place it can be caught before deployment is a test that loads it.
+func TestDeployConfigMapConfigLoads(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	//nolint:gosec // a path built from the module root this test located itself
+	raw, err := os.ReadFile(filepath.Join(root, "deploy", "kubernetes", "configmap.yaml"))
+	if err != nil {
+		t.Fatalf("reading the ConfigMap: %v", err)
+	}
+
+	var manifest struct {
+		Data map[string]string `yaml:"data"`
+	}
+
+	if err := yaml.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("the ConfigMap is not parseable YAML: %v", err)
+	}
+
+	embedded, ok := manifest.Data["config.yaml"]
+	if !ok || strings.TrimSpace(embedded) == "" {
+		t.Fatal("deploy/kubernetes/configmap.yaml has no non-empty data[\"config.yaml\"]. The pods " +
+			"mount that key at /etc/objectfs/config.yaml and pass it to --config, so an empty or " +
+			"renamed key is a mount that fails at startup")
+	}
+
+	// Written to a file and loaded through LoadFromFile rather than unmarshalled here, so this
+	// exercises the same strict decode and the same validation a real mount does. A hand-rolled
+	// unmarshal would accept keys the mount rejects, which is the agreement under test.
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(embedded), 0o600); err != nil {
+		t.Fatalf("writing the embedded config: %v", err)
+	}
+
+	cfg := NewDefault()
+	if err := cfg.LoadFromFile(path); err != nil {
+		t.Fatalf("the config the pods mount does not load: %v\n\nLoadFromFile uses "+
+			"yaml.UnmarshalStrict, so an unknown key fails here exactly as it would fail the pod at "+
+			"startup", err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("the config the pods mount does not validate: %v", err)
+	}
+
+	// The one setting whose default is wrong in a container, asserted on the loaded value rather than
+	// on the file text. See TestDeployPodsBindHealthOffLoopback for why; here the point is that the
+	// ConfigMap is *allowed* to keep the loopback default because both pod specs override it, and this
+	// records which of the two is doing the work.
+	if cfg.Monitoring.HealthChecks.Addr != DefaultHealthAddr {
+		t.Logf("the ConfigMap now sets health_checks.addr = %q rather than leaving the loopback "+
+			"default; the pod specs' OBJECTFS_HEALTH_ADDR override is then redundant rather than "+
+			"load-bearing", cfg.Monitoring.HealthChecks.Addr)
+	}
+}
+
+// TestDeployPodsBindHealthOffLoopback pins the setting whose default is wrong in a pod.
+//
+// config.DefaultHealthAddr is 127.0.0.1:8081, which is the right default for a host install of an
+// unauthenticated endpoint and unusable in Kubernetes: the kubelet probes over the *pod IP*, so a
+// loopback listener refuses the connection. The readiness probe then never passes and the liveness
+// probe kills the pod, forever, over an endpoint that could never have answered. Nothing in the
+// manifest looks wrong — the probe names the right port and the right path.
+//
+// Checked on the manifest text rather than through a typed unmarshal because what matters is that the
+// override is present in each pod spec, and there are two of them in separate files.
+func TestDeployPodsBindHealthOffLoopback(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	for _, rel := range []string{
+		"deploy/kubernetes/daemonset.yaml",
+		"deploy/kubernetes/statefulset.yaml",
+		// Compose's healthcheck runs *inside* the container, where loopback would work — but the port
+		// is published, and a loopback listener is not reachable from the host either. Same override,
+		// same reason.
+		"deploy/docker/docker-compose.yaml",
+	} {
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+
+			body := readDeployManifest(t, root, rel)
+
+			if !strings.Contains(body, "OBJECTFS_HEALTH_ADDR") {
+				t.Fatalf("%s never sets OBJECTFS_HEALTH_ADDR, so the health endpoint keeps its "+
+					"loopback default (%s). In Kubernetes that is a pod the kubelet cannot probe: "+
+					"readiness never passes and liveness restarts it forever, over an endpoint that "+
+					"refused the connection by design", rel, DefaultHealthAddr)
+			}
+
+			// The variable being present is not enough — it has to be set to something that is not
+			// loopback, which is the mistake worth catching: an override copied from the config file.
+			for line := range strings.SplitSeq(body, "\n") {
+				if !strings.Contains(line, "OBJECTFS_HEALTH_ADDR") {
+					continue
+				}
+				// The `value:` is on the following line in the Kubernetes form, so only the compose
+				// form has the address on this one. Checking what is here is enough to catch the
+				// copied default; the Kubernetes form is checked by the next loop.
+				if strings.Contains(line, "127.0.0.1") || strings.Contains(line, "localhost") {
+					t.Errorf("%s sets OBJECTFS_HEALTH_ADDR to a loopback address: %s", rel,
+						strings.TrimSpace(line))
+				}
+			}
+
+			if strings.Contains(body, "value: 127.0.0.1:8081") {
+				t.Errorf("%s has a `value: 127.0.0.1:8081`, which is the loopback default in an env "+
+					"override — the override is present and does nothing", rel)
+			}
+		})
+	}
+}
+
+// readDeployManifest reads one manifest, failing rather than returning an empty string.
+//
+// The distinction matters here more than usual: every caller then searches the text for something, and
+// a missing file returning "" would make every one of those searches find nothing and report success.
+func readDeployManifest(t *testing.T, root, rel string) string {
+	t.Helper()
+
+	//nolint:gosec // a path built from the module root this test located itself
+	body, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatalf("reading %s: %v", rel, err)
+	}
+
+	if len(body) == 0 {
+		t.Fatalf("%s is empty, and every assertion against it would pass", rel)
+	}
+
+	return string(body)
+}


### PR DESCRIPTION
Closes #146.

`deploy/` was an empty directory. It now holds a StatefulSet, a DaemonSet, a headless Service and a ConfigMap for Kubernetes, plus a three-node Compose cluster over MinIO for local development.

## Four of the environment variables this was to be built on did not exist

#146's spec configured its nodes with `OBJECTFS_CLUSTER_ENABLED`, `_NODE_ID`, `_ADVERTISE_ADDR` and `_SEEDS`. `getEnvMappings` had **none** of them — established by calling it rather than by grep: 24 mappings, no cluster entries. Both `sdks/python/README.md` and `sdks/javascript/README.md` already told operators to export the first one.

That is the worst available failure shape. Every pod starts, mounts, and serves reads, each one a cluster of one, with no error anywhere — because an unread variable cannot complain. Cache invalidations from peers are never received, so a node serves an object another node has already overwritten.

Five are now read (`_LISTEN_ADDR` is the fifth). `_ENABLED` uses `ParseBool` and **returns** the error, joining the monitoring toggles rather than the feature flags that coerce anything but `"true"` to false — the asymmetry is an integrity argument, since coerced to false it is a mount that succeeds, serves reads, and is invisible to every peer. `_SEEDS` is comma-separated, trimmed, empties dropped, so a manifest wrapped across lines cannot produce an empty seed (which would reach gossip as an address to dial and be reported as an unreachable peer rather than as the configuration error it is).

## Three places this departs from the issue body

**A StatefulSet, where #146 specified a DaemonSet — and both ship.** A clustered node needs a stable identity: `node_id` names it in gossip, `advertise_addr` is what peers dial back, and a seed list must name something still there after a restart. A DaemonSet's pods get generated names that change on reschedule and no per-pod DNS, so no seed list can be written. A StatefulSet plus a headless Service gives ordinal names and resolvable records. `advertise_addr` comes from the DNS name and not `status.podIP`, because a pod IP changes on reschedule and a peer holding the old one only sees a member that stopped answering. The DaemonSet stays for the genuinely uncoordinated case — one independent mount per host — and says plainly that those nodes exchange no invalidations, so each cache is its own until `cache.ttl` expires.

**MinIO, not LocalStack.** Coordination rests on conditional writes, and a conditional write is a *correctness* capability: per the project thesis it fails closed rather than degrading, so an endpoint that accepts `If-None-Match` and ignores it does not give a slower cluster but two nodes each believing it holds the same exclusive claim. `docs/design/conditional-write-compatibility.md` is the probed matrix — MinIO is a measured row, LocalStack is not. Building the development environment on an unmeasured endpoint would make it the one place a coordination bug is invisible.

**`replicas: 3` with per-pod identity from the downward API.** This is the second reason the env vars must exist: one ConfigMap is shared by every replica, so a per-pod value cannot come from a config file, and Kubernetes delivers a pod's own name and namespace as environment variables and in no other form.

## Two settings that are invisible until they are wrong

- **`OBJECTFS_HEALTH_ADDR` moves health off loopback.** `DefaultHealthAddr` is `127.0.0.1:8081` — right for a host install of an unauthenticated endpoint, unusable in a pod. The kubelet probes over the pod IP, gets a refused connection, never passes readiness, and the pod is restarted forever by a liveness probe that could not have succeeded, while the manifest names the right port and path throughout.
- **`terminationGracePeriodSeconds: 120`, not the default 30.** A FUSE mount is unmounted by its own process on a signal. SIGKILL at the end of the grace period leaves the kernel holding a mount whose server is gone and loses any dirty range that had not reached S3. Liveness is also far more patient than readiness (10 failures vs 3): readiness failing removes a pod from a Service, liveness failing kills it — discarding buffered writes and doing nothing about a slow backend.

## The gate, split the way `systemd-unit` is

`kubeconform` approves all five resources here and would equally approve a container invoking a subcommand that does not exist — the same hole `systemd-analyze verify` left in the shipped unit for a year. Schema-valid and wrong is a manifest's default state.

`internal/config/deploy_test.go` checks what a schema cannot: subcommands and flags scraped from `cmd/objectfs/main.go`, every `OBJECTFS_*` name read by something (in both directions), the ConfigMap's embedded config loading through the real `LoadFromFile` strict unmarshal, and health bound off loopback in every pod spec. A new `deploy-manifests` CI job adds what Go cannot: `kubeconform -strict`, and `docker compose config` to expand the anchors and confirm three *distinct* node identities.

## Verification

Every gate mutation-verified — inventing an env var, misspelling a flag, dropping the health override, typo'ing a config key, deleting one node's identity override, and unquoting the secret each fail with the intended diagnostic, and each file restores clean.

- `kubeconform -strict` → 5/5 valid
- `objectfs mount --config deploy/docker/node-config.yaml --dry-run` → validates
- `go test -race ./...` → no FAIL, panic, or DATA RACE
- `golangci-lint run` → 0 issues
- coverage gate → 35 packages at or above floor, `internal/config` 91.9% (floor 88%)
- the CI job's shell logic run locally, and both of its assertions mutation-checked

`docker compose config` earned its place by finding a defect in my own file: the placeholder secret was 64 **unquoted** zeros, which YAML reads as the integer `0` and renders back as `"0"`. A one-byte secret fails `minSecretLen` while nothing in the file appears to set it — and a real `openssl rand -hex 32` value would almost never reproduce it, since it usually contains a letter. Quoted now, and the CI job asserts the resolved length.

## Not in scope

Applying any of this. That needs a cluster and a FUSE-capable runner, and is worth its own job rather than a half-measure here. The `mountPropagation: Bidirectional` lines are shipped commented, since they require a privileged container on some versions and a hostPath a pod mounts over deserves an operator's deliberate decision.