### PR TITLE
feat(install): a script that verifies what it downloads (#138)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1106,3 +1106,144 @@ jobs:
             "failure, not a pass."
           exit 1
         fi
+
+  # ---------------------------------------------------------------------------------------------
+  # install-script — scripts/install.sh in the distributions it claims to support.
+  #
+  # This is part (b) of #138, and the job exists because the two defects it caught cannot be caught
+  # any other way. `shellcheck` passes on this script and always did; the local run on macOS
+  # succeeded; and the script still failed on two of the three images #138 names, both times with an
+  # error naming the wrong cause:
+  #
+  #   - ubuntu:24.04 has neither curl nor wget, and the script reported "could not reach the GitHub
+  #     API to find the latest release. Pass --version to skip this step" — advice that cannot work.
+  #   - opensuse/leap:15.6 has neither tar nor gzip, and the script downloaded the archive,
+  #     verified its checksum, and then reported "a tar that cannot read the archive rather than a
+  #     corrupt file". Installing only tar moved the same misattribution one layer down, because
+  #     `tar -xzf` shells out to gzip and reports the child's failure as its own.
+  #
+  # A wrong cause is the expensive failure direction: it sends the reader to check the release, the
+  # network and the file, and never mentions the missing package. So both success and refusal are
+  # asserted below — a job that only checked the refusal would pass against a script that can no
+  # longer install anything.
+  #
+  # Two things this deliberately does not do. It does not use LocalStack, which #138 specifies:
+  # nothing here touches S3, since the script downloads a GitHub release asset and runs `objectfs
+  # --version`, and adding a mock S3 endpoint to a job that makes no S3 request is machinery with
+  # nothing behind it. And it does not test the PR's own code — the installer fetches a *published
+  # release*, so what runs here is the last release's binary. That is the right subject: the thing
+  # under test is the install path, and pointing it at an artifact built in this workflow would test
+  # a URL no user will ever fetch.
+  #
+  # The images are #138's three, and the versions are pinned rather than floating. An image that
+  # gains curl in a later build would silently stop exercising the wget path, which is the branch
+  # that resolves the latest release through the API on a machine without curl.
+  # ---------------------------------------------------------------------------------------------
+  install-script:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # ubuntu:24.04 ships neither downloader, so this row is the wget path *and* the refusal.
+        - image: ubuntu:24.04
+          missing: curl or wget
+          install: apt-get update -qq && apt-get install -y -qq wget
+        # rockylinux:9 has curl, sha256sum, tar and gzip already, so it is the row where the script
+        # works with nothing installed — the only row that would catch a preflight check that has
+        # become wrong about what it needs.
+        - image: rockylinux:9
+          missing: ''
+          install: ''
+        - image: opensuse/leap:15.6
+          missing: tar
+          install: zypper -q -n install tar gzip
+    steps:
+    - uses: actions/checkout@v7
+
+    # Not `container:` on the job, because the checkout has to happen on the runner and the script
+    # has to run inside each image — a job-level container would put the checkout inside it too and
+    # need git installed in all three.
+    - name: The script refuses, or installs, and says which
+      env:
+        IMAGE: ${{ matrix.image }}
+        MISSING: ${{ matrix.missing }}
+        INSTALL: ${{ matrix.install }}
+      run: |
+        set -euo pipefail
+
+        # A bare image that is missing a requirement must refuse *before downloading*, and must name
+        # the thing that is missing. This is the assertion the two defects above would have failed.
+        if [ -n "$MISSING" ]; then
+          out=$(docker run --rm -v "$PWD/scripts/install.sh":/install.sh:ro "$IMAGE" \
+            bash -c '/install.sh --prefix /opt/ofs 2>&1; echo "EXIT=$?"' || true)
+          echo "$out"
+
+          if ! grep -q "EXIT=1" <<<"$out"; then
+            echo "::error::$IMAGE is missing $MISSING and install.sh did not exit 1. A script that" \
+              "proceeds without $MISSING fails later, blaming something else."
+            exit 1
+          fi
+
+          if ! grep -q "$MISSING" <<<"$out"; then
+            echo "::error::install.sh refused on $IMAGE without naming '$MISSING'. An error that" \
+              "does not name the missing tool sends the reader to check the release, the network" \
+              "and the file — none of which is the problem."
+            exit 1
+          fi
+
+          # And nothing may be left behind by a refusal.
+          if docker run --rm -v "$PWD/scripts/install.sh":/install.sh:ro "$IMAGE" \
+            bash -c '/install.sh --prefix /opt/ofs >/dev/null 2>&1 || true; test -e /opt/ofs/bin/objectfs'; then
+            echo "::error::install.sh refused on $IMAGE but left a binary at /opt/ofs/bin/objectfs."
+            exit 1
+          fi
+        fi
+
+        # Then it has to actually work. Installing the missing package first where there is one;
+        # rockylinux:9 installs nothing, which is what makes it the row that catches a preflight
+        # demanding something the script does not need.
+        prep=""
+        [ -n "$INSTALL" ] && prep="$INSTALL >/dev/null 2>&1;"
+
+        out=$(docker run --rm -v "$PWD/scripts/install.sh":/install.sh:ro "$IMAGE" \
+          bash -c "$prep /install.sh --prefix /opt/ofs 2>&1; echo \"EXIT=\$?\"; /opt/ofs/bin/objectfs --version")
+        echo "$out"
+
+        grep -q "EXIT=0" <<<"$out" || {
+          echo "::error::install.sh did not succeed on $IMAGE."; exit 1; }
+
+        grep -q "checksum verified" <<<"$out" || {
+          echo "::error::install.sh installed on $IMAGE without reporting a verified checksum." \
+            "The checksum is not optional and there is no flag to skip it, so its absence from the" \
+            "output means the verification step was bypassed."
+          exit 1; }
+
+        grep -qE "^objectfs version [0-9]+\.[0-9]+\.[0-9]+" <<<"$out" || {
+          echo "::error::the installed binary on $IMAGE did not print a version. An installer that" \
+            "succeeds and leaves a binary that cannot run has produced the same outcome as one" \
+            "that failed, minus the explanation."
+          exit 1; }
+
+    # Twice, same result. #138 asks for idempotency and the interesting half is not "it does not
+    # crash" — it is that the second run leaves the identical binary, which is what makes re-running
+    # the documented one-liner safe on a machine that already has objectfs.
+    - name: Running it twice leaves the same binary
+      env:
+        IMAGE: ${{ matrix.image }}
+        INSTALL: ${{ matrix.install }}
+      run: |
+        set -euo pipefail
+
+        prep=""
+        [ -n "$INSTALL" ] && prep="$INSTALL >/dev/null 2>&1;"
+
+        out=$(docker run --rm -v "$PWD/scripts/install.sh":/install.sh:ro "$IMAGE" \
+          bash -c "$prep \
+            /install.sh --prefix /opt/ofs >/dev/null 2>&1; a=\$(sha256sum /opt/ofs/bin/objectfs | cut -d' ' -f1); \
+            /install.sh --prefix /opt/ofs >/dev/null 2>&1; b=\$(sha256sum /opt/ofs/bin/objectfs | cut -d' ' -f1); \
+            echo \"a=\$a b=\$b\"; [ \"\$a\" = \"\$b\" ] && echo SAME || echo DIFFERENT")
+        echo "$out"
+
+        grep -q SAME <<<"$out" || {
+          echo "::error::two runs of install.sh on $IMAGE left different binaries."; exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scripts/install.sh`** ([#138]), which downloads the release binary for the running platform,
+  verifies its SHA-256 against the checksum published beside it, and installs it — plus a CI job that
+  runs it in three distributions and `internal/config/install_script_test.go` for the rows CI cannot
+  reach.
+
+  This is deliberately **not** the script #138 specifies. That one detects the package manager and adds
+  a repository at `packages.objectfs.io`, a host that does not exist: both `objectfs.io` and
+  `packages.objectfs.io` resolve to registrar parking IPs and neither completes a TLS handshake. A
+  script written to that spec could not be run, could not be tested, and would fail at its first
+  `curl` with a TLS error naming a domain the reader has no way to interpret. What GitHub already
+  hosts is a tarball per platform with a checksum beside it, which needs no hosting decision, so that
+  is what this installs.
+
+  **The checksum is verified and there is no flag to skip it.** The reason to publish a checksum is
+  that the download path is not trusted, and an installer treating verification as skippable has spent
+  the cost without buying the property. What it establishes is stated rather than implied: the
+  `.sha256` travels the same channel as the tarball, so this detects corruption and a mangling mirror,
+  not a compromise of the release host. That is a signature's job.
+
+  The default prefix is `~/.local`, not `/usr/local`, reversing the usual convention on purpose. This
+  project's users are frequently on a shared login node with no root, and an installer whose default
+  needs `sudo` teaches them to run the whole thing under `sudo` — which writes a root-owned binary and
+  root-owned cache directories into a home their own jobs use.
+
+  **`shellcheck` passed on this script from the first draft and the local run succeeded, and it still
+  failed on two of the three images #138 names** — both times with an error naming the wrong cause,
+  which is the expensive failure direction, because it sends the reader to check the release, the
+  network and the file and never mentions the missing package:
+
+  - `ubuntu:24.04` ships neither `curl` nor `wget`. The download helper handled that correctly, but
+    the release-resolution path called `wget` unconditionally when `curl` was absent, so the user was
+    told *"could not reach the GitHub API to find the latest release. Pass `--version` to skip this
+    step"* — advice that cannot work on a machine with no downloader at all.
+  - `opensuse/leap:15.6` ships neither `tar` nor `gzip`. The script downloaded the archive, verified
+    its checksum, and then reported *"a tar that cannot read the archive rather than a corrupt file"* —
+    a confident claim about the file when `tar` was not installed. Installing only `tar` moved the same
+    misattribution one layer down: `tar -xzf` shells out to `gzip` and reports the child's exit status
+    as its own, producing `tar: Child returned status 2`.
+
+  Both are now one preflight check that runs before anything touches the network, reports **every**
+  missing tool at once — openSUSE would otherwise need three attempts to learn what it needs — and
+  names the package to install. It runs ahead of `--dry-run` too, since a dry run's job is to report
+  whether this would work.
+
+  The gate covers what the container job cannot. That job runs on x86_64, so it exercises exactly one
+  row of the platform mapping: a mapping wrong for arm64, armv7 or darwin passes all three images. So
+  `TestInstallScriptNamesEveryPublishedAsset` couples the script's `uname` translation to
+  `release.yml`'s build matrix in both directions — a published platform the script cannot name is a
+  404 through the documented install path, and a name the script invents is the same 404 from the other
+  side. **One mutation is recorded as unverified locally rather than claimed as caught**: reversing the
+  x86_64 mapping was expected to fail the container run and did not, because podman on an Apple
+  Silicon host runs an arm64 binary inside an emulated amd64 container through binfmt, so the
+  wrong-architecture binary executed and printed its version. On a real x86_64 runner the script's
+  final `--version` check catches it; the static assertion is what makes that independent of the host.
+
+  Ten mutations were run and one initially survived, which is the one worth recording: moving
+  `preflight` to sit immediately above the download still passed, because it was still *before the
+  download* — but by then the script has already queried the GitHub API, which on a machine with no
+  downloader is precisely the failure preflight exists to pre-empt. The check is now anchored to the
+  API call rather than the download, and both orderings are asserted.
+
 - **Releases now attach the `.deb` and `.rpm` packages** ([#138]), plus
   `internal/config/release_packages_test.go` to keep them attached.
 

--- a/README.md
+++ b/README.md
@@ -327,13 +327,27 @@ worth filing.
 Linux, or macOS with [macFUSE](https://macfuse.io) installed.
 
 ```bash
+# Download the release binary for this platform, verify its SHA-256, install to ~/.local/bin
+curl -fsSL https://raw.githubusercontent.com/scttfrdmn/objectfs/main/scripts/install.sh | bash
+
+# or from source
 git clone https://github.com/scttfrdmn/objectfs.git
 cd objectfs
-make build          # produces ./objectfs
+make build          # produces ./bin/objectfs
 
 # or
 go install github.com/scttfrdmn/objectfs/cmd/objectfs@latest
 ```
+
+The install script always verifies the checksum and has no flag to skip it. `--prefix` chooses where
+to install and `--version` pins a release; `--dry-run` prints what it would fetch. It refuses before
+downloading anything if the machine lacks a tool it needs, naming all of them at once — worth knowing
+because two of the three container images this is tested against are missing something
+(`ubuntu:24.04` ships neither `curl` nor `wget`, `opensuse/leap:15.6` ships neither `tar` nor `gzip`).
+
+Debian and RPM packages are attached to each release alongside the tarballs. There is no apt or yum
+repository yet, so install the downloaded file directly: `apt install ./objectfs_*.deb` or
+`dnf install ./objectfs-*.rpm`.
 
 ### HPC sites: environment modules
 

--- a/docs-platform/guide/getting-started.md
+++ b/docs-platform/guide/getting-started.md
@@ -24,9 +24,29 @@ Before you begin, ensure you have:
 
 ## Installation
 
-Build from source, or install with `go install`. Release binaries are attached to the
-[GitHub releases page](https://github.com/scttfrdmn/objectfs/releases); that is the only prebuilt
-artifact, and the release workflow builds no packages.
+The install script is the shortest path. It downloads the release binary for this platform, verifies
+its SHA-256 against the checksum published beside it, and installs it under `~/.local/bin`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/scttfrdmn/objectfs/main/scripts/install.sh | bash
+```
+
+`--prefix` installs elsewhere and `--version` pins a release. The checksum is always verified and
+there is no flag to skip it — note what that does and does not establish: the `.sha256` travels the
+same channel as the tarball, so a mismatch means a corrupted or tampered download, not that the
+release itself is authentic. That is a signature's job, and this project does not sign releases yet.
+
+The default prefix is `~/.local` rather than `/usr/local` deliberately. Many of this project's users
+are on a shared login node with no root, and an installer whose default needs `sudo` teaches people
+to run the whole thing under `sudo` — which then writes a root-owned binary and root-owned cache
+directories into a home directory their own jobs use.
+
+Debian and RPM packages are attached to each release from v0.14.0 onward, alongside the binary
+tarballs, on the [releases page](https://github.com/scttfrdmn/objectfs/releases). There is no apt or
+yum repository to add — `dnf install ./objectfs-*.rpm` and `apt install ./objectfs_*.deb` against a
+downloaded file are what works today.
+
+Or build from source:
 
 ```bash
 git clone https://github.com/scttfrdmn/objectfs.git

--- a/docs/index.md
+++ b/docs/index.md
@@ -213,11 +213,16 @@ make build          # produces ./objectfs
 go install github.com/scttfrdmn/objectfs/cmd/objectfs@latest
 ```
 
-There is no Homebrew tap and no `.deb`/`.rpm` package. This section listed all three, plus a
-`get.objectfs.io` install script; none of those channels exists, and the release workflow does not
-build them. Release binaries are attached to the
-[GitHub releases page](https://github.com/scttfrdmn/objectfs/releases) — that is the only prebuilt
-artifact.
+There is no Homebrew tap and no package repository to add. This section once listed both, plus a
+`get.objectfs.io` install script; none of those exist. What does exist is attached to each
+[release](https://github.com/scttfrdmn/objectfs/releases): a binary tarball per platform with a
+SHA-256 beside it, and — from v0.14.0 — a `.deb` and an `.rpm`. Install a package from the downloaded
+file (`apt install ./objectfs_*.deb`, `dnf install ./objectfs-*.rpm`), since there is no apt or yum
+repository behind it.
+
+`scripts/install.sh` in this repository is the shortest path for the tarball. It resolves the
+platform, verifies the checksum, and installs under `~/.local/bin`; the checksum is always verified
+and there is no flag to skip it.
 
 ### Basic Usage
 

--- a/internal/config/install_script_test.go
+++ b/internal/config/install_script_test.go
@@ -1,0 +1,335 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This file couples scripts/install.sh to the assets a release actually publishes.
+//
+// It is part (b) of #138 and the same shape of gate as release_platforms_test.go is for #198 and
+// release_packages_test.go is for the packages: two files that must agree, with nothing connecting
+// them. install.sh builds a download URL out of a platform name it derives from `uname`, and
+// release.yml decides what those names are. A platform the release publishes and the script cannot
+// name is a user on that architecture reading a 404; a name the script produces and the release does
+// not publish is the same 404 from the other direction.
+//
+// The CI job that runs the script in three containers cannot see either of these. It runs on
+// x86_64, so it exercises exactly one row of the mapping — the armv7 and arm64 and darwin rows are
+// unreached there, and a mapping wrong for arm64 passes every container in that matrix.
+//
+// One mutation is worth recording because this project's own harness could not catch it. Reversing
+// the amd64 arm64 mapping — `x86_64) arch="arm64"` — was expected to fail the container run and did
+// not: podman on an Apple Silicon host runs an arm64 binary inside an emulated amd64 container
+// through binfmt, so the wrong-architecture binary executed and printed its version. On a real
+// x86_64 runner the script's final `--version` check catches it, but the local harness could not
+// demonstrate that, which is the argument for asserting the mapping statically here rather than
+// relying on the run.
+
+// installScript reads scripts/install.sh.
+func installScript(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(repoRoot(t), "scripts", "install.sh")
+
+	//nolint:gosec // A path built from the repository root, in a test.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("could not read %s: %v", path, err)
+	}
+
+	return string(b)
+}
+
+// TestInstallScriptNamesEveryPublishedAsset is the coupling itself.
+//
+// Every asset in release.yml's build matrix must be a name install.sh can produce, and every name
+// install.sh can produce must be a published asset. Both directions, because they fail differently
+// and both fail as a 404 the user cannot interpret: a published platform the script cannot name is
+// unreachable through the documented install path, and a name the script invents is a download that
+// does not exist.
+func TestInstallScriptNamesEveryPublishedAsset(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	// The asset names, taken from the same matrix release_platforms_test.go reads. `name:` is the
+	// authority rather than goos/goarch, because the asset is called objectfs-linux-armv7 while the
+	// matrix cell is goarch: arm with goarm: 7 — deriving the name from the pair would reproduce the
+	// arithmetic release.yml already did and could disagree with it.
+	published := releaseAssetNames(t, readFile(t, filepath.Join(root, ".github", "workflows",
+		"release.yml")))
+	if len(published) == 0 {
+		t.Fatal("read no asset names out of release.yml's build matrix — the job may have been " +
+			"renamed or its matrix reformatted, and an empty set satisfies everything below without " +
+			"checking anything")
+	}
+
+	produced := installScriptPlatforms(t, installScript(t))
+	if len(produced) == 0 {
+		t.Fatal("read no platform names out of scripts/install.sh — its case statements may have " +
+			"been reformatted, which makes this test vacuous rather than failing")
+	}
+
+	for _, asset := range published {
+		if produced[asset] {
+			continue
+		}
+
+		t.Errorf("release.yml publishes objectfs-%s.tar.gz and scripts/install.sh cannot produce the "+
+			"name %q, so there is no `uname` result on that platform that leads to that asset. A user "+
+			"there gets a 404 from the documented install path, or is told their machine is "+
+			"unsupported on a platform this project ships a binary for", asset, asset)
+	}
+
+	for asset := range produced {
+		if slices.Contains(published, asset) {
+			continue
+		}
+
+		t.Errorf("scripts/install.sh can produce the platform name %q and release.yml publishes no "+
+			"objectfs-%s.tar.gz, so a machine of that shape downloads a URL that does not exist. The "+
+			"404 arrives with no explanation of which of the two files is wrong", asset, asset)
+	}
+}
+
+// TestInstallScriptVerifiesTheChecksum guards the property the script's own header calls
+// non-optional.
+//
+// Three separate ways to lose it, and each of them leaves a script that installs successfully:
+// dropping the comparison, making the checksum download non-fatal, or adding a flag to skip it. All
+// three are plausible edits under pressure — the checksum is exactly the step someone disables when
+// a release is broken and they want the binary anyway.
+func TestInstallScriptVerifiesTheChecksum(t *testing.T) {
+	t.Parallel()
+
+	script := installScript(t)
+
+	if !strings.Contains(script, `[ "$want" != "$got" ]`) {
+		t.Error("scripts/install.sh does not compare the published checksum against the downloaded " +
+			"file. Publishing a .sha256 and not checking it spends the cost of checksums without " +
+			"buying the property — and the failure is silent, because an unverified install succeeds")
+	}
+
+	// The comparison has to abort, not warn. A mismatch that prints a warning and installs anyway is
+	// the same outcome as no check, plus a line in a log nobody reads.
+	if !strings.Contains(script, "checksum mismatch for") {
+		t.Error("scripts/install.sh has no checksum-mismatch failure message, so either the " +
+			"comparison does not abort or its wording changed. A mismatch must stop the install: it " +
+			"means the download is not what the release publishes")
+	}
+
+	// A missing .sha256 is fatal too. This is the half most likely to be softened, because it fires
+	// on a release that is broken upstream of the user, and "install anyway" looks helpful there.
+	if !strings.Contains(script, "Refusing to install an unverified binary") {
+		t.Error("scripts/install.sh does not refuse when a checksum cannot be obtained. A release " +
+			"asset with no .sha256 beside it is a broken release, not a reason to install without " +
+			"verifying — release.yml writes one per asset in the step that builds it")
+	}
+
+	// And no escape hatch. Searched for as flag spellings rather than as prose, since the header
+	// paragraph explaining why there is no such flag would satisfy a looser check — the same defect
+	// release_packages_test.go was rewritten to avoid.
+	for _, flag := range []string{"--skip-checksum", "--no-verify", "--insecure", "SKIP_CHECKSUM"} {
+		if strings.Contains(script, flag) {
+			t.Errorf("scripts/install.sh accepts %s. The checksum is the only thing establishing that "+
+				"the download matches the release, and a flag to skip it will be pasted into the "+
+				"one-liner by the first person whose download fails for an unrelated reason", flag)
+		}
+	}
+}
+
+// TestInstallScriptChecksItsToolsBeforeDownloading pins the fix for the two container defects.
+//
+// Both were the same failure with different subjects: the script proceeded without a tool it needed
+// and then reported the resulting error, which named the wrong cause. ubuntu:24.04 has no downloader
+// and was told the GitHub API was unreachable; opensuse/leap:15.6 has no tar and no gzip and was
+// told its archive could not be read.
+//
+// A wrong cause is the expensive direction — it sends the reader to check the release, the network
+// and the file, and never mentions the missing package — so the requirement is not merely that the
+// script fails, but that it fails before downloading and names what is absent.
+func TestInstallScriptChecksItsToolsBeforeDownloading(t *testing.T) {
+	t.Parallel()
+
+	script := installScript(t)
+
+	if !strings.Contains(script, "preflight()") || !strings.Contains(script, "\n    preflight\n") {
+		t.Fatal("scripts/install.sh has no preflight check, or does not call it. Without one the " +
+			"script downloads first and then fails on a missing tar or gzip, reporting a corrupt " +
+			"archive — a confident claim about the file when the real problem is an absent package")
+	}
+
+	// gzip specifically, because it is the one that looks redundant next to tar and is not: `tar
+	// -xzf` shells out to gzip and reports the child's exit status as its own, so a machine with tar
+	// and no gzip produced "a tar that cannot read the archive". opensuse/leap:15.6 is that machine.
+	for _, tool := range []string{"curl", "wget", "sha256sum", "shasum", "tar", "gzip"} {
+		if !strings.Contains(script, tool) {
+			t.Errorf("scripts/install.sh never mentions %s, so it cannot be checking for it. Every "+
+				"tool the install path uses has to be established up front: the two defects this "+
+				"guards against were both a missing tool reported as something else", tool)
+		}
+	}
+
+	// Preflight must run ahead of the first *network* call, which is what makes "nothing was
+	// downloaded" true. Compared by position, since both orders contain both lines.
+	//
+	// Anchored to resolve_latest rather than to the download, and that distinction is a mutation this
+	// test initially missed. Moving the call to sit immediately above `say "downloading"` still put it
+	// before the download and the weaker check passed — but by then the script has already queried the
+	// GitHub API to resolve the latest release, which on a machine with no downloader is the very
+	// failure preflight exists to pre-empt, reported as "could not reach the GitHub API". The
+	// requirement is not "before the tarball" but "before anything touches the network".
+	preflightAt := strings.Index(script, "\n    preflight\n")
+	resolveAt := strings.Index(script, `say "resolving the latest release"`)
+	downloadAt := strings.Index(script, `say "downloading"`)
+
+	if preflightAt < 0 || resolveAt < 0 || downloadAt < 0 {
+		t.Fatal("could not locate the preflight call, the release resolution, or the download in " +
+			"scripts/install.sh. One of them was renamed, and a position comparison against a missing " +
+			"anchor is vacuous")
+	}
+
+	if preflightAt > resolveAt {
+		t.Error("scripts/install.sh calls preflight after it queries the GitHub API for the latest " +
+			"release. On a machine with neither curl nor wget that API call is what fails, and its " +
+			"error names the API rather than the missing downloader — which is exactly the defect " +
+			"preflight was added to fix, moved a few lines down")
+	}
+
+	if preflightAt > downloadAt {
+		t.Error("scripts/install.sh calls preflight after it starts downloading. Checking afterwards " +
+			"gets the error message right and still leaves a partially-done install on a machine " +
+			"that was never going to finish")
+	}
+}
+
+// releaseAssetNames reads the `name:` values out of release.yml's build matrix.
+//
+// The same walk releasePlatforms does, reading a different key. Kept separate rather than
+// generalised: that function's callers want goos/goarch pairs to compare against ci.yml's
+// cross-build cells, and this one wants the asset suffix, which is a third value in the same cell.
+func releaseAssetNames(t *testing.T, workflow string) []string {
+	t.Helper()
+
+	var (
+		names    []string
+		inMatrix bool
+		inEntry  bool
+	)
+
+	for line := range strings.SplitSeq(workflow, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "include:" {
+			inMatrix = true
+
+			continue
+		}
+
+		if !inMatrix {
+			continue
+		}
+
+		if releaseMatrixEntry.MatchString(trimmed) {
+			inEntry = true
+
+			continue
+		}
+
+		if !inEntry {
+			break
+		}
+
+		m := yamlKeyValue.FindStringSubmatch(trimmed)
+		if m == nil {
+			break
+		}
+
+		if m[1] == "name" {
+			names = append(names, m[2])
+		}
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// installScriptPlatforms returns every `<os>-<arch>` name detect_platform can produce.
+//
+// Read out of the two case statements rather than by executing the script, because the whole point
+// is to check the rows this host cannot reach: running it on any one machine exercises exactly one
+// os and one arch.
+func installScriptPlatforms(t *testing.T, script string) map[string]bool {
+	t.Helper()
+
+	oses := caseTargets(script, `case "$os" in`)
+	arches := caseTargets(script, `case "$arch" in`)
+
+	platforms := make(map[string]bool)
+
+	for _, os := range oses {
+		for _, arch := range arches {
+			// armv7 is published for Linux only, and the script refuses it on darwin by name. Encoding
+			// that here rather than taking the cross product blindly keeps this from demanding a
+			// darwin-armv7 asset that deliberately does not exist.
+			if arch == "armv7" && os != "linux" {
+				continue
+			}
+
+			platforms[os+"-"+arch] = true
+		}
+	}
+
+	return platforms
+}
+
+// caseTargets returns the values assigned by the arms of one case statement in install.sh.
+//
+// It reads the assigned value — `arch="amd64"` — not the pattern being matched, because the pattern
+// is what `uname` prints and the value is what the URL is built from. Those differ on every row that
+// matters: x86_64 becomes amd64, aarch64 becomes arm64, Darwin becomes darwin.
+func caseTargets(script, opener string) []string {
+	var (
+		targets []string
+		inCase  bool
+	)
+
+	// Both variables are assigned by the same two names in this script, so one pattern reads either
+	// statement.
+	assign := regexp.MustCompile(`(?:os|arch)="([a-z0-9]+)"`)
+
+	for line := range strings.SplitSeq(script, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.Contains(trimmed, opener) {
+			inCase = true
+
+			continue
+		}
+
+		if !inCase {
+			continue
+		}
+
+		// `esac` ends it, and so does the `*)` catch-all arm, whose body is a die() and assigns
+		// nothing. Stopping at esac is what matters; the catch-all is skipped by the assign match.
+		if trimmed == "esac" {
+			break
+		}
+
+		if m := assign.FindStringSubmatch(trimmed); m != nil {
+			targets = append(targets, m[1])
+		}
+	}
+
+	sort.Strings(targets)
+
+	return targets
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# ObjectFS installer: fetch a release binary from GitHub, verify its checksum, install it.
+#
+# This is part (b) of #138, and it is deliberately not the script that issue specifies. #138's
+# install.sh detects the package manager and adds an apt or yum repository at
+# packages.objectfs.io — a host that does not exist. Both objectfs.io and packages.objectfs.io
+# resolve to registrar parking IPs and neither completes a TLS handshake, so a script written to
+# that spec could not be tested, could not be run, and would fail at its first curl with a TLS
+# error naming a domain the reader has no way to interpret.
+#
+# What GitHub already hosts is a tarball per platform and a SHA-256 beside it. That needs no
+# hosting decision, so it is what this installs. When a package repository exists, this script
+# gains a branch that prefers it; the download path stays, because it is the one that works on a
+# machine with no root, no package manager entry, and no network path to a third-party repo —
+# which describes a large share of the HPC login nodes this project is for.
+#
+# THE CHECKSUM IS NOT OPTIONAL AND THERE IS NO FLAG TO SKIP IT.
+#
+# The whole reason to publish a checksum is that the download path is not trusted, and an installer
+# that treats verification as a step that may be skipped when inconvenient has spent the cost of
+# checksums without buying the property. So a missing .sha256, an unreadable one, or a mismatch
+# each abort before anything is installed. The one thing this cannot do is establish that the
+# checksum itself is authentic — it comes down the same channel as the tarball, so it detects
+# corruption and a mirror that mangled the file, not a compromise of the release host. That is a
+# signature's job, and this script says so rather than implying more than it delivers.
+#
+# Everything is staged in a temporary directory and moved into place at the end, so a failure at
+# any point leaves no half-installed binary. An interrupted install that leaves `objectfs` on PATH
+# as a truncated file is worse than one that leaves nothing.
+
+set -euo pipefail
+
+readonly REPO="scttfrdmn/objectfs"
+readonly PROGRAM="objectfs"
+
+# The default prefix is ~/.local, not /usr/local, and that is a deliberate reversal of the usual
+# installer convention. This project's users are frequently on a shared login node where they have
+# no root at all, and an installer whose default requires sudo teaches them to run the whole thing
+# under sudo — which then writes a root-owned binary and a root-owned cache directory into a home
+# they share with their own jobs. ~/.local/bin is on PATH by default on every distribution this
+# targets, and --prefix is one flag away for a site install.
+PREFIX="${PREFIX:-$HOME/.local}"
+
+# Empty means "whatever the latest release is". Resolved through the API rather than by following
+# the /latest/download redirect, because the resolved tag is worth printing: an installer that says
+# "installed objectfs" without saying which version has told the user nothing they can check.
+VERSION="${VERSION:-}"
+
+DRY_RUN=0
+
+# say prints progress to stderr, not stdout.
+#
+# So that `install.sh --print-url` style composition stays possible and, more importantly, so that
+# a user piping this script's output somewhere does not get progress chatter mixed into it. The
+# convention matches scripts/postinstall.sh, which sends warnings to stderr for the same reason.
+say() {
+    echo "objectfs-install: $*" >&2
+}
+
+die() {
+    echo "objectfs-install: error: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Install ObjectFS from a GitHub release, verifying its SHA-256 checksum.
+
+Usage: install.sh [options]
+
+Options:
+  --version VERSION   Release to install, with or without a leading v (default: latest)
+  --prefix PATH       Install under PATH/bin (default: ~/.local)
+  --dry-run           Report what would happen; download and verify nothing
+  -h, --help          This message
+
+Environment:
+  VERSION, PREFIX     Same as the flags above
+  GITHUB_TOKEN        Sent as a bearer token when resolving the latest release, which raises the
+                      API rate limit. Never required, and never sent to the download host.
+
+The checksum is always verified and there is no option to skip it. Note what that does and does
+not establish: the .sha256 travels the same channel as the tarball, so a mismatch means corruption
+or a tampered mirror, not necessarily an authentic release.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version)
+            [ $# -ge 2 ] || die "--version needs a value"
+            VERSION="$2"
+            shift 2
+            ;;
+        --version=*)
+            VERSION="${1#--version=}"
+            shift
+            ;;
+        --prefix)
+            [ $# -ge 2 ] || die "--prefix needs a value"
+            PREFIX="$2"
+            shift 2
+            ;;
+        --prefix=*)
+            PREFIX="${1#--prefix=}"
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            die "unrecognized argument: $1"
+            ;;
+    esac
+done
+
+# The asset name is platform-<arch>, and the arch names are the release workflow's, not uname's.
+#
+# This mapping is the part most likely to rot, so it is written as a translation from what uname
+# reports to what release.yml publishes, with both sides visible. `uname -m` says x86_64 where the
+# release says amd64 and aarch64 where it says arm64, and getting that backwards produces a 404
+# from the download rather than a clear error — which is why an unrecognized machine is refused
+# here, by name, with the list of what exists.
+detect_platform() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Linux) os="linux" ;;
+        Darwin) os="darwin" ;;
+        *) die "unsupported operating system: $os. Releases are built for Linux and macOS" ;;
+    esac
+
+    case "$arch" in
+        x86_64 | amd64) arch="amd64" ;;
+        aarch64 | arm64) arch="arm64" ;;
+        # armv7l is published for Linux only, and naming it here rather than letting the download
+        # 404 is the difference between "no arm build exists" and "no arm build exists for macOS".
+        armv7l | armv7)
+            [ "$os" = "linux" ] || die "armv7 is published for Linux only, and this is $os"
+            arch="armv7"
+            ;;
+        *)
+            die "unsupported machine: $arch. Releases are built for amd64, arm64, and armv7 (Linux only)"
+            ;;
+    esac
+
+    echo "${os}-${arch}"
+}
+
+# preflight refuses to start when a tool this needs is missing, naming all of them at once.
+#
+# This exists because of two failures found by running the script in the containers #138 names, and
+# both were of the expensive kind: the error blamed the wrong thing.
+#
+#   - ubuntu:24.04 ships neither curl nor wget. resolve_latest's wget branch is reached whenever
+#     curl is absent, so the message was "could not reach the GitHub API to find the latest
+#     release. Pass --version to skip this step" — advice that cannot work, on a machine whose
+#     actual problem is that nothing can download anything.
+#   - opensuse/leap:15.6 ships no tar. The extract failed *after* a successful download and a
+#     verified checksum, reporting "this is a tar that cannot read the archive rather than a
+#     corrupt file" — a confident claim about the archive, when tar was not installed.
+#
+# An error that names the wrong cause is worse than a blunt one: it sends the reader to check the
+# release, the network, or the file, and the one thing it does not mention is the missing package.
+# So every requirement is checked before the first byte is fetched, all of them are reported
+# together rather than one per run, and each carries the package to install. Checking up front also
+# means a machine that cannot finish never gets as far as writing to the prefix.
+preflight() {
+    local missing=()
+
+    command -v curl > /dev/null 2>&1 || command -v wget > /dev/null 2>&1 \
+        || missing+=("curl or wget (to download; install either one)")
+
+    # No skip-verification flag exists, so a machine with no digest tool cannot install. That is
+    # the intended outcome and it is stated as a refusal rather than reported as a tool error.
+    command -v sha256sum > /dev/null 2>&1 || command -v shasum > /dev/null 2>&1 \
+        || missing+=("sha256sum or shasum (to verify the download; there is no option to skip verification)")
+
+    command -v tar > /dev/null 2>&1 || missing+=("tar (to unpack the release archive)")
+
+    # gzip separately from tar, because `tar -xzf` does not decompress by itself — it shells out to
+    # gzip, and reports the child's failure as its own. opensuse/leap:15.6 has neither by default,
+    # and installing only tar there produced `tar: Child returned status 2` plus this script's
+    # confident and wrong "a tar that cannot read the archive". That is the same misattribution the
+    # missing tar caused, one layer down: the tool that failed is not the tool that is missing.
+    command -v gzip > /dev/null 2>&1 || command -v gunzip > /dev/null 2>&1 \
+        || missing+=("gzip (tar shells out to it to decompress a .tar.gz, and reports its failure as a tar error)")
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        say "this machine is missing something needed to install objectfs:"
+        local item
+        for item in "${missing[@]}"; do
+            say "  - $item"
+        done
+        say "install what is listed above and run this again. Nothing was downloaded."
+        exit 1
+    fi
+}
+
+# fetch writes a URL to a path, or fails.
+#
+# curl and wget are both handled because neither is universally present: the minimal Debian and
+# Alpine images this is tested against ship wget and not curl, while RHEL-family images ship curl
+# and not wget. A one-liner documented with curl that then requires curl to also be the downloader
+# would fail on exactly the container it was piped into.
+#
+# --fail matters more than it looks. Without it curl writes GitHub's 404 HTML page to the output
+# file and exits 0, and the install then fails at the checksum with a mismatch — which reads as
+# corruption when the real problem is a version that does not exist.
+fetch() {
+    local url="$1" out="$2"
+
+    if command -v curl > /dev/null 2>&1; then
+        curl -fsSL --retry 3 --retry-delay 1 -o "$out" "$url"
+    elif command -v wget > /dev/null 2>&1; then
+        wget -q -O "$out" "$url"
+    else
+        die "neither curl nor wget is available, so nothing can be downloaded"
+    fi
+}
+
+# resolve_latest returns the tag of the most recent release.
+#
+# Through the API rather than by following the /latest/download redirect, so the tag can be
+# printed and recorded. The parse is a grep for the first "tag_name" rather than a jq invocation,
+# because jq is not present on the minimal images this must run on, and adding a dependency to
+# read one field of one response is the wrong trade.
+resolve_latest() {
+    local body auth=()
+    body="$(mktemp)"
+
+    # A token is used when one is present and never required. Unauthenticated API calls are rate
+    # limited by IP, which is fine for a person and not fine for CI on a shared runner.
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+
+    if command -v curl > /dev/null 2>&1; then
+        curl -fsSL --retry 3 --retry-delay 1 "${auth[@]}" \
+            "https://api.github.com/repos/$REPO/releases/latest" -o "$body" \
+            || die "could not reach the GitHub API to find the latest release. Pass --version to skip this step"
+    else
+        # wget, which preflight has already established is present if curl is not. Reaching this
+        # branch with neither installed is what produced the "could not reach the GitHub API"
+        # message on a machine that had no downloader at all.
+        #
+        # wget's header flag has a different shape, and the token is passed the same way.
+        local hdr=()
+        [ -n "${GITHUB_TOKEN:-}" ] && hdr=(--header="Authorization: Bearer $GITHUB_TOKEN")
+        wget -q "${hdr[@]}" -O "$body" \
+            "https://api.github.com/repos/$REPO/releases/latest" \
+            || die "could not reach the GitHub API to find the latest release. Pass --version to skip this step"
+    fi
+
+    local tag
+    tag="$(grep -m1 '"tag_name"' "$body" | sed -e 's/.*"tag_name"[[:space:]]*:[[:space:]]*"//' -e 's/".*//')"
+    rm -f "$body"
+
+    [ -n "$tag" ] || die "the GitHub API returned no tag_name, so the latest release could not be identified"
+
+    echo "$tag"
+}
+
+# sha256_of prints the SHA-256 of a file.
+#
+# sha256sum on Linux, shasum -a 256 on macOS. Both are checked for rather than branching on uname,
+# since a Linux image can have either and a macOS machine with coreutils installed has both — and
+# what matters is which command exists, not which OS this is.
+sha256_of() {
+    local file="$1"
+
+    if command -v sha256sum > /dev/null 2>&1; then
+        sha256sum "$file" | awk '{print $1}'
+    elif command -v shasum > /dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print $1}'
+    else
+        die "neither sha256sum nor shasum is available, so the download cannot be verified. Refusing to install an unverified binary"
+    fi
+}
+
+main() {
+    local platform tag asset base
+
+    # Before the platform check, because a missing tar is a fact about this machine that does not
+    # depend on which release exists, and before the dry run for a reason worth stating: the point
+    # of --dry-run is to report whether this would work. A dry run that says nothing about the
+    # missing tar has answered the question wrongly.
+    preflight
+
+    platform="$(detect_platform)"
+
+    if [ -n "$VERSION" ]; then
+        # Accept 0.13.0 and v0.13.0 both, since the tag carries the v and the version constant
+        # does not, and a user reading `objectfs version` output will type it without.
+        case "$VERSION" in
+            v*) tag="$VERSION" ;;
+            *) tag="v$VERSION" ;;
+        esac
+    else
+        say "resolving the latest release"
+        tag="$(resolve_latest)"
+    fi
+
+    asset="$PROGRAM-$platform.tar.gz"
+    base="https://github.com/$REPO/releases/download/$tag"
+
+    say "release $tag, platform $platform"
+    say "  archive:  $base/$asset"
+    say "  checksum: $base/$asset.sha256"
+    say "  install:  $PREFIX/bin/$PROGRAM"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        say "dry run, so nothing was downloaded"
+        return 0
+    fi
+
+    # Everything happens in here and is removed on any exit, successful or not. The trap is set
+    # before the first download rather than at the top of the script so it cannot fire against an
+    # unset variable.
+    local work
+    work="$(mktemp -d)"
+    # shellcheck disable=SC2064 # $work is expanded now on purpose: the trap must name this
+    # directory even if a later assignment changes the variable.
+    trap "rm -rf '$work'" EXIT
+
+    say "downloading"
+    fetch "$base/$asset" "$work/$asset" \
+        || die "could not download $asset for $tag. Check that this release exists and publishes a $platform build: https://github.com/$REPO/releases"
+
+    # The checksum is fetched second and its absence is fatal. A release missing a .sha256 is a
+    # broken release, not a reason to install without checking — the release workflow writes one
+    # per asset in the same step that builds it, so a tarball with no checksum means something
+    # went wrong upstream of this script.
+    fetch "$base/$asset.sha256" "$work/$asset.sha256" \
+        || die "$asset exists for $tag but its .sha256 does not, so the download cannot be verified. Refusing to install an unverified binary"
+
+    # The published file is `<hash>  <name>`, which is sha256sum -c's format — but -c resolves the
+    # name relative to the working directory, so comparing the hash field directly is what makes
+    # this work regardless of where the file was staged. Extracting the field also means one code
+    # path for sha256sum and shasum, whose -c output differs.
+    local want got
+    want="$(awk '{print $1}' "$work/$asset.sha256")"
+    [ -n "$want" ] || die "the checksum file for $asset is empty or malformed. Refusing to install an unverified binary"
+
+    got="$(sha256_of "$work/$asset")"
+
+    if [ "$want" != "$got" ]; then
+        die "checksum mismatch for $asset.
+  published: $want
+  download:  $got
+Nothing was installed. This means the download does not match what the release publishes — a
+truncated transfer, a caching proxy that mangled it, or a tampered copy. Retrying may fix the
+first two."
+    fi
+
+    say "checksum verified"
+
+    # The tarball holds one file, named for the platform — objectfs-linux-amd64, not objectfs — so
+    # the extract and the rename are separate steps and the destination name is spelled out. A
+    # `tar -x` straight into the prefix would install a binary the user cannot invoke by name.
+    tar -xzf "$work/$asset" -C "$work" \
+        || die "could not extract $asset. The download passed its checksum, so this is a tar that cannot read the archive rather than a corrupt file"
+
+    local binary="$work/$PROGRAM-$platform"
+    [ -f "$binary" ] || die "$asset does not contain $PROGRAM-$platform. The release layout has changed and this script needs updating"
+
+    mkdir -p "$PREFIX/bin" || die "could not create $PREFIX/bin. Pass --prefix to install somewhere writable"
+
+    chmod 0755 "$binary"
+
+    # install(1) where it exists, because it replaces the destination atomically-ish and does not
+    # trip over a running binary; cp -f as the fallback for images that lack it. Overwriting an
+    # existing objectfs is the intended behaviour on a re-run, which is what makes this idempotent.
+    if command -v install > /dev/null 2>&1; then
+        install -m 0755 "$binary" "$PREFIX/bin/$PROGRAM" \
+            || die "could not install to $PREFIX/bin/$PROGRAM"
+    else
+        cp -f "$binary" "$PREFIX/bin/$PROGRAM" || die "could not install to $PREFIX/bin/$PROGRAM"
+        chmod 0755 "$PREFIX/bin/$PROGRAM"
+    fi
+
+    say "installed $PREFIX/bin/$PROGRAM"
+
+    # And say so when it is not reachable. An installer that succeeds and leaves the user with
+    # "command not found" has produced the same experience as one that failed, minus the
+    # explanation — this is the same failure the modulefiles refuse to load rather than cause.
+    case ":$PATH:" in
+        *":$PREFIX/bin:"*) ;;
+        *)
+            say "note: $PREFIX/bin is not on PATH. Add it:"
+            say "  export PATH=\"$PREFIX/bin:\$PATH\""
+            ;;
+    esac
+
+    # Run it. The version it prints is the authority on what was installed, and it is also the
+    # only check here that the binary actually executes on this machine — a wrong-architecture
+    # download that somehow passed its checksum surfaces as an exec format error right here,
+    # rather than the first time the user tries to mount something.
+    if "$PREFIX/bin/$PROGRAM" --version > /dev/null 2>&1; then
+        say "$("$PREFIX/bin/$PROGRAM" --version 2>&1 | head -1)"
+    else
+        die "$PREFIX/bin/$PROGRAM was installed but does not run. This is usually a binary built for a different architecture than this machine"
+    fi
+
+    say "next: objectfs mount s3://your-bucket /mnt/point   (see https://github.com/$REPO#quick-start)"
+}
+
+main "$@"


