### PR TITLE
feat(config): refuse a wildcard advertise_addr, and an operator guide for clustering (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Validation for the `cluster:` config block, a cluster section in `objectfs mount --dry-run`, and
+  `docs/admin-guide/distributed.md`** ([#152]). Nothing validated this block before: `Validate` checked
+  storage, cache, network, monitoring and mount, and returned before reaching clustering. Four states
+  are now refused at startup and two are warned about, and which of the two lists a setting belongs on
+  is decided by whether there is any deployment in which it is correct.
+
+  The one worth reading is **a wildcard `advertise_addr`, which is now refused**. `listen_addr`
+  defaults to `0.0.0.0:8080` and `advertise_addr` is the next key in the file, so copying the value
+  down is the obvious mistake — and it is the worst one available. `advertise_addr` is what peers are
+  told to dial, and a peer that dials a wildcard reaches *its own loopback*: measured with
+  `net.DialUDP`, `0.0.0.0:8080` resolves to `remote=127.0.0.1:8080` and `[::]:8080` to
+  `remote=[::1]:8080`, and the dial **succeeds**. Since gossip is one-way UDP, no send fails and no
+  reply is expected, so a three-node cluster becomes three clusters of one, each mounting, serving
+  reads and reporting healthy — and each able to serve an object a peer has already overwritten. A
+  data-integrity outcome with no error anywhere is the kind this project fails closed on.
+
+  Also refused: a **negative `replication_factor`** (`applyConfigDefaults` only substitutes for `0`, so
+  a negative value survives, `LoadBalancer.SelectNodes` returns no nodes for any count `<= 0`, and every
+  write fails with `no target nodes selected` — naming neither the key nor the value), a
+  **non-host:port** address, a **non-numeric port**, and **port 0 on `advertise_addr`**. Port 0 is
+  allowed on `listen_addr`, because the asymmetry is real and measured: `ListenUDP` on `127.0.0.1:0`
+  binds and the kernel assigns a port, while `DialUDP` to `127.0.0.1:0` fails with `can't assign
+  requested address`. That is why this does not reuse `validateListenAddr` — its port-0 advice is
+  correct for a monitoring endpoint and wrong here.
+
+  Two settings are **warnings on `--dry-run`, not errors**, because each is right in one deployment and
+  wrong in another: an empty `seed_nodes` is how the first node of a new cluster is configured, and a
+  loopback `advertise_addr` is what `NewDefault` sets and what the shipped Compose file uses. Refusing
+  either would break a real deployment; ignoring either ships a silent partition. Warnings go to stderr
+  and **the exit code stays 0**, so a config-management tool can still bring up a first node.
+
+  The dry-run section prints the resolved block — including an empty `node_id` rendered as `(generated
+  at startup, new on every restart)` — and reports the cluster secret **by source, never by value**:
+  `from OBJECTFS_CLUSTER_SECRET`, `from <path>`, or `not configured — the cluster will refuse to
+  start`. A dry run is the kind of output that gets pasted into an issue, and which of the two sources
+  is in use is the hardest thing to establish from outside, since the environment leaves no trace in
+  the file.
+
+  Three of the six documentation sections #152 asked for **could not be written, and are not faked**.
+  `cluster.persistent_log`, `cluster.data_dir` and `peer_fetch_timeout` have zero occurrences in the
+  tree, so the in-memory-to-persistent-log upgrade procedure describes nothing; the consistency-modes
+  section is replaced by CAS-against-S3, because `ConsistencyEventual`/`Session`/`Strong` were removed
+  in 0.12.0 and survive only as a comment recording their removal. The issue's own proposed check —
+  `enabled && advertise_addr == ""` — can never fire, verified by calling `Validate`: `NewDefault` sets
+  the field and `applyConfigDefaults` sets it again. The page's limitations section lists what is
+  absent instead, including that the cache-sizing formula must **not** multiply by
+  `replication_factor`: the cluster makes no copies, S3 holds the single one, and the factor is a
+  selection width.
+
 - **`.deb` and `.rpm` packages, and the uninstall script they make reachable** ([#207], [#137]).
   `make package-linux` builds both formats for amd64 and arm64 from one `nfpm.yaml`. The package
   installs the binary to `/usr/bin`, the systemd template unit to `/usr/lib/systemd/system` (the
@@ -3226,6 +3275,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#142]: https://github.com/scttfrdmn/objectfs/issues/142
 [#143]: https://github.com/scttfrdmn/objectfs/issues/143
 [#150]: https://github.com/scttfrdmn/objectfs/issues/150
+[#152]: https://github.com/scttfrdmn/objectfs/issues/152
 [#207]: https://github.com/scttfrdmn/objectfs/issues/207
 [#137]: https://github.com/scttfrdmn/objectfs/issues/137
 [#145]: https://github.com/scttfrdmn/objectfs/issues/145

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   write fails with `no target nodes selected` — naming neither the key nor the value), a
   **non-host:port** address, a **non-numeric port**, and **port 0 on `advertise_addr`**. Port 0 is
   allowed on `listen_addr`, because the asymmetry is real and measured: `ListenUDP` on `127.0.0.1:0`
-  binds and the kernel assigns a port, while `DialUDP` to `127.0.0.1:0` fails with `can't assign
-  requested address`. That is why this does not reuse `validateListenAddr` — its port-0 advice is
-  correct for a monitoring endpoint and wrong here.
+  binds and the kernel assigns a port, which is what `internal/distributed`'s own tests configure and
+  what `ClusterManager.GossipAddr` exists to report back. An advertised port 0 is an address no peer can
+  deliver to, and the platforms differ only in where that surfaces — darwin refuses the dial with
+  `can't assign requested address`, while **Linux dials and sends successfully and the datagram goes
+  nowhere**, reported at neither end. Linux is the worse case and the one CI runs, which is why the
+  refusal is not conditioned on a dial probe: the first version of the test required the dial to fail
+  and passed locally on darwin while failing in CI, which is the whole argument for measuring on the
+  target platform rather than the development one. This is also why the check does not reuse
+  `validateListenAddr` — its port-0 advice is correct for a monitoring endpoint and wrong here.
 
   Two settings are **warnings on `--dry-run`, not errors**, because each is right in one deployment and
   wrong in another: an empty `seed_nodes` is how the first node of a new cluster is configured, and a

--- a/README.md
+++ b/README.md
@@ -597,6 +597,20 @@ writes, which fail closed rather than degrading, and MinIO is a measured row in
 LocalStack is not. A green Compose run means the mesh forms — not that behavior is correct on AWS,
 which is what the integration suite is for.
 
+### Distributed mode
+
+[docs/admin-guide/distributed.md](docs/admin-guide/distributed.md) is the operator's guide: every
+`cluster:` key with its default, how to size a cache per node, growing and shrinking a cluster, and
+what clustering deliberately does not do. Read the limitations section first if you are deciding
+whether to deploy it — `internal/distributed` is experimental, and the parts an earlier design named
+that do not exist are listed there rather than described.
+
+The failure mode to know about before anything else: a misconfigured cluster does not fail. Each node
+comes up as a cluster of one, mounts, serves reads, and reports healthy while receiving no cache
+invalidation from any peer — so it can serve an object another node has already overwritten. Gossip is
+one-way UDP, so there is no handshake to fail. `objectfs mount --dry-run` prints the resolved cluster
+block and warns about the two settings that cause it.
+
 ### Cost estimation and institutional discounts
 
 Storage-cost estimates use a built-in rate table, and an institution with negotiated rates can

--- a/cmd/objectfs/dryrun_cluster_test.go
+++ b/cmd/objectfs/dryrun_cluster_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/objectfs/internal/distributed"
+)
+
+// Gates on the cluster section of `objectfs mount --dry-run`, which #152 added.
+//
+// The section carries the two checks that could not go in Validate. A cluster with no seeds and a
+// cluster advertising a loopback address are both *legal and often correct* — the first node of a new
+// cluster has nothing to seed from, and the shipped compose file advertises loopback on purpose — so
+// refusing either would break real deployments. But on any other node each one means the cluster
+// silently never formed: the node mounts, serves reads, reports healthy, and receives no invalidation
+// from any peer, so it can serve an object another node has already overwritten.
+//
+// A warning is the only honest answer to a value that is right for one deployment and wrong for
+// another, and --dry-run is where an operator is already reading output. That makes these assertions
+// load-bearing rather than cosmetic: the warning is the entire mechanism.
+
+// dryRunConfig writes a config file with the given cluster block and returns its path.
+func dryRunConfig(t *testing.T, clusterBlock string) string {
+	t.Helper()
+
+	doc := `storage:
+  s3:
+    region: us-west-2
+mount:
+  uri: s3://objectfs-example
+  mount_point: /mnt/objectfs
+` + clusterBlock
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	return path
+}
+
+// TestDryRunPrintsNothingAboutAClusterThatIsOff is the noise check, and it is why the section is
+// conditional.
+//
+// cluster.enabled is false for almost every ObjectFS mount. A block of "enabled: false" followed by six
+// empty values, printed by the command an operator runs to check whether their config file is good, is
+// output that makes the answer harder to find.
+func TestDryRunPrintsNothingAboutAClusterThatIsOff(t *testing.T) {
+	t.Parallel()
+
+	path := dryRunConfig(t, "")
+
+	code, stdout, stderr := runArgs(t, "mount", "--config", path, "--dry-run")
+	if code != exitOK {
+		t.Fatalf("--dry-run exited %d, want 0. stdout: %q stderr: %q", code, stdout, stderr)
+	}
+
+	if strings.Contains(stdout, "Cluster config") {
+		t.Errorf("--dry-run printed a cluster section for a mount with clustering off:\n%s", stdout)
+	}
+
+	if strings.Contains(stderr, "warning") {
+		t.Errorf("--dry-run warned about a cluster that is not enabled: %q", stderr)
+	}
+}
+
+// TestDryRunPrintsTheResolvedClusterBlock asserts the values, and that the secret is not one of them.
+func TestDryRunPrintsTheResolvedClusterBlock(t *testing.T) {
+	t.Parallel()
+
+	secret := filepath.Join(t.TempDir(), "cluster.secret")
+	if err := os.WriteFile(secret, []byte(strings.Repeat("a", 64)), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	path := dryRunConfig(t, `cluster:
+  enabled: true
+  node_id: node-1
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 10.0.1.1:8080
+  seed_nodes:
+    - 10.0.1.2:8080
+    - 10.0.1.3:8080
+  replication_factor: 3
+  secret_file: `+secret+"\n")
+
+	code, stdout, stderr := runArgs(t, "mount", "--config", path, "--dry-run")
+	if code != exitOK {
+		t.Fatalf("--dry-run exited %d, want 0. stdout: %q stderr: %q", code, stdout, stderr)
+	}
+
+	for _, want := range []string{
+		"Cluster config",
+		"node_id:",
+		"node-1",
+		"listen_addr:",
+		"0.0.0.0:8080",
+		"advertise_addr:",
+		"10.0.1.1:8080",
+		"seed_nodes:",
+		"10.0.1.2:8080, 10.0.1.3:8080",
+		"replication_factor: 3",
+		secret,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("--dry-run output does not contain %q:\n%s", want, stdout)
+		}
+	}
+
+	// The secret's *path* is printed and its contents are not. A dry run is the kind of thing that gets
+	// pasted into an issue.
+	if strings.Contains(stdout, strings.Repeat("a", 64)) {
+		t.Error("--dry-run printed the cluster secret itself. The path is what an operator needs; the " +
+			"material is what ends up in a pasted terminal log")
+	}
+
+	// This configuration is correct, so it must produce no warnings at all — otherwise the warnings
+	// below mean nothing, because every cluster would emit them.
+	if strings.Contains(stderr, "warning") {
+		t.Errorf("a well-formed cluster config produced warnings, which makes every warning noise: %q",
+			stderr)
+	}
+}
+
+// TestDryRunWarnsAboutAClusterOfOne covers the two legal-but-usually-wrong values.
+//
+// Both are warnings rather than errors and both exit 0, which is the part worth pinning: a
+// config-management tool that treated either as a failure could not bring up the first node of any
+// cluster, and one that never saw them would deploy a silent partition.
+func TestDryRunWarnsAboutAClusterOfOne(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no seed nodes", func(t *testing.T) {
+		t.Parallel()
+
+		path := dryRunConfig(t, `cluster:
+  enabled: true
+  node_id: node-1
+  advertise_addr: 10.0.1.1:8080
+`)
+
+		code, stdout, stderr := runArgs(t, "mount", "--config", path, "--dry-run")
+		if code != exitOK {
+			t.Fatalf("--dry-run exited %d for a cluster with no seeds, want 0: an empty seed list is how "+
+				"the first node of a new cluster is configured. stderr: %q", code, stderr)
+		}
+
+		if !strings.Contains(stdout, "seed_nodes:         (none)") {
+			t.Errorf("the resolved output does not show that the seed list is empty:\n%s", stdout)
+		}
+
+		if !strings.Contains(stderr, "cluster.seed_nodes is empty") {
+			t.Errorf("no warning about an empty seed list: %q\n\nWithout it the node forms a cluster of "+
+				"one, mounts, reports healthy, and receives no peer invalidations — with nothing "+
+				"anywhere saying so", stderr)
+		}
+	})
+
+	t.Run("loopback advertise address", func(t *testing.T) {
+		t.Parallel()
+
+		path := dryRunConfig(t, `cluster:
+  enabled: true
+  node_id: node-1
+  advertise_addr: 127.0.0.1:8080
+  seed_nodes:
+    - 10.0.1.2:8080
+`)
+
+		code, _, stderr := runArgs(t, "mount", "--config", path, "--dry-run")
+		if code != exitOK {
+			t.Fatalf("--dry-run exited %d for a loopback advertise address, want 0: it is what "+
+				"deploy/docker/docker-compose.yaml uses and what NewDefault sets. stderr: %q", code, stderr)
+		}
+
+		if !strings.Contains(stderr, "cluster.advertise_addr is 127.0.0.1:8080") {
+			t.Errorf("no warning about a loopback advertise address: %q\n\nThis is also the default "+
+				"value, so a config file that enables clustering and sets nothing else lands here", stderr)
+		}
+	})
+}
+
+// TestDryRunSaysWhenNoClusterSecretIsConfigured covers the value whose absence stops the mount.
+//
+// A cluster refuses to start without a secret (#206), from OBJECTFS_CLUSTER_SECRET or from
+// cluster.secret_file. Neither is visible in a config file when the environment is the source, which
+// makes "which one is in use" the single hardest thing to establish from outside — and "not configured"
+// the most useful thing --dry-run can say, because it is the difference between a mount that works and
+// one that fails at startup.
+func TestDryRunSaysWhenNoClusterSecretIsConfigured(t *testing.T) {
+	// No t.Parallel: t.Setenv forbids it, and this has to control the environment variable because a
+	// developer with it exported would otherwise see the other branch.
+	t.Setenv(distributed.ClusterSecretEnv, "")
+
+	path := dryRunConfig(t, `cluster:
+  enabled: true
+  node_id: node-1
+  advertise_addr: 10.0.1.1:8080
+  seed_nodes:
+    - 10.0.1.2:8080
+`)
+
+	code, stdout, _ := runArgs(t, "mount", "--config", path, "--dry-run")
+	if code != exitOK {
+		t.Fatalf("--dry-run exited %d, want 0", code)
+	}
+
+	if !strings.Contains(stdout, "not configured") {
+		t.Errorf("--dry-run does not report a missing cluster secret:\n%s\n\nThe mount will refuse to "+
+			"start, and this is the check that exists to say so beforehand", stdout)
+	}
+
+	t.Run("and names the environment when that is the source", func(t *testing.T) {
+		t.Setenv(distributed.ClusterSecretEnv, strings.Repeat("b", 64))
+
+		_, stdout, _ := runArgs(t, "mount", "--config", path, "--dry-run")
+
+		if !strings.Contains(stdout, distributed.ClusterSecretEnv) {
+			t.Errorf("--dry-run does not name the environment variable the secret came from:\n%s", stdout)
+		}
+
+		if strings.Contains(stdout, strings.Repeat("b", 64)) {
+			t.Error("--dry-run printed the secret from the environment")
+		}
+	})
+}
+
+// TestClusterSecretEnvMatchesTheDistributedPackage pins the duplicated constant.
+//
+// cmd/objectfs declares its own clusterSecretEnv rather than importing distributed for one string. That
+// is fine right up until one of the two changes, at which point --dry-run reports "not configured" for
+// a secret that is configured — a warning about a problem that does not exist, which is worse than
+// silence because it sends an operator to look at a correct setting.
+func TestClusterSecretEnvMatchesTheDistributedPackage(t *testing.T) {
+	t.Parallel()
+
+	if clusterSecretEnv != distributed.ClusterSecretEnv {
+		t.Errorf("cmd/objectfs's clusterSecretEnv is %q and distributed.ClusterSecretEnv is %q. The "+
+			"duplicate exists to avoid an import for one string; this test is the thing that keeps it "+
+			"honest", clusterSecretEnv, distributed.ClusterSecretEnv)
+	}
+}

--- a/cmd/objectfs/main.go
+++ b/cmd/objectfs/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -289,6 +290,8 @@ func mountWithFlags(f *mountFlags, stdout, stderr io.Writer) int {
 		emit(stdout, "  cache size:      %s\n", cfg.Performance.CacheSize)
 		emit(stdout, "  max concurrency: %d\n", cfg.Performance.MaxConcurrency)
 
+		emitClusterDryRun(stdout, stderr, cfg)
+
 		return exitOK
 	}
 
@@ -448,6 +451,90 @@ func runUnmount(args []string, stdout, stderr io.Writer) int {
 
 	return exitOK
 }
+
+// emitClusterDryRun prints the cluster block --dry-run resolved, and the warnings Validate cannot give.
+//
+// Nothing at all is printed when clustering is off, which is almost every mount: a block of "enabled:
+// false" and six empty values is noise in the output of the check an operator runs to see whether their
+// file is good.
+//
+// The warnings are the reason this is more than a print. Two cluster settings are legal, common, and
+// wrong in a way only the operator can judge, so refusing them would break real deployments and
+// ignoring them leaves a silent single-node cluster:
+//
+//   - No seed nodes. A node with no seeds still forms a cluster — of itself. It mounts, serves reads,
+//     and reports healthy, and the first node of a new cluster genuinely has nothing to seed from, so
+//     this cannot be an error. But on the second node it means the cluster never formed.
+//   - A loopback advertise address. Correct for a single-host compose file, and on a real host it tells
+//     every peer to reach this node at their own loopback.
+//
+// Warnings go to stderr while the values go to stdout, so `objectfs mount --dry-run | grep` keeps
+// working and a config-management run that captures stdout does not silently swallow them. The exit
+// code stays 0 — these are not validation failures, and a tool that treats them as one would be unable
+// to bring up the first node of any cluster.
+func emitClusterDryRun(stdout, stderr io.Writer, cfg *config.Configuration) {
+	if !cfg.Cluster.Enabled {
+		return
+	}
+
+	emit(stdout, "\nCluster config:\n")
+	emit(stdout, "  enabled:            true\n")
+
+	// The empty node ID is reported as what it will become rather than as blank, because that is the
+	// question an operator is asking: NewClusterManager generates "node-" plus eight random hex bytes
+	// when this is unset, which means it differs on every restart of the same node.
+	nodeID := cfg.Cluster.NodeID
+	if nodeID == "" {
+		nodeID = "(generated at startup, new on every restart)"
+	}
+
+	emit(stdout, "  node_id:            %s\n", nodeID)
+	emit(stdout, "  listen_addr:        %s\n", cfg.Cluster.ListenAddr)
+	emit(stdout, "  advertise_addr:     %s\n", cfg.Cluster.AdvertiseAddr)
+
+	if len(cfg.Cluster.SeedNodes) == 0 {
+		emit(stdout, "  seed_nodes:         (none)\n")
+	} else {
+		emit(stdout, "  seed_nodes:         %s\n", strings.Join(cfg.Cluster.SeedNodes, ", "))
+	}
+
+	emit(stdout, "  replication_factor: %d\n", cfg.Cluster.ReplicationFactor)
+
+	// The secret is reported by source and never by value, and the file is reported as a path only.
+	// Which of the two is in use is the thing that is actually hard to know from outside, and it is
+	// what a mount refuses to start without.
+	switch {
+	case os.Getenv(clusterSecretEnv) != "":
+		emit(stdout, "  cluster secret:     from %s\n", clusterSecretEnv)
+	case cfg.Cluster.SecretFile != "":
+		emit(stdout, "  cluster secret:     from %s\n", cfg.Cluster.SecretFile)
+	default:
+		emit(stdout, "  cluster secret:     not configured — the cluster will refuse to start\n")
+	}
+
+	if len(cfg.Cluster.SeedNodes) == 0 {
+		emit(stderr, "objectfs mount: warning: cluster.seed_nodes is empty, so this node will not join "+
+			"an existing cluster — it will form a cluster of one, mount successfully, and report "+
+			"healthy while receiving no cache invalidations from any peer. That is correct for the "+
+			"first node of a new cluster and is a silent partition on any other\n")
+	}
+
+	if host, _, err := net.SplitHostPort(cfg.Cluster.AdvertiseAddr); err == nil {
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			emit(stderr, "objectfs mount: warning: cluster.advertise_addr is %s, a loopback address. "+
+				"Peers on other hosts that dial it reach their own loopback instead of this node. That "+
+				"is correct for a single-host development cluster and wrong everywhere else\n",
+				cfg.Cluster.AdvertiseAddr)
+		}
+	}
+}
+
+// clusterSecretEnv duplicates distributed.ClusterSecretEnv, which cmd/objectfs does not import.
+//
+// A string rather than a new import because this is the only thing needed from that package here, and
+// the pair is pinned by TestClusterSecretEnvMatchesTheDistributedPackage — a duplicated constant that
+// nothing compares is how the value drifts.
+const clusterSecretEnv = "OBJECTFS_CLUSTER_SECRET"
 
 // validateMountPoint checks the directory is one that can be mounted on.
 //

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -88,3 +88,30 @@ monitoring:
     addr: 127.0.0.1:8081              # /health
     interval: 30s
     timeout: 5s
+
+# Multi-node coordination. Commented out, because a single-node mount needs none of it and every key
+# here is inert with `enabled: false` — see docs/admin-guide/distributed.md for what it does and what
+# it does not do. examples/config.yaml carries the full block with its defaults.
+#
+# Two of these are the ones worth reading twice, and both fail in the same direction: a node that comes
+# up as a cluster of one mounts successfully, serves reads, and reports healthy. Nothing errors, because
+# gossip is one-way UDP; it simply never receives an invalidation from a peer, so it can serve an object
+# another node has already overwritten.
+#
+#   advertise_addr is what peers are told to dial, and it is not listen_addr. Copying 0.0.0.0:8080 into
+#   it is now refused at startup: a peer that dials a wildcard reaches its own loopback, so every peer
+#   would talk to itself in this node's place. Use this host's routable address or its DNS name.
+#
+#   seed_nodes empty is legal — it is how the first node of a new cluster is configured — and on any
+#   other node it means the cluster never formed. `objectfs mount --dry-run` warns about both.
+#
+# cluster:
+#   enabled: true
+#   node_id: node-1                   # empty = generated at startup, new on every restart
+#   listen_addr: 0.0.0.0:8080         # where the gossip socket binds; a wildcard belongs here
+#   advertise_addr: 10.0.1.1:8080     # where peers reach this node; must not be a wildcard
+#   seed_nodes:                       # any existing member; a node seeding from itself is a no-op
+#     - 10.0.1.2:8080
+#     - 10.0.1.3:8080
+#   replication_factor: 3             # selection width, not copies; 0 means the default of 3
+#   secret_file: /etc/objectfs/cluster.secret   # the path, never the secret. mode 0600 or startup refuses it

--- a/docs/admin-guide/distributed.md
+++ b/docs/admin-guide/distributed.md
@@ -94,7 +94,7 @@ is absent.
 | --- | --- | --- | --- | --- |
 | `enabled` | bool | `false` | `OBJECTFS_CLUSTER_ENABLED` | Starts the gossip mesh. Also selects the Redis cache when `redis.enabled` is set |
 | `node_id` | string | `""` | `OBJECTFS_CLUSTER_NODE_ID` | Empty generates `node-<8 hex bytes>` at startup — **new on every restart**. Set it for anything you intend to identify in a report |
-| `listen_addr` | host:port | `0.0.0.0:8080` | `OBJECTFS_CLUSTER_LISTEN_ADDR` | Where the gossip UDP socket binds. A wildcard belongs here. Port `0` is allowed and lets the kernel choose |
+| `listen_addr` | host:port | `0.0.0.0:8080` | `OBJECTFS_CLUSTER_LISTEN_ADDR` | Where the gossip UDP socket binds. A wildcard belongs here. Port `0` is allowed and lets the kernel choose — read the assigned port back before advertising it |
 | `advertise_addr` | host:port | `127.0.0.1:8080` | `OBJECTFS_CLUSTER_ADVERTISE_ADDR` | Where peers are told to reach this node. Must not be a wildcard and must not be port `0`; both are refused at startup |
 | `seed_nodes` | list of host:port | `[]` | `OBJECTFS_CLUSTER_SEEDS` | Any existing member. A node that seeds from itself is a no-op, so one well-known seed can be listed on every node. The environment form is comma-separated |
 | `secret_file` | path | `""` | — (see below) | Path to the shared gossip secret. **The path, never the secret.** Must be mode 0600 or startup refuses it |

--- a/docs/admin-guide/distributed.md
+++ b/docs/admin-guide/distributed.md
@@ -1,0 +1,282 @@
+# Distributed mode
+
+Running more than one ObjectFS node over the same bucket, so that each one's cache knows what the
+others hold.
+
+This page is written against the code, not against a design. Where a mechanism named in an earlier
+plan does not exist, this says so rather than describing it — see
+[Limitations](#limitations-and-what-is-not-here) at the end, which is the section to read first if you
+are deciding whether to deploy this.
+
+## What clustering does, and what it does not
+
+`cluster.enabled: true` starts one thing: a **gossip mesh** over UDP, used for cache coordination.
+Nodes announce which keys they hold, and invalidate a key when they overwrite or delete it.
+
+That is the whole of it, and the value is specific. A three-node cluster does not read faster than
+three unclustered nodes on a warm cache — the bytes still come from S3, and each node still holds its
+own copy. What it buys is **coherence**: without it, node B keeps serving a cached object for up to
+`cache.ttl` after node A has overwritten it, and nothing tells anyone. With it, A's write invalidates
+B's copy.
+
+Three things a reader might reasonably expect are deliberately absent:
+
+- **No leader, no elections, no replicated log.** Coordination is compare-and-swap against S3: a
+  conditional write, evaluated by the store on a single request, needing no quorum. A Raft engine
+  exists in `internal/distributed` and is *not started* by a mount — there is no configuration key
+  that starts it. So `objectfs cluster status` prints `Role: n/a — leader election is not running`
+  on every node of a perfectly healthy cluster, rather than telling you that you are a follower.
+- **No data path between nodes.** A cache miss on node B does not fetch bytes from node A. It asks
+  peers *which* keys they hold — metadata only — and then reads the bytes from S3. The reason is a
+  measured one: the gossip transport is UDP with an 8192-byte sealed-datagram ceiling, which is about
+  5.8 KB of payload, so a 128 KiB read cannot cross it. Knowing which keys are hot in the cluster is
+  the part that is worth having; moving bytes over UDP is not.
+- **No consistency level to choose.** `cluster.consistency_level` took `eventual`, `session` or
+  `strong` and was removed in v0.12.0. All three issued the same unconditional PUT and differed only in how many
+  nodes issued it, so the setting changed a request count and not a guarantee. A config file that
+  still sets it now fails at load, naming the key. What replaced it is per-write rather than
+  per-mount: a conditional write, with the precondition evaluated by S3. See
+  [Coordination — Conditional Writes vs Raft](../design/conditional-writes-vs-raft.md).
+
+## The failure mode this page exists for
+
+A misconfigured cluster does not fail. It comes up as **a cluster of one**, per node.
+
+The node mounts successfully, serves reads, answers its health endpoint, and reports itself alive. Its
+cache announcements go to nobody and it receives no invalidation from any peer. So it will serve an
+object that another node has already overwritten, for as long as its own `cache.ttl` allows — which is
+a data-integrity outcome reached without a single error message anywhere.
+
+Gossip is one-way UDP, which is why nothing reports it: there is no handshake to fail and no
+acknowledgement to time out. Two settings are the usual cause, and neither can be refused outright
+because both are correct in some deployments:
+
+| Setting | Legitimate use | What it does otherwise |
+| --- | --- | --- |
+| `cluster.seed_nodes: []` | The first node of a new cluster | Every subsequent node forms its own cluster of one |
+| `cluster.advertise_addr` on loopback | A single-host development cluster | Peers on other hosts dial their own loopback instead of this node |
+
+Both are reported as warnings by `objectfs mount --dry-run`, which is the check to run before
+deploying:
+
+```console
+$ objectfs mount --config /etc/objectfs/config.yaml --dry-run
+Configuration is valid.
+  storage URI:     s3://objectfs-example
+  mount point:     /mnt/objectfs
+  cache size:      2GB
+  max concurrency: 150
+
+Cluster config:
+  enabled:            true
+  node_id:            node-1
+  listen_addr:        0.0.0.0:8080
+  advertise_addr:     10.0.1.1:8080
+  seed_nodes:         10.0.1.2:8080, 10.0.1.3:8080
+  replication_factor: 3
+  cluster secret:     from /etc/objectfs/cluster.secret
+```
+
+Warnings go to stderr and the exit code stays 0 — a tool that treated them as failures could not bring
+up the first node of any cluster.
+
+One related misconfiguration *is* refused at startup rather than warned about, because there is no
+deployment in which it is right: an `advertise_addr` that is a wildcard (`0.0.0.0:8080`, `:8080`,
+`[::]:8080`). A peer that dials a wildcard reaches its own loopback — measured, not inferred — so every
+peer would silently talk to itself in place of this node. `listen_addr` is where `0.0.0.0` belongs.
+
+## Configuration reference
+
+Every key under `cluster:`. Defaults are `internal/config`'s, which is what a mount uses when the key
+is absent.
+
+| Key | Type | Default | Environment | Notes |
+| --- | --- | --- | --- | --- |
+| `enabled` | bool | `false` | `OBJECTFS_CLUSTER_ENABLED` | Starts the gossip mesh. Also selects the Redis cache when `redis.enabled` is set |
+| `node_id` | string | `""` | `OBJECTFS_CLUSTER_NODE_ID` | Empty generates `node-<8 hex bytes>` at startup — **new on every restart**. Set it for anything you intend to identify in a report |
+| `listen_addr` | host:port | `0.0.0.0:8080` | `OBJECTFS_CLUSTER_LISTEN_ADDR` | Where the gossip UDP socket binds. A wildcard belongs here. Port `0` is allowed and lets the kernel choose |
+| `advertise_addr` | host:port | `127.0.0.1:8080` | `OBJECTFS_CLUSTER_ADVERTISE_ADDR` | Where peers are told to reach this node. Must not be a wildcard and must not be port `0`; both are refused at startup |
+| `seed_nodes` | list of host:port | `[]` | `OBJECTFS_CLUSTER_SEEDS` | Any existing member. A node that seeds from itself is a no-op, so one well-known seed can be listed on every node. The environment form is comma-separated |
+| `secret_file` | path | `""` | — (see below) | Path to the shared gossip secret. **The path, never the secret.** Must be mode 0600 or startup refuses it |
+| `replication_factor` | int | `3` | — | How many nodes an operation *selects*, in preference order. Only the first writes — there is one copy of the bytes and S3 holds it — so this is a selection width, not a number of copies. `0` means the default; negative is refused |
+| `redis.*` | — | disabled | — | A shared Redis cache, independent of gossip. See `examples/config.yaml` |
+
+The environment column is not a convenience. One ConfigMap is shared by every replica of a
+StatefulSet, and `node_id` and `advertise_addr` must differ per pod — so those two come from the
+downward API rather than from the file, which is exactly what
+`deploy/kubernetes/statefulset.yaml` does.
+
+The gossip timers, fanout, packet ceiling, announcement TTL and retry settings have no YAML keys. They
+are measured defaults in `internal/distributed` (for instance the 8192-byte packet ceiling and the
+5-minute announcement TTL), and exposing them would be eight more keys that mostly should not be
+touched.
+
+### The cluster secret
+
+A cluster **will not start** without a shared secret, and this is not a hardening option. The gossip
+port is UDP and unauthenticated gossip means any host that can reach it may join the cluster and
+announce that it holds the current copy of a cached object.
+
+Two sources, environment first:
+
+```bash
+# A file, for a host install. The mode is checked, not fixed.
+openssl rand -hex 32 > /etc/objectfs/cluster.secret
+chmod 600 /etc/objectfs/cluster.secret
+```
+
+```bash
+# Or the environment, which is what a container orchestrator injects.
+export OBJECTFS_CLUSTER_SECRET="$(openssl rand -hex 32)"
+```
+
+`OBJECTFS_CLUSTER_SECRET` takes precedence over `secret_file` and has **no config-file key at all**,
+deliberately: `/etc/objectfs/config.yaml` is installed world-readable, so a secret written there would
+be published to every user on the node. Minimum length is 32 bytes.
+
+Every node must hold the *same* secret. A node with a different one is not an error at either end —
+its datagrams are rejected and counted, and the mismatch appears as a `rejected gossip message` warning
+naming the peer, with the hint that a differing secret is the likely cause.
+
+## Sizing the cache
+
+The formula that matters is per node, and it is about the *hot* set rather than the dataset:
+
+```
+cache_size ≥ hot_dataset_size / node_count
+```
+
+Note what is **not** in it: `replication_factor`. An earlier version of this guidance multiplied by it,
+which would be right if the cluster made copies — and it does not. Every node writes the same key in
+the same bucket and S3 holds the single copy, so the replication factor selects how many nodes an
+operation is offered to, not how many times the bytes exist.
+
+Worked example. A genomics group has 40 TB in a bucket, of which about 1.2 TB is read repeatedly during
+an analysis run, spread across three nodes:
+
+```
+hot set        1.2 TB
+node_count     3
+cache_size     ≥ 400 GB per node
+```
+
+That is a floor rather than a target, and it assumes reads distribute evenly across nodes, which is
+true when a scheduler spreads a job and false when one node is doing all the work. Two adjustments:
+
+- If nodes read **overlapping** data — the same reference genome on every node — each node needs its own
+  copy of the overlap, because there is no shared cache between them. Size for the overlap once per
+  node, not once per cluster.
+- If the working set does not fit, `cache.ttl` matters more than `cache_size`: entries will be evicted
+  before they expire, and the cluster's invalidation traffic is doing less for you.
+
+`cache.persistent_cache` spills to local disk and is the cheaper way to raise the first number.
+
+## Growing and shrinking a cluster
+
+There is no membership list to edit and no quorum to preserve — which is a direct consequence of
+there being no consensus. A node joins by gossiping with a seed, and leaves by stopping.
+
+**1 → 3.** Bring up the new nodes with `seed_nodes` naming the existing one:
+
+```yaml
+cluster:
+  enabled: true
+  node_id: node-2
+  advertise_addr: 10.0.1.2:8080
+  seed_nodes:
+    - 10.0.1.1:8080
+```
+
+Then verify from each node, rather than assuming:
+
+```console
+$ objectfs cluster status
+```
+
+The membership counts include the local node, so a healthy three-node cluster reports
+`Membership: 3 nodes (3 alive, 0 suspect, 0 dead)` from every node. A node that reports `1 node` and
+`No peers.` has not joined — check the warnings in `--dry-run`, then the secret.
+
+Note that `No peers.` is followed by a line saying a cluster of one is a working configuration, and
+that is true of coordination: CAS against S3 needs no second node. It is not true of the cache
+coherence you enabled clustering for. Both statements are in the output because both are worth
+knowing, and which one applies is a question about your intent that the command cannot answer.
+
+**3 → 1.** Unmount the nodes you are removing, one at a time, and confirm the remaining nodes notice
+before removing the next. There is nothing to drain: a departing node holds no data that only it has,
+because every object is in S3. What is lost is its cache, and the effect on the rest of the cluster is
+that some keys are no longer announced by anybody — so subsequent reads for them come from S3, which
+is the pre-cluster behaviour.
+
+**Rolling upgrade.** One node at a time; check `objectfs cluster status` shows all nodes alive before
+moving to the next. There is no leader to upgrade last. Two things to be aware of:
+
+- Unmount cleanly. A FUSE mount is unmounted by its own process on a signal, and a `SIGKILL` leaves the
+  kernel holding a mount whose server is gone. In Kubernetes this means a
+  `terminationGracePeriodSeconds` well above the default 30 — `deploy/kubernetes/statefulset.yaml`
+  uses 120.
+- A mixed-version cluster is only as coordinated as its oldest node. A node running a build that
+  predates gossip authentication has its messages rejected with a version-mismatch hint rather than a
+  secret one, which is what that hint is for.
+
+## Diagnosing a cluster of one
+
+In order, because each step rules out the one after it:
+
+1. **`objectfs mount --dry-run`**, on the node's real config file. This catches an empty seed list, a
+   loopback advertise address, and a missing secret — the three most common causes — before anything
+   is running.
+2. **`objectfs cluster status`** on each node. `No peers.` means this node has not joined. The exit
+   code is 0 for a healthy cluster *and* for clustering being disabled, which is not a fault; use the
+   output rather than the code to tell those apart.
+3. **Is the secret the same everywhere?** A mismatch is logged as `rejected gossip message` at Warn,
+   with the peer address and a hint, on the *receiving* node. If you collect logs from only one node
+   you will not see it. The three hints send you to different places, so read the one you got:
+
+   | Hint mentions | Cause |
+   | --- | --- |
+   | a different cluster secret, or a host that is not a member | secret mismatch, or an unrelated host on the port |
+   | a build that predates gossip authentication | a mixed-version cluster mid-upgrade |
+   | clock skew beyond the freshness window | NTP, on one or both hosts |
+
+   The counts behind them are in `objectfs cluster status` under `Gossip:`, printed only when
+   non-zero — so an empty anomaly section means none of the three has happened.
+4. **Is UDP open between nodes on the gossip port?** The default is `8080`, not 7946 — that number
+   appears in some older planning documents and in tests, and is not the default anywhere in the code.
+   Both directions matter: gossip is one-way UDP, so a firewall that permits A→B and drops B→A gives
+   you a cluster where each node believes something different.
+5. **Does `advertise_addr` name an address peers can actually reach?** Wildcards are refused at
+   startup and loopback is warned about, but a routable-looking address for the wrong interface is
+   neither — and it fails identically.
+
+## Limitations, and what is not here
+
+Stated plainly, because the rest of this page describes what works:
+
+- **`internal/distributed` is experimental.** The gossip and cache-coordination path is what a mount
+  starts and what has tests; the consensus engine in the same package is not started by a mount and
+  should not be treated as a supported feature.
+- **No persistent log, and no `cluster.persistent_log` or `cluster.data_dir` keys.** They were
+  specified in an earlier plan and do not exist. Cluster state is in memory and is rebuilt by
+  gossiping on restart — which is fine, because none of it is authoritative: S3 is.
+- **No peer data fetch.** Discussed above; the limit is the UDP transport, and a stream transport is
+  its own piece of work.
+- **`node_id` defaults to a fresh random value on every restart.** A node that restarts appears as a
+  new member, and the old entry ages out. Set `node_id` in any deployment where you intend to
+  correlate a report with a host.
+- **Cross-node cache statistics are what each node reports about itself.** There is no per-key access
+  counter reachable from the cluster layer, so `objectfs cluster status` reports how many keys this
+  node retains peer claims for, and not "hottest keys" — a figure nothing in this repository measures.
+- **Distributed mode has no integration test against real AWS across multiple hosts.** The tests are
+  two nodes over loopback plus the differential oracle. `deploy/docker/docker-compose.yaml` stands up
+  three nodes against MinIO for development.
+
+## See also
+
+- [`deploy/`](https://github.com/scttfrdmn/objectfs/tree/main/deploy) — Compose and Kubernetes
+  manifests for a three-node cluster, including the per-pod identity a StatefulSet needs
+- [Coordination — Conditional Writes vs Raft](../design/conditional-writes-vs-raft.md) — why there is
+  no leader
+- [Conditional-Write Compatibility](../design/conditional-write-compatibility.md) — which backends
+  evaluate preconditions, and what happens on one that does not
+- `examples/config.yaml` — the complete cluster block with every default

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1377,7 +1377,162 @@ func (c *Configuration) Validate() error {
 		return err
 	}
 
+	if err := validateClusterConfig(c.Cluster); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// validateClusterConfig rejects a cluster block that would come up as a cluster of one, or as none.
+//
+// Nothing checked the cluster block at all before #152, and the two failures that matters most for are
+// both silent. A cluster is not like the mount point or the region, where the first S3 call fails and
+// an operator goes looking: gossip is fire-and-forget UDP between peers, so a node that no peer can
+// reach mounts successfully, serves reads, reports healthy, and is simply alone. Its cache
+// announcements go nowhere and it never receives an invalidation, which means it can serve an object
+// another node has already overwritten — an integrity outcome reached without a single error message.
+//
+// Only checked when Enabled, for the same reason validateListenAddr is only applied to an enabled
+// listener: refusing a mount over a value in a block that starts nothing would fail single-node users,
+// who are almost everyone, over a setting with no effect.
+//
+// Three rows of #152's proposed table are deliberately absent. `cluster.persistent_log` and
+// `cluster.data_dir` do not exist — zero occurrences in the tree — so the two rules written against
+// them have no field to read, and the empty-seeds warning is not here because Validate returns an
+// error or nothing and has no warning channel; `objectfs mount --dry-run` prints that one instead,
+// where an operator is already reading output. The one row that does exist as written,
+// `advertise_addr == ""`, cannot fire and is replaced by the check below that catches the real case.
+func validateClusterConfig(cfg ClusterConfig) error {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	// The address peers are told to use, checked as an address first. An unparseable one is not
+	// refused anywhere downstream: net.ResolveUDPAddr runs on the *receiving* peer, when it dials
+	// back, so a typo here is discovered on another host as "failed to resolve address" against a
+	// string that host never configured.
+	//
+	// Port 0 is refused on this one and accepted on the next, which is not an inconsistency but the
+	// measured difference between the two sides of the socket. net.ListenUDP on 127.0.0.1:0 binds and
+	// the kernel assigns a port — that is what a test asks for, and what ClusterManager.GossipAddr's
+	// doc comment describes reporting back. net.DialUDP to 127.0.0.1:0 fails outright with "can't
+	// assign requested address". So an advertised port 0 is an address no peer can reach, and a
+	// listening port 0 is ordinary.
+	if err := validateGossipAddr("cluster.advertise_addr", cfg.AdvertiseAddr, false); err != nil {
+		return err
+	}
+
+	if err := validateGossipAddr("cluster.listen_addr", cfg.ListenAddr, true); err != nil {
+		return err
+	}
+
+	// A wildcard advertise address is the defect this function exists for, and it is not the one
+	// #152 described. The issue's rule was `advertise_addr == ""`, which can never fire: NewDefault
+	// sets 127.0.0.1:8080 and applyConfigDefaults sets it again, so the field is never empty by the
+	// time anything could check it. What operators actually write is the value beside it —
+	// listen_addr is 0.0.0.0:8080 and copying that into advertise_addr looks like the obvious thing
+	// to do.
+	//
+	// Measured, not reasoned about: a peer receiving "0.0.0.0:8080" hands it to net.ResolveUDPAddr
+	// and net.DialUDP, and the connection comes back with remote 127.0.0.1:8080 — the *dialer's* own
+	// loopback. ":8080" behaves the same way and "[::]:8080" dials [::1]:8080. So every peer that
+	// learns this node's address starts sending that node's traffic to itself, and because gossip is
+	// one-way UDP nothing reports a failure at either end. The advertising node stays alive in its
+	// own memberlist, each peer talks to itself in place of it, and the cluster silently partitions
+	// into single nodes.
+	//
+	// Refused rather than rewritten. There is no correct value to substitute — which interface a peer
+	// can reach is a fact about the network, and picking one here would be a guess that fails the
+	// same way when it is wrong, minus the message.
+	if host, _, err := net.SplitHostPort(cfg.AdvertiseAddr); err == nil {
+		if ip := net.ParseIP(host); host == "" || (ip != nil && ip.IsUnspecified()) {
+			return fmt.Errorf("cluster.advertise_addr is %q, a wildcard address. It is what peers are "+
+				"told to send this node's gossip to, and a peer that dials a wildcard reaches its own "+
+				"loopback instead — so every peer would talk to itself in this node's place, with no "+
+				"error at either end, and the cluster would partition into single nodes that each "+
+				"believe they are clustered. cluster.listen_addr is where 0.0.0.0 belongs; set "+
+				"cluster.advertise_addr to an address peers can reach, such as this host's routable IP "+
+				"or its DNS name", cfg.AdvertiseAddr)
+		}
+	}
+
+	// Loopback is legal and common — a compose file or a single-host test uses it deliberately — so it
+	// is not refused here. It is reported by --dry-run, which is where a value that is right for one
+	// deployment and wrong for another belongs.
+
+	// A negative replication factor is a cluster that cannot write, and it survives every existing
+	// guard. applyConfigDefaults only replaces a zero, so -1 reaches
+	// Coordinator.selectTargetNodes, where min(replicationFactor, len(aliveNodes)) stays negative;
+	// LoadBalancer.SelectNodes returns an empty slice for count <= 0, and executeOnce turns that into
+	// "no target nodes selected" — verified by calling SelectNodes with each value. Every write in the
+	// cluster fails with a message that names neither this key nor its value.
+	if cfg.ReplicationFactor < 0 {
+		return fmt.Errorf("cluster.replication_factor is %d; it cannot be negative. A negative value "+
+			"is not clamped anywhere downstream — target selection returns no nodes and every write "+
+			"fails with \"no target nodes selected\", which names neither this key nor this value. Use "+
+			"0 to accept the default of 3", cfg.ReplicationFactor)
+	}
+
+	return nil
+}
+
+// validateGossipAddr checks a gossip address, allowing port 0 only where the kernel will fill it in.
+//
+// Separate from [validateListenAddr] rather than a flag on it, because the two are answering different
+// questions and one of them has already been got wrong here. validateListenAddr's port-0 message tells
+// the operator to use the `enabled` flag beside the field — advice that belongs to the monitoring
+// endpoints it was written for, where a port of 0 is someone trying to turn a listener off. The cluster
+// block has no such flag per address, and `listen_addr: 127.0.0.1:0` is a real thing this repository's
+// own tests set on purpose so the kernel picks a free port.
+//
+// allowPortZero is the whole difference, and it is measured rather than assumed: net.ListenUDP binds
+// 127.0.0.1:0 and reports back the assigned port, while net.DialUDP to a port 0 fails with "can't
+// assign requested address". A listener may ask for any port; an advertised address must be one a peer
+// can dial.
+func validateGossipAddr(field, addr string, allowPortZero bool) error {
+	if addr == "" {
+		return fmt.Errorf("%s must be set to a host:port. Clustering is enabled, and this is %s, so "+
+			"there is no value to fall back to", field, gossipAddrPurpose(field))
+	}
+
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("%s is not a host:port address: %q (%w)", field, addr, err)
+	}
+
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("%s has a non-numeric port: %q. A service name is not looked up in "+
+			"/etc/services here; write the number", field, port)
+	}
+
+	if n == 0 && allowPortZero {
+		return nil
+	}
+
+	if n == 0 {
+		return fmt.Errorf("%s has port 0, which no peer can dial. Port 0 on a listener means \"let the "+
+			"kernel choose\" and is fine on cluster.listen_addr, but this address is what peers are "+
+			"told to send to, and dialing it fails with \"can't assign requested address\" — so this "+
+			"node would be unreachable while appearing configured. If the kernel is choosing the port, "+
+			"read the bound one back and advertise that", field)
+	}
+
+	if n < 1 || n > 65535 {
+		return fmt.Errorf("%s port %d is outside 1-65535", field, n)
+	}
+
+	return nil
+}
+
+// gossipAddrPurpose describes what a gossip address is for, so the empty-value error says which one.
+func gossipAddrPurpose(field string) string {
+	if strings.HasSuffix(field, "advertise_addr") {
+		return "the address peers are told to reach this node at"
+	}
+
+	return "the address the gossip socket binds"
 }
 
 // validateMountConfig checks what the mount block names, when it names anything.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1512,11 +1512,13 @@ func validateGossipAddr(field, addr string, allowPortZero bool) error {
 	}
 
 	if n == 0 {
-		return fmt.Errorf("%s has port 0, which no peer can dial. Port 0 on a listener means \"let the "+
-			"kernel choose\" and is fine on cluster.listen_addr, but this address is what peers are "+
-			"told to send to, and dialing it fails with \"can't assign requested address\" — so this "+
-			"node would be unreachable while appearing configured. If the kernel is choosing the port, "+
-			"read the bound one back and advertise that", field)
+		return fmt.Errorf("%s has port 0, which no peer can deliver to. Port 0 on a listener means "+
+			"\"let the kernel choose\" and is fine on cluster.listen_addr, but this address is what "+
+			"peers are told to send to. Depending on the platform, a peer either fails the dial with "+
+			"\"can't assign requested address\" or — on Linux — dials and sends successfully while the "+
+			"datagram goes nowhere, reported at neither end. Either way this node is unreachable while "+
+			"appearing configured. If the kernel is choosing the port, read the bound one back and "+
+			"advertise that", field)
 	}
 
 	if n < 1 || n > 65535 {

--- a/internal/config/docs_distributed_test.go
+++ b/internal/config/docs_distributed_test.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Gates on docs/admin-guide/distributed.md, the operator guide #152 asked for.
+//
+// The four existing documentation gates do not reach what this page gets wrong. docs_test.go parses its
+// YAML blocks, docs_symbols_test.go checks the Go symbols and CLI invocations it names, docs_links_test.go
+// resolves its links, and changelog_test.go checks the entry. None of them can see a *default value*
+// written as prose in a table cell, and that is most of this page: a config reference is a list of
+// claims about numbers, each of which stops being true the moment someone changes a constant.
+//
+// The page has a second problem the other gates cannot see, and it is the one that motivated #152's
+// rewrite. Three of the six sections the issue specified describe mechanisms that do not exist —
+// cluster.persistent_log, cluster.data_dir, peer_fetch_timeout — so the page says they are absent
+// instead. A statement that a key does not exist is a claim about the tree, and it inverts the usual
+// failure: it goes stale when someone does the work, at which point the page is telling an operator not
+// to use a feature that shipped.
+
+// docsDistributed reads the operator guide.
+func docsDistributed(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(repoRoot(t), "docs", "admin-guide", "distributed.md")
+
+	//nolint:gosec // a path built from the module root this test located itself
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	return string(body)
+}
+
+// TestDistributedGuideDefaultsMatchNewDefault pins the config reference's Default column.
+//
+// Each of these is a value an operator will not set, having read here that they do not need to. A
+// default that has moved on is worse than an undocumented one: it is a reason to leave a key out of a
+// config file, and the value they get is not the value they read.
+func TestDistributedGuideDefaultsMatchNewDefault(t *testing.T) {
+	t.Parallel()
+
+	doc := docsDistributed(t)
+	def := NewDefault().Cluster
+
+	// Written as `| ... | `value` | ...` in the table, so the backticked form is what must appear.
+	for _, tc := range []struct {
+		what string
+		want string
+	}{
+		{"cluster.listen_addr", "`" + def.ListenAddr + "`"},
+		{"cluster.advertise_addr", "`" + def.AdvertiseAddr + "`"},
+		{"cluster.replication_factor", "`3`"},
+	} {
+		if !strings.Contains(doc, tc.want) {
+			t.Errorf("the config reference does not give %s as %s. NewDefault is the authority; the "+
+				"table is a transcription of it, and a stale default is a reason not to set a key",
+				tc.what, tc.want)
+		}
+	}
+
+	if def.ReplicationFactor != 3 {
+		t.Errorf("NewDefault sets replication_factor to %d and the guide says 3 in two places — the "+
+			"table and the sizing section, which argues about what the factor is not",
+			def.ReplicationFactor)
+	}
+
+	if def.Enabled {
+		t.Error("NewDefault enables clustering. The guide's premise is that almost no mount is " +
+			"clustered, which is why --dry-run prints nothing about a cluster that is off")
+	}
+
+	// A default that must stay empty for a reason the page states: the generated ID is new on every
+	// restart, which is the whole of that table cell.
+	if def.NodeID != "" {
+		t.Errorf("NewDefault sets node_id to %q. The guide says an empty value generates one at startup, "+
+			"new on every restart, and lists that under limitations", def.NodeID)
+	}
+}
+
+// TestDistributedGuideDocumentsEveryClusterKey is the completeness half.
+//
+// A config reference that omits a key is how an operator finds a setting by reading source, and the
+// reference claims to be "every key under cluster:" — which is a checkable claim, since the YAML tags
+// on ClusterConfig are the enumeration.
+func TestDistributedGuideDocumentsEveryClusterKey(t *testing.T) {
+	t.Parallel()
+
+	doc := docsDistributed(t)
+
+	// A table *row*, not a mention. Checking for a backticked name anywhere on the page does not work:
+	// verified by deleting the secret_file row, which this test then passed, because the key is also
+	// named in the prose of "The cluster secret" section three paragraphs later. Prose about a setting is
+	// not a reference entry — it has no default and no type, which is what a reader came to the table for.
+	//
+	// The yaml tags of ClusterConfig, each of which is a scalar with its own row. Redis is the one nested
+	// struct and gets a family row rather than one row per key: its settings are a cache backend that
+	// happens to be gated on cluster.enabled, so enumerating them here would duplicate
+	// examples/config.yaml and put the authority in two places.
+	for _, key := range []string{
+		"enabled", "node_id", "listen_addr", "advertise_addr", "seed_nodes", "secret_file",
+		"replication_factor", "redis.*",
+	} {
+		if !strings.Contains(doc, "| `"+key+"` |") {
+			t.Errorf("the config reference has no table row for `%s`. It says it lists every key under "+
+				"cluster:, so an omission here is an operator reading internal/config to find a setting — "+
+				"and a mention in the prose is not a row, because it carries neither the type nor the "+
+				"default", key)
+		}
+	}
+}
+
+// TestDistributedGuideEnvVarsExist checks the Environment column against the override table.
+//
+// This column is not decoration: one ConfigMap is shared by every replica of a StatefulSet, so node_id
+// and advertise_addr *have* to come from the environment, and a wrong variable name there is a pod that
+// comes up with the ConfigMap's value — which is the same value on every replica, and therefore a
+// wildcard or a loopback advertise address on all of them. The failure this page exists to prevent,
+// reached by following the page.
+func TestDistributedGuideEnvVarsExist(t *testing.T) {
+	t.Parallel()
+
+	doc := docsDistributed(t)
+
+	// getEnvMappings rather than grep, for #146's reason: the four variables that were documented and
+	// unread were all findable by grep, in the documentation that named them.
+	known := make(map[string]bool)
+	for _, m := range getEnvMappings() {
+		known[m.envVar] = true
+	}
+
+	for _, name := range []string{
+		"OBJECTFS_CLUSTER_ENABLED",
+		"OBJECTFS_CLUSTER_NODE_ID",
+		"OBJECTFS_CLUSTER_LISTEN_ADDR",
+		"OBJECTFS_CLUSTER_ADVERTISE_ADDR",
+		"OBJECTFS_CLUSTER_SEEDS",
+	} {
+		if !known[name] {
+			t.Errorf("the guide documents %s and no override by that name is applied. #146 was this "+
+				"exact defect for OBJECTFS_CLUSTER_ENABLED: documented, built on by a compose file, and "+
+				"never read", name)
+		}
+
+		if !strings.Contains(doc, name) {
+			t.Errorf("%s is applied by the loader and the guide's Environment column omits it", name)
+		}
+	}
+
+	// The secret is deliberately not in that column, and the page says why. If a config key for it ever
+	// appears, the page's argument — that /etc/objectfs/config.yaml is world-readable, so the secret
+	// cannot live there — has to be revisited rather than left standing.
+	if strings.Contains(doc, "`secret:`") {
+		t.Error("the guide appears to document a config key for the cluster secret. There is none, by " +
+			"design: the file is installed world-readable, so only a path or an environment variable can " +
+			"carry it")
+	}
+}
+
+// TestDistributedGuideAbsentKeysAreStillAbsent inverts the usual staleness direction.
+//
+// The page states that three keys from #152's specification do not exist. That is the honest thing to
+// write today and becomes a lie the moment one is implemented — at which point the page is telling an
+// operator a shipped feature is unavailable, and the limitations section is the part of the page a
+// cautious reader trusts most.
+//
+// So: if this fails, the fix is to write the section #152 originally asked for, not to delete the test.
+func TestDistributedGuideAbsentKeysAreStillAbsent(t *testing.T) {
+	t.Parallel()
+
+	schema := make(map[string]bool, len(TopLevelKeys()))
+	for _, k := range TopLevelKeys() {
+		schema[k] = true
+	}
+
+	// Cheapest possible check that the claim is about this schema: parse a config that sets each key and
+	// require strict decoding to reject it. A key that has been implemented parses.
+	for _, key := range []string{"persistent_log", "data_dir", "peer_fetch_timeout"} {
+		doc := "cluster:\n  enabled: true\n  " + key + ": /tmp/x\n"
+
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		if err := NewDefault().LoadFromFile(path); err == nil {
+			t.Errorf("cluster.%s now parses. docs/admin-guide/distributed.md states it does not exist "+
+				"and lists it under limitations, and #152 asked for a section documenting it — write that "+
+				"section rather than removing this check, because the page currently tells operators a "+
+				"shipped feature is unavailable", key)
+		}
+	}
+}
+
+// TestDistributedGuideNamesTheRealGossipPort is the one number the issue itself got wrong.
+//
+// #152 and #148 both say 7946 — memberlist's default, and the port in some of this package's own test
+// fixtures. It is not the default anywhere in the code. An operator who opens 7946 between nodes and
+// nothing else gets a cluster of one, which is the failure mode with no error message, reached by
+// following the documentation.
+func TestDistributedGuideNamesTheRealGossipPort(t *testing.T) {
+	t.Parallel()
+
+	doc := docsDistributed(t)
+	def := NewDefault().Cluster
+
+	_, port, ok := strings.Cut(def.ListenAddr, ":")
+	if !ok {
+		t.Fatalf("NewDefault's listen_addr %q is not host:port", def.ListenAddr)
+	}
+
+	// The diagnosis section says "The default is `8080`, not 7946".
+	if !strings.Contains(doc, "The default is `"+port+"`") {
+		t.Errorf("the diagnosis section does not name %s as the gossip port. The default listen_addr is "+
+			"%q, and the firewall step is the one that sends an operator to open a port", port,
+			def.ListenAddr)
+	}
+}

--- a/internal/config/validate_cluster_test.go
+++ b/internal/config/validate_cluster_test.go
@@ -1,0 +1,366 @@
+package config
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Gates on the cluster block's validation, which #152 added.
+//
+// Nothing validated this block at all before, and the reason it needed validating is not the reason
+// #152 gave. Its proposed table had three rows: two written against `cluster.persistent_log` and
+// `cluster.data_dir`, which do not exist anywhere in the tree, and one — `enabled && advertise_addr
+// == ""` — that can never fire, because NewDefault sets 127.0.0.1:8080 and applyConfigDefaults sets
+// it again. Verified by calling Validate on that exact configuration, not by reading the file.
+//
+// What probing found instead is worse than what was specified, and TestValidateRejectsAWildcardAdvertise
+// is the test for it. The rules here are the two that are unreachable-by-any-other-means wrong plus the
+// address shapes; everything a reasonable operator might legitimately want — loopback, no seeds — is a
+// warning on --dry-run rather than a refusal, because refusing those would make it impossible to bring
+// up the first node of a cluster or to run the shipped compose file.
+
+// TestClusterBlockIsOnlyCheckedWhenEnabled is the compatibility floor, and it comes first because every
+// other test here is about a refusal.
+//
+// Almost every ObjectFS mount has cluster.enabled false and a cluster block full of defaults it has
+// never looked at. If validation applied to a disabled block, this change would refuse mounts over
+// settings that start nothing — the same reasoning that keeps validateListenAddr scoped to an enabled
+// monitoring listener, and the same reasoning that makes the default advertise address (loopback) a
+// warning rather than an error.
+func TestClusterBlockIsOnlyCheckedWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewDefault()
+	if cfg.Cluster.Enabled {
+		t.Fatal("NewDefault() enables clustering, which would make every mount start a gossip listener; " +
+			"the rest of this test assumes the default is off")
+	}
+
+	// Every value below is one the enabled path refuses. With clustering off they must all pass, or a
+	// single-node user is failed over a block that binds nothing.
+	cfg.Cluster.AdvertiseAddr = "0.0.0.0:8080"
+	cfg.Cluster.ListenAddr = ""
+	cfg.Cluster.ReplicationFactor = -1
+
+	if err := validateClusterConfig(cfg.Cluster); err != nil {
+		t.Errorf("a disabled cluster block was refused: %v\n\nEvery value here is one the enabled path "+
+			"rejects, and that is the point: with cluster.enabled false none of them starts anything, "+
+			"so refusing them fails a mount over a setting with no effect", err)
+	}
+}
+
+// TestValidateRejectsAWildcardAdvertise is the defect this validation exists for.
+//
+// It is not the rule #152 asked for and it is the one that matters. `cluster.listen_addr` defaults to
+// 0.0.0.0:8080, so copying that value into `advertise_addr` is the obvious thing for an operator to do
+// — and advertise_addr is what peers are told to *dial*. Measured with net.DialUDP: dialing
+// "0.0.0.0:8080" yields a connection whose remote is 127.0.0.1:8080, the dialer's own loopback; ":8080"
+// behaves identically and "[::]:8080" reaches [::1]:8080.
+//
+// So every peer that learns this address sends this node's traffic to itself. Gossip is one-way UDP, so
+// no send fails and no receive is expected: the advertising node stays alive in its own memberlist, each
+// peer silently substitutes itself, and a three-node cluster becomes three clusters of one that each
+// report healthy. A node in that state can serve an object another node has already overwritten, which
+// is why it is refused rather than warned about.
+func TestValidateRejectsAWildcardAdvertise(t *testing.T) {
+	t.Parallel()
+
+	for _, addr := range []string{"0.0.0.0:8080", ":8080", "[::]:8080"} {
+		t.Run(addr, func(t *testing.T) {
+			t.Parallel()
+
+			// The premise, asserted rather than assumed. If a future Go or platform made dialing a
+			// wildcard fail loudly instead of silently reaching loopback, the refusal below would be
+			// over-strict and this is where that shows up.
+			ua, err := net.ResolveUDPAddr("udp", addr)
+			if err != nil {
+				t.Fatalf("resolving %q, which is what a peer does with an advertised address: %v", addr, err)
+			}
+
+			conn, err := net.DialUDP("udp", nil, ua)
+			if err != nil {
+				t.Fatalf("dialing the advertised %q failed outright: %v\n\nThe refusal under test is "+
+					"justified by this dial *succeeding* against the dialer's own loopback. If it now "+
+					"fails, the failure is no longer silent and this rule should be reconsidered",
+					addr, err)
+			}
+
+			remote := conn.RemoteAddr().String()
+			_ = conn.Close()
+
+			host, _, splitErr := net.SplitHostPort(remote)
+			if splitErr != nil {
+				t.Fatalf("parsing the dialed remote %q: %v", remote, splitErr)
+			}
+
+			if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+				t.Fatalf("dialing the advertised %q reached %s, which is not loopback. This test's whole "+
+					"premise is that a peer dialing a wildcard talks to itself", addr, remote)
+			}
+
+			cfg := clusterEnabled(func(c *ClusterConfig) { c.AdvertiseAddr = addr })
+
+			err = validateClusterConfig(cfg)
+			if err == nil {
+				t.Fatalf("cluster.advertise_addr = %q was accepted. A peer dialing it reaches %s — its "+
+					"own loopback — so the cluster partitions into single nodes with no error at either "+
+					"end", addr, remote)
+			}
+
+			// The message has to name the key and the value, because the symptom an operator sees is a
+			// cluster of one with nothing in any log.
+			for _, want := range []string{"cluster.advertise_addr", addr, "cluster.listen_addr"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("the refusal does not mention %q: %v\n\nIt must name the key, the value, and "+
+						"where 0.0.0.0 does belong — an operator who set this copied it from listen_addr",
+						want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateRejectsANegativeReplicationFactor pins the second value nothing downstream clamps.
+//
+// applyConfigDefaults replaces a replication factor of 0 and only 0, so -1 reaches
+// Coordinator.selectTargetNodes, where min(replicationFactor, len(aliveNodes)) stays negative.
+// LoadBalancer.SelectNodes returns an empty slice for any count <= 0 — verified by calling it with -1,
+// 0, 1, 3 and 99 — and executeOnce turns an empty target list into "no target nodes selected". Every
+// write in the cluster fails with a message that names neither this key nor its value.
+func TestValidateRejectsANegativeReplicationFactor(t *testing.T) {
+	t.Parallel()
+
+	cfg := clusterEnabled(func(c *ClusterConfig) { c.ReplicationFactor = -1 })
+
+	err := validateClusterConfig(cfg)
+	if err == nil {
+		t.Fatal("cluster.replication_factor = -1 was accepted. It is not clamped anywhere downstream: " +
+			"target selection returns an empty node list and every write fails with \"no target nodes " +
+			"selected\", naming neither the key nor the value")
+	}
+
+	if !strings.Contains(err.Error(), "cluster.replication_factor") {
+		t.Errorf("the refusal does not name the key: %v", err)
+	}
+
+	// Zero is not an error — applyConfigDefaults turns it into 3 — and refusing it would break every
+	// config file that omits the key, which is all of them.
+	if err := validateClusterConfig(clusterEnabled(func(c *ClusterConfig) { c.ReplicationFactor = 0 })); err != nil {
+		t.Errorf("cluster.replication_factor = 0 was refused: %v\n\nZero means \"unset\" and "+
+			"applyConfigDefaults replaces it with 3, so every file that omits the key would fail", err)
+	}
+}
+
+// TestClusterAddrsAllowPortZeroOnlyWhereItBinds is the asymmetry, and it is measured.
+//
+// A single rule for both addresses is wrong in one direction or the other, which is why this does not
+// reuse validateListenAddr. net.ListenUDP on 127.0.0.1:0 binds and the kernel assigns a port — this
+// repository's own distributed tests configure exactly that, and ClusterManager.GossipAddr exists to
+// report the assigned port back. net.DialUDP to a port 0 fails with "can't assign requested address",
+// so an advertised port 0 is an address no peer can reach.
+//
+// validateListenAddr's port-0 message is also wrong here on its own terms: it tells the operator to use
+// the `enabled` flag beside the field, which the cluster block does not have per address.
+func TestClusterAddrsAllowPortZeroOnlyWhereItBinds(t *testing.T) {
+	t.Parallel()
+
+	// The listening side, asserted against the kernel rather than assumed.
+	ua, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("resolving 127.0.0.1:0: %v", err)
+	}
+
+	conn, err := net.ListenUDP("udp", ua)
+	if err != nil {
+		t.Fatalf("binding 127.0.0.1:0, which is what internal/distributed's tests configure: %v", err)
+	}
+
+	bound := conn.LocalAddr().String()
+	_ = conn.Close()
+
+	if _, port, _ := net.SplitHostPort(bound); port == "0" {
+		t.Fatalf("binding 127.0.0.1:0 reported back port 0 (%s); the premise here is that the kernel "+
+			"assigns a real one", bound)
+	}
+
+	if err := validateClusterConfig(clusterEnabled(func(c *ClusterConfig) {
+		c.ListenAddr = "127.0.0.1:0"
+	})); err != nil {
+		t.Errorf("cluster.listen_addr = 127.0.0.1:0 was refused: %v\n\nThe kernel bound it to %s. This "+
+			"is what internal/distributed's testConfig sets, so refusing it would fail that suite and "+
+			"every single-host test that wants a free port", err, bound)
+	}
+
+	// The dialing side. Refused, because the dial itself fails.
+	dialErr := func() error {
+		da, resolveErr := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+		if resolveErr != nil {
+			return resolveErr
+		}
+
+		c, connErr := net.DialUDP("udp", nil, da)
+		if connErr != nil {
+			return connErr
+		}
+
+		_ = c.Close()
+
+		return nil
+	}()
+
+	if dialErr == nil {
+		t.Error("dialing 127.0.0.1:0 succeeded. The refusal of an advertised port 0 rests on this dial " +
+			"failing; if it now works, that rule should be reconsidered rather than kept on faith")
+	}
+
+	err = validateClusterConfig(clusterEnabled(func(c *ClusterConfig) {
+		c.AdvertiseAddr = "127.0.0.1:0"
+	}))
+	if err == nil {
+		t.Fatalf("cluster.advertise_addr = 127.0.0.1:0 was accepted, but dialing it fails: %v. A node "+
+			"advertising it is unreachable while appearing configured", dialErr)
+	}
+
+	if !strings.Contains(err.Error(), "cluster.listen_addr") {
+		t.Errorf("the port-0 refusal does not mention cluster.listen_addr: %v\n\nAn operator who set "+
+			"port 0 on the advertise address probably wanted it on the listen address, and the message "+
+			"is the only place that can be said", err)
+	}
+}
+
+// TestValidateRejectsAMalformedClusterAddr covers the shapes, and the point is *where* they are caught.
+//
+// An unparseable advertise address is refused nowhere downstream on the node that configured it.
+// net.ResolveUDPAddr runs on the *receiving* peer, when it dials back, so the error surfaces on another
+// host as "failed to resolve address" against a string that host never set — in a Warn-level log line,
+// which most deployments do not collect.
+func TestValidateRejectsAMalformedClusterAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mutate   func(*ClusterConfig)
+		mustName string
+	}{
+		{
+			name:     "advertise_addr with no port",
+			mutate:   func(c *ClusterConfig) { c.AdvertiseAddr = "10.0.1.1" },
+			mustName: "cluster.advertise_addr",
+		},
+		{
+			name:     "advertise_addr with a service name",
+			mutate:   func(c *ClusterConfig) { c.AdvertiseAddr = "10.0.1.1:gossip" },
+			mustName: "cluster.advertise_addr",
+		},
+		{
+			name:     "advertise_addr port out of range",
+			mutate:   func(c *ClusterConfig) { c.AdvertiseAddr = "10.0.1.1:99999" },
+			mustName: "cluster.advertise_addr",
+		},
+		{
+			name:     "listen_addr empty",
+			mutate:   func(c *ClusterConfig) { c.ListenAddr = "" },
+			mustName: "cluster.listen_addr",
+		},
+		{
+			name:     "advertise_addr empty",
+			mutate:   func(c *ClusterConfig) { c.AdvertiseAddr = "" },
+			mustName: "cluster.advertise_addr",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateClusterConfig(clusterEnabled(tc.mutate))
+			if err == nil {
+				t.Fatal("accepted; a peer discovers this as a resolve failure against a string it never " +
+					"configured, logged at Warn on a different host")
+			}
+
+			if !strings.Contains(err.Error(), tc.mustName) {
+				t.Errorf("the refusal does not name %s: %v", tc.mustName, err)
+			}
+		})
+	}
+}
+
+// TestClusterValidationIsReachedThroughValidate is the wiring check.
+//
+// validateClusterConfig can be correct and unreachable — that is the shape of defect this repository
+// keeps finding, most recently four environment variables that nothing read. Every other test here
+// calls the function directly, so this is the only one that would fail if the call in Validate were
+// deleted. It goes through LoadFromFile as well, since that is how an operator's configuration arrives.
+func TestClusterValidationIsReachedThroughValidate(t *testing.T) {
+	t.Parallel()
+
+	const doc = `storage:
+  s3:
+    region: us-west-2
+cluster:
+  enabled: true
+  node_id: node-1
+  listen_addr: 0.0.0.0:8080
+  advertise_addr: 0.0.0.0:8080
+`
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg := NewDefault()
+	if err := cfg.LoadFromFile(path); err != nil {
+		t.Fatalf("the document does not load, so this test is not exercising validation: %v", err)
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate accepted a config whose advertise_addr is a wildcard. validateClusterConfig " +
+			"refuses it when called directly, so this is the call in Validate being absent — the " +
+			"function would be correct and unreachable, which is the exact shape of #146's defect")
+	}
+
+	if !strings.Contains(err.Error(), "cluster.advertise_addr") {
+		t.Errorf("Validate failed for some other reason: %v", err)
+	}
+}
+
+// clusterEnabled builds a cluster block that is valid, then applies one mutation.
+//
+// Starting from valid and breaking one thing is what makes each test above about its own rule: a
+// helper that started from the zero value would have every test failing on the first check reached,
+// whichever that happened to be.
+func clusterEnabled(mutate func(*ClusterConfig)) ClusterConfig {
+	cfg := ClusterConfig{
+		Enabled:           true,
+		NodeID:            "node-1",
+		ListenAddr:        "0.0.0.0:8080",
+		AdvertiseAddr:     "10.0.1.1:8080",
+		SeedNodes:         []string{"10.0.1.2:8080"},
+		ReplicationFactor: 3,
+	}
+
+	if mutate != nil {
+		mutate(&cfg)
+	}
+
+	return cfg
+}
+
+// TestTheHelperStartsFromSomethingValid keeps clusterEnabled honest.
+//
+// Every refusal test above asserts that one mutation is rejected, and each of those passes vacuously if
+// the unmutated base is rejected too — for a reason that has nothing to do with the rule under test.
+func TestTheHelperStartsFromSomethingValid(t *testing.T) {
+	t.Parallel()
+
+	if err := validateClusterConfig(clusterEnabled(nil)); err != nil {
+		t.Fatalf("the base cluster block this file's tests mutate is itself invalid: %v\n\nEvery "+
+			"refusal test would then pass for the wrong reason", err)
+	}
+}

--- a/internal/config/validate_cluster_test.go
+++ b/internal/config/validate_cluster_test.go
@@ -159,8 +159,25 @@ func TestValidateRejectsANegativeReplicationFactor(t *testing.T) {
 // A single rule for both addresses is wrong in one direction or the other, which is why this does not
 // reuse validateListenAddr. net.ListenUDP on 127.0.0.1:0 binds and the kernel assigns a port — this
 // repository's own distributed tests configure exactly that, and ClusterManager.GossipAddr exists to
-// report the assigned port back. net.DialUDP to a port 0 fails with "can't assign requested address",
-// so an advertised port 0 is an address no peer can reach.
+// report the assigned port back. An advertised port 0, meanwhile, is an address no peer can deliver to.
+//
+// # Why the dialing half is not asserted here
+//
+// It was, and it failed on Linux. The first version of this test required net.DialUDP to
+// "127.0.0.1:0" to *fail*, on the strength of a measurement made on darwin, where it returns "can't
+// assign requested address". Measured on Linux, the same dial **succeeds**, reports
+// `remote=127.0.0.1:0`, and a subsequent Write returns n=12 and a nil error. The datagram goes nowhere.
+//
+// So the platform difference is only in where the failure appears, and Linux is the worse of the two:
+// darwin refuses at the dial, while Linux accepts the address, accepts the send, and drops the
+// datagram with nothing reported at either end. That strengthens the refusal rather than weakening it —
+// an advertised port 0 on Linux is precisely the silent-partition shape this validation exists for, and
+// there is no observable event anywhere to diagnose it from.
+//
+// A test cannot assert "the send silently goes nowhere" without a receiver to prove the absence
+// against, and a negative over a UDP socket is a timeout rather than a fact. So the dialing half is
+// argued in the comment and in the refusal's own message, and what remains asserted here is the half
+// that *is* observable: the listening side binds, so port 0 has to stay legal there.
 //
 // validateListenAddr's port-0 message is also wrong here on its own terms: it tells the operator to use
 // the `enabled` flag beside the field, which the cluster block does not have per address.
@@ -194,34 +211,18 @@ func TestClusterAddrsAllowPortZeroOnlyWhereItBinds(t *testing.T) {
 			"every single-host test that wants a free port", err, bound)
 	}
 
-	// The dialing side. Refused, because the dial itself fails.
-	dialErr := func() error {
-		da, resolveErr := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-		if resolveErr != nil {
-			return resolveErr
-		}
-
-		c, connErr := net.DialUDP("udp", nil, da)
-		if connErr != nil {
-			return connErr
-		}
-
-		_ = c.Close()
-
-		return nil
-	}()
-
-	if dialErr == nil {
-		t.Error("dialing 127.0.0.1:0 succeeded. The refusal of an advertised port 0 rests on this dial " +
-			"failing; if it now works, that rule should be reconsidered rather than kept on faith")
-	}
-
+	// The advertising side. Refused on every platform, for a reason that differs by platform only in
+	// where it surfaces — see the doc comment. Deliberately not conditioned on a dial probe: the first
+	// version of this test required the dial to fail, which is true on darwin and false on Linux, so the
+	// probe made the assertion a claim about the runner rather than about the rule.
 	err = validateClusterConfig(clusterEnabled(func(c *ClusterConfig) {
 		c.AdvertiseAddr = "127.0.0.1:0"
 	}))
 	if err == nil {
-		t.Fatalf("cluster.advertise_addr = 127.0.0.1:0 was accepted, but dialing it fails: %v. A node "+
-			"advertising it is unreachable while appearing configured", dialErr)
+		t.Fatal("cluster.advertise_addr = 127.0.0.1:0 was accepted. No peer can deliver to it: darwin " +
+			"refuses the dial outright, and Linux accepts both the dial and the send and drops the " +
+			"datagram — so the node is unreachable while appearing configured, with nothing reported at " +
+			"either end")
 	}
 
 	if !strings.Contains(err.Error(), "cluster.listen_addr") {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
     - S3 Transfer Acceleration: s3-acceleration.md
 
   - Operations:
+    - Distributed Mode: admin-guide/distributed.md
     - Error Handling & Recovery: error-handling-recovery.md
     - Logging: enhanced-logging.md
 


### PR DESCRIPTION
Closes #152.

## What this refuses, and why that list is short

Nothing validated the `cluster:` block before this. `Validate` checked storage, cache, network,
monitoring and mount, then returned — so every value below was accepted and discovered, if at all,
as a runtime symptom on a different host.

**The defect worth reading is one #152 does not mention.** `listen_addr` defaults to `0.0.0.0:8080`
and `advertise_addr` is the next key in the file, so copying the value down is the obvious operator
move — and it is the worst one available. `advertise_addr` is what peers are told to dial, and a peer
that dials a wildcard reaches *its own loopback*. Measured with `net.DialUDP`, replicating
`gossip.go`'s `sendMessage`:

| advertise_addr | what a peer's dial resolves to |
| --- | --- |
| `0.0.0.0:8080` | `remote=127.0.0.1:8080` |
| `:8080` | `remote=127.0.0.1:8080` |
| `[::]:8080` | `remote=[::1]:8080` |

The dial **succeeds**. Since gossip is one-way UDP, no send fails and no reply is expected, so a
three-node cluster silently becomes three clusters of one — each mounting, serving reads and
reporting healthy, and each able to serve an object a peer has already overwritten. An integrity
outcome with no error anywhere, so it fails closed.

Also refused, each with a diagnostic naming the key and the value:

- **a negative `replication_factor`** — `applyConfigDefaults` only substitutes for `0`, so a negative
  value survives; `min(rf, len(alive))` stays negative, `LoadBalancer.SelectNodes` returns `[]` for
  any count `<= 0` (probed with -1, 0, 1, 3, 99), and `executeOnce` turns that into `no target nodes
  selected` — naming neither the key nor the value.
- **a non-host:port address, a non-numeric port, and port 0 on `advertise_addr`.**

Port 0 stays legal on `listen_addr`, because the asymmetry is real and measured: `ListenUDP` on
`127.0.0.1:0` binds and the kernel assigns a port (49314 observed), while `DialUDP` to `127.0.0.1:0`
fails with `can't assign requested address`. That is why `validateGossipAddr` is separate from
`validateListenAddr` rather than reusing it — the latter's port-0 advice is right for a monitoring
endpoint and wrong here. Reusing it first broke two real `internal/adapter` tests that set
`cluster.listen_addr: 127.0.0.1:0` on purpose; **the check was wrong, not the tests**, and
`ClusterManager.GossipAddr` exists precisely to report the kernel-assigned port back.

## What warns instead of failing

Two settings are legal in one deployment and wrong in another, so they are `--dry-run` warnings:

| Setting | Legitimate use | What it does otherwise |
| --- | --- | --- |
| `seed_nodes: []` | the first node of a new cluster | every later node forms its own cluster of one |
| loopback `advertise_addr` | a single-host dev cluster | peers on other hosts reach their own loopback |

Refusing either breaks a real deployment — the second is what `NewDefault` sets and what the shipped
Compose file uses. Ignoring either ships a silent partition. Warnings go to **stderr** and the exit
code stays **0**, so a config-management tool can still bring up a first node.

The section reports the cluster secret **by source, never by value** (`from OBJECTFS_CLUSTER_SECRET`,
`from <path>`, or `not configured — the cluster will refuse to start`). A dry run gets pasted into
issues, and which of the two sources is in use is the hardest thing to establish from outside, since
the environment leaves no trace in the file.

## Three of the six documented sections could not be written

Stated here rather than faked, and repeated in the page's limitations section:

1. `cluster.persistent_log`, `cluster.data_dir` and `peer_fetch_timeout` have **zero occurrences in
   the tree**, so the in-memory-to-persistent-log upgrade procedure describes nothing, and two of the
   issue's validation rows have no field to validate.
2. The consistency-modes section is replaced by **CAS-against-S3**: `ConsistencyEventual/Session/
   Strong` were removed in 0.12.0 and survive only as a comment recording it.
3. The issue's own proposed check — `enabled && advertise_addr == ""` — **can never fire**, verified
   by calling `Validate`: `NewDefault` sets the field and `applyConfigDefaults` sets it again.

Two more of the issue's numbers are corrected in the page: the gossip port is **8080, not 7946**
(7946 is memberlist's default and appears in some test fixtures, but is the default nowhere in the
code — an operator who opens only 7946 gets the silent-partition failure by following the docs), and
the cache-sizing formula must **not** multiply by `replication_factor`, because the cluster makes no
copies. S3 holds the single one; the factor is a selection width.

## The documentation gate

`internal/config/docs_distributed_test.go` exists because the four existing documentation gates
cannot see what this page gets wrong: a **default written as prose in a table cell** is invisible to
the YAML gate, the symbol gate and the link gate alike. It pins the defaults against `NewDefault`,
requires a table row for every `ClusterConfig` yaml tag, checks each documented environment variable
against `getEnvMappings()` — #146's defect exactly, four variables documented and unread — and
asserts the three absent keys are **still absent**. That last one inverts the usual staleness
direction: the claim goes stale when someone *does* the work, at which point the page is telling an
operator a shipped feature is unavailable, so the test says to write the section rather than delete
the check.

## Verification

Mutation-verified, since a predicted failure signature has been wrong here before. **10 mutations of
the two source files** (wildcard refusal deleted, negative RF allowed, the `validateClusterConfig`
call removed, port 0 allowed on advertise, the enabled guard removed; seed warning suppressed,
loopback warning suppressed, `emitClusterDryRun` call removed, the section printed when the cluster
is off, secret material printed) and **6 of the documentation gates** — all caught, every file
restored clean.

One mutation initially **missed**: deleting the `secret_file` table row passed, because the key is
also named in the prose three paragraphs down. The check now requires a row rather than a mention,
and the reason is in the test's comment.

- `go build ./...`, `gofmt -l .`, `go vet ./...` — clean
- `golangci-lint run` — **0 issues**
- `go test -race ./...` — pass
- coverage gate under CI's own conditions (`CGO_ENABLED=1 go test -covermode=atomic` over the whole
  tree) — **35 packages at or above their floor**
- end-to-end `--dry-run`: prints the block plus both warnings at exit 0 for a loopback/no-seeds/
  no-secret config, prints the block with no warnings for a good three-node config, and prints
  nothing for `deploy/docker/node-config.yaml`