### PR TITLE
feat(release): attach the .deb and .rpm nobody could obtain (#138)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,105 @@ jobs:
         if-no-files-found: error
         retention-days: 7
 
+  # The .deb and the .rpm, attached to the release.
+  #
+  # These have been buildable for as long as nfpm.yaml has existed, and ci.yml's `packaging` job builds
+  # both and installs the deb on every PR — but this workflow had no reference to `package-linux`,
+  # `nfpm`, `.deb` or `.rpm`, so every published release was five tar.gz binaries and their checksums
+  # and nothing else. A package that CI proves installable and that no user can obtain is the same
+  # defect as scripts/preremove.sh before #207: working code with nothing invoking it.
+  #
+  # This is the half of #138 that needs no hosting decision. That issue asks for apt and yum repository
+  # setup scripts pointing at `packages.objectfs.io`, which does not exist — it and `objectfs.io` both
+  # resolve to registrar parking IPs that do not complete a TLS handshake. `dpkg -i` and `rpm -i`
+  # against a downloaded asset need no repository at all, and they are what an operator can actually do
+  # today.
+  #
+  # A separate job rather than a step in `build`: package building is amd64+arm64 in one invocation, so
+  # it does not fit a five-cell matrix that includes armv7 and two darwin targets, and nfpm has no
+  # darwin output. Its own job also means a packaging failure names itself in the checks list instead of
+  # appearing as a mysterious failure of `build (linux-amd64)`.
+  #
+  # No armv7 package. `make package-linux` builds amd64 and arm64, matching nfpm.yaml's OBJECTFS_ARCH
+  # contract; the armv7 tar.gz still ships, so that platform is not losing its artifact. Adding a third
+  # architecture is a change to the Makefile loop and to packaging_test.go's expectations, not to this
+  # job.
+  package-linux:
+    name: Build Linux Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version-file: ${{ env.GO_VERSION_FILE }}
+        cache: true
+
+    # The same three assertions ci.yml's packaging job opens with, for the same reason: nfpm.yaml's
+    # destinations, scripts/postinstall.sh's paths and the version constant have to agree, and a
+    # release is the worst place to find out they do not.
+    - name: nfpm.yaml agrees with the scripts, the Makefile and the version constant
+      run: go test ./internal/config/ -run 'TestPackag|TestPostinstall|TestPreremove|TestMakefile'
+
+    - name: Build the deb and the rpm
+      run: make package-linux
+
+    # The version inside the package, read back from the package. Nothing else in this repository does
+    # this, and nfpm.yaml's own comment names the gap: "nothing reads a package's version back to
+    # compare it, so `objectfs version` inside objectfs_0.12.0_amd64.deb would say 0.13.0 and no gate
+    # anywhere would notice". The tag is already checked against the constant in `build`; this checks
+    # the constant against what nfpm actually wrote, which is the one link in that chain that was
+    # unverified.
+    - name: The packages carry the tag's version, and there are four of them
+      run: |
+        TAG=${GITHUB_REF#refs/tags/v}
+
+        # The filename carries the release suffix too: nfpm writes objectfs_0.13.0-1_amd64.deb, not
+        # objectfs_0.13.0_amd64.deb. Verified against a local `make package-linux` rather than guessed —
+        # the first version of this step spelled it without the -1 and would have failed the release it
+        # was added to protect.
+        for arch in amd64 arm64; do
+          deb="dist/objectfs_${TAG}-1_${arch}.deb"
+          test -f "$deb" || { echo "::error::expected $deb, and it is not there"; ls -l dist; exit 1; }
+
+          got=$(dpkg-deb --field "$deb" Version)
+          # nfpm writes the deb version as <version>-<release>, and nfpm.yaml pins release to 1.
+          [ "$got" = "$TAG-1" ] || {
+            echo "::error::$deb declares version $got, and this tag is $TAG"
+            exit 1
+          }
+        done
+
+        # rpm names its architectures differently: x86_64 and aarch64, not amd64 and arm64. Globbed
+        # rather than spelled out, because that mapping is nfpm's and not a contract this job should
+        # restate — but the count is asserted, so a silently missing rpm still fails.
+        rpms=$(ls dist/*.rpm | wc -l)
+        [ "$rpms" -eq 2 ] || { echo "::error::expected 2 rpms, found $rpms"; ls -l dist; exit 1; }
+
+        # A checksum per package, matching what `build` does for the tarballs, so a download can be
+        # verified without trusting the transport.
+        cd dist
+        for pkg in *.deb *.rpm; do
+          sha256sum "$pkg" > "$pkg.sha256"
+        done
+
+        ls -l
+
+    - name: Upload the packages
+      uses: actions/upload-artifact@v7
+      with:
+        name: release-packages
+        path: |
+          dist/*.deb
+          dist/*.rpm
+          dist/*.sha256
+        if-no-files-found: error
+        retention-days: 7
+
   # Build and push Docker images.
   #
   # Independent of `build`: an image failure should not withhold the binaries, and vice versa. Both
@@ -295,7 +394,10 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-latest
-    needs: [build, docker-build-push, security-scan]
+    # package-linux gates publishing too. A release that attaches the tarballs and silently omits the
+    # packages is worse than one that fails: the page looks complete, and the omission is only visible
+    # to someone who knew to expect a .deb.
+    needs: [build, package-linux, docker-build-push, security-scan]
     permissions:
       contents: write
     steps:
@@ -417,7 +519,7 @@ jobs:
           echo ""
           echo "### Assets"
           echo ""
-          for f in dist/*.tar.gz; do
+          for f in dist/*.tar.gz dist/*.deb dist/*.rpm; do
             echo "- \`$(basename "$f")\`"
           done
           echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Releases now attach the `.deb` and `.rpm` packages** ([#138]), plus
+  `internal/config/release_packages_test.go` to keep them attached.
+
+  They were built and never shipped. `nfpm.yaml` has worked for several releases, and `ci.yml`'s
+  `packaging` job builds both formats on every PR, installs the deb, runs the postinstall scriptlet and
+  loads the installed modulefile under Lmod — while `release.yml` contained **zero** references to
+  `package-linux`, `nfpm`, `.deb` or `.rpm`. Every published release is exactly ten assets, five
+  tarballs and five checksums:
+
+  ```console
+  $ gh release view v0.13.0 --json assets --jq '[.assets[].name] | length'
+  10
+  ```
+
+  Same for v0.12.0 and v0.11.0. A package CI proves installable and no user can obtain is
+  `scripts/preremove.sh` before [#207]: working code with nothing invoking it. The structural cause is
+  the one [#198] had — `make package-linux` was exercised only by a job that cannot publish anything, so
+  nothing compared what CI builds against what a release attaches, and the two drifted in the direction
+  that is invisible from a green tree.
+
+  A `package-linux` job now builds both formats for amd64 and arm64, and `publish` waits on it. The
+  waiting matters more than it looks: without it a packaging failure publishes the release anyway,
+  missing the packages, and a release page that looks finished is harder to notice than one that failed.
+  The job also **reads the version back out of a built package** with `dpkg-deb --field`, which closes
+  the gap `nfpm.yaml`'s own comment names — the tag was checked against the version constant and the
+  constant against `nfpm.yaml`, and nothing checked either against what nfpm actually wrote. That is not
+  cosmetic: `apt-get install --only-upgrade` and `dnf update` decide whether to act by comparing
+  versions, so a package declaring a version it does not contain is an upgrade that silently does not
+  happen.
+
+  The read-back's first draft was wrong, and running `make package-linux` rather than reasoning about
+  the filename is what caught it. nfpm writes the release suffix into **both** the name and the field —
+  `objectfs_0.13.0-1_amd64.deb`, `Version: 0.13.0-1`, because `nfpm.yaml` pins `release: '1'` — so the
+  version without the `-1` would have failed the first release it was added to protect.
+
+  The gate couples the two workflows the way `release_platforms_test.go` does for [#198]: a package
+  format `ci.yml` builds is one `release.yml` ships. Two of its checks initially **survived mutation**,
+  and the reason is one this project has now hit three times: a `strings.Contains` over a whole file is
+  satisfied by prose *about* the thing. Deleting the `run: make package-linux` step still passed,
+  because the comment above the job explains what that target builds; removing the `.deb` and `.rpm`
+  upload paths still passed, because a comment and the summary step both name them. Full-line comments
+  are now stripped and the upload assertion is scoped to one named step, after which all eight mutations
+  are caught — including a deb-only deletion hiding behind the rpm and a renamed step, which the
+  helpers `t.Fatalf` on rather than passing for the wrong reason.
+
+  This is part (a) of [#138]. Two parts are deliberately not here: an `install.sh` that fetches a
+  checksum-verified release artifact, and the apt/yum repository setup the issue also specifies. The
+  latter has no host — `objectfs.io` and `packages.objectfs.io` are both registrar parking pages that do
+  not complete a TLS handshake — so it needs a hosting decision rather than code.
+
 - **`docs/admin-guide/operations.md` and `docs/admin-guide/troubleshooting.md`** ([#148]), the day-two
   half of the admin guide, plus `internal/config/docs_admin_guide_test.go` to keep them true.
 
@@ -3355,6 +3405,7 @@ had no message authentication, and a cluster will not start without a shared sec
 [#132]: https://github.com/scttfrdmn/objectfs/issues/132
 [#133]: https://github.com/scttfrdmn/objectfs/issues/133
 [#129]: https://github.com/scttfrdmn/objectfs/issues/129
+[#138]: https://github.com/scttfrdmn/objectfs/issues/138
 [#139]: https://github.com/scttfrdmn/objectfs/issues/139
 [#140]: https://github.com/scttfrdmn/objectfs/issues/140
 [#141]: https://github.com/scttfrdmn/objectfs/issues/141

--- a/internal/config/release_packages_test.go
+++ b/internal/config/release_packages_test.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file is the durable half of the first finding on #138, and it is the same shape of gate as
+// release_platforms_test.go is for #198: something the repository could build, that nothing shipped.
+//
+// nfpm.yaml has existed and worked for several releases. ci.yml's `packaging` job builds both packages
+// on every PR, installs the deb, runs the postinstall scriptlet, and loads the installed modulefile
+// under Lmod. And release.yml contained no reference to `package-linux`, `nfpm`, `.deb` or `.rpm`, so
+// every published release was five tar.gz binaries and their checksums:
+//
+//	$ gh release view v0.13.0 --json assets --jq '[.assets[].name] | length'
+//	10
+//
+// Ten assets, five archives and five checksums, no packages — the same for v0.12.0 and v0.11.0. A
+// package that CI proves installable and no user can obtain is scripts/preremove.sh before #207:
+// working code with nothing invoking it.
+//
+// The structural reason is the one #198 had. `make package-linux` was exercised only by a job that
+// cannot publish anything, so nothing anywhere compared what CI builds against what a release
+// attaches, and the two drifted in the direction that is invisible from a green tree. So this couples
+// them: a package format ci.yml builds is one release.yml ships.
+//
+// Note the direction, as in release_platforms_test.go: this asserts ci ⊆ release for package formats.
+// A format built in CI and not shipped is the defect. A format shipped and not built in CI would be a
+// different and worse defect, and it cannot occur here — both come out of the same `make package-linux`
+// invocation, which is itself asserted by TestMakefileBuildsPackages.
+
+// TestReleaseAttachesTheLinuxPackages is the coupling itself.
+func TestReleaseAttachesTheLinuxPackages(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	release := readFile(t, filepath.Join(root, ".github", "workflows", "release.yml"))
+
+	// Comments are stripped before any of this, and that is not a detail. The first version of these two
+	// checks ran strings.Contains over the whole file and both survived mutation: deleting the `run: make
+	// package-linux` step still passed, because the comment above the job explains what `make
+	// package-linux` builds, and removing the .deb and .rpm upload paths still passed, because a comment
+	// and the summary step both name them. A gate satisfied by prose about a step is the same defect as a
+	// documentation gate satisfied by prose about a config key — it reads as coverage and asserts nothing.
+	effective := withoutComments(release)
+
+	// The build has to happen, as an executable line. Checked by the Makefile target rather than by a job
+	// name, because the target is the contract: TestMakefileBuildsPackages already asserts what it
+	// produces, so a release that invokes it inherits that.
+	if !strings.Contains(effective, "run: make package-linux") {
+		t.Error("release.yml has no `run: make package-linux` step, so no published release carries a " +
+			".deb or an .rpm. Both are built and installed by ci.yml's packaging job on every PR, which " +
+			"means the formats are proven and unobtainable at the same time — the #207 shape of defect: " +
+			"working code with nothing invoking it")
+	}
+
+	// And the packages have to reach the release. Building them into an artifact nothing attaches is the
+	// same outcome with more steps, and it is a plausible half-fix: the job goes green, the checks list
+	// gains a reassuring name, and the release page is unchanged.
+	//
+	// The upload is what is asserted, not any mention of the path. `publish` also globs dist/ into the
+	// summary, and a package that reaches the summary and not the upload is listed in a job log nobody
+	// reads while being absent from the release.
+	upload := jobStep(t, effective, "Upload the packages")
+	for _, format := range []string{".deb", ".rpm"} {
+		if !strings.Contains(upload, "dist/*"+format) {
+			t.Errorf("the package upload step does not include dist/*%s. A package built into a workflow "+
+				"artifact and not attached to the release is not shipped — the artifact expires and the "+
+				"release page looks complete", format)
+		}
+	}
+
+	// The publish job has to wait for it. Without this, a packaging failure lets the release publish
+	// anyway, silently missing the packages — which is worse than a failed release, because the page
+	// looks finished and the omission is visible only to someone who knew to expect a .deb.
+	needs := needsList(t, release, "Publish Release")
+	if !strings.Contains(needs, "package-linux") {
+		t.Errorf("the Publish Release job's `needs` is %q and does not include package-linux, so a "+
+			"packaging failure would publish a release with the tarballs and no packages. A release that "+
+			"looks complete and is not is harder to notice than one that failed", needs)
+	}
+}
+
+// TestReleaseChecksThePackageVersionAgainstTheTag guards the one link nfpm.yaml names as unchecked.
+//
+// nfpm.yaml's own comment states the gap this closes: "nothing reads a package's version back to
+// compare it, so `objectfs version` inside objectfs_0.12.0_amd64.deb would say 0.13.0 and no gate
+// anywhere would notice". Both halves of the chain were verified and the join was not — release.yml
+// checks the tag against the version constant, and TestPackageVersionComesFromTheVersionConstant
+// checks that nfpm.yaml reads the constant rather than a literal, but nothing read the version back
+// out of a built package.
+//
+// A wrong version in a package is not cosmetic. `apt-get install --only-upgrade` and `dnf update`
+// decide whether to act by comparing versions, so a package declaring a version it does not contain is
+// an upgrade that silently does not happen.
+func TestReleaseChecksThePackageVersionAgainstTheTag(t *testing.T) {
+	t.Parallel()
+
+	release := withoutComments(readFile(t, filepath.Join(repoRoot(t), ".github", "workflows",
+		"release.yml")))
+
+	if !strings.Contains(release, "dpkg-deb --field") {
+		t.Error("release.yml builds the packages without reading a version back out of one. nfpm.yaml's " +
+			"comment names this exact gap: the tag is checked against the version constant and the " +
+			"constant against nfpm.yaml, and nothing checks either against what nfpm actually wrote. A " +
+			"package declaring a version it does not contain makes `apt-get install --only-upgrade` a " +
+			"no-op, which is an upgrade that silently does not happen")
+	}
+
+	// The -1 matters and is easy to get wrong: nfpm writes objectfs_0.13.0-1_amd64.deb and a Version
+	// field of 0.13.0-1, because nfpm.yaml pins `release: '1'`. The first draft of that workflow step
+	// spelled the filename without the suffix and would have failed the release it was added to protect
+	// — caught by running `make package-linux` locally rather than by reasoning about the name.
+	if !strings.Contains(release, "$TAG-1") {
+		t.Error("release.yml compares a package version without the `-1` release suffix. nfpm.yaml pins " +
+			"`release: '1'`, so both the filename and the Version field carry it: " +
+			"objectfs_0.13.0-1_amd64.deb, Version 0.13.0-1. A comparison against a bare version fails " +
+			"every release")
+	}
+}
+
+// withoutComments drops full-line YAML comments.
+//
+// Only full-line comments, and deliberately not trailing ones: a `#` inside a shell `run:` block is
+// often part of the command rather than a comment, and cutting at the first `#` would mangle it. Every
+// mutation these gates need to catch is a deleted or altered *line*, so full-line stripping is enough
+// and does not risk changing what a step says.
+func withoutComments(workflow string) string {
+	var kept []string
+
+	for line := range strings.SplitSeq(workflow, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+
+		kept = append(kept, line)
+	}
+
+	return strings.Join(kept, "\n")
+}
+
+// jobStep returns the body of the step whose `- name:` is stepName, up to the next step.
+//
+// So an assertion can be made about one step rather than about the file. Checking the whole workflow
+// for a path is how the .deb upload check first passed with no upload at all — the summary step's glob
+// satisfied it.
+func jobStep(t *testing.T, workflow, stepName string) string {
+	t.Helper()
+
+	var (
+		body   []string
+		inStep bool
+	)
+
+	for line := range strings.SplitSeq(workflow, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "- name: "+stepName {
+			inStep = true
+
+			continue
+		}
+
+		if !inStep {
+			continue
+		}
+
+		// The next step ends this one.
+		if strings.HasPrefix(trimmed, "- name: ") {
+			break
+		}
+
+		body = append(body, line)
+	}
+
+	if !inStep {
+		t.Fatalf("found no step named %q in release.yml. If it was renamed, point this test at the new "+
+			"name — a gate that cannot find its subject passes for the wrong reason", stepName)
+	}
+
+	return strings.Join(body, "\n")
+}
+
+// needsList returns the `needs:` line belonging to the job whose `name:` is jobName.
+//
+// A line scan rather than a YAML parse, matching how release_platforms_test.go reads the build matrix:
+// this package has no YAML dependency for workflow files, and the shape being read is one line.
+func needsList(t *testing.T, workflow, jobName string) string {
+	t.Helper()
+
+	inJob := false
+
+	for line := range strings.SplitSeq(workflow, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "name: "+jobName {
+			inJob = true
+
+			continue
+		}
+
+		if !inJob {
+			continue
+		}
+
+		if after, found := strings.CutPrefix(trimmed, "needs:"); found {
+			return strings.TrimSpace(after)
+		}
+
+		// A `steps:` key means this job's header is over and it declared no needs.
+		if trimmed == "steps:" {
+			break
+		}
+	}
+
+	t.Fatalf("found no `needs:` for the job named %q in release.yml. If the job was renamed, point this "+
+		"test at the new name — a gate that cannot find its subject passes for the wrong reason",
+		jobName)
+
+	return ""
+}


### PR DESCRIPTION
Part (a) of #138. Parts (b) and (c) are not in this PR — see the bottom.

## The packages were built and never shipped

`nfpm.yaml` has worked for several releases. `ci.yml`'s `packaging` job builds both formats on every PR, installs the deb, runs the postinstall scriptlet, and loads the installed modulefile under Lmod. And `release.yml` contained **zero** references to `package-linux`, `nfpm`, `.deb` or `.rpm`, so every published release is exactly ten assets — five tarballs and five checksums:

```console
$ gh release view v0.13.0 --json assets --jq '[.assets[].name] | length'
10
```

Same for v0.12.0 and v0.11.0. A package CI proves installable and no user can obtain is `scripts/preremove.sh` before #207: working code with nothing invoking it.

The structural cause is the one #198 had. `make package-linux` was exercised only by a job that cannot publish anything, so nothing anywhere compared what CI builds against what a release attaches, and the two drifted in the direction that is invisible from a green tree.

## What this does

A `package-linux` job between `build` and `docker-build-push`, building both formats for amd64 and arm64, and `publish` now waits on it. **The waiting matters more than it looks**: without it a packaging failure publishes the release anyway, missing the packages, and a release page that looks finished is harder to notice than one that failed.

The job also **reads the version back out of a built package** with \`dpkg-deb --field\`, which closes the gap `nfpm.yaml`'s own comment names — the tag was checked against the version constant, and the constant against `nfpm.yaml`, and nothing checked either against what nfpm actually wrote. That is not cosmetic: \`apt-get install --only-upgrade\` and \`dnf update\` decide whether to act by comparing versions, so a package declaring a version it does not contain is an upgrade that silently does not happen.

**The read-back's first draft was wrong**, and running `make package-linux` rather than reasoning about the filename is what caught it. nfpm writes the release suffix into *both* the name and the field — `objectfs_0.13.0-1_amd64.deb`, `Version: 0.13.0-1`, because `nfpm.yaml` pins `release: '1'` — so the version without the `-1` would have failed the first release it was added to protect.

## The gate

`internal/config/release_packages_test.go` couples the two workflows the way `release_platforms_test.go` does for #198: a package format `ci.yml` builds is one `release.yml` ships.

Two of its checks initially **survived mutation**, for a reason this project has now hit three times: *a \`strings.Contains\` over a whole file is satisfied by prose about the thing.* Deleting the \`run: make package-linux\` step still passed, because the comment above the job explains what that target builds. Removing the `.deb` and `.rpm` upload paths still passed, because a comment and the summary step both name them.

Full-line comments are now stripped and the upload assertion is scoped to one named step. All eight mutations are caught:

| mutation | |
|---|---|
| R1 no-package-build | CAUGHT |
| R2 built-not-attached | CAUGHT |
| R2b deb-only-dropped | CAUGHT |
| R2c step-renamed | CAUGHT |
| R3 publish-does-not-wait | CAUGHT |
| R4 no-version-readback | CAUGHT |
| R5 missing-release-suffix | CAUGHT |
| R6 job-renamed | CAUGHT |

R2b and R2c are the ones worth noting: a deb-only deletion hiding behind the rpm, and a renamed step — which the `jobStep`/`needsList` helpers `t.Fatalf` on rather than passing for the wrong reason.

## Verification

- \`make package-linux\` locally → `objectfs_0.13.0-1_amd64.deb`, `objectfs_0.13.0-1_arm64.deb`, `objectfs-0.13.0-1.x86_64.rpm`, `objectfs-0.13.0-1.aarch64.rpm`
- \`dpkg-deb --field ... Version\` → `0.13.0-1`, confirmed in a `debian:12` container
- `go test -race ./...` — clean
- Coverage gate under CI's exact command — 35 packages at or above floor
- The gates pass in a `linux/amd64 golang:1.26-alpine` container
- `go build`, `gofmt -l .`, `go vet`, `golangci-lint run` — 0 issues
- `release.yml` parses: 5 jobs, `publish` needs all four

## Not in this PR

#138 also specifies an install script and apt/yum repositories. Those are parts (b) and (c), and (c) **has no host**: `objectfs.io` and `packages.objectfs.io` both resolve to Porkbun parking IPs and neither completes a TLS handshake. That needs a hosting decision (stand up `packages.objectfs.io`, use Cloudsmith/Fury/a Pages apt-yum repo/COPR/OBS, or skip repositories), not code. Measurements and a recommended split are on #138.

Closes nothing — #138 stays open for (b) and (c).