### PR DESCRIPTION
Part (b) of #138. Part (a) merged in #420; part (c) still needs a hosting decision.

## Not the script #138 specifies, and why

#138's `install.sh` detects the package manager and adds a repository at `packages.objectfs.io`. **That host does not exist** — both `objectfs.io` and `packages.objectfs.io` resolve to registrar parking IPs and neither completes a TLS handshake. A script written to that spec could not be run, could not be tested, and would fail at its first `curl` with a TLS error naming a domain the reader has no way to interpret.

What GitHub already hosts is a tarball per platform with a SHA-256 beside it. That needs no hosting decision, so it is what this installs.

## The checksum is verified and there is no flag to skip it

The reason to publish a checksum is that the download path is not trusted, and an installer that treats verification as skippable has spent the cost without buying the property. What it establishes is stated on the page rather than implied: the `.sha256` travels the same channel as the tarball, so this detects corruption and a mangling mirror — **not** a compromise of the release host. That is a signature's job, and this project does not sign releases.

The default prefix is `~/.local`, not `/usr/local`, reversing the usual convention on purpose. This project's users are frequently on a shared login node with no root, and an installer whose default needs `sudo` teaches them to run the whole thing under `sudo` — which writes a root-owned binary and root-owned cache directories into a home their own jobs use.

