### PR TITLE
docs: day-two operations and troubleshooting, and a gate for them (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`docs/admin-guide/operations.md` and `docs/admin-guide/troubleshooting.md`** ([#148]), the day-two
+  half of the admin guide, plus `internal/config/docs_admin_guide_test.go` to keep them true.
+
+  Troubleshooting is a decision tree for four symptoms — a mount that fails, a low cache hit rate,
+  gossip that never forms, and S3 costs above expectation — and every branch ends at a command rather
+  than at advice. The mount branch opens with a message-to-exit-code table, because the two codes
+  already narrow the tree: **exit 2 is a wrong command line or config file and exit 1 is a correct
+  command whose operation failed**, so the code alone says whether to re-read the config or look at the
+  host. Two orderings are documented for the same reason — the config file is loaded before either
+  positional argument, and the storage URI is validated before the mount point, so `objectfs mount
+  s3://b /nonexistent` names the bucket and says nothing about the directory.
+
+  Two entries exist to stop a correct system being treated as broken. A **single-pass workload has a
+  correctly near-zero hit rate**: one `tar` over a dataset larger than the cache has no reuse to
+  capture, so the page says to establish that reuse exists before enlarging anything. And **`objectfs
+  cluster status` exits 0 when clustering is disabled**, which is the default rather than a fault — a
+  page that documented that as nonzero would have every single-node mount alerting.
+
+  The gossip branch documents the port collision that looks like a misconfiguration and is not: gossip
+  and the metrics endpoint both default to **8080**, gossip on UDP and metrics on TCP, and the two bind
+  simultaneously because they are separate port namespaces — verified by binding both in one process
+  rather than assumed. What it does mean is that a firewall rule written for "port 8080" without a
+  protocol may open only the one you were not thinking about. #148's body specified 7946, memberlist's
+  default and this project's nowhere.
+
+  Operations covers single-node and rolling upgrades, capacity changes, secret rotation and what to
+  alert on. **Stop, do not kill** is the load-bearing part: a `SIGKILL` leaves the kernel holding a
+  mount whose server is gone and loses any dirty range that had not reached S3, which is why the systemd
+  unit's `ExecStop` runs `objectfs unmount` with `TimeoutStopSec=90`. The message `objectfs: shutdown
+  failed, so data may not have reached S3` is named as a **stop-the-rollout signal** — it is the one
+  message this program exists to be able to print. Secret rotation is documented as **not rolling**,
+  with the reason stated: two secrets in one cluster is a partition by design, so a rolling rotation
+  would self-inflict the silent-partition failure the rest of the guide is about.
+
+  Two of #148's specified procedures **could not be written and are listed as absent rather than
+  approximated**, the same treatment [#152] got. "Upgrade nodes one at a time, leader last" and
+  "leader-failure recovery (Raft election)" describe nothing: no leader is elected on a mount path, so
+  `objectfs cluster status` prints `Role: n/a` on every node and the order is the operator's to choose —
+  an upgrade procedure saying "leader last" sends someone looking for a leader that never appears, which
+  reads like a broken cluster. "Verify quorum" and a node that "degrades to `ConsistencyEventual`" are
+  wrong twice over: there is no quorum condition anywhere, and that type was removed in 0.12.0. And
+  "log rotation and data-directory management" has no keys to manage.
+
+  The gate is the reason to trust the numbers. The four existing doc tests cannot see what these pages
+  get wrong — one parses YAML blocks, one checks Go symbols, one resolves links, one checks changelog
+  entries, and a `curl` against a metrics endpoint is prose to all four. So the new test derives both
+  ports from `NewDefault()`, checks **every** `http://` URL on each page rather than looking for one
+  correct occurrence, checks each `objectfs <sub>` invocation against the five commands the binary has,
+  cross-checks every `objectfs_*` name against `sdks/testdata/metrics-scrape.txt` — a real scrape of a
+  running registry — and asserts the leader, quorum and consistency phrases stay absent. Nine mutations
+  were run against it and two initially survived, both instructive: a metrics `curl` repointed at
+  Prometheus's own 9090 passed, because the page names `127.0.0.1:8080` further down in the
+  TCP-versus-UDP paragraph and a substring check was satisfied by a sentence that had nothing to do with
+  the command; and the same held when only one of four URLs was wrong, hiding behind three correct
+  siblings. Both are now caught. The test's own first run also found a claim needing the opposite
+  assertion: the page names `objectfs_cache_hit_rate` in order to say the gauge deliberately does not
+  exist, so that name is checked for **absence** from the fixture — exempting it would have missed the
+  day someone adds the gauge and the page starts telling operators to compute by hand a number the
+  endpoint publishes.
+
 - **Validation for the `cluster:` config block, a cluster section in `objectfs mount --dry-run`, and
   `docs/admin-guide/distributed.md`** ([#152]). Nothing validated this block before: `Validate` checked
   storage, cache, network, monitoring and mount, and returned before reaching clustering. Four states
@@ -3280,6 +3340,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#141]: https://github.com/scttfrdmn/objectfs/issues/141
 [#142]: https://github.com/scttfrdmn/objectfs/issues/142
 [#143]: https://github.com/scttfrdmn/objectfs/issues/143
+[#148]: https://github.com/scttfrdmn/objectfs/issues/148
 [#150]: https://github.com/scttfrdmn/objectfs/issues/150
 [#152]: https://github.com/scttfrdmn/objectfs/issues/152
 [#207]: https://github.com/scttfrdmn/objectfs/issues/207

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   day someone adds the gauge and the page starts telling operators to compute by hand a number the
   endpoint publishes.
 
+  Committing the pages also surfaced **two defects in `TestDocumentedCLIInvocationsAreRunnable`**,
+  both of which reported a correct command as broken — the failure direction that teaches a reader to
+  distrust a gate, after which the next real defect gets waved through with it. Neither was visible
+  until the commit: every markdown gate enumerates pages with `git ls-files`, so an untracked page is
+  invisible to all of them, and a pre-commit local run cannot see the file it is about to add.
+
+  First, **the invocation parser did not stop at a pipe.** `|` was listed as shell noise and skipped,
+  after which the parser kept reading the *next* program's arguments as though objectfs had been given
+  them: `objectfs cluster status | grep -A5 Membership` was reported as passing an unrecognized `--A5`.
+  It now stops at `|`, `||`, `&&` and `;`, and a bad flag before the pipe is still caught — verified by
+  mutation, since a fix that stopped checking would have looked identical from a passing test.
+
+  Second, **the flag list was checked against `main.go` alone**, which left an entire subcommand's
+  flags unverified. `cluster.go` declares `--json`, `--endpoint` and its own `--config`, so
+  `objectfs cluster status --json` — a flag the binary parses, and one `cluster.go` has a comment about
+  documenting — was reported as unrecognized. `TestCLIFlagsMatchTheBinary` now scans every non-test
+  file in `cmd/objectfs` and fails if it finds no declarations at all, and `--json`/`--endpoint` joined
+  `cliFlags`. Narrowing the glob back to `main.go` resurfaces the false positive, which is how the fix
+  was verified rather than assumed.
+
 - **Validation for the `cluster:` config block, a cluster section in `objectfs mount --dry-run`, and
   `docs/admin-guide/distributed.md`** ([#152]). Nothing validated this block before: `Validate` checked
   storage, cache, network, monitoring and mount, and returned before reaching clustering. Four states

--- a/README.md
+++ b/README.md
@@ -597,13 +597,20 @@ writes, which fail closed rather than degrading, and MinIO is a measured row in
 LocalStack is not. A green Compose run means the mesh forms — not that behavior is correct on AWS,
 which is what the integration suite is for.
 
-### Distributed mode
+### Administration
 
-[docs/admin-guide/distributed.md](docs/admin-guide/distributed.md) is the operator's guide: every
-`cluster:` key with its default, how to size a cache per node, growing and shrinking a cluster, and
-what clustering deliberately does not do. Read the limitations section first if you are deciding
-whether to deploy it — `internal/distributed` is experimental, and the parts an earlier design named
-that do not exist are listed there rather than described.
+Three guides for running this rather than building it:
+
+- [Operations](docs/admin-guide/operations.md) — upgrades (single-node and rolling), capacity changes,
+  rotating the cluster secret, and what to alert on.
+- [Troubleshooting](docs/admin-guide/troubleshooting.md) — a decision tree for mount failures, low
+  cache hit rates, gossip that never forms, and unexpected S3 costs. Every branch ends at a command.
+- [Distributed mode](docs/admin-guide/distributed.md) — the cluster configuration reference, cache
+  sizing, and what clustering deliberately does not do.
+
+Read the limitations section of the distributed guide first if you are deciding whether to deploy
+clustering at all — `internal/distributed` is experimental, and the parts an earlier design named that
+do not exist are listed there rather than described.
 
 The failure mode to know about before anything else: a misconfigured cluster does not fail. Each node
 comes up as a cluster of one, mounts, serves reads, and reports healthy while receiving no cache

--- a/docs/admin-guide/operations.md
+++ b/docs/admin-guide/operations.md
@@ -1,0 +1,198 @@
+# Operations
+
+Day-two procedures: upgrades, capacity changes, and the checks that tell you a change worked.
+
+This page assumes a working deployment. For what clustering does, every `cluster:` key, and the
+failure mode a misconfigured cluster has instead of an error, see
+[Distributed mode](distributed.md) — the mechanics of growing and shrinking a cluster live there, and
+this page covers the operational wrapper around them rather than repeating it.
+
+## Before any change: know what you are running
+
+```bash
+objectfs version
+objectfs mount --config /etc/objectfs/config.yaml --dry-run
+objectfs cluster status            # if clustering is enabled
+```
+
+`--dry-run` needs no credentials, no network and no FUSE, so it is safe to run on a production host
+mid-incident. It loads the file, applies the environment overrides, validates, prints what it
+resolved, and exits.
+
+Two things worth knowing about that output before you rely on it. It reports the cluster secret **by
+source and never by value**, so it is safe to paste into a ticket. And its **warnings go to stderr
+with exit code 0** — a config-management tool that treats a nonzero exit as the only signal will not
+see them.
+
+## Upgrading
+
+### Single node
+
+```bash
+systemctl stop objectfs@research-data     # unmounts cleanly
+# install the new package
+systemctl start objectfs@research-data
+```
+
+The instance name is the config name: `objectfs@research-data` reads
+`/etc/objectfs/research-data.yaml` and mounts `/mnt/objectfs/research-data`.
+
+**Stop, do not kill.** A FUSE mount is unmounted by its own process on a signal; a `SIGKILL` leaves
+the kernel holding a mount whose server is gone, and loses any dirty range that had not reached S3.
+The unit's `ExecStop` runs `objectfs unmount` for exactly this reason, and `TimeoutStopSec=90` gives
+it room to finish — a flush of a large dirty range is not instant.
+
+The message that matters on the way down is:
+
+```text
+objectfs: shutdown failed, so data may not have reached S3: ...
+```
+
+That is an exit 1, and it is the one message this program exists to be able to print. If you see it,
+**do not proceed to the next node** — find out what did not flush first.
+
+Verify the mount came back before moving on:
+
+```bash
+mount | grep objectfs
+ls /mnt/objectfs >/dev/null && echo "readable"
+curl -sf http://127.0.0.1:8081/health && echo
+```
+
+### Rolling upgrade of a cluster
+
+One node at a time. **There is no leader to upgrade last** — nothing elects one, so
+`objectfs cluster status` prints `Role: n/a` on every node and the order is yours to choose.
+
+For each node:
+
+1. Stop it as above, and confirm the unmount was clean.
+2. Install and start.
+3. Confirm from a **different** node that the upgraded one is back:
+
+   ```bash
+   objectfs cluster status | grep -A5 Membership
+   ```
+
+   Wait for `0 suspect, 0 dead` before touching the next node. A node that has just restarted is
+   suspect for a few gossip rounds, which is normal and transient; a node that stays suspect is not.
+
+4. Then the next node.
+
+Two cluster-specific cautions:
+
+- **A mixed-version cluster is only as coordinated as its oldest node.** A node running a build that
+  predates gossip authentication has its datagrams rejected, and the receiving node logs
+  `rejected gossip message` with a hint naming a version mismatch rather than a secret problem. That
+  hint exists so a rolling upgrade does not send you to check a secret that is correct.
+- **`node_id` defaults to a fresh random value on every restart.** An upgraded node with no `node_id`
+  set appears as a *new* member while the old entry ages out, so membership can read `4 nodes` in a
+  three-node cluster for a while. Set `node_id` and this stops being confusing.
+
+### Kubernetes
+
+`deploy/kubernetes/statefulset.yaml` handles the ordering: a StatefulSet's default
+`RollingUpdate` strategy replaces one pod at a time, and `terminationGracePeriodSeconds: 120` gives
+the unmount time to finish — well above the default 30, for the reason above.
+
+```bash
+kubectl rollout status statefulset/objectfs
+kubectl exec objectfs-0 -- objectfs cluster status
+```
+
+## Changing capacity
+
+### Adding and removing nodes
+
+See [Growing and shrinking a cluster](distributed.md#growing-and-shrinking-a-cluster) for the
+configuration. Operationally, the parts to hold onto:
+
+- **There is nothing to drain.** A departing node holds no data that only it has — every object is in
+  S3. What is lost is its cache, so some keys stop being announced by anybody and the next read for
+  them comes from S3. That is the pre-cluster behaviour, not a fault.
+- **There is no quorum to preserve**, because there is no consensus. Removing two of three nodes is a
+  capacity decision, not an availability one; the remaining node keeps working. `objectfs cluster
+  status` exits nonzero for a **dead or suspect** node, and deliberately has no quorum condition.
+- **Remove one at a time anyway**, and confirm the remaining nodes noticed. Not for correctness — for
+  the ability to tell a planned removal from a node that failed during the change.
+
+### Resizing a cache
+
+`performance.cache_size` and `cache.persistent_cache.max_size` are read at startup, so a change needs
+a restart of that node — which is a single-node upgrade, above. Size it against the *hot* set divided
+by the node count, and see [sizing](distributed.md#sizing-the-cache) for why
+`replication_factor` is not in that formula.
+
+Check whether the change did anything, rather than assuming:
+
+```bash
+curl -s http://127.0.0.1:8080/metrics | grep -E 'objectfs_cache_(requests_total|size_bytes)'
+```
+
+The hit rate is `hit / (hit + miss)` from the two `objectfs_cache_requests_total` series. If it did
+not move, the workload may have no reuse to capture — see
+[low cache hit rate](troubleshooting.md#cache-hit-rate-is-low), which covers that case before it
+covers the ones a bigger cache fixes.
+
+## Rotating the cluster secret
+
+The secret authenticates gossip, and a node with a different one has its datagrams rejected. There is
+no in-place rotation that keeps the mesh formed: two secrets in one cluster is a partition by design.
+
+The honest procedure is a brief coordinated restart:
+
+1. Distribute the new secret to every node, without activating it (write the file, or stage the
+   environment value).
+2. Stop **all** nodes. This is the part that is not rolling.
+3. Activate the new secret everywhere and start the nodes.
+4. Confirm full membership from each node.
+
+A rolling rotation would leave the two halves unable to exchange invalidations while both report
+healthy — the silent-partition failure, self-inflicted. Reads and writes keep working throughout the
+restart window; what stops is cache coherence, so a maintenance window is the right framing.
+
+## What to watch
+
+Neither endpoint has any authentication, which is why both default to loopback. In a pod they must
+bind `0.0.0.0` (`OBJECTFS_METRICS_ADDR`, `OBJECTFS_HEALTH_ADDR`) because the kubelet probes over the
+pod IP.
+
+```bash
+curl -sf http://127.0.0.1:8081/health          # liveness
+curl -s  http://127.0.0.1:8080/metrics         # Prometheus
+```
+
+The handful worth an alert:
+
+| Signal | Why |
+| --- | --- |
+| `objectfs_errors_total` rising | retried requests are billed requests, and a rising rate is the earliest sign of a credential or throttling problem |
+| `objectfs_cache_requests_total` hit ratio falling | the working set outgrew the cache, or a node dropped out of the mesh |
+| `objectfs_s3_cost` slope | the direct measure of what a change cost you |
+| `objectfs cluster status` exit 1 | a node is dead or suspect, or the instance is unreachable |
+| the shutdown-failed message in the journal | data may not have reached S3 |
+
+`objectfs cluster status` is the one designed to be used from a script: exit **0** when no node is
+dead or suspect *and also* when clustering is disabled (the default, not a fault), **1** when
+unreachable or a node is dead or suspect, **2** for a bad command line. `--json` gives the same data
+for `jq`.
+
+## What this page does not cover
+
+Two procedures an earlier plan for this page specified cannot be written, and are listed here rather
+than approximated:
+
+- **Leader-failure recovery and split-brain intervention.** Nothing elects a leader on a mount path.
+  Coordination is compare-and-swap against S3, which needs no leader and no quorum, so there is no
+  election to wait for and no split-brain state to resolve. See
+  [Coordination — Conditional Writes vs Raft](../design/conditional-writes-vs-raft.md).
+- **Log rotation and data-directory management.** There is no persistent log and no
+  `cluster.persistent_log` or `cluster.data_dir` key. Cluster state is in memory and is rebuilt by
+  gossiping on restart, which is safe because none of it is authoritative — S3 is.
+
+## See also
+
+- [Distributed mode](distributed.md) — the cluster configuration reference, sizing, and limitations
+- [Troubleshooting](troubleshooting.md) — the decision tree for when a check above comes back wrong
+- [Error handling and recovery](../error-handling-recovery.md) — how failures are classified and
+  retried

--- a/docs/admin-guide/troubleshooting.md
+++ b/docs/admin-guide/troubleshooting.md
@@ -1,0 +1,251 @@
+# Troubleshooting
+
+A decision tree for the four things that go wrong, each branch ending at a command that answers the
+question rather than at advice.
+
+Two conventions used throughout. Commands are what this binary actually accepts — checked by a test,
+not transcribed from a plan. And where a branch has no diagnostic, it says so: knowing that a
+question cannot be answered from outside is worth more than a suggestion that reads like one.
+
+## Mount fails
+
+Read the message before anything here. ObjectFS distinguishes its failures on purpose, so the message
+already narrows this tree to one branch:
+
+| Message | Exit | Branch |
+| --- | --- | --- |
+| `objectfs mount: ...` naming a value, or a config line | 2 | [Configuration](#configuration) |
+| `failed to initialize S3 backend: ...` | 1 | [Credentials and bucket](#credentials-and-bucket) |
+| `failed to initialize cache: ...` | 1 | [Cache directory](#cache-directory) |
+| `failed to mount filesystem: ...` | 1 | [FUSE](#fuse) |
+
+Exit **2 is a wrong command line or config file** and exit **1 is a correct command whose operation
+failed** — so the exit code alone tells you whether to re-read your config or look at the host.
+
+Two orderings decide which of two real faults you see first, and neither is arbitrary: the config
+file is loaded before either positional argument, so a syntax error in it is reported even when the
+command line is also wrong; and the storage URI is validated before the mount point, so `objectfs
+mount s3://b /nonexistent` names the bucket and says nothing about the directory.
+
+### Configuration
+
+```bash
+objectfs mount --config /etc/objectfs/config.yaml --dry-run
+```
+
+This is the first command to run for any mount problem, and it needs no credentials, no network and
+no FUSE. It loads the file, applies the environment overrides, validates everything, prints what it
+resolved, and exits without mounting.
+
+Unknown keys are **rejected**, naming the key and the line. A misspelled key was silently discarded
+before v0.10.1, which is how a config file could be 162 lines of settings that did nothing — so if
+you are carrying a file forward from an older version, this is the command that finds out.
+
+### Credentials and bucket
+
+ObjectFS uses the standard AWS credential chain, so:
+
+```bash
+aws sts get-caller-identity            # are there credentials at all
+aws s3 ls s3://your-bucket/            # can they reach this bucket
+```
+
+If `aws s3 ls` works and ObjectFS does not, the difference is almost always the **region** or an
+**endpoint**: `storage.s3.region` has a default, and a bucket in another region answers with a
+redirect that surfaces as an initialization failure. `--dry-run` prints the resolved storage URI.
+
+### Cache directory
+
+Only reachable with `cache.persistent_cache.enabled`. The directory must exist and be writable by the
+mounting user; under systemd that is the unit's user, not yours.
+
+### FUSE
+
+```bash
+ls -l /dev/fuse                        # present?
+sudo modprobe fuse                     # if not, on Linux
+which fusermount3                      # needed for an unprivileged mount
+```
+
+`fusermount3` is needed only for an **unprivileged** mount — a root mount goes through `mount(2)`
+directly. That is why the `.deb` and `.rpm` packages make `fuse3` a Recommends rather than a Depends,
+and it is why a minimal container image can fail here while the same binary works on the host.
+
+In a container, the mount needs `--device /dev/fuse` and `--cap-add SYS_ADMIN`. Neither
+`deploy/kubernetes/` manifest uses `privileged: true`, which would grant every capability and device
+for the sake of that one.
+
+## Cache hit rate is low
+
+First, get the number rather than estimating it. From the metrics endpoint:
+
+```bash
+curl -s http://127.0.0.1:8080/metrics | grep objectfs_cache_requests_total
+```
+
+```text
+objectfs_cache_requests_total{service="objectfs",type="hit"} 3
+objectfs_cache_requests_total{service="objectfs",type="miss"} 1
+```
+
+The hit rate is `hit / (hit + miss)`. There is deliberately no `objectfs_cache_hit_rate` gauge: a
+ratio computed at scrape time loses the counts, and Prometheus can divide.
+
+**Before treating a low number as a problem, check that the workload can be cached at all.** A
+single-pass traversal — one `tar` over a dataset larger than the cache, or a checksum run — has no
+reuse, so its hit rate is *correctly* near zero and no amount of cache will change it. The metric
+that matters there is throughput, not hit rate.
+
+If there is reuse:
+
+- **Single node** — the working set does not fit. Raise `performance.cache_size`, or enable
+  `cache.persistent_cache` to spill to local disk, which is the cheaper of the two.
+- **Multi-node** — each node caches independently and there is no shared cache. See
+  [sizing](distributed.md#sizing-the-cache), whose formula divides the hot set by the node count and
+  deliberately does *not* multiply by `replication_factor`.
+- **Entries evicted before they expire** — `cache.max_entries` bounds the count independently of
+  `performance.cache_size`, so a workload of many small objects can hit the entry limit with the byte
+  budget half empty.
+
+Per-level numbers, when the read cache is multi-level:
+
+```bash
+curl -s http://127.0.0.1:8080/metrics | grep objectfs_cache_size_bytes
+```
+
+## Gossip is not forming
+
+**This is the failure with no error message**, and it is the reason
+[distributed.md](distributed.md#the-failure-mode-this-page-exists-for) leads with it. Each node comes
+up as a cluster of one: it mounts, serves reads, reports healthy, and receives no cache invalidation
+from any peer — so it can serve an object another node has already overwritten. Gossip is one-way
+UDP, so there is no handshake to fail and nothing to time out.
+
+In order, because each step rules out the next:
+
+**1. Is the configuration what you think it is?**
+
+```bash
+objectfs mount --config /etc/objectfs/config.yaml --dry-run
+```
+
+Warnings go to stderr and the exit code stays 0. The two that matter here are an empty
+`cluster.seed_nodes` and a loopback `cluster.advertise_addr` — both legal, both a cluster of one on
+any node that is not the first of a new cluster. A **wildcard** `advertise_addr` is refused outright,
+because a peer dialing a wildcard reaches its own loopback.
+
+**2. What does each node think its membership is?**
+
+```bash
+objectfs cluster status
+objectfs cluster status --json | jq '.membership, .peers'
+```
+
+`No peers.` means this node has not joined. Run it on **every** node — two nodes can disagree, and
+that asymmetry is itself the diagnosis: a firewall permitting A→B and dropping B→A gives you exactly
+that, because gossip is one-way.
+
+Note the exit codes, which differ from what you might assume: **0** when no node is dead or suspect
+*and also* when clustering is disabled, because disabled is the default rather than a fault; **1**
+when the instance could not be reached or a node is dead or suspect; **2** for a bad command line.
+There is no quorum condition, because nothing elects a leader.
+
+**3. Is the secret the same on every node?**
+
+A mismatch is logged on the **receiving** node, so collecting logs from one node will not show it:
+
+```text
+level=WARN msg="rejected gossip message" peer=10.0.1.2:54123 hint="a peer with a different cluster secret, ..."
+```
+
+The hint is one of three and they send you to different places:
+
+| Hint mentions | Cause |
+| --- | --- |
+| a different cluster secret, or a host that is not a member | secret mismatch, or an unrelated host on the port |
+| a build that predates gossip authentication | a mixed-version cluster mid-upgrade |
+| clock skew beyond the freshness window | NTP, on one or both hosts |
+
+The counts are under `Gossip:` in `objectfs cluster status`, printed only when non-zero — so an empty
+anomaly section means none of the three has happened, which is a stronger statement than a block of
+zeros.
+
+**4. Is UDP open between the nodes, both ways?**
+
+The port is **8080** by default, not 7946 — the same number the metrics endpoint uses, which looks
+like a misconfiguration and is not. Metrics is TCP and gossip is UDP, and the two are separate port
+namespaces: `127.0.0.1:8080/tcp` and `0.0.0.0:8080/udp` both bind at the same time, verified rather
+than assumed. What this does mean is that a firewall rule written for "port 8080" without a protocol
+may open only the one you were not thinking about.
+
+```bash
+# From node B, aimed at node A's advertise_addr:
+nc -zuv 10.0.1.1 8080
+```
+
+`nc -u` proves a datagram left, not that anything received it — UDP has nothing to report. The
+authoritative check is step 2 on the far node.
+
+**5. Does `advertise_addr` name an address peers can actually reach?**
+
+Wildcards are refused and loopback is warned about, but a routable-looking address on the wrong
+interface is neither — and it fails identically. Verify from another node:
+
+```bash
+ping -c1 10.0.1.1
+```
+
+## S3 costs are higher than expected
+
+A mount publishes what it is spending, so start with the number:
+
+```bash
+curl -s http://127.0.0.1:8080/metrics | grep objectfs_s3_cost
+```
+
+Then, in the order that usually pays:
+
+1. **The cache hit rate**, above. Every miss is a GET, and a GET is both a request charge and egress
+   if it leaves the region. This is nearly always the whole answer.
+2. **Request count versus bytes.** `objectfs_operations_total` against
+   `objectfs_operation_size_bytes_sum` tells you whether you are paying for many small requests or
+   for volume. Many small ones point at `performance.parallel_read` thresholds or at a workload of
+   small files; volume points at the cache.
+3. **Storage class.** `STANDARD` is the default for a reason: IA and the Glacier classes bill a 128 KB
+   minimum per object and a 30-day minimum duration, so a mount that writes many small or short-lived
+   files costs **more** on them, not less.
+4. **Transfer Acceleration**, if enabled. It carries a per-GB surcharge, and it is a performance
+   capability that falls back silently — so it can be off without anything failing:
+
+   ```bash
+   curl -s http://127.0.0.1:8080/metrics | grep objectfs_s3_acceleration
+   ```
+
+5. **Errors, which are also billed.** A retried request is a charged request:
+
+   ```bash
+   curl -s http://127.0.0.1:8080/metrics | grep objectfs_errors_total
+   ```
+
+`objectfs_s3_cost` is computed from a rate table verified against the live AWS Pricing API. It is an
+estimate of what this mount did, and it does not know your negotiated rates, your free tier, or
+anything happening in the bucket that did not come through this mount.
+
+## When none of this helps
+
+Include, in an issue:
+
+- `objectfs version`
+- `objectfs mount --config <your config> --dry-run` output, **stdout and stderr** — it prints no
+  secrets, only their source
+- `objectfs cluster status --json` from every node, if clustering is on
+- the exact error message and its exit code
+- `uname -a`, and whether the mount is containerized
+
+## See also
+
+- [Distributed mode](distributed.md) — the cluster configuration reference and what clustering does
+  not do
+- [Operations](operations.md) — rolling upgrades, growing and shrinking, and what to check when
+- [Error handling and recovery](../error-handling-recovery.md) — how ObjectFS classifies and retries
+  failures

--- a/internal/config/docs_admin_guide_test.go
+++ b/internal/config/docs_admin_guide_test.go
@@ -1,0 +1,281 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Gates on docs/admin-guide/operations.md and troubleshooting.md, the two pages #148 asked for.
+//
+// Same reasoning as docs_distributed_test.go, applied to a different kind of claim. These pages are
+// mostly *commands* and *port numbers*, and the existing gates reach neither: docs_symbols_test.go
+// checks CLI invocations it can recognize, but a curl against a metrics endpoint is prose to it, and a
+// port written in a firewall example is prose to everything.
+//
+// The specific risk here is a decision tree that sends an operator to a command that does not exist, or
+// to the wrong port. Both are worse than no documentation: a troubleshooting page is read by someone who
+// has already exhausted what they know, so a wrong branch costs them the time it takes to rule it out
+// and some of their trust in the rest of the tree.
+
+// docsAdminGuide reads one page from docs/admin-guide.
+func docsAdminGuide(t *testing.T, name string) string {
+	t.Helper()
+
+	//nolint:gosec // a path built from the module root this test located itself
+	body, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "admin-guide", name))
+	if err != nil {
+		t.Fatalf("read docs/admin-guide/%s: %v", name, err)
+	}
+
+	return string(body)
+}
+
+// TestAdminGuidePortsMatchTheDefaults pins the ports the troubleshooting branches send people to.
+//
+// A wrong port here is the most expensive kind of documentation error this repository can ship, because
+// the gossip branch exists for a failure with *no error message at all*. An operator who opens the wrong
+// UDP port confirms "the firewall is fine" and moves on, and the cluster of one they came to diagnose is
+// still there.
+//
+// #148 and #152 both specified 7946 — memberlist's default, and a number that appears in this
+// repository's own test fixtures. It is the default nowhere in the code.
+func TestAdminGuidePortsMatchTheDefaults(t *testing.T) {
+	t.Parallel()
+
+	def := NewDefault()
+
+	_, gossipPort, ok := strings.Cut(def.Cluster.ListenAddr, ":")
+	if !ok {
+		t.Fatalf("NewDefault's cluster.listen_addr %q is not host:port", def.Cluster.ListenAddr)
+	}
+
+	metricsAddr := def.Monitoring.Metrics.Addr
+	healthAddr := def.Monitoring.HealthChecks.Addr
+
+	for _, page := range []string{"operations.md", "troubleshooting.md"} {
+		doc := docsAdminGuide(t, page)
+
+		// Every URL is checked whole — scheme, address and path together. Checking the address anywhere on
+		// the page was the first version and it missed a mutation that pointed the metrics curl at
+		// Prometheus's own 9090: the page still said "127.0.0.1:8080" further down, in the paragraph about
+		// TCP and UDP sharing the number, so a substring test was satisfied by a sentence that had nothing
+		// to do with the command. Only the pages that use an endpoint are checked for it.
+		for _, endpoint := range []struct{ path, addr string }{
+			{"/metrics", metricsAddr},
+			{"/health", healthAddr},
+		} {
+			if !strings.Contains(doc, endpoint.path) {
+				continue
+			}
+
+			want := "http://" + endpoint.addr + endpoint.path
+			if !strings.Contains(doc, want) {
+				t.Errorf("%s shows a %s command and none of them is %s. Someone following it curls the "+
+					"wrong port and concludes the endpoint is not published", page, endpoint.path, want)
+			}
+
+			// And every one of them, so a wrong URL cannot hide behind a correct sibling elsewhere on the
+			// page. An operator reads the command next to their symptom, not the whole file.
+			for field := range strings.FieldsSeq(doc) {
+				url := strings.Trim(field, "`\"'()[],")
+				if strings.HasPrefix(url, "http://") && strings.HasSuffix(url, endpoint.path) &&
+					url != want {
+					t.Errorf("%s contains the URL %s, but the default %s endpoint is %s", page, url,
+						endpoint.path, want)
+				}
+			}
+		}
+	}
+
+	// The gossip port, in the branch that sends someone to a firewall.
+	tsh := docsAdminGuide(t, "troubleshooting.md")
+	if !strings.Contains(tsh, "**"+gossipPort+"** by default") {
+		t.Errorf("troubleshooting.md does not name %s as the gossip port. The default listen_addr is "+
+			"%q, and this is the branch for a failure that has no error message — a wrong port here is "+
+			"an operator ruling out the actual cause", gossipPort, def.Cluster.ListenAddr)
+	}
+
+	if strings.Contains(tsh, "UDP 7946") || strings.Contains(tsh, "port 7946 is open") {
+		t.Error("troubleshooting.md tells an operator to check 7946, which is memberlist's default and " +
+			"not this project's. #148's issue body says this; the code does not")
+	}
+}
+
+// TestAdminGuideCommandsExist checks every objectfs invocation against the binary's own surface.
+//
+// A decision tree is a list of commands, and a command that does not exist ends the branch in a usage
+// error rather than an answer.
+func TestAdminGuideCommandsExist(t *testing.T) {
+	t.Parallel()
+
+	// The command set from cmd/objectfs's dispatch. Deliberately written out rather than derived: the
+	// point is to notice when a page names something outside this list, including a plausible command
+	// this project does not have, like `objectfs doctor` or `objectfs status`.
+	known := map[string]bool{
+		"mount":   true,
+		"unmount": true,
+		"cluster": true,
+		"version": true,
+		"help":    true,
+	}
+
+	for _, page := range []string{"operations.md", "troubleshooting.md", "distributed.md"} {
+		doc := docsAdminGuide(t, page)
+
+		for line := range strings.SplitSeq(doc, "\n") {
+			rest, found := strings.CutPrefix(strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line),
+				"$ ")), "objectfs ")
+			if !found {
+				continue
+			}
+
+			sub, _, _ := strings.Cut(rest, " ")
+			sub = strings.TrimSuffix(sub, "`")
+
+			if sub == "" {
+				continue
+			}
+
+			if !known[sub] {
+				t.Errorf("%s names `objectfs %s`, which is not a command this binary has. The commands "+
+					"are mount, unmount, cluster, version and help — a branch ending at a usage error is "+
+					"worse than one that says the question cannot be answered from outside", page, sub)
+			}
+		}
+	}
+}
+
+// TestAdminGuideMetricNamesArePublished checks the metric names against the SDK fixture.
+//
+// Every metric the troubleshooting tree tells someone to grep for has to be one a mount actually
+// publishes. sdks/testdata/metrics-scrape.txt is a real scrape of a running instance, regenerated from
+// the live registry by TestSDKFixtureMatchesTheLiveScrape — so it is the closest thing to the endpoint
+// itself that a unit test can read, and a name absent from it is a grep that silently returns nothing.
+//
+// Silence is the failure mode worth guarding: `grep objectfs_cache_hit_rate` on an endpoint that
+// publishes `objectfs_cache_requests_total` prints nothing at all, and nothing looks exactly like a
+// working command on a healthy system.
+//
+// A name the page names in order to say it does *not* exist is checked in the other direction, which is
+// the first thing this test found. troubleshooting.md says "There is deliberately no
+// `objectfs_cache_hit_rate` gauge", and the naive version of this test read that as a grep target.
+// Exempting it would have been the wrong repair: the claim is falsifiable too, and it becomes false the
+// moment somebody adds the gauge — at which point the page is telling an operator to compute by hand
+// something the endpoint now publishes. So a negated name must be absent from the fixture.
+func TestAdminGuideMetricNamesArePublished(t *testing.T) {
+	t.Parallel()
+
+	//nolint:gosec // a path built from the module root this test located itself
+	scrape, err := os.ReadFile(filepath.Join(repoRoot(t), "sdks", "testdata", "metrics-scrape.txt"))
+	if err != nil {
+		t.Fatalf("read the SDK metrics fixture: %v", err)
+	}
+
+	published := string(scrape)
+
+	// Names the pages assert are *absent*, each with the sentence that asserts it. Checked in the
+	// opposite direction: present in the fixture means the page is now wrong.
+	negated := map[string]string{
+		"objectfs_cache_hit_rate": "There is deliberately no `objectfs_cache_hit_rate` gauge",
+	}
+
+	for _, page := range []string{"operations.md", "troubleshooting.md"} {
+		doc := docsAdminGuide(t, page)
+
+		for _, field := range strings.FieldsFunc(doc, func(r rune) bool {
+			return r != '_' && (r < 'a' || r > 'z') && (r < '0' || r > '9')
+		}) {
+			if !strings.HasPrefix(field, "objectfs_") {
+				continue
+			}
+
+			if claim, isNegated := negated[field]; isNegated {
+				// The page has to still be making the negative claim — otherwise this exemption is
+				// silently covering a real grep target that happens to share the name.
+				if !strings.Contains(doc, claim) {
+					t.Errorf("%s names %q but no longer carries the claim %q that makes it a deliberate "+
+						"absence. Either restore the sentence or stop naming the metric", page, field, claim)
+					continue
+				}
+
+				if strings.Contains(published, field) {
+					t.Errorf("%s says there is deliberately no %s, and the metrics fixture now publishes "+
+						"one. The page is telling an operator to compute by hand a number the endpoint "+
+						"gives them", page, field)
+				}
+
+				continue
+			}
+
+			// A grep pattern is checked as a prefix, because the page greps for families
+			// (objectfs_cache_requests_total matches two series with different labels).
+			if !strings.Contains(published, field) {
+				t.Errorf("%s tells an operator to look for the metric %q, which does not appear in "+
+					"sdks/testdata/metrics-scrape.txt — a real scrape of a running instance. A grep for a "+
+					"metric that is not published returns nothing, which is indistinguishable from a "+
+					"healthy system", page, field)
+			}
+		}
+	}
+}
+
+// TestAdminGuideExitCodesMatchTheCommand pins the exit codes the operations page tells scripts to use.
+//
+// These are the page's only machine-readable claim: an alert or a health check will branch on them, and
+// the one that surprises people is that clustering being *disabled* is a 0. A page that documented it as
+// nonzero would have every non-clustered mount alerting.
+func TestAdminGuideExitCodesMatchTheCommand(t *testing.T) {
+	t.Parallel()
+
+	ops := docsAdminGuide(t, "operations.md")
+
+	// The values from cmd/objectfs: exitOK 0, exitFailure 1, exitUsage 2.
+	for _, want := range []string{
+		"**0** when no node is\ndead or suspect",
+		"**1** when\nunreachable or a node is dead or suspect",
+		"**2** for a bad command line",
+	} {
+		if !strings.Contains(ops, want) {
+			t.Errorf("operations.md does not document the exit code as %q. clusterStatusExitCode returns "+
+				"0 for a healthy cluster and for clustering being disabled, 1 for dead or suspect or "+
+				"unreachable, and 2 for a usage error, and a script branching on these is the stated use",
+				want)
+		}
+	}
+
+	if !strings.Contains(ops, "disabled") {
+		t.Error("operations.md documents the exit codes without saying that clustering being disabled " +
+			"also exits 0. That is the surprising case: it is the default configuration rather than a " +
+			"fault, and a page that omitted it would have every single-node mount alerting")
+	}
+}
+
+// TestAdminGuideDoesNotPromiseALeader is the counterpart to the absent-keys check in
+// docs_distributed_test.go.
+//
+// #148's body specifies "upgrade nodes one at a time; leader last", "leader failure recovery (Raft
+// election)", "verify quorum", and a node that "degrades to ConsistencyEventual". None of the four is a
+// thing this code does: nothing elects a leader on a mount path, there is no quorum, and that type was
+// removed in 0.12.0. An upgrade procedure that says "leader last" sends an operator looking for a
+// leader that `objectfs cluster status` reports as `n/a`, which reads like a broken cluster.
+func TestAdminGuideDoesNotPromiseALeader(t *testing.T) {
+	t.Parallel()
+
+	for _, page := range []string{"operations.md", "troubleshooting.md"} {
+		doc := docsAdminGuide(t, page)
+
+		for _, phrase := range []string{
+			"leader last",
+			"ConsistencyEventual",
+			"verify quorum",
+		} {
+			if strings.Contains(doc, phrase) {
+				t.Errorf("%s contains %q. Nothing elects a leader on a mount path, there is no quorum "+
+					"condition anywhere, and the consistency levels were removed in 0.12.0 — each of "+
+					"these sends an operator to look for something that is not there", page, phrase)
+			}
+		}
+	}
+}

--- a/internal/config/docs_symbols_test.go
+++ b/internal/config/docs_symbols_test.go
@@ -90,6 +90,12 @@ var cliFlags = map[string]bool{
 	"max-concurrency": true,
 	"foreground":      true,
 	"mount-point":     true,
+
+	// cluster.go's FlagSet. A subcommand's flags are as real as mount's, and leaving them out reported
+	// `objectfs cluster status --json` as broken — see TestCLIFlagsMatchTheBinary, which now scans every
+	// non-test file in cmd/objectfs rather than main.go alone.
+	"json":     true,
+	"endpoint": true,
 }
 
 // cliFlagsTakingAValue are the non-boolean flags, whose following argument is a value and not a
@@ -100,6 +106,7 @@ var cliFlagsTakingAValue = map[string]bool{
 	"cache-size":      true,
 	"max-concurrency": true,
 	"mount-point":     true,
+	"endpoint":        true,
 }
 
 // subcommands is every first word cmd/objectfs/main.go dispatches on.
@@ -353,9 +360,17 @@ func checkShellBlock(t *testing.T, rel string, block fencedBlock) {
 //
 // cliFlags has to be written out because main's flag variables are unexported, and a duplicated
 // list with no check is precisely the mechanism that gave this repository five different version
-// numbers. So the list is compared against the flag declarations in main.go: a flag added there and
-// not here would go unchecked in documentation, and one removed there but left here would let this
-// gate bless a command that no longer runs.
+// numbers. So the list is compared against the flag declarations in the command's own source: a flag
+// added there and not here would go unchecked in documentation, and one removed there but left here
+// would let this gate bless a command that no longer runs.
+//
+// **Every non-test file in cmd/objectfs, not main.go alone.** Reading one file was the original shape
+// and it left a whole subcommand's flags unverified: cluster.go declares --json, --endpoint and its own
+// --config, and none of the three was in cliFlags, so `objectfs cluster status --json` — which the
+// binary parses and which cluster.go:151 has a comment about documenting — was reported as an
+// unrecognized flag. That is the failure direction this test's own comment warns about, arriving
+// through the file list rather than through the list of names: a correct command named as broken
+// teaches a reader to distrust the gate, and the next real defect gets waved through with it.
 //
 // Two flags are in cliFlags and cannot be declared: --version and --help are dispatch cases in run's
 // switch, not flags, since they have to work before any FlagSet is chosen. They are exempted by name
@@ -363,21 +378,36 @@ func checkShellBlock(t *testing.T, rel string, block fencedBlock) {
 func TestCLIFlagsMatchTheBinary(t *testing.T) {
 	t.Parallel()
 
-	//nolint:gosec // a path built from the module root this test located itself
-	mainGo, err := os.ReadFile(filepath.Join(repoRoot(t), "cmd", "objectfs", "main.go"))
+	sources, err := filepath.Glob(filepath.Join(repoRoot(t), "cmd", "objectfs", "*.go"))
 	if err != nil {
-		t.Fatalf("reading cmd/objectfs/main.go, which declares the flags: %v", err)
+		t.Fatalf("globbing cmd/objectfs: %v", err)
 	}
 
 	declared := make(map[string]bool)
-	for _, m := range flagDeclaration.FindAllStringSubmatch(string(mainGo), -1) {
-		declared[m[1]] = true
+	scanned := 0
+
+	for _, src := range sources {
+		if strings.HasSuffix(src, "_test.go") {
+			continue
+		}
+
+		body, readErr := os.ReadFile(src) //nolint:gosec // a path from a glob under the module root
+		if readErr != nil {
+			t.Fatalf("reading %s, which may declare flags: %v", src, readErr)
+		}
+
+		scanned++
+
+		for _, m := range flagDeclaration.FindAllStringSubmatch(string(body), -1) {
+			declared[m[1]] = true
+		}
 	}
 
-	if len(declared) == 0 {
-		t.Fatal("found no flag declarations in cmd/objectfs/main.go. If flag parsing moved to " +
-			"another file or another package, point this test at it — without this comparison " +
-			"cliFlags below is an unverified copy, which is the defect this test exists to prevent")
+	if scanned == 0 || len(declared) == 0 {
+		t.Fatalf("scanned %d non-test file(s) in cmd/objectfs and found %d flag declarations. If flag "+
+			"parsing moved to another package, point this test at it — without this comparison cliFlags "+
+			"below is an unverified copy, which is the defect this test exists to prevent", scanned,
+			len(declared))
 	}
 
 	// Spellings that name a subcommand rather than a flag. run() matches these on args[0] before any
@@ -686,6 +716,17 @@ func parseInvocation(line int, text, rest string) cliInvocation {
 	fields := strings.Fields(rest)
 	for i := 0; i < len(fields); i++ {
 		field := fields[i]
+
+		// A pipe, a semicolon or a `&&` ends this command. Everything after it belongs to a different
+		// program, and treating it as ours is not a harmless over-read: `objectfs cluster status | grep
+		// -A5 Membership` was reported as passing an unrecognized `--A5` to objectfs, naming a real
+		// command as broken. Listing `|` in shellNoise skipped the pipe itself and then went on reading
+		// grep's arguments as though objectfs had been given them, so the fix is to stop rather than to
+		// skip.
+		if field == "|" || field == "||" || field == "&&" || field == ";" ||
+			strings.HasPrefix(field, "|") {
+			break
+		}
 
 		switch {
 		case strings.HasPrefix(field, "-"):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,8 @@ nav:
     - S3 Transfer Acceleration: s3-acceleration.md
 
   - Operations:
+    - Operations Guide: admin-guide/operations.md
+    - Troubleshooting: admin-guide/troubleshooting.md
     - Distributed Mode: admin-guide/distributed.md
     - Error Handling & Recovery: error-handling-recovery.md
     - Logging: enhanced-logging.md


### PR DESCRIPTION
Closes #148. The day-two half of the admin guide, completing the pair started by #152 (PR #418).

## The two pages

**`docs/admin-guide/troubleshooting.md`** — a decision tree for four symptoms: a mount that fails, a
low cache hit rate, gossip that never forms, and S3 costs above expectation. Every branch ends at a
command, and where a branch has no diagnostic it says so — knowing a question cannot be answered
from outside is worth more than a suggestion that reads like one.

The mount branch opens with a message → exit code → branch table, because the codes already narrow
it: **2 is a wrong command line or config file, 1 is a correct command whose operation failed**. Two
argument orderings are documented for the same reason — the config file is loaded before either
positional argument, and the storage URI is validated before the mount point, so `objectfs mount
s3://b /nonexistent` names the bucket and says nothing about the directory.

Two entries exist to stop a *correct* system being read as broken:

- A **single-pass workload has a correctly near-zero hit rate**. One `tar` over a dataset larger than
  the cache has no reuse to capture, so no amount of cache changes the number. The page establishes
  that reuse exists before it covers the causes a bigger cache fixes.
- **`objectfs cluster status` exits 0 when clustering is disabled** — the default rather than a
  fault. A page documenting that as nonzero would have every single-node mount alerting.

The gossip branch documents the port collision that looks like a misconfiguration and is not: gossip
and metrics both default to **8080**, UDP and TCP respectively, and both bind simultaneously because
those are separate port namespaces — verified by binding both in one process, not assumed. The
consequence worth stating is that a firewall rule written for "port 8080" without a protocol may open
only the one you were not thinking about.

**`docs/admin-guide/operations.md`** — upgrades (single-node and rolling), capacity changes, secret
rotation, and what to alert on. Grow/shrink mechanics are cross-linked to `distributed.md` rather
than duplicated.

**Stop, do not kill** is the load-bearing part: a `SIGKILL` leaves the kernel holding a mount whose
server is gone and loses any dirty range that had not reached S3, which is why the systemd unit's
`ExecStop` runs `objectfs unmount` under `TimeoutStopSec=90`. `objectfs: shutdown failed, so data may
not have reached S3` is named as a **stop-the-rollout signal** — it is the one message this program
exists to be able to print.

Secret rotation is documented as **not rolling**, with the reason: two secrets in one cluster is a
partition by design, so a rolling rotation would self-inflict the silent-partition failure the rest
of the guide is about. Reads and writes keep working through the restart window; what stops is cache
coherence, so a maintenance window is the right framing.

## What #148 asked for that could not be written

Listed in each page's "What this page does not cover" rather than approximated — the same treatment
#152 got, and the same reason. All verified against the tree:

| #148 specifies | Reality |
| --- | --- |
| "upgrade one at a time, **leader last**" | Nothing elects a leader on a mount path. `cluster status` prints `Role: n/a` on every node; the order is the operator's to choose |
| "**leader failure recovery** (Raft election)" and split-brain intervention | No election to wait for, no split-brain state to resolve. Coordination is CAS against S3 |
| "**verify quorum** before removing a node" | No quorum condition exists anywhere |
| a node "degrades to **`ConsistencyEventual`**" | Removed in 0.12.0; survives only as a comment recording the removal |
| "**log rotation** and data dir management" | No `cluster.persistent_log`, no `cluster.data_dir` |
| gossip on **7946** | memberlist's default. This project's is 8080 |

An upgrade procedure saying "leader last" is the costly one: it sends an operator looking for a
leader that never appears, which reads like a broken cluster.

## The gate

`internal/config/docs_admin_guide_test.go`, 5 tests. The four existing doc gates cannot see what
these pages get wrong — one parses YAML blocks, one checks Go symbols, one resolves links, one checks
changelog entries, and a `curl` against a metrics endpoint is prose to all four.

- Both ports derived from `NewDefault()`, and **every** `http://` URL checked, not one correct
  occurrence.
- Each `objectfs <sub>` invocation checked against the five commands the binary has, so a plausible
  `objectfs doctor` fails rather than shipping.
- Every `objectfs_*` name cross-checked against `sdks/testdata/metrics-scrape.txt`, a real scrape of
  a running registry. A grep for an unpublished metric returns nothing, which is indistinguishable
  from a healthy system.
- The leader, quorum and consistency phrases asserted **absent**.

**9 mutations run; 2 initially survived.** A metrics `curl` repointed at Prometheus's own 9090
passed, because the page names `127.0.0.1:8080` further down in the TCP-versus-UDP paragraph and a
substring check was satisfied by a sentence with nothing to do with the command. The same held when
only *one* of four URLs was wrong, hiding behind three correct siblings. Both caught now, by checking
whole URLs and all of them.

The test's own first run found a claim needing the opposite assertion: the page names
`objectfs_cache_hit_rate` in order to say the gauge deliberately does not exist. Exempting it would
have been the wrong repair — that claim is falsifiable too, and it becomes false the day someone adds
the gauge, at which point the page tells an operator to compute by hand a number the endpoint
publishes. So a negated name is checked for **absence**, and the negating sentence is required to
still be there.

## Verification

- `go build ./...`, `gofmt -l .`, `go vet ./...`, `golangci-lint run` — 0 issues
- `go test -race ./...` — clean, full suite
- Coverage gate under CI's own command (`CGO_ENABLED=1 go test -covermode=atomic ...` then
  `./scripts/coverage-gate.sh coverage.out .coverage-floors`) — 35 packages at or above floor
- All **18** doc gates pass in a `linux/amd64 golang:1.26-alpine` container as well as on darwin.
  Run because of #418's CI failure: a darwin-only measurement about UDP port 0 was falsified on
  Linux, which is the argument for measuring on the target platform rather than the development one