## shellcheck passed and it was still broken on two of three images

`shellcheck` was clean from the first draft. The local macOS run installed successfully against the real v0.13.0 release. And the script failed on two of the three images #138 names — **both times with an error naming the wrong cause:**

| image | what it lacks | what the script said |
|---|---|---|
| `ubuntu:24.04` | neither `curl` nor `wget` | *"could not reach the GitHub API to find the latest release. Pass `--version` to skip this step"* |
| `opensuse/leap:15.6` | neither `tar` nor `gzip` | *"a tar that cannot read the archive rather than a corrupt file"* — after a successful download and a verified checksum |

Installing only `tar` on openSUSE moved the same misattribution one layer down: `tar -xzf` shells out to `gzip` and reports the child's status as its own, giving `tar: Child returned status 2`.

A wrong cause is the expensive failure direction — it sends the reader to check the release, the network and the file, and never mentions the missing package. Both are now one `preflight` that runs **before anything touches the network**, reports *every* missing tool at once (openSUSE would otherwise need three attempts to learn what it needs), and names the package to install. It runs ahead of `--dry-run` too, since a dry run's job is to report whether this would work.

## The CI job

`install-script`, matrix over #138's three images. It asserts **refusal and success** per row — a job that checked only the refusal would pass against a script that can no longer install anything — plus that the checksum line appears, that the installed binary prints a version, and that two runs leave the identical binary.

`rockylinux:9` installs nothing beforehand, which makes it the row that would catch a preflight demanding something the script does not need.

It does **not** use LocalStack, which #138 specifies: nothing here touches S3. The script downloads a GitHub release asset and runs `objectfs --version`, so a mock S3 endpoint would be machinery with nothing behind it. It also tests the *last release's* binary rather than the PR's, which is the right subject — the thing under test is the install path, and pointing it at an artifact built in this workflow would test a URL no user will ever fetch.

## The gate covers what CI cannot

That job runs on x86_64, so it exercises exactly one row of the platform mapping: **a mapping wrong for arm64, armv7 or darwin passes all three images.** So `TestInstallScriptNamesEveryPublishedAsset` couples the script's `uname` translation to `release.yml`'s build matrix in both directions.

One mutation is **recorded as unverified locally rather than claimed as caught**: reversing the x86_64 mapping was expected to fail the container run and did not, because podman on an Apple Silicon host runs an arm64 binary inside an emulated amd64 container through binfmt — so the wrong-architecture binary executed and printed its version. On a real x86_64 runner the script's final `--version` check catches it; the static assertion is what makes that independent of the host.

Ten mutations, and one initially survived:

| | |
|---|---|
| G1 arch mapping wrong (the one containers missed) | CAUGHT |
| G2 arm64 row dropped | CAUGHT |
| G3 darwin dropped | CAUGHT |
| G4 checksum comparison skipped | CAUGHT |
| G5 missing .sha256 softened to a warning | CAUGHT |
| G6 `--skip-checksum` escape hatch added | CAUGHT |
| G7 preflight call removed | CAUGHT |
| G8 preflight moved below the API call | **initially MISSED** → CAUGHT |
| G8b preflight moved below the download | CAUGHT |
| G9 new release platform the script cannot name | CAUGHT |

G8 is the instructive one: moving `preflight` to sit immediately above the download still passed, because it was still *before the download* — but by then the script has already queried the GitHub API, which on a machine with no downloader is precisely the failure preflight exists to pre-empt. The check is now anchored to the API call rather than the download, and both orderings are asserted.

## Verification

- The installer run against the real v0.13.0 release: macOS arm64, and all three container images
- `ubuntu:24.04` with only `wget` installed — exercises the wget branch of release resolution, which is the path that produced the original wrong error
- Failure paths: nonexistent version (exit 1, no misleading checksum error, nothing installed), unwritable prefix, bad flag, flag missing its value — all exit 1, no leftover temp dirs
- Idempotent: two runs, identical binary hash
- The CI job's own shell logic run locally against all three rows with podman standing in for docker — 15/15 assertions
- `shellcheck` clean; `gofmt`, `go vet`, `golangci-lint` 0 issues; `ci.yml` parses, 15 jobs

## Docs

Three pages claimed no packages are built, which part (a) made false — `docs-platform/guide/getting-started.md`, `docs/index.md`, and the README's install section. The README also said `make build` produces `./objectfs` when it produces `./bin/objectfs`.

## Still open on #138

Part (c) — the apt/yum repository setup scripts and the `curl | bash` one-liner against a project domain — needs a hosting decision, not code: stand up `packages.objectfs.io`, use Cloudsmith/Fury/a Pages apt-yum repo/COPR/OBS, or skip repositories entirely. Measurements and the recommended split are on #138. **#138 stays open